### PR TITLE
Enhancement: client completions support context_arguments

### DIFF
--- a/docs/python-sdk/fastmcp-client-client.mdx
+++ b/docs/python-sdk/fastmcp-client-client.mdx
@@ -374,7 +374,7 @@ containing the prompt messages and any additional metadata.
 #### `complete_mcp` <sup><a href="https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/client/client.py#L744" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-complete_mcp(self, ref: mcp.types.ResourceTemplateReference | mcp.types.PromptReference, argument: dict[str, str]) -> mcp.types.CompleteResult
+complete_mcp(self, ref: mcp.types.ResourceTemplateReference | mcp.types.PromptReference, argument: dict[str, str], context_arguments: dict[str, Any] | None = None) -> mcp.types.CompleteResult
 ```
 
 Send a completion request and return the complete MCP protocol result.
@@ -382,6 +382,7 @@ Send a completion request and return the complete MCP protocol result.
 **Args:**
 - `ref`: The reference to complete.
 - `argument`: Arguments to pass to the completion request.
+- `context_arguments`: Optional context arguments to include with the completion request. Defaults to None.
 
 **Returns:**
 - mcp.types.CompleteResult: The complete response object from the protocol,
@@ -391,10 +392,10 @@ containing the completion and any additional metadata.
 - `RuntimeError`: If called while the client is not connected.
 
 
-#### `complete` <sup><a href="https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/client/client.py#L767" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `complete` <sup><a href="https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/client/client.py#L772" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-complete(self, ref: mcp.types.ResourceTemplateReference | mcp.types.PromptReference, argument: dict[str, str]) -> mcp.types.Completion
+complete(self, ref: mcp.types.ResourceTemplateReference | mcp.types.PromptReference, argument: dict[str, str], context_arguments: dict[str, Any] | None = None) -> mcp.types.Completion
 ```
 
 Send a completion request to the server.
@@ -402,6 +403,7 @@ Send a completion request to the server.
 **Args:**
 - `ref`: The reference to complete.
 - `argument`: Arguments to pass to the completion request.
+- `context_arguments`: Optional context arguments to include with the completion request. Defaults to None.
 
 **Returns:**
 - mcp.types.Completion: The completion object.

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -745,12 +745,15 @@ class Client(Generic[ClientTransportT]):
         self,
         ref: mcp.types.ResourceTemplateReference | mcp.types.PromptReference,
         argument: dict[str, str],
+        context_arguments: dict[str, Any] | None = None,
     ) -> mcp.types.CompleteResult:
         """Send a completion request and return the complete MCP protocol result.
 
         Args:
             ref (mcp.types.ResourceTemplateReference | mcp.types.PromptReference): The reference to complete.
             argument (dict[str, str]): Arguments to pass to the completion request.
+            context_arguments (dict[str, Any] | None, optional): Optional context arguments to
+                include with the completion request. Defaults to None.
 
         Returns:
             mcp.types.CompleteResult: The complete response object from the protocol,
@@ -761,19 +764,24 @@ class Client(Generic[ClientTransportT]):
         """
         logger.debug(f"[{self.name}] called complete: {ref}")
 
-        result = await self.session.complete(ref=ref, argument=argument)
+        result = await self.session.complete(
+            ref=ref, argument=argument, context_arguments=context_arguments
+        )
         return result
 
     async def complete(
         self,
         ref: mcp.types.ResourceTemplateReference | mcp.types.PromptReference,
         argument: dict[str, str],
+        context_arguments: dict[str, Any] | None = None,
     ) -> mcp.types.Completion:
         """Send a completion request to the server.
 
         Args:
             ref (mcp.types.ResourceTemplateReference | mcp.types.PromptReference): The reference to complete.
             argument (dict[str, str]): Arguments to pass to the completion request.
+            context_arguments (dict[str, Any] | None, optional): Optional context arguments to
+                include with the completion request. Defaults to None.
 
         Returns:
             mcp.types.Completion: The completion object.
@@ -781,7 +789,9 @@ class Client(Generic[ClientTransportT]):
         Raises:
             RuntimeError: If called while the client is not connected.
         """
-        result = await self.complete_mcp(ref=ref, argument=argument)
+        result = await self.complete_mcp(
+            ref=ref, argument=argument, context_arguments=context_arguments
+        )
         return result.completion
 
     # --- Tools ---


### PR DESCRIPTION
Problem: The client complete_mcp()/complete() methods couldn’t pass optional context arguments to the underlying MCP SDK, limiting advanced completion scenarios.

  - Solution: Add context_arguments: dict[str, Any] | None = None to both methods and forward to session.complete(...).
  - Example:
      - Before: await client.complete(ref, argument)
      - After: await client.complete(ref, argument, context_arguments={"user_id": "123"})
  - References:
      - src/fastmcp/client/client.py:744
      - src/fastmcp/client/client.py:772
      - docs/python-sdk/fastmcp-client-client.mdx:374
      - docs/python-sdk/fastmcp-client-client.mdx:395


**Contributors Checklist**
- [x] My change closes #1905 
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
