### PR TITLE
Ensure default fields are not marked nullable

### DIFF
--- a/src/fastmcp/utilities/json_schema_type.py
+++ b/src/fastmcp/utilities/json_schema_type.py
@@ -561,9 +561,7 @@ def _create_dataclass(
             else:
                 field_def = field(default=None, metadata=meta)
 
-        if is_required and default_val is not MISSING:
-            fields.append((field_name, field_type, field_def))
-        elif is_required:
+        if is_required or default_val is not MISSING:
             fields.append((field_name, field_type, field_def))
         else:
             fields.append((field_name, Union[field_type, type(None)], field_def))  # type: ignore[misc]  # noqa: UP007


### PR DESCRIPTION
#1167 highlighted a bug in the schema-to-type converter where fields with default values were being marked as nullable. This created an error and was discovered when used in combination with elicitation, which prohibits null values in schemas. 

The fix is relatively small -- we ensure that optional fields *with defaults* do not go into the logic branch that reflects them as nullable.