### PR TITLE
Fix Marvin workflow to support development tools

### DIFF
--- a/.github/workflows/marvin.yml
+++ b/.github/workflows/marvin.yml
@@ -31,6 +31,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Set up Python environment
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Install UV package manager
+      - name: Install UV
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      # Install project dependencies
+      - name: Install dependencies
+        run: uv sync --dev
+
+      # Install pre-commit hooks automatically
+      - name: Install pre-commit hooks
+        run: |
+          uv run pre-commit install
+          echo "✅ Pre-commit hooks installed"
+
       - name: Generate Marvin App token
         id: marvin-token
         uses: actions/create-github-app-token@v2
@@ -47,6 +70,6 @@ jobs:
           mode: tag
           trigger_phrase: "/marvin"
           allowed_bots: "*"
-          allowed_tools: "WebSearch,WebFetch,mcp__github__add_issue_comment,mcp__github__create_issue,mcp__github__get_issue,mcp__github__list_issues,mcp__github__search_issues,mcp__github__update_issue,mcp__github__update_issue_comment,mcp__github__create_pull_request,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__list_pull_requests,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,mcp__github__update_pull_request_comment,mcp__github__merge_pull_request"
+          allowed_tools: "WebSearch,WebFetch,Bash(uv:*),Bash(pre-commit:*),Bash(pytest:*),Bash(ruff:*),Bash(pyright:*),Bash(git:*),Bash(gh:*),mcp__github__add_issue_comment,mcp__github__create_issue,mcp__github__get_issue,mcp__github__list_issues,mcp__github__search_issues,mcp__github__update_issue,mcp__github__update_issue_comment,mcp__github__create_pull_request,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__list_pull_requests,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,mcp__github__update_pull_request_comment,mcp__github__merge_pull_request"
           additional_permissions: |
             actions: read


### PR DESCRIPTION
The Marvin bot was unable to run essential development commands like pre-commit and pytest, causing static check failures as seen in PR #1534. The bot would push changes without validation because it lacked permission to run the required tools.

This PR adds the necessary development environment setup and tool permissions to the Marvin workflow. Now the bot will have pre-commit hooks automatically installed and can run validation commands before pushing changes.

## Key improvements

With these changes, Marvin can now follow the required development workflow:

```bash
# Dependencies are pre-installed in the action
uv run pre-commit run --all-files  # Now allowed via Bash(pre-commit:*)
uv run pytest                       # Now allowed via Bash(pytest:*)
```

Pre-commit hooks are automatically installed, so commits will be validated even without explicit commands. This prevents the static check failures that were occurring when the bot couldn't verify its changes before pushing.