### PR TITLE
Fix pr labeler permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5


### PR DESCRIPTION
We are sometimes seeing permissions error in the PR labeler like

```
Error: HttpError: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"} Error: You do not have permission to create labels on this repository.: {"resource":"Repository",
```

Based on https://github.com/actions/labeler/issues/870 and https://github.com/orgs/community/discussions/156181 it seems like the solution is to add this additional `issues: write` permission

cc @zzstoatzz 