### PR TITLE
Default to FastMCP version when server version not specified

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -197,7 +197,7 @@ class FastMCP(Generic[LifespanResultT]):
         self._mcp_server = LowLevelServer[LifespanResultT](
             fastmcp=self,
             name=name or self.generate_name(),
-            version=version,
+            version=version or fastmcp.__version__,
             instructions=instructions,
             lifespan=_lifespan_wrapper(self, lifespan),
         )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -9,6 +9,7 @@ from mcp import McpError
 from mcp.client.auth import OAuthClientProvider
 from pydantic import AnyUrl
 
+import fastmcp
 from fastmcp.client import Client
 from fastmcp.client.auth.bearer import BearerAuth
 from fastmcp.client.transports import (
@@ -435,11 +436,8 @@ async def test_server_info_custom_version():
     async with client:
         result = client.initialize_result
         assert result.serverInfo.name == "DefaultVersionServer"
-        # Should fall back to MCP library version
-        assert result.serverInfo.version is not None
-        assert (
-            result.serverInfo.version != "1.2.3"
-        )  # Should be different from custom version
+        # Should fall back to FastMCP version
+        assert result.serverInfo.version == fastmcp.__version__
 
 
 async def test_client_nested_context_manager(fastmcp_server):

--- a/tests/utilities/test_inspect.py
+++ b/tests/utilities/test_inspect.py
@@ -90,7 +90,7 @@ class TestGetFastMCPInfo:
         assert info.fastmcp_version == fastmcp.__version__
         assert info.mcp_version == importlib.metadata.version("mcp")
         assert info.server_generation == 2  # v2 server
-        assert info.version is None
+        assert info.version == fastmcp.__version__
         assert info.tools == []
         assert info.prompts == []
         assert info.resources == []
@@ -405,7 +405,7 @@ class TestFastMCP1xCompatibility:
         assert info1x.server_generation == 1  # v1
         assert info2x.server_generation == 2  # v2
         assert info1x.version is None
-        assert info2x.version is None
+        assert info2x.version == fastmcp.__version__
 
         # No templates added in these tests
         assert len(info1x.templates) == 0


### PR DESCRIPTION
Fixes #2007

When a FastMCP server is initialized without an explicit `version` parameter, it now defaults to the FastMCP framework version instead of the underlying MCP SDK version.

Before: `serverInfo.version` showed "1.15.0" (MCP SDK)
After: `serverInfo.version` shows "2.12.4" (FastMCP)

**Implementation:**
- Changed `src/fastmcp/server/server.py:200` from `version=version` to `version=version or fastmcp.__version__`
- Updated tests to verify new default behavior

Generated with [Claude Code](https://claude.ai/code)