### PR TITLE
Add Context Snapshot Support

### DIFF
--- a/examples/state_snapshot_demo.py
+++ b/examples/state_snapshot_demo.py
@@ -8,6 +8,7 @@ from fastmcp.server.context import Context
 
 mcp = FastMCP("State Snapshot Demo")
 
+
 @mcp.tool
 def setup_user_data(username: str, theme: str, language: str, ctx: Context) -> str:
     """Set up some user preferences in the context state."""
@@ -15,13 +16,15 @@ def setup_user_data(username: str, theme: str, language: str, ctx: Context) -> s
     ctx.set_state("theme", theme)
     ctx.set_state("language", language)
     ctx.set_state("session_start", "2024-01-15T10:30:00Z")
-    
+
     return f"User data set up for {username} (theme: {theme}, language: {language})"
+
 
 @mcp.tool
 def create_state_snapshot(snapshot_name: str, ctx: Context) -> str:
     """Create a named snapshot of the current context state."""
     return ctx.create_snapshot(snapshot_name)
+
 
 @mcp.tool
 def show_current_state(ctx: Context) -> dict:
@@ -34,16 +37,19 @@ def show_current_state(ctx: Context) -> dict:
             current_state[key] = value
     return current_state
 
+
 @mcp.tool
 def modify_state(key: str, value: str, ctx: Context) -> str:
     """Modify a state value."""
     ctx.set_state(key, value)
     return f"Set {key} = {value}"
 
+
 @mcp.tool
 def list_all_snapshots(ctx: Context) -> list[str]:
     """List all available snapshots."""
     return ctx.list_snapshots()
+
 
 @mcp.tool
 def restore_from_snapshot(snapshot_name: str, ctx: Context) -> str:
@@ -53,6 +59,7 @@ def restore_from_snapshot(snapshot_name: str, ctx: Context) -> str:
     except KeyError as e:
         return f"Error: {e}"
 
+
 @mcp.tool
 def delete_state_snapshot(snapshot_name: str, ctx: Context) -> str:
     """Delete a named snapshot."""
@@ -60,6 +67,7 @@ def delete_state_snapshot(snapshot_name: str, ctx: Context) -> str:
         return ctx.delete_snapshot(snapshot_name)
     except KeyError as e:
         return f"Error: {e}"
+
 
 @mcp.tool
 def get_snapshot_data(snapshot_name: str, ctx: Context) -> dict:
@@ -69,6 +77,7 @@ def get_snapshot_data(snapshot_name: str, ctx: Context) -> dict:
     except KeyError as e:
         return {"error": str(e)}
 
+
 @mcp.tool
 def compare_snapshots(snapshot1_name: str, snapshot2_name: str, ctx: Context) -> dict:
     """Compare two snapshots and show the differences."""
@@ -76,6 +85,7 @@ def compare_snapshots(snapshot1_name: str, snapshot2_name: str, ctx: Context) ->
         return ctx.get_snapshot_diff(snapshot1_name, snapshot2_name)
     except KeyError as e:
         return {"error": str(e)}
+
 
 # Example usage flow:
 """

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -592,11 +592,11 @@ class Context:
 
     def create_snapshot(self, name: str) -> str:
         """Create a named snapshot of the current context state.
-        
+
         Args:
-            name: The name for this snapshot. If a snapshot with this name already 
+            name: The name for this snapshot. If a snapshot with this name already
                   exists, it will be overwritten.
-                  
+
         Returns:
             A confirmation message about the snapshot creation.
         """
@@ -605,7 +605,7 @@ class Context:
 
     def list_snapshots(self) -> list[str]:
         """List all available snapshot names for this session.
-        
+
         Returns:
             A list of snapshot names.
         """
@@ -613,64 +613,72 @@ class Context:
 
     def restore_snapshot(self, name: str) -> str:
         """Restore the context state from a named snapshot.
-        
+
         Args:
             name: The name of the snapshot to restore.
-            
+
         Returns:
             A confirmation message about the snapshot restoration.
-            
+
         Raises:
             KeyError: If the snapshot name doesn't exist.
         """
         if name not in self._snapshots:
-            raise KeyError(f"Snapshot '{name}' not found. Available snapshots: {list(self._snapshots.keys())}")
-        
+            raise KeyError(
+                f"Snapshot '{name}' not found. Available snapshots: {list(self._snapshots.keys())}"
+            )
+
         self._state = copy.deepcopy(self._snapshots[name])
         return f"State restored from snapshot '{name}' with {len(self._state)} items"
 
     def delete_snapshot(self, name: str) -> str:
         """Delete a named snapshot.
