### PR TITLE
Update context docs for session_id property

### DIFF
--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -293,6 +293,7 @@ async def request_info(ctx: Context) -> dict:
 
 - **`ctx.request_id -> str`**: Get the unique ID for the current MCP request
 - **`ctx.client_id -> str | None`**: Get the ID of the client making the request, if provided during initialization
+- **`ctx.session_id -> str | None`**: Get the MCP session ID for session-based data sharing (HTTP transports only)
 
 ### Advanced Access
 


### PR DESCRIPTION
## Summary
- Add session_id property to the context documentation

## Details
Fast follow to #881 to document the new `session_id` property in the context documentation. The property was implemented but documentation was missed in the original PR.

🤖 Generated with [Claude Code](https://claude.ai/code)