### PR TITLE
docs: update release dates based on github releases

### DIFF
--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,7 +5,7 @@ icon: "sparkles"
 tag: NEW
 ---
 
-<Update label="FastMCP 2.12" description="December 31, 2024" tags={["Releases"]}>
+<Update label="FastMCP 2.12" description="August 31, 2025" tags={["Releases"]}>
 <Card 
 title="FastMCP 2.12: Auth to the Races" 
 href="https://github.com/jlowin/fastmcp/releases/tag/v2.12.0" 
@@ -21,7 +21,7 @@ FastMCP 2.12 represents one of our most significant releases to date. After exte
 </Card>
 </Update>
 
-<Update label="FastMCP 2.11" description="December 13, 2024" tags={["Releases"]}>
+<Update label="FastMCP 2.11" description="August 1, 2025" tags={["Releases"]}>
 <Card 
 title="FastMCP 2.11: Auth to a Good Start" 
 href="https://github.com/jlowin/fastmcp/releases/tag/v2.11.0" 
@@ -39,7 +39,7 @@ This release emphasizes speed and simplicity while setting the foundation for fu
 </Card>
 </Update>
 
-<Update label="FastMCP 2.10" description="November 21, 2024" tags={["Releases"]}>
+<Update label="FastMCP 2.10" description="July 2, 2025" tags={["Releases"]}>
 <Card 
 title="FastMCP 2.10: Great Spec-tations" 
 href="https://github.com/jlowin/fastmcp/releases/tag/v2.10.0" 


### PR DESCRIPTION
Issue: https://github.com/jlowin/fastmcp/issues/1889

## Description
Change releases dates on changes page based on the GitHub [releases](https://github.com/jlowin/fastmcp/releases):
- [v2.12.0](https://github.com/jlowin/fastmcp/releases/tag/v2.12.0)
- [v2.11.0](https://github.com/jlowin/fastmcp/releases/tag/v2.11.0)
- [v2.10.0](https://github.com/jlowin/fastmcp/releases/tag/v2.10.0)

- [x] My change closes [#1889](https://github.com/jlowin/fastmcp/issues/1889)
- [x] I have performed all required documentation updates

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
