### PR TITLE
Remove shell=True from Windows subprocess calls

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -46,9 +46,7 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run(
-                    [cmd, "--version"], check=True, capture_output=True, shell=True
-                )
+                subprocess.run([cmd, "--version"], check=True, capture_output=True)
                 return cmd
             except subprocess.CalledProcessError:
                 continue
@@ -277,12 +275,10 @@ async def dev(
         # Set marker to prevent infinite loops when subprocess calls FastMCP
         env = dict(os.environ.items()) | env_vars | {"FASTMCP_UV_SPAWNED": "1"}
 
-        # Run the MCP Inspector command with shell=True on Windows
-        shell = sys.platform == "win32"
+        # Run the MCP Inspector command
         process = subprocess.run(
             [npx_cmd, inspector_cmd] + uv_cmd,
             check=True,
-            shell=shell,
             env=env,
         )
         sys.exit(process.returncode)

--- a/src/fastmcp/cli/install/cursor.py
+++ b/src/fastmcp/cli/install/cursor.py
@@ -56,7 +56,7 @@ def open_deeplink(deeplink: str) -> bool:
             subprocess.run(["open", deeplink], check=True, capture_output=True)
         elif sys.platform == "win32":  # Windows
             subprocess.run(
-                ["start", deeplink], shell=True, check=True, capture_output=True
+                ["cmd", "/c", "start", deeplink], check=True, capture_output=True
             )
         else:  # Linux and others
             subprocess.run(["xdg-open", deeplink], check=True, capture_output=True)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -416,7 +416,6 @@ class TestWindowsSpecific:
                 ["npx.cmd", "--version"],
                 check=True,
                 capture_output=True,
-                shell=True,
             )
 
     @patch("subprocess.run")

--- a/tests/cli/test_cursor.py
+++ b/tests/cli/test_cursor.py
@@ -145,7 +145,7 @@ class TestOpenDeeplink:
 
             assert result is True
             mock_run.assert_called_once_with(
-                ["start", "cursor://test"], shell=True, check=True, capture_output=True
+                ["cmd", "/c", "start", "cursor://test"], check=True, capture_output=True
             )
 
     @patch("subprocess.run")


### PR DESCRIPTION
Windows subprocess calls were using shell=True unnecessarily, which invokes cmd.exe as an intermediary and increases attack surface. While these calls are user-initiated and don't accept untrusted input, removing shell=True follows security best practices and eliminates potential future concerns.

The change replaces shell=True with explicit command construction where needed. This should have no impact on functionalit.