### PR TITLE
fix(type): lifespan is partially unknown

### DIFF
--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -40,7 +40,7 @@ _current_http_request: ContextVar[Request | None] = ContextVar(
 
 class StarletteWithLifespan(Starlette):
     @property
-    def lifespan(self) -> Lifespan:
+    def lifespan(self) -> Lifespan[Starlette]:
         return self.router.lifespan_context
 
 


### PR DESCRIPTION
Fix missing GenericType on Lifespan, casuing pylance to complain

```
Type of "lifespan" is partially unknown
  Type of "lifespan" is "((Unknown) -> AbstractAsyncContextManager[None, bool | None]) | ((Unknown) -> AbstractAsyncContextManager[Mapping[str, Any], bool | None])"
```