### PR TITLE
Fix `fastmcp install` sub-command docs

### DIFF
--- a/docs/patterns/cli.mdx
+++ b/docs/patterns/cli.mdx
@@ -182,10 +182,10 @@ The `install` command supports the same `file.py:object` notation as the `run` c
 
 | Option | Flag | Description |
 | ------ | ---- | ----------- |
-| Server Name | `--name`, `-n` | Custom name for the server (defaults to server's name attribute or file name) |
+| Server Name | `--server-name`, `-n` | Custom name for the server (defaults to server's name attribute or file name) |
 | Editable Package | `--with-editable`, `-e` | Directory containing pyproject.toml to install in editable mode |
 | Additional Packages | `--with` | Additional packages to install (can be used multiple times) |
-| Environment Variables | `--env-var`, `-v` | Environment variables in KEY=VALUE format (can be used multiple times) |
+| Environment Variables | `--env`, `-v` | Environment variables in KEY=VALUE format (can be used multiple times) |
 | Environment File | `--env-file`, `-f` | Load environment variables from a .env file |
 
 **Examples**
@@ -201,16 +201,16 @@ fastmcp install claude-desktop server.py:my_server
 fastmcp install claude-desktop server.py:my_server -n "My Analysis Server" --with pandas
 
 # Install in Claude Code with environment variables
-fastmcp install claude-code server.py --env-var API_KEY=secret --env-var DEBUG=true
+fastmcp install claude-code server.py --env API_KEY=secret --env DEBUG=true
 
 # Install in Cursor with environment variables
-fastmcp install cursor server.py --env-var API_KEY=secret --env-var DEBUG=true
+fastmcp install cursor server.py --env API_KEY=secret --env DEBUG=true
 
 # Install with environment file
 fastmcp install cursor server.py --env-file .env
 
 # Generate MCP JSON configuration
-fastmcp install mcp-json server.py --name "My Server" --with pandas
+fastmcp install mcp-json server.py --server-name "My Server" --with pandas
 
 # Copy JSON configuration to clipboard
 fastmcp install mcp-json server.py --copy


### PR DESCRIPTION
Fix the docs for  the install sub-command:
 - `--name` to `--server-name`
 - `--env-var` to `--env`

Also, the docs gave me the impression `mcp-json` would emit the entire settings object, but it does not:

```
$ uv run fastmcp install mcp-json main.py -n "Enum MCP"
{
  "command": "uv",
  "args": [
    "run",
    "--with",
    "fastmcp",
    "fastmcp",
    "run",
    "/source/fastmcp/experiments/main.py"
  ]
}
```

This makes the `--server-name` argument useless for `mcp-json` (its existence is why I expected to receive the entire settings object).  Am I supposed to use `--server-spec <FILE>` to ask it to install to an existing file?  That option is marked as "required", but it is not ☝️, and:

```
$ uv run fastmcp install mcp-json main.py -n "Enum MCP" --server-spec foo.json
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Unused Tokens: ['main.py'].                                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

A bug?  I can't quite intuit what is intended here.  Perhaps I've misunderstood the `mcp-json` command.

I glanced at the sub-command code, and see the shared aspect to the config object assembly.  I notice `install_mcp_config` is only used by the install sub-command, so perhaps it could emit with the wrapper if no `--server-spec` (and that argument was optional; as now, effectively).

Emitting a full config would be helpful, because I want to do this: `claude mcp-config foo.json` for quick testing, and *not install* the server to any Claude configuration.

Admittedly, this is trivial:

`$ uv run fastmcp install mcp-json main.py -n "Enum MCP" | jq --arg n "enum" '{mcpServers: {($n): .}}'`

But, one more thing to do , and I'm used to FastMCP doing so much for me.  😂  It's amazing, thank you!  🔥