### PR TITLE
Document container limitations for Image/Audio/File objects

### DIFF
--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -387,12 +387,13 @@ FastMCP automatically converts tool return values into appropriate MCP content b
 - **`fastmcp.utilities.types.Image`**: Sent as `ImageContent`
 - **`fastmcp.utilities.types.Audio`**: Sent as `AudioContent`
 - **`fastmcp.utilities.types.File`**: Sent as base64-encoded `EmbeddedResource`
-- **A list of any of the above**: Converts each item appropriately
+- **MCP SDK content blocks**: Sent as-is
+- **A list of any of the above**: Converts each item according to the above rules
 - **`None`**: Results in an empty response
 
 #### Media Helper Classes
 
-For returning images, audio, and files, FastMCP provides helper classes that handle MIME type detection and base64 encoding automatically, returning them in MCP-native formats that meet the protocol's requirements:
+FastMCP provides helper classes for returning images, audio, and files. When you return one of these classes, either directly or as part of a list, FastMCP automatically converts it to the appropriate MCP content block. For example, if you return a `fastmcp.utilities.types.Image` object, FastMCP will convert it to an MCP `ImageContent` block with the correct MIME type and base64 encoding.
 
 ```python
 from fastmcp.utilities.types import Image, Audio, File
@@ -400,24 +401,29 @@ from fastmcp.utilities.types import Image, Audio, File
 @mcp.tool
 def get_chart() -> Image:
     """Generate a chart image."""
-    # From file path - MIME type detected from extension
     return Image(path="chart.png")
 
-    # Or from raw bytes with explicit format
-    # return Image(data=image_bytes, format="png")
-
 @mcp.tool
-def get_recording() -> Audio:
-    """Get an audio recording."""
-    return Audio(path="recording.wav")
-    # Or: Audio(data=audio_bytes, format="wav")
-
-@mcp.tool
-def get_document() -> File:
-    """Retrieve a PDF document."""
-    return File(path="report.pdf")
-    # Or: File(data=pdf_bytes, format="pdf", name="report")
+def get_multiple_charts() -> list[Image]:
+    """Return multiple charts."""
+    return [Image(path="chart1.png"), Image(path="chart2.png")]
 ```
+
+<Tip>
+Helper classes are only automatically converted to MCP content blocks when returned **directly** or as part of a **list**. For more complex containers like dicts, you can manually convert them to MCP types:
+
+```python
+# ✅ Automatic conversion
+return Image(path="chart.png")
+return [Image(path="chart1.png"), "text content"]
+
+# ❌ Will not be automatically converted
+return {"image": Image(path="chart.png")}
+
+# ✅ Manual conversion for nested use
+return {"image": Image(path="chart.png").to_image_content()}
+```
+</Tip>
 
 Each helper class accepts either `path=` or `data=` (mutually exclusive):
 - **`path`**: File path (string or Path object) - MIME type detected from extension
@@ -425,27 +431,6 @@ Each helper class accepts either `path=` or `data=` (mutually exclusive):
 - **`format`**: Optional format override (e.g., "png", "wav", "pdf")
 - **`name`**: Optional name for `File` when using `data=`
 - **`annotations`**: Optional MCP annotations for the content
-
-<Warning>
-**Container Limitations:** `Image`, `Audio`, and `File` objects must be returned directly or in a list/tuple at the top level. They cannot be nested inside dictionaries or other data structures.
-
-```python
-# ✅ Works - direct return
-return Image(path="chart.png")
-
-# ✅ Works - list of images
-return [Image(path="chart1.png"), Image(path="chart2.png")]
-
-# ❌ Does not work - nested in dict
-return {"image": Image(path="chart.png")}  # Returns string representation
-
-# ✅ Alternative - use MCP native types directly
-from mcp.types import ImageContent
-return {"image": Image(path="chart.png").to_image_content()}
-```
-
-To return media alongside structured data, either return them separately in a list or use `ToolResult` to control both content blocks and structured output independently.
-</Warning>
 
 ### Structured Output
 


### PR DESCRIPTION
This PR addresses issue #2115 by clarifying the documentation around how `Image`, `Audio`, and `File` helper objects can be returned from tools.

The current behavior is intentional: these helper objects are only converted to MCP content blocks when returned directly or in a top-level list/tuple. They cannot be nested inside dictionaries or other containers.

Closes #2115