### PR TITLE
Fix Typo in CLI module

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -1,4 +1,4 @@
-"""FastmMCP CLI tools."""
+"""FastMCP CLI tools."""
 
 import importlib.metadata
 import importlib.util


### PR DESCRIPTION
This PR fixes the typo in the CLI module docstring. 