### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+FastMCP v2.x receives security updates. Earlier versions are no longer supported.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately using [GitHub's security advisory feature](https://github.com/jlowin/fastmcp/security/advisories/new).
+
+Do not open public issues for security concerns.


### PR DESCRIPTION
Adds a SECURITY.md file to establish clear guidelines for reporting security vulnerabilities in FastMCP.

The policy directs users to GitHub's private security advisory feature rather than public issues, ensuring vulnerabilities are handled responsibly before disclosure. It also clarifies that v2.x is the actively supported version line receiving security updates.