### PR TITLE
Add session_id property to Context for data sharing

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -181,15 +181,15 @@ class Context:
     @property
     def session_id(self) -> str | None:
         """Get the MCP session ID for HTTP transports.
-        
+
         Returns the session ID that can be used as a key for session-based
         data storage (e.g., Redis) to share data between tool calls within
         the same client session.
-        
+
         Returns:
             The session ID for HTTP transports (SSE, StreamableHTTP), or None
             for stdio and in-memory transports which don't use session IDs.
-            
+
         Example:
             ```python
             @server.tool
@@ -202,6 +202,7 @@ class Context:
         """
         try:
             from fastmcp.server.dependencies import get_http_headers
+
             headers = get_http_headers(include_all=True)
             return headers.get("mcp-session-id")
         except RuntimeError:

--- a/tests/server/test_context.py
+++ b/tests/server/test_context.py
@@ -92,7 +92,7 @@ class TestSessionId:
     def test_session_id_with_http_headers(self, context):
         """Test that session_id returns the value from mcp-session-id header."""
         mock_headers = {"mcp-session-id": "test-session-123"}
-        
+
         with patch(
             "fastmcp.server.dependencies.get_http_headers", return_value=mock_headers
         ):
@@ -101,15 +101,15 @@ class TestSessionId:
     def test_session_id_without_http_headers(self, context):
         """Test that session_id returns None when no HTTP headers are available."""
         with patch(
-            "fastmcp.server.dependencies.get_http_headers", 
-            side_effect=RuntimeError("No active HTTP request found.")
+            "fastmcp.server.dependencies.get_http_headers",
+            side_effect=RuntimeError("No active HTTP request found."),
         ):
             assert context.session_id is None
 
     def test_session_id_with_missing_header(self, context):
         """Test that session_id returns None when mcp-session-id header is missing."""
         mock_headers = {"other-header": "value"}
-        
+
         with patch(
             "fastmcp.server.dependencies.get_http_headers", return_value=mock_headers
         ):
@@ -118,7 +118,7 @@ class TestSessionId:
     def test_session_id_with_empty_header(self, context):
         """Test that session_id returns None when mcp-session-id header is empty."""
         mock_headers = {"mcp-session-id": ""}
-        
+
         with patch(
             "fastmcp.server.dependencies.get_http_headers", return_value=mock_headers
         ):


### PR DESCRIPTION
## Summary

Adds `session_id` property to FastMCP's `Context` class to enable session-based data sharing between tools. This addresses the Redis-based data sharing architecture requested in #875.

```python
@server.tool
def store_data(data: dict, ctx: Context) -> str:
    if session_id := ctx.session_id:
        redis_client.set(f"session:{session_id}:data", json.dumps(data))
        return f"Data stored for session {session_id}"
    return "No session available (stdio/memory transport)"
```

## Key Changes

- **New property**: `Context.session_id` returns MCP session ID from HTTP headers
- **Transport aware**: Returns `None` for stdio/memory transports (per MCP spec)
- **HTTP only**: Works with SSE and StreamableHTTP transports that use session IDs
- **Thread safe**: Uses existing `get_http_headers()` utility

## Session ID Behavior

| Transport | Session ID | Use Case |
|-----------|------------|----------|
| HTTP (SSE/StreamableHTTP) | ✅ UUID | Web APIs, data sharing |
| Stdio | ❌ None | CLI tools |
| In-memory | ❌ None | Testing |

## Test Coverage

- ✅ Session ID extraction from HTTP headers
- ✅ Graceful fallback for non-HTTP transports  
- ✅ Missing header handling
- ✅ Integration test with real server

This enables the exact data sharing workflow described in #875 and addresses persistent community requests as mentioned in https://github.com/modelcontextprotocol/python-sdk/issues/986, https://github.com/modelcontextprotocol/python-sdk/issues/942, and https://github.com/modelcontextprotocol/python-sdk/issues/485.

🤖 Generated with [Claude Code](https://claude.ai/code)