### PR TITLE
fix: PromptArgument.required should accept None

### DIFF
--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -61,7 +61,7 @@ class PromptArgument(FastMCPBaseModel):
     description: str | None = Field(
         default=None, description="Description of what the argument does"
     )
-    required: bool = Field(
+    required: bool | None = Field(
         default=False, description="Whether the argument is required"
     )
 


### PR DESCRIPTION
Update `PromptArgument` so the `required` property also accepts `bool | None` instead of just `bool`, just like the original types from `mcp.types.Prompt`.

This fixes an issue where FastMCP will error for some MCP Servers that return `required` as `None` –– for example, the Github Remote MCP:
```
[Prompt(name='AssignCodingAgent', title=None, description='Assign GitHub Coding Agent to multiple tasks in a GitHub repository.', arguments=[PromptArgument(name='repo', description='The repository to assign tasks in (owner/repo).', required=True)], meta=None), Prompt(name='IssueToFixWorkflow', title=None, description='Create an issue for a problem and then generate a pull request to fix it', arguments=[PromptArgument(name='owner', description='Repository owner', required=True), PromptArgument(name='repo', description='Repository name', required=True), PromptArgument(name='title', description='Issue title', required=True), PromptArgument(name='description', description='Issue description', required=True), PromptArgument(name='labels', description='Comma-separated list of labels to apply (optional)', required=None), PromptArgument(name='assignees', description='Comma-separated list of assignees (optional)', required=None)], meta=None)]
```

Will trigger the error:
```
{"jsonrpc":"2.0","id":2,"error":{"code":0,"message":"2 validation errors for ProxyPrompt\\narguments.4.required\\n  Input should be a valid boolean [type=bool_type, input_value=None, input_type=NoneType]\\n    For further information visit https://errors.pydantic.dev/2.11/v/bool_type\\narguments.5.required\\n  Input should be a valid boolean [type=bool_type, input_value=None, input_type=NoneType]\\n    For further information visit https://errors.pydantic.dev/2.11/v/bool_type"}}
```