### PR TITLE
Only configure logging one time

### DIFF
--- a/src/fastmcp/__init__.py
+++ b/src/fastmcp/__init__.py
@@ -1,10 +1,15 @@
 """FastMCP - An ergonomic MCP interface."""
 
 import warnings
-from importlib.metadata import version
+from importlib.metadata import version as _version
 from fastmcp.settings import Settings
+from fastmcp.utilities.logging import configure_logging as _configure_logging
 
 settings = Settings()
+_configure_logging(
+    level=settings.log_level,
+    enable_rich_tracebacks=settings.enable_rich_tracebacks,
+)
 
 from fastmcp.server.server import FastMCP
 from fastmcp.server.context import Context
@@ -13,7 +18,7 @@ import fastmcp.server
 from fastmcp.client import Client
 from . import client
 
-__version__ = version("fastmcp")
+__version__ = _version("fastmcp")
 
 
 # ensure deprecation warnings are displayed by default

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -5,7 +5,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, field_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import (
     BaseSettings,
@@ -170,17 +170,6 @@ class Settings(BaseSettings):
             description="The timeout for the client's initialization handshake, in seconds. Set to None or 0 to disable.",
         ),
     ] = None
-
-    @model_validator(mode="after")
-    def setup_logging(self) -> Self:
-        """Finalize the settings."""
-        from fastmcp.utilities.logging import configure_logging
-
-        configure_logging(
-            self.log_level, enable_rich_tracebacks=self.enable_rich_tracebacks
-        )
-
-        return self
 
     # HTTP settings
     host: str = "127.0.0.1"


### PR DESCRIPTION
Closes #1168 by only configuring logging once, allowing users to modify as needed.