### PR TITLE
Update --name flag documentation for Cursor/Claude

### DIFF
--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -114,7 +114,7 @@ fastmcp install claude-code server.py --project /path/to/my-project
 If your server needs environment variables (like API keys), you must include them:
 
 ```bash
-fastmcp install claude-code server.py --name "Weather Server" \
+fastmcp install claude-code server.py --server-name "Weather Server" \
   --env API_KEY=your-api-key \
   --env DEBUG=true
 ```
@@ -122,7 +122,7 @@ fastmcp install claude-code server.py --name "Weather Server" \
 Or load them from a `.env` file:
 
 ```bash
-fastmcp install claude-code server.py --name "Weather Server" --env-file .env
+fastmcp install claude-code server.py --server-name "Weather Server" --env-file .env
 ```
 
 <Warning>

--- a/docs/integrations/claude-desktop.mdx
+++ b/docs/integrations/claude-desktop.mdx
@@ -136,7 +136,7 @@ Claude Desktop runs servers in a completely isolated environment with no access 
 If your server needs environment variables (like API keys), you must include them:
 
 ```bash
-fastmcp install claude-desktop server.py --name "Weather Server" \
+fastmcp install claude-desktop server.py --server-name "Weather Server" \
   --env API_KEY=your-api-key \
   --env DEBUG=true
 ```
@@ -144,7 +144,7 @@ fastmcp install claude-desktop server.py --name "Weather Server" \
 Or load them from a `.env` file:
 
 ```bash
-fastmcp install claude-desktop server.py --name "Weather Server" --env-file .env
+fastmcp install claude-desktop server.py --server-name "Weather Server" --env-file .env
 ```
 <Warning>
 - **`uv` must be installed and available in your system PATH**. Claude Desktop runs in its own isolated environment and needs `uv` to manage dependencies.

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -120,7 +120,7 @@ Cursor runs servers in a completely isolated environment with no access to your 
 If your server needs environment variables (like API keys), you must include them:
 
 ```bash
-fastmcp install cursor server.py --name "Weather Server" \
+fastmcp install cursor server.py --server-name "Weather Server" \
   --env API_KEY=your-api-key \
   --env DEBUG=true
 ```
@@ -128,7 +128,7 @@ fastmcp install cursor server.py --name "Weather Server" \
 Or load them from a `.env` file:
 
 ```bash
-fastmcp install cursor server.py --name "Weather Server" --env-file .env
+fastmcp install cursor server.py --server-name "Weather Server" --env-file .env
 ```
 
 <Warning>
@@ -145,10 +145,10 @@ You can generate MCP JSON configuration for manual use:
 
 ```bash
 # Generate configuration and output to stdout
-fastmcp install mcp-json server.py --name "Dice Roller" --with pandas
+fastmcp install mcp-json server.py --server-name "Dice Roller" --with pandas
 
 # Copy configuration to clipboard for easy pasting
-fastmcp install mcp-json server.py --name "Dice Roller" --copy
+fastmcp install mcp-json server.py --server-name "Dice Roller" --copy
 ```
 
 This generates the standard `mcpServers` configuration format that can be used with any MCP-compatible client.

--- a/docs/patterns/cli.mdx
+++ b/docs/patterns/cli.mdx
@@ -253,7 +253,7 @@ The `install` command supports the same `file.py:object` notation as the `run` c
 
 | Option | Flag | Description |
 | ------ | ---- | ----------- |
-| Server Name | `--name`, `-n` | Custom name for the server (defaults to server's name attribute or file name) |
+| Server Name | `--server-name`, `-n` | Custom name for the server (defaults to server's name attribute or file name) |
 | Editable Package | `--with-editable`, `-e` | Directory containing pyproject.toml to install in editable mode |
 | Additional Packages | `--with` | Additional packages to install (can be used multiple times) |
 | Environment Variables | `--env` | Environment variables in KEY=VALUE format (can be used multiple times) |
@@ -272,7 +272,7 @@ fastmcp install claude-desktop server.py
 fastmcp install claude-desktop server.py:my_server
 
 # With custom name and dependencies
-fastmcp install claude-desktop server.py:my_server --name "My Analysis Server" --with pandas
+fastmcp install claude-desktop server.py:my_server --server-name "My Analysis Server" --with pandas
 
 # Install in Claude Code with environment variables
 fastmcp install claude-code server.py --env API_KEY=secret --env DEBUG=true


### PR DESCRIPTION
The flag for the custom server name was updated from `--name` to `--server-name` for cursor/claude desktop/claude code [here](https://github.com/jlowin/fastmcp/commit/919d7e35efa6fe531d2a361a2b75fd9e7f1ac95d#diff-97d62bcb01a343f45bbff08a97fe5eb377281fd780b40b25987e975befca25c5R132) but the documentation needs to be updated to match.

The mcp-json command looks like it got changed back from `--server-name` to `--name` [here](https://github.com/jlowin/fastmcp/pull/1185/files#diff-f9ee4bf3e9e951757684707ac299c637a2c57b5faa8e71f68e8d1631ea774ca8R105) so I didn't update that documentation.