### PR TITLE
Add client_storage property to aws provider

### DIFF
--- a/src/fastmcp/server/auth/providers/aws.py
+++ b/src/fastmcp/server/auth/providers/aws.py
@@ -23,6 +23,7 @@ Example:
 
 from __future__ import annotations
 
+from key_value.aio.protocols import AsyncKeyValue
 from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -131,6 +132,7 @@ class AWSCognitoProvider(OIDCProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | NotSetT = NotSet,
         allowed_client_redirect_uris: list[str] | NotSetT = NotSet,
+        client_storage: AsyncKeyValue | None = None,
     ):
         """Initialize AWS Cognito OAuth provider.
 
@@ -144,6 +146,7 @@ class AWSCognitoProvider(OIDCProxy):
             required_scopes: Required Cognito scopes (defaults to ["openid"])
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 If None (default), all URIs are allowed. If empty list, no URIs are allowed.
+            client_storage: An AsyncKeyValue-compatible store for client registrations, registrations are stored in memory if not provided
         """
 
         settings = AWSCognitoProviderSettings.model_validate(
@@ -205,6 +208,7 @@ class AWSCognitoProvider(OIDCProxy):
             base_url=settings.base_url,
             redirect_path=redirect_path_final,
             allowed_client_redirect_uris=allowed_client_redirect_uris_final,
+            client_storage=client_storage,
         )
 
         logger.info(


### PR DESCRIPTION
This pull request adds support for injecting a custom asynchronous key-value storage backend for client registrations in the AWS Cognito OAuth provider. This makes client registration storage more flexible and allows for using persistent or distributed storage instead of the default in-memory approach.

Integration of custom client storage:

* Added an optional `client_storage` parameter of type `AsyncKeyValue` to the AWS Cognito provider's constructor, allowing the use of any compatible async key-value store for client registrations. [[1]](diffhunk://#diff-8c5c6f98838c6490bf4b2af6d377945e74ee89dbb35d2c5cd3271e2a01564456R135) [[2]](diffhunk://#diff-8c5c6f98838c6490bf4b2af6d377945e74ee89dbb35d2c5cd3271e2a01564456R149)
* Imported `AsyncKeyValue` protocol to enable type checking and usage of custom storage backends.
* Passed the `client_storage` parameter through the provider initialization, ensuring the configured backend is used for client registration management.## Description
<!-- 
Please provide a clear and concise description of the changes made in this pull request.

Using AI to generate code? Please include a note in the description with which AI tool you used.
-->

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [ ] My change closes #2103 
- [ ] I have followed the repository's development workflow
- [ ] I have tested my changes manually and by adding relevant tests
- [ ] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [ ] I have self-reviewed my changes
- [ ] My Pull Request is ready for review

---
