### PR TITLE
Allow direct instantiation of Prompt and Resource classes

### DIFF
--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -4,7 +4,6 @@ from __future__ import annotations as _annotations
 
 import inspect
 import json
-from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any
 
@@ -62,7 +61,7 @@ class PromptArgument(FastMCPBaseModel):
     )
 
 
-class Prompt(FastMCPComponent, ABC):
+class Prompt(FastMCPComponent):
     """A prompt template that can be rendered with parameters."""
 
     arguments: list[PromptArgument] | None = Field(
@@ -139,13 +138,16 @@ class Prompt(FastMCPComponent, ABC):
             meta=meta,
         )
 
-    @abstractmethod
     async def render(
         self,
         arguments: dict[str, Any] | None = None,
     ) -> list[PromptMessage]:
-        """Render the prompt with arguments."""
-        raise NotImplementedError("Prompt.render() must be implemented by subclasses")
+        """Render the prompt with arguments.
+
+        This method is not implemented in the base Prompt class and must be
+        implemented by subclasses.
+        """
+        raise NotImplementedError("Subclasses must implement render()")
 
 
 class FunctionPrompt(Prompt):

--- a/src/fastmcp/resources/resource.py
+++ b/src/fastmcp/resources/resource.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import abc
 import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Annotated, Any
@@ -31,7 +30,7 @@ if TYPE_CHECKING:
     pass
 
 
-class Resource(FastMCPComponent, abc.ABC):
+class Resource(FastMCPComponent):
     """Base class for all resources."""
 
     model_config = ConfigDict(validate_default=True)
@@ -111,10 +110,13 @@ class Resource(FastMCPComponent, abc.ABC):
             raise ValueError("Either name or uri must be provided")
         return self
 
-    @abc.abstractmethod
     async def read(self) -> str | bytes:
-        """Read the resource content."""
-        pass
+        """Read the resource content.
+
+        This method is not implemented in the base Resource class and must be
+        implemented by subclasses.
+        """
+        raise NotImplementedError("Subclasses must implement read()")
 
     def to_mcp_resource(
         self,

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -85,14 +85,15 @@ class TestResourceValidation:
         )
         assert resource.mime_type == "application/json"
 
-    async def test_resource_read_abstract(self):
-        """Test that Resource.read() is abstract."""
+    async def test_resource_read_not_implemented(self):
+        """Test that Resource.read() raises NotImplementedError."""
 
         class ConcreteResource(Resource):
             pass
 
-        with pytest.raises(TypeError, match="abstract method"):
-            ConcreteResource(uri=AnyUrl("test://test"), name="test")  # type: ignore
+        resource = ConcreteResource(uri=AnyUrl("test://test"), name="test")  # type: ignore
+        with pytest.raises(NotImplementedError, match="Subclasses must implement read"):
+            await resource.read()
 
     def test_resource_meta_parameter(self):
         """Test that meta parameter is properly handled."""


### PR DESCRIPTION
Aligns Prompt and Resource with the pattern already established by Tool: removes ABC inheritance and abstract methods in favor of runtime enforcement via NotImplementedError.

This allows users to directly instantiate these classes when they know what they're doing (e.g., for prototyping or when dynamically providing implementations), while still enforcing the contract at runtime if the required methods aren't overridden.

**Changes:**
- Remove `ABC` inheritance from `Prompt` and `Resource` classes
- Replace `@abstractmethod` decorators with `NotImplementedError` raises
- Update test to verify runtime behavior instead of compile-time validation