### PR TITLE
Improve docs on prefix rules

### DIFF
--- a/docs/servers/composition.mdx
+++ b/docs/servers/composition.mdx
@@ -41,6 +41,8 @@ FastMCP supports [MCP proxying](/servers/proxy), which allows you to mirror a lo
 
 You can also create proxies from configuration dictionaries that follow the MCPConfig schema, which is useful for quickly connecting to one or more remote servers. See the [Proxy Servers documentation](/servers/proxy#configuration-based-proxies) for details on configuration-based proxying. Note that MCPConfig follows an emerging standard and its format may evolve over time.
 
+Prefixing rules for tools, prompts, resources, and templates are identical across importing, mounting, and proxies.
+
 ## Importing (Static Composition)
 
 The `import_server()` method copies all components (tools, resources, templates, prompts) from one `FastMCP` instance (the *subserver*) into another (the *main server*). An optional `prefix` can be provided to avoid naming conflicts. If no prefix is provided, components are imported without modification. When multiple servers are imported with the same prefix (or no prefix), the most recently imported server's components take precedence.

--- a/docs/servers/proxy.mdx
+++ b/docs/servers/proxy.mdx
@@ -245,10 +245,28 @@ config = {
 # Create a unified proxy to multiple servers
 composite_proxy = FastMCP.as_proxy(config, name="Composite Proxy")
 
-# Tools and resources are accessible with prefixes:
-# - weather_get_forecast, calendar_add_event 
-# - weather://weather/icons/sunny, calendar://calendar/events/today
+# Tools, resources, prompts, and templates are accessible with prefixes:
+# - Tools: weather_get_forecast, calendar_add_event
+# - Prompts: weather_daily_summary, calendar_quick_add
+# - Resources: weather://weather/icons/sunny, calendar://calendar/events/today
+# - Templates: weather://weather/locations/{id}, calendar://calendar/events/{date}
 ```
+
+## Component Prefixing
+
+When proxying one or more servers, component names are prefixed the same way as with mounting and importing:
+
+- Tools: `{prefix}_{tool_name}`
+- Prompts: `{prefix}_{prompt_name}`
+- Resources: `protocol://{prefix}/path/to/resource` (default path format)
+- Resource templates: `protocol://{prefix}/...` and template names are also prefixed
+
+These rules apply uniformly whether you:
+- Mount a proxy on another server
+- Create a multi-server proxy from an `MCPConfig`
+- Use `FastMCP.as_proxy()` directly
+
+For resource URI prefix formats (path vs legacy protocol style) and configuration options, see Server Composition → Resource Prefix Formats.
 
 ## Mirrored Components
 
@@ -332,4 +350,3 @@ def custom_client_factory():
 
 proxy = FastMCPProxy(client_factory=custom_client_factory)
 ```
-


### PR DESCRIPTION
Our prefixing docs covered e.g. prompts only on the composition doc, so this spreads the knowledge out a little bit