### PR TITLE
Skip flaky windows test / mulit-client garbage collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dev = [
     "pytest-timeout>=2.4.0",
     "pytest-xdist>=3.6.1",
     "ruff",
-    "pytest-rerunfailures>=15.1",
 ]
 
 [project.scripts]

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -244,10 +244,9 @@ async def test_multi_client(tmp_path: Path):
 
 
 @pytest.mark.skipif(
-    running_under_debugger(), reason="Debugger holds a reference to the transport"
+    running_under_debugger() or sys.platform.startswith("win32"),
+    reason="Debugger holds a reference to the transport; Windows has process lifecycle issues",
 )
-# this test can be flaky on windows
-@pytest.mark.flaky(reruns=3, condition=sys.platform.startswith("win32"))
 @pytest.mark.timeout(5)
 async def test_multi_client_lifespan(tmp_path: Path):
     pid_1: int | None = None

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,6 @@ dev = [
     { name = "pytest-flakefinder" },
     { name = "pytest-httpx" },
     { name = "pytest-report" },
-    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -618,7 +617,6 @@ dev = [
     { name = "pytest-flakefinder" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-report", specifier = ">=0.2.1" },
-    { name = "pytest-rerunfailures", specifier = ">=15.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff" },
@@ -1617,19 +1615,6 @@ dependencies = [
     { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/82/e141da085de0b6dac3f047ae009e136bcedbcfca4ada082a55359d6f735e/pytest-report-0.2.1.tar.gz", hash = "sha256:d382e8db4c52a815d39dae5f21ee5edc0da3ae8ec19a22e55e9be5c60714a39d", size = 3517, upload-time = "2016-05-11T02:08:04.665Z" }
-
-[[package]]
-name = "pytest-rerunfailures"
-version = "15.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/78/e6e358545537a8e82c4dc91e72ec0d6f80546a3786dd27c76b06ca09db77/pytest_rerunfailures-15.1.tar.gz", hash = "sha256:c6040368abd7b8138c5b67288be17d6e5611b7368755ce0465dda0362c8ece80", size = 26981, upload-time = "2025-05-08T06:36:33.483Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/30/11d836ff01c938969efa319b4ebe2374ed79d28043a12bfc908577aab9f3/pytest_rerunfailures-15.1-py3-none-any.whl", hash = "sha256:f674c3594845aba8b23c78e99b1ff8068556cc6a8b277f728071fdc4f4b0b355", size = 13274, upload-time = "2025-05-08T06:36:32.029Z" },
-]
 
 [[package]]
 name = "pytest-timeout"


### PR DESCRIPTION
This test seems to fail with some regularity on windows with an unexpected error. Unfortunately we can't use typical flaky retries because when it fails it kills the entire test process