### PR TITLE
fix: Add persistent storage for OAuth proxy client registrations

### DIFF
--- a/src/fastmcp/server/auth/client_storage.py
+++ b/src/fastmcp/server/auth/client_storage.py
@@ -1,0 +1,116 @@
+"""Persistent storage for OAuth client registrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import ValidationError
+
+from fastmcp import settings as fastmcp_global_settings
+from fastmcp.utilities.logging import get_logger
+from fastmcp.utilities.storage import JSONFileStorage
+
+if TYPE_CHECKING:
+    pass
+
+logger = get_logger(__name__)
+
+
+def default_oauth_proxy_cache_dir() -> Path:
+    """Default cache directory for OAuth proxy client storage."""
+    return fastmcp_global_settings.home / "oauth-proxy-clients"
+
+
+class OAuthClientStorage:
+    """Persistent storage for OAuth client registrations.
+
+    This class provides file-based storage for OAuth client information,
+    allowing client registrations to persist across server restarts.
+
+    Each client is stored as a separate JSON file, with the client_id
+    used as the filename (after sanitization).
+
+    Args:
+        cache_dir: Directory for storing client data.
+                  Defaults to ~/.fastmcp/oauth-proxy-clients/
+    """
+
+    def __init__(self, cache_dir: Path | None = None):
+        """Initialize OAuth client storage."""
+        self.cache_dir = cache_dir or default_oauth_proxy_cache_dir()
+        self.storage = JSONFileStorage(self.cache_dir, prefix="client")
+
+    async def get_client(
+        self, client_id: str, allowed_redirect_uri_patterns: list[str] | None = None
+    ) -> OAuthClientInformationFull | None:
+        """Load client information from storage.
+
+        Args:
+            client_id: The client ID to retrieve
+            allowed_redirect_uri_patterns: Patterns for ProxyDCRClient validation
+
+        Returns:
+            The client information or None if not found
+        """
+        try:
+            data = await self.storage.get(client_id)
+            if data is None:
+                return None
+
+            # Check if this is a ProxyDCRClient (has the special flag we'll add)
+            is_proxy_client = data.get("_is_proxy_dcr_client", False)
+
+            if is_proxy_client:
+                # Import here to avoid circular dependency
+                from fastmcp.server.auth.oauth_proxy import ProxyDCRClient
+
+                # Remove the flag before creating the object
+                data.pop("_is_proxy_dcr_client", None)
+
+                # Create ProxyDCRClient with validation patterns
+                return ProxyDCRClient(
+                    allowed_redirect_uri_patterns=allowed_redirect_uri_patterns,
+                    **data,
+                )
+            else:
+                # Regular OAuthClientInformationFull
+                return OAuthClientInformationFull(**data)  # type: ignore[missing-argument]
+
+        except (ValidationError, TypeError) as e:
+            logger.warning(f"Failed to load client {client_id}: {e}")
+            return None
+
+    async def save_client(
+        self, client: OAuthClientInformationFull, is_proxy_dcr: bool = False
+    ) -> None:
+        """Save client information to storage.
+
+        Args:
+            client: The client information to save
+            is_proxy_dcr: Whether this is a ProxyDCRClient (for special handling)
+        """
+        # Convert to dict for storage
+        data = client.model_dump(mode="json")
+
+        # Add flag if this is a ProxyDCRClient
+        if is_proxy_dcr:
+            data["_is_proxy_dcr_client"] = True
+
+        await self.storage.set(client.client_id, data)
+        logger.debug(f"Saved client {client.client_id} to persistent storage")
+
+    async def delete_client(self, client_id: str) -> None:
+        """Delete client information from storage.
+
+        Args:
+            client_id: The client ID to delete
+        """
+        await self.storage.delete(client_id)
+        logger.debug(f"Deleted client {client_id} from persistent storage")
+
+    async def clear_all(self) -> None:
+        """Clear all stored client information."""
+        await self.storage.clear()
+        logger.info("Cleared all OAuth client registrations from storage")

--- a/src/fastmcp/utilities/storage.py
+++ b/src/fastmcp/utilities/storage.py
@@ -1,0 +1,125 @@
+"""File-based storage utilities for persistent data management."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ValidationError
+
+from fastmcp.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class FileKVStorage(Protocol):
+    """Protocol for file-based key-value storage."""
+
+    async def get(self, key: str) -> Any | None:
+        """Get a value by key."""
+        ...
+
+    async def set(self, key: str, value: Any) -> None:
+        """Set a value by key."""
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Delete a value by key."""
+        ...
+
+    async def clear(self) -> None:
+        """Clear all stored values."""
+        ...
+
+
+class JSONFileStorage:
+    """JSON file-based key-value storage implementation.
+
+    This class provides a simple file-based storage mechanism for JSON-serializable
+    data. Each key-value pair is stored as a separate JSON file on disk.
+
+    Args:
+        cache_dir: Directory for storing JSON files
+        prefix: Prefix for all file names (e.g. "oauth_client")
+    """
+
+    def __init__(self, cache_dir: Path, prefix: str = ""):
+        """Initialize JSON file storage."""
+        self.cache_dir = cache_dir
+        self.prefix = prefix
+        self.cache_dir.mkdir(exist_ok=True, parents=True)
+
+    def _get_safe_key(self, key: str) -> str:
+        """Convert key to filesystem-safe string."""
+        # Replace problematic characters with underscores
+        safe_key = key
+        for char in [".", "/", "\\", ":", "*", "?", '"', "<", ">", "|", " "]:
+            safe_key = safe_key.replace(char, "_")
+        return safe_key
+
+    def _get_file_path(self, key: str) -> Path:
+        """Get the file path for a given key."""
+        safe_key = self._get_safe_key(key)
+        filename = (
+            f"{self.prefix}_{safe_key}.json" if self.prefix else f"{safe_key}.json"
+        )
+        return self.cache_dir / filename
+
+    async def get(self, key: str) -> Any | None:
+        """Get a value from storage by key.
+
+        Args:
+            key: The key to retrieve
+
+        Returns:
+            The stored value or None if not found
+        """
+        path = self._get_file_path(key)
+        try:
+            data = json.loads(path.read_text())
+            logger.debug(f"Loaded data for key '{key}' from {path}")
+            return data
+        except FileNotFoundError:
+            logger.debug(f"No data found for key '{key}'")
+            return None
+        except (json.JSONDecodeError, ValidationError) as e:
+            logger.warning(f"Failed to load data for key '{key}': {e}")
+            return None
+
+    async def set(self, key: str, value: Any) -> None:
+        """Set a value in storage.
+
+        Args:
+            key: The key to store under
+            value: The value to store (must be JSON-serializable)
+        """
+        path = self._get_file_path(key)
+
+        # Handle Pydantic models
+        if isinstance(value, BaseModel):
+            json_data = value.model_dump_json(indent=2)
+        else:
+            json_data = json.dumps(value, indent=2, default=str)
+
+        path.write_text(json_data)
+        logger.debug(f"Saved data for key '{key}' to {path}")
+
+    async def delete(self, key: str) -> None:
+        """Delete a value from storage.
+
+        Args:
+            key: The key to delete
+        """
+        path = self._get_file_path(key)
+        if path.exists():
+            path.unlink()
+            logger.debug(f"Deleted data for key '{key}'")
+
+    async def clear(self) -> None:
+        """Clear all stored values with this prefix."""
+        pattern = f"{self.prefix}_*.json" if self.prefix else "*.json"
+        for path in self.cache_dir.glob(pattern):
+            path.unlink()
+            logger.debug(f"Deleted {path}")
+        logger.info(f"Cleared all stored values with prefix '{self.prefix}'")

--- a/tests/server/auth/test_oauth_client_storage.py
+++ b/tests/server/auth/test_oauth_client_storage.py
@@ -1,0 +1,182 @@
+"""Tests for OAuth client persistent storage functionality."""
+
+from pathlib import Path
+
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+from fastmcp.server.auth.client_storage import OAuthClientStorage
+from fastmcp.server.auth.oauth_proxy import ProxyDCRClient
+
+
+class TestOAuthClientStorage:
+    """Tests for OAuth client persistent storage."""
+
+    @pytest.fixture
+    def temp_cache_dir(self, tmp_path: Path) -> Path:
+        """Create a temporary cache directory."""
+        cache_dir = tmp_path / "oauth-clients"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
+
+    @pytest.fixture
+    def client_storage(self, temp_cache_dir: Path) -> OAuthClientStorage:
+        """Create a client storage instance with temp directory."""
+        return OAuthClientStorage(cache_dir=temp_cache_dir)
+
+    async def test_save_and_load_client(self, client_storage: OAuthClientStorage):
+        """Test saving and loading a basic OAuth client."""
+        # Create a client
+        client = OAuthClientInformationFull(
+            client_id="test-client-123",
+            client_secret="test-secret",
+            redirect_uris=[AnyUrl("http://localhost:8080/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            scope="read write",
+        )
+
+        # Save the client
+        await client_storage.save_client(client)
+
+        # Load the client back
+        loaded_client = await client_storage.get_client("test-client-123")
+
+        # Verify it matches
+        assert loaded_client is not None
+        assert loaded_client.client_id == "test-client-123"
+        assert loaded_client.client_secret == "test-secret"
+        assert len(loaded_client.redirect_uris) == 1
+        assert str(loaded_client.redirect_uris[0]) == "http://localhost:8080/callback"
+        assert loaded_client.grant_types == ["authorization_code", "refresh_token"]
+        assert loaded_client.scope == "read write"
+
+    async def test_save_and_load_proxy_dcr_client(
+        self, client_storage: OAuthClientStorage
+    ):
+        """Test saving and loading a ProxyDCRClient with special handling."""
+        # Create a ProxyDCRClient
+        proxy_client = ProxyDCRClient(
+            client_id="proxy-client-456",
+            client_secret="proxy-secret",
+            redirect_uris=[AnyUrl("http://localhost:9090/callback")],
+            grant_types=["authorization_code"],
+            scope="openid profile",
+            token_endpoint_auth_method="none",
+            allowed_redirect_uri_patterns=["http://localhost:*"],
+        )
+
+        # Save as ProxyDCRClient
+        await client_storage.save_client(proxy_client, is_proxy_dcr=True)
+
+        # Load it back with patterns
+        loaded_client = await client_storage.get_client(
+            "proxy-client-456", allowed_redirect_uri_patterns=["http://localhost:*"]
+        )
+
+        # Verify it's loaded as ProxyDCRClient
+        assert loaded_client is not None
+        assert isinstance(loaded_client, ProxyDCRClient)
+        assert loaded_client.client_id == "proxy-client-456"
+        assert loaded_client.client_secret == "proxy-secret"
+        assert loaded_client.scope == "openid profile"
+
+        # Test that the ProxyDCRClient validation works
+        # This should pass for ProxyDCRClient but would fail for regular client
+        validated_uri = loaded_client.validate_redirect_uri(
+            AnyUrl("http://localhost:12345/different")
+        )
+        assert validated_uri is not None
+
+    async def test_load_nonexistent_client(self, client_storage: OAuthClientStorage):
+        """Test loading a client that doesn't exist returns None."""
+        loaded_client = await client_storage.get_client("nonexistent-client")
+        assert loaded_client is None
+
+    async def test_delete_client(self, client_storage: OAuthClientStorage):
+        """Test deleting a client from storage."""
+        # Create and save a client
+        client = OAuthClientInformationFull(
+            client_id="delete-me",
+            client_secret="secret",
+            redirect_uris=[AnyUrl("http://localhost:8080/callback")],
+        )
+        await client_storage.save_client(client)
+
+        # Verify it exists
+        loaded = await client_storage.get_client("delete-me")
+        assert loaded is not None
+
+        # Delete it
+        await client_storage.delete_client("delete-me")
+
+        # Verify it's gone
+        loaded = await client_storage.get_client("delete-me")
+        assert loaded is None
+
+    async def test_clear_all_clients(self, client_storage: OAuthClientStorage):
+        """Test clearing all clients from storage."""
+        # Create and save multiple clients
+        for i in range(3):
+            client = OAuthClientInformationFull(
+                client_id=f"client-{i}",
+                client_secret=f"secret-{i}",
+                redirect_uris=[AnyUrl(f"http://localhost:{8080 + i}/callback")],
+            )
+            await client_storage.save_client(client)
+
+        # Verify they exist
+        for i in range(3):
+            loaded = await client_storage.get_client(f"client-{i}")
+            assert loaded is not None
+
+        # Clear all
+        await client_storage.clear_all()
+
+        # Verify they're all gone
+        for i in range(3):
+            loaded = await client_storage.get_client(f"client-{i}")
+            assert loaded is None
+
+    async def test_client_persistence_across_instances(self, temp_cache_dir: Path):
+        """Test that clients persist across storage instances (simulating restart)."""
+        # Create first storage instance and save a client
+        storage1 = OAuthClientStorage(cache_dir=temp_cache_dir)
+        client = OAuthClientInformationFull(
+            client_id="persistent-client",
+            client_secret="persistent-secret",
+            redirect_uris=[AnyUrl("http://localhost:8080/callback")],
+            scope="read write delete",
+        )
+        await storage1.save_client(client)
+
+        # Create new storage instance (simulating server restart)
+        storage2 = OAuthClientStorage(cache_dir=temp_cache_dir)
+
+        # Load the client from the new instance
+        loaded_client = await storage2.get_client("persistent-client")
+
+        # Verify it persisted
+        assert loaded_client is not None
+        assert loaded_client.client_id == "persistent-client"
+        assert loaded_client.client_secret == "persistent-secret"
+        assert loaded_client.scope == "read write delete"
+
+    async def test_special_characters_in_client_id(
+        self, client_storage: OAuthClientStorage
+    ):
+        """Test that client IDs with special characters are handled correctly."""
+        # Create client with special characters in ID
+        client = OAuthClientInformationFull(
+            client_id="client.with/special:chars*in?id",
+            client_secret="secret",
+            redirect_uris=[AnyUrl("http://localhost:8080/callback")],
+        )
+
+        # Save and load it
+        await client_storage.save_client(client)
+        loaded = await client_storage.get_client("client.with/special:chars*in?id")
+
+        # Verify it works
+        assert loaded is not None
+        assert loaded.client_id == "client.with/special:chars*in?id"

