### PR TITLE
add server name to mounted server warnings

### DIFF
--- a/src/fastmcp/prompts/prompt_manager.py
+++ b/src/fastmcp/prompts/prompt_manager.py
@@ -78,7 +78,7 @@ class PromptManager:
             except Exception as e:
                 # Skip failed mounts silently, matches existing behavior
                 logger.warning(
-                    f"Failed to get prompts from {mounted.server.name} server mounted at '{mounted.prefix}': {e}"
+                    f"Failed to get prompts from server: {mounted.server.name!r}, mounted at: {mounted.prefix!r}: {e}"
                 )
                 continue
 

--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -109,7 +109,7 @@ class ResourceManager:
             except Exception as e:
                 # Skip failed mounts silently, matches existing behavior
                 logger.warning(
-                    f"Failed to get resources from {mounted.server.name} server mounted at '{mounted.prefix}': {e}"
+                    f"Failed to get resources from server: {mounted.server.name!r}, mounted at: {mounted.prefix!r}: {e}"
                 )
                 continue
 
@@ -157,7 +157,7 @@ class ResourceManager:
             except Exception as e:
                 # Skip failed mounts silently, matches existing behavior
                 logger.warning(
-                    f"Failed to get templates from {mounted.server.name} server mounted at '{mounted.prefix}': {e}"
+                    f"Failed to get templates from server: {mounted.server.name!r}, mounted at: {mounted.prefix!r}: {e}"
                 )
                 continue
 

--- a/src/fastmcp/tools/tool_manager.py
+++ b/src/fastmcp/tools/tool_manager.py
@@ -76,7 +76,7 @@ class ToolManager:
             except Exception as e:
                 # Skip failed mounts silently, matches existing behavior
                 logger.warning(
-                    f"Failed to get tools from {mounted.server.name} server mounted at '{mounted.prefix}': {e}"
+                    f"Failed to get tools from server: {mounted.server.name!r}, mounted at: {mounted.prefix!r}: {e}"
                 )
                 continue
 

--- a/tests/server/test_mount.py
+++ b/tests/server/test_mount.py
@@ -317,16 +317,18 @@ class TestMultipleServerMount:
             record.message for record in caplog.records if record.levelname == "WARNING"
         ]
         assert any(
-            "Failed to get tools from FastMCP server mounted at 'unreachable'" in msg
-            for msg in warning_messages
-        )
-        assert any(
-            "Failed to get resources from FastMCP server mounted at 'unreachable'"
+            "Failed to get tools from server: 'FastMCP', mounted at: 'unreachable'"
             in msg
             for msg in warning_messages
         )
         assert any(
-            "Failed to get prompts from FastMCP server mounted at 'unreachable'" in msg
+            "Failed to get resources from server: 'FastMCP', mounted at: 'unreachable'"
+            in msg
+            for msg in warning_messages
+        )
+        assert any(
+            "Failed to get prompts from server: 'FastMCP', mounted at: 'unreachable'"
+            in msg
             for msg in warning_messages
         )
 


### PR DESCRIPTION
We currently mount a bunch of servers at the same prefix, and were having issues decoding which one was erroring. Adding server name to the warning can help differentiate errors.