### PR TITLE
Formalize resource/functionresource replationship

### DIFF
--- a/src/fastmcp/resources/__init__.py
+++ b/src/fastmcp/resources/__init__.py
@@ -1,10 +1,9 @@
-from .resource import Resource
+from .resource import FunctionResource, Resource
 from .template import ResourceTemplate
 from .types import (
     BinaryResource,
     DirectoryResource,
     FileResource,
-    FunctionResource,
     HttpResource,
     TextResource,
 )

--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -7,7 +7,6 @@ from typing import Any
 from pydantic import AnyUrl
 
 from fastmcp.exceptions import NotFoundError, ResourceError
-from fastmcp.resources import FunctionResource
 from fastmcp.resources.resource import Resource
 from fastmcp.resources.template import (
     ResourceTemplate,
@@ -121,13 +120,13 @@ class ResourceManager:
             The added resource. If a resource with the same URI already exists,
             returns the existing resource.
         """
-        resource = FunctionResource(
+        resource = Resource.from_function(
             fn=fn,
-            uri=AnyUrl(uri),
+            uri=uri,
             name=name,
             description=description,
-            mime_type=mime_type or "text/plain",
-            tags=tags or set(),
+            mime_type=mime_type,
+            tags=tags,
         )
         return self.add_resource(resource)
 

--- a/src/fastmcp/resources/template.py
+++ b/src/fastmcp/resources/template.py
@@ -10,14 +10,13 @@ from urllib.parse import unquote
 
 from mcp.types import ResourceTemplate as MCPResourceTemplate
 from pydantic import (
-    AnyUrl,
     BeforeValidator,
     Field,
     field_validator,
     validate_call,
 )
 
-from fastmcp.resources.types import FunctionResource, Resource
+from fastmcp.resources.types import Resource
 from fastmcp.server.dependencies import get_context
 from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.types import (
@@ -189,12 +188,12 @@ class ResourceTemplate(FastMCPBaseModel):
                 result = await result
             return result
 
-        return FunctionResource(
-            uri=AnyUrl(uri),  # Explicitly convert to AnyUrl
+        return Resource.from_function(
+            fn=resource_read_fn,
+            uri=uri,
             name=self.name,
             description=self.description,
             mime_type=self.mime_type,
-            fn=resource_read_fn,
             tags=self.tags,
         )
 

--- a/tests/resources/test_function_resources.py
+++ b/tests/resources/test_function_resources.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import AnyUrl, BaseModel
 
-from fastmcp.resources import FunctionResource
+from fastmcp.resources.resource import FunctionResource
 
 
 class TestFunctionResource:

--- a/tests/resources/test_resource_manager.py
+++ b/tests/resources/test_resource_manager.py
@@ -7,10 +7,10 @@ from pydantic import AnyUrl, FileUrl
 from fastmcp.exceptions import NotFoundError, ResourceError
 from fastmcp.resources import (
     FileResource,
-    FunctionResource,
     ResourceManager,
     ResourceTemplate,
 )
+from fastmcp.resources.resource import FunctionResource
 
 
 @pytest.fixture

--- a/tests/resources/test_resource_template.py
+++ b/tests/resources/test_resource_template.py
@@ -5,7 +5,8 @@ import pytest
 from pydantic import BaseModel
 
 from fastmcp import Context
-from fastmcp.resources import FunctionResource, ResourceTemplate
+from fastmcp.resources import ResourceTemplate
+from fastmcp.resources.resource import FunctionResource
 from fastmcp.resources.template import match_uri_template
 
 

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -1,7 +1,8 @@
 import pytest
 from pydantic import AnyUrl
 
-from fastmcp.resources import FunctionResource, Resource
+from fastmcp.resources import Resource
+from fastmcp.resources.resource import FunctionResource
 
 
 class TestResourceValidation:

--- a/tests/server/test_server_interactions.py
+++ b/tests/server/test_server_interactions.py
@@ -20,7 +20,8 @@ from fastmcp import Client, Context, FastMCP
 from fastmcp.client.transports import FastMCPTransport
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts.prompt import EmbeddedResource, PromptMessage
-from fastmcp.resources import FileResource, FunctionResource
+from fastmcp.resources import FileResource
+from fastmcp.resources.resource import FunctionResource
 from fastmcp.utilities.types import Image
 
 


### PR DESCRIPTION
Follow up to #700 and #701 to apply similar strict logic to the `Resource` and `FunctionResource` classes