### PR TITLE
feat(settings): add log level normalization

### DIFF
--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -5,7 +5,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import (
     BaseSettings,
@@ -99,7 +99,16 @@ class Settings(BaseSettings):
     home: Path = Path.home() / ".fastmcp"
 
     test_mode: bool = False
+
     log_level: LOG_LEVEL = "INFO"
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def normalize_log_level(cls, v):
+        if isinstance(v, str):
+            return v.upper()
+        return v
+
     enable_rich_tracebacks: Annotated[
         bool,
         Field(


### PR DESCRIPTION
- Add log_level setting with validation to normalize input to uppercase
- Update import statements to include field_validator

Based on the fastmcp documentation, I integrated mcp_app into my FastAPI application.
Originally, my FastAPI settings allowed logging levels to be specified in either uppercase or lowercase.
However, after mounting mcp_app, using lowercase logging levels started triggering validation errors from Pydantic.