### PR TITLE
Disable parallel test execution on Windows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv sync --upgrade
 
       - name: Run tests (excluding integration and client_process)
-        run: uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
+        run: uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" ${{ matrix.os == 'windows-latest' && '' || '--numprocesses auto --maxprocesses 4 --dist worksteal' }}
 
       - name: Run client process tests separately
         run: uv run pytest --inline-snapshot=disable tests -m "client_process" -x


### PR DESCRIPTION
Windows CI tests have been failing when using pytest workers. The parallel test execution (`--numprocesses auto --maxprocesses 4 --dist worksteal`) causes test processes to die unexpectedly on Windows runners.

This PR conditionally disables parallel execution on Windows while maintaining it on Linux:

```yaml
# Before: always parallel
run: uv run pytest ... --numprocesses auto --maxprocesses 4 --dist worksteal

# After: conditional based on OS
run: uv run pytest ... ${{ matrix.os == 'windows-latest' && '' || '--numprocesses auto --maxprocesses 4 --dist worksteal' }}
```

This should resolve the Windows test failures while keeping faster test execution on Linux runners.