### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Learn more in the [**Composition Documentation**](https://gofastmcp.com/patterns
 
 Automatically generate FastMCP servers from existing OpenAPI specifications (`FastMCP.from_openapi()`) or FastAPI applications (`FastMCP.from_fastapi()`), instantly bringing your web APIs to the MCP ecosystem.
 
-Learn more: [**OpenAPI Integration**](https://gofastmcp.com/patterns/openapi) | [**FastAPI Integration**](https://gofastmcp.com/patterns/fastapi).
+Learn more: [**OpenAPI Integration**](https://gofastmcp.com/servers/openapi#openapi-integration) | [**FastAPI Integration**](https://gofastmcp.com/deployment/asgi#fastapi-integration).
 
 ### Authentication & Security
 


### PR DESCRIPTION
Just a quick fix 2 links provided in the README.md was wrong.