### PR TITLE
docs: update get_state and set_state references

### DIFF
--- a/docs/python-sdk/fastmcp-server-context.mdx
+++ b/docs/python-sdk/fastmcp-server-context.mdx
@@ -45,8 +45,8 @@ def my_tool(x: int, ctx: Context) -> str:
     client_id = ctx.client_id
 
     # Manage state across the request
-    ctx.set_state_value("key", "value")
-    value = ctx.get_state_value("key")
+    ctx.set_state("key", "value")
+    value = ctx.get_state("key")
 
     return str(x)
 ```

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -222,8 +222,8 @@ async def secure_operation(data: str, ctx: Context) -> str:
 ```
 
 **Method signatures:**
-- **`ctx.set_state_value(key: str, value: Any) -> None`**: Store a value in the context state
-- **`ctx.get_state_value(key: str) -> Any`**: Retrieve a value from the context state (returns None if not found)
+- **`ctx.set_state(key: str, value: Any) -> None`**: Store a value in the context state
+- **`ctx.get_state(key: str) -> Any`**: Retrieve a value from the context state (returns None if not found)
 
 **State Inheritance:**
 When a new context is created (nested contexts), it inherits a copy of its parent's state. This ensures that:

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -85,8 +85,8 @@ class Context:
         client_id = ctx.client_id
 
         # Manage state across the request
-        ctx.set_state_value("key", "value")
-        value = ctx.get_state_value("key")
+        ctx.set_state("key", "value")
+        value = ctx.get_state("key")
 
         return str(x)
     ```


### PR DESCRIPTION
Only updates docs.

Fixes a small inconsistency in the docs where, I think, `get_state_value` and `set_state_value` shouldn't have `_value`.