### PR TITLE
Update client.mdx: ClientError namespace

### DIFF
--- a/docs/clients/client.mdx
+++ b/docs/clients/client.mdx
@@ -345,7 +345,7 @@ For consistent behavior across all transports, we recommend explicitly setting t
 
 #### Error Handling
 
-When a `call_tool` request results in an error on the server (e.g., the tool function raised an exception), the `client.call_tool()` method will raise a `fastmcp.client.ClientError`.
+When a `call_tool` request results in an error on the server (e.g., the tool function raised an exception), the `client.call_tool()` method will raise a `fastmcp.exceptions.ClientError`.
 
 ```python
 async def safe_call_tool():


### PR DESCRIPTION
`ClientError` is in the `fastmcp.exceptions` namespace, not `fastmcp.client`.