### PR TITLE
Fix : fix path error to CLI Documentation

### DIFF
--- a/docs/deployment/running-server.mdx
+++ b/docs/deployment/running-server.mdx
@@ -59,7 +59,7 @@ For development and testing, you can use the `dev` command to run your server wi
 fastmcp dev server.py
 ```
 
-See the [CLI documentation](/deployment/cli) for detailed information about all available commands and options.
+See the [CLI documentation](/patterns/cli) for detailed information about all available commands and options.
 
 ## Transport Options
 


### PR DESCRIPTION
CLI Documentation path was wrongly pointed under servers/development, fixed it to patterns