--- a/tests/server/auth/test_oauth_proxy_persistence.py
+++ b/tests/server/auth/test_oauth_proxy_persistence.py
@@ -1,0 +1,165 @@
+"""Tests for OAuth proxy with persistent client storage."""
+
+from pathlib import Path
+
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+
+
+class TestOAuthProxyPersistence:
+    """Tests for OAuth proxy with persistent client storage."""
+
+    @pytest.fixture
+    def temp_cache_dir(self, tmp_path: Path) -> Path:
+        """Create a temporary cache directory."""
+        cache_dir = tmp_path / "oauth-proxy-test"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
+
+    @pytest.fixture
+    def jwt_verifier(self):
+        """Create a mock JWT verifier."""
+        from unittest.mock import AsyncMock, Mock
+
+        verifier = Mock()
+        verifier.required_scopes = ["read", "write"]
+        verifier.verify_token = AsyncMock(return_value=None)
+        return verifier
+
+    def create_oauth_proxy(
+        self, jwt_verifier, client_cache_dir: Path | None = None
+    ) -> OAuthProxy:
+        """Create an OAuth proxy instance with specified cache directory."""
+        return OAuthProxy(
+            upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
+            upstream_token_endpoint="https://github.com/login/oauth/access_token",
+            upstream_client_id="test-client-id",
+            upstream_client_secret="test-client-secret",
+            token_verifier=jwt_verifier,
+            base_url="https://myserver.com",
+            redirect_path="/auth/callback",
+            client_cache_dir=client_cache_dir,
+        )
+
+    async def test_client_persists_across_proxy_instances(
+        self, jwt_verifier, temp_cache_dir: Path
+    ):
+        """Test that registered clients persist across OAuth proxy instances."""
+        # Create first proxy instance
+        proxy1 = self.create_oauth_proxy(jwt_verifier, temp_cache_dir)
+
+        # Register a client
+        client_info = OAuthClientInformationFull(
+            client_id="persistent-oauth-client",
+            client_secret="oauth-secret-123",
+            redirect_uris=[AnyUrl("http://localhost:54321/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            scope="read write",
+        )
+        await proxy1.register_client(client_info)
+
+        # Verify it's registered
+        client = await proxy1.get_client("persistent-oauth-client")
+        assert client is not None
+        assert client.client_id == "persistent-oauth-client"
+
+        # Create new proxy instance (simulating server restart)
+        proxy2 = self.create_oauth_proxy(jwt_verifier, temp_cache_dir)
+
+        # Get the client from the new proxy instance (should load from storage)
+        loaded_client = await proxy2.get_client("persistent-oauth-client")
+
+        # Verify it persisted
+        assert loaded_client is not None
+        assert loaded_client.client_id == "persistent-oauth-client"
+        assert loaded_client.client_secret == "oauth-secret-123"
+        assert loaded_client.scope == "read write"
+        assert len(loaded_client.redirect_uris) == 1
+        assert str(loaded_client.redirect_uris[0]) == "http://localhost:54321/callback"
+
+    async def test_multiple_clients_persistence(
+        self, jwt_verifier, temp_cache_dir: Path
+    ):
+        """Test that multiple clients persist correctly."""
+        # Create proxy and register multiple clients
+        proxy1 = self.create_oauth_proxy(jwt_verifier, temp_cache_dir)
+
+        clients = []
+        for i in range(3):
+            client = OAuthClientInformationFull(
+                client_id=f"client-{i}",
+                client_secret=f"secret-{i}",
+                redirect_uris=[AnyUrl(f"http://localhost:{8080 + i}/callback")],
+                scope=f"scope{i}",
+            )
+            clients.append(client)
+            await proxy1.register_client(client)
+
+        # Create new proxy instance
+        proxy2 = self.create_oauth_proxy(jwt_verifier, temp_cache_dir)
+
+        # Verify all clients persisted
+        for i in range(3):
+            loaded = await proxy2.get_client(f"client-{i}")
+            assert loaded is not None
+            assert loaded.client_secret == f"secret-{i}"
+            assert loaded.scope == f"scope{i}"
+
+    async def test_proxy_without_cache_dir_uses_default(self, jwt_verifier):
+        """Test that proxy without specified cache_dir uses default location."""
+        # Create proxy without specifying cache_dir
+        proxy = self.create_oauth_proxy(jwt_verifier, client_cache_dir=None)
+
+        # Register a client
+        client_info = OAuthClientInformationFull(
+            client_id="default-location-client",
+            client_secret="default-secret",
+            redirect_uris=[AnyUrl("http://localhost:9999/callback")],
+        )
+        await proxy.register_client(client_info)
+
+        # Verify it's stored (this will use ~/.fastmcp/oauth-proxy-clients/)
+        client = await proxy.get_client("default-location-client")
+        assert client is not None
+
+        # Clean up the default location to not leave test artifacts
+        from fastmcp.server.auth.client_storage import OAuthClientStorage
+
+        storage = OAuthClientStorage(cache_dir=None)
+        await storage.delete_client("default-location-client")
+
+    async def test_in_memory_cache_performance(
+        self, jwt_verifier, temp_cache_dir: Path
+    ):
+        """Test that in-memory caching works for performance."""
+        proxy = self.create_oauth_proxy(jwt_verifier, temp_cache_dir)
+
+        # Register a client
+        client_info = OAuthClientInformationFull(
+            client_id="cached-client",
+            client_secret="cached-secret",
+            redirect_uris=[AnyUrl("http://localhost:7777/callback")],
+        )
+        await proxy.register_client(client_info)
+
+        # First get - loads from storage to memory
+        client1 = await proxy.get_client("cached-client")
+        assert client1 is not None
+
+        # Delete the file to simulate it being unavailable
+        storage_file = temp_cache_dir / "client_cached-client.json"
+        if storage_file.exists():
+            storage_file.unlink()
+
+        # Second get should still work from in-memory cache
+        client2 = await proxy.get_client("cached-client")
+        assert client2 is not None
+        assert client2.client_id == "cached-client"
+
+        # Create new proxy instance - now it won't find the client
+        proxy2 = self.create_oauth_proxy(jwt_verifier, temp_cache_dir)
+        client3 = await proxy2.get_client("cached-client")
+        assert client3 is None  # Not in memory or storage


### PR DESCRIPTION
## Fixes #1762

This PR implements persistent file-based storage for OAuth proxy client registrations, solving the issue where clients would lose authentication after server restarts.

## Problem

Previously, the OAuth proxy stored client registrations only in memory (`self._clients` dict). When the server restarted, all client registrations were lost, causing authentication failures with "Client ID not found" errors. This was a critical issue for production deployments.

## Solution  

Added a file-based storage layer that persists client registrations to disk while maintaining an in-memory cache for performance. Client registrations now survive server restarts.

### Key Changes

1. **Generic Storage Utility** (`src/fastmcp/utilities/storage.py`)
   - `JSONFileStorage` class for file-based key-value storage
   - Handles safe key generation, JSON serialization, and file I/O
   - Can be reused for other persistence needs

2. **OAuth Client Storage** (`src/fastmcp/server/auth/client_storage.py`)
   - `OAuthClientStorage` class specifically for OAuth client registrations
   - Handles both regular clients and `ProxyDCRClient` with special validation
   - Default storage location: `~/.fastmcp/oauth-proxy-clients/`

3. **Updated OAuthProxy**
   - Added `client_cache_dir` parameter for configurable storage location
   - Implements write-through caching: saves to disk, caches in memory
   - Read-through loading: checks memory first, then loads from disk if needed

### Example Usage

```python
# OAuth proxy with persistent storage (default location)
proxy = OAuthProxy(
    upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
    upstream_token_endpoint="https://github.com/login/oauth/access_token", 
    upstream_client_id="your-client-id",
    upstream_client_secret="your-secret",
    token_verifier=jwt_verifier,
    base_url="https://myserver.com",
    # Client registrations persist in ~/.fastmcp/oauth-proxy-clients/
)

# Custom storage location
proxy = OAuthProxy(
    # ... other params ...
    client_cache_dir=Path("/var/lib/fastmcp/oauth-clients")
)
```

## Testing

Added comprehensive test coverage:
- `test_oauth_client_storage.py`: Tests for storage layer functionality
- `test_oauth_proxy_persistence.py`: Tests for OAuth proxy with persistence
- All existing OAuth proxy tests continue to pass

The tests verify:
- Client persistence across server restarts
- In-memory caching for performance  
- Special character handling in client IDs
- ProxyDCRClient special handling