### PR TITLE
Fixed wrong import path in new docs page

### DIFF
--- a/docs/servers/auth/oauth-proxy.mdx
+++ b/docs/servers/auth/oauth-proxy.mdx
@@ -165,7 +165,7 @@ The `OAuthProxy` class provides the complete proxy implementation:
 
 ```python
 from fastmcp import FastMCP
-from fastmcp.server.auth.providers.proxy import OAuthProxy
+from fastmcp.server.auth.proxy import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 
 # Configure token validation for your provider


### PR DESCRIPTION
Just fixed one import from an example in new 2.12 docs page.