-        
+
         Args:
             name: The name of the snapshot to delete.
-            
+
         Returns:
             A confirmation message about the snapshot deletion.
-            
+
         Raises:
             KeyError: If the snapshot name doesn't exist.
         """
         if name not in self._snapshots:
-            raise KeyError(f"Snapshot '{name}' not found. Available snapshots: {list(self._snapshots.keys())}")
-        
+            raise KeyError(
+                f"Snapshot '{name}' not found. Available snapshots: {list(self._snapshots.keys())}"
+            )
+
         del self._snapshots[name]
         return f"Snapshot '{name}' deleted"
 
     def get_snapshot(self, name: str) -> dict[str, Any]:
         """Get the data from a named snapshot.
-        
+
         Args:
             name: The name of the snapshot to retrieve.
-            
+
         Returns:
             A deep copy of the snapshot data.
-            
+
         Raises:
             KeyError: If the snapshot name doesn't exist.
         """
         if name not in self._snapshots:
-            raise KeyError(f"Snapshot '{name}' not found. Available snapshots: {list(self._snapshots.keys())}")
-        
+            raise KeyError(
+                f"Snapshot '{name}' not found. Available snapshots: {list(self._snapshots.keys())}"
+            )
+
         return copy.deepcopy(self._snapshots[name])
 
-    def get_snapshot_diff(self, snapshot1_name: str, snapshot2_name: str) -> dict[str, Any]:
+    def get_snapshot_diff(
+        self, snapshot1_name: str, snapshot2_name: str
+    ) -> dict[str, Any]:
         """Compare two snapshots and return the differences.
-        
+
         Args:
             snapshot1_name: The name of the first snapshot (baseline).
             snapshot2_name: The name of the second snapshot (comparison).
-            
+
         Returns:
             A dictionary containing the differences:
             {
@@ -681,28 +689,32 @@ class Context:
                 },
                 "unchanged": {...}   # Keys with same values (optional, for completeness)
             }
-            
+
         Raises:
             KeyError: If either snapshot name doesn't exist.
         """
         if snapshot1_name not in self._snapshots:
-            raise KeyError(f"Snapshot '{snapshot1_name}' not found. Available snapshots: {list(self._snapshots.keys())}")
+            raise KeyError(
+                f"Snapshot '{snapshot1_name}' not found. Available snapshots: {list(self._snapshots.keys())}"
+            )
         if snapshot2_name not in self._snapshots:
-            raise KeyError(f"Snapshot '{snapshot2_name}' not found. Available snapshots: {list(self._snapshots.keys())}")
-        
+            raise KeyError(
+                f"Snapshot '{snapshot2_name}' not found. Available snapshots: {list(self._snapshots.keys())}"
+            )
+
         snap1 = self._snapshots[snapshot1_name]
         snap2 = self._snapshots[snapshot2_name]
-        
+
         # Get all unique keys from both snapshots
         all_keys = set(snap1.keys()) | set(snap2.keys())
-        
+
         diff = {
-            "added": {},      # In snap2 but not in snap1
-            "removed": {},    # In snap1 but not in snap2
-            "modified": {},   # Different values
-            "unchanged": {}   # Same values
+            "added": {},  # In snap2 but not in snap1
+            "removed": {},  # In snap1 but not in snap2
+            "modified": {},  # Different values
+            "unchanged": {},  # Same values
         }
-        
+
         for key in all_keys:
             if key in snap1 and key in snap2:
                 # Key exists in both snapshots
@@ -716,7 +728,7 @@ class Context:
             else:
                 # Key only in snapshot1 (removed)
                 diff["removed"][key] = snap1[key]
-        
+
         return diff
 
     def _queue_tool_list_changed(self) -> None:


### PR DESCRIPTION
A common pattern I am implementing to test agentic AI is to 

1. Initialize an MCP server session
2. Client calls a `load_data`-type function that initializes the MCP session with a previous / external state
3. Agent / client calls tools that can adjust the session state
4. On session close or the end of agent execution trace, capture the new context state
5. For unit tests, compute the difference between the initial state and the end state and write assertions accordingly.

I wanted to create a series of functions to make getting and comparing context states easier to work with.

I think this could be the go-to way people are evaluating MCP agents for consistency 🚀 