### PR TITLE
transform NotFoundError to standard MCP error

### DIFF
--- a/src/fastmcp/server/middleware/error_handling.py
+++ b/src/fastmcp/server/middleware/error_handling.py
@@ -9,6 +9,8 @@ from typing import Any
 from mcp import McpError
 from mcp.types import ErrorData
 
+from fastmcp.exceptions import NotFoundError
+
 from .middleware import CallNext, Middleware, MiddlewareContext
 
 
@@ -90,7 +92,7 @@ class ErrorHandlingMiddleware(Middleware):
             return McpError(
                 ErrorData(code=-32602, message=f"Invalid params: {str(error)}")
             )
-        elif error_type in (FileNotFoundError, KeyError):
+        elif error_type in (FileNotFoundError, KeyError, NotFoundError):
             return McpError(
                 ErrorData(code=-32001, message=f"Resource not found: {str(error)}")
             )

--- a/tests/server/middleware/test_error_handling.py
+++ b/tests/server/middleware/test_error_handling.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from mcp import McpError
 
+from fastmcp.exceptions import NotFoundError
 from fastmcp.server.middleware.error_handling import (
     ErrorHandlingMiddleware,
     RetryMiddleware,
@@ -139,6 +140,17 @@ class TestErrorHandlingMiddleware:
         """Test transforming FileNotFoundError."""
         middleware = ErrorHandlingMiddleware()
         error = FileNotFoundError("test error")
+
+        result = middleware._transform_error(error)
+
+        assert isinstance(result, McpError)
+        assert result.error.code == -32001
+        assert "Resource not found: test error" in result.error.message
+
+    def test_transform_error_not_found_error(self):
+        """Test transforming NotFoundError."""
+        middleware = ErrorHandlingMiddleware()
+        error = NotFoundError("test error")
 
         result = middleware._transform_error(error)
 


### PR DESCRIPTION
## Description
<!-- 
Please provide a clear and concise description of the changes made in this pull request (see [this issue](https://github.com/jlowin/fastmcp/issues/2127) for more details)
-->
Added `NotFoundError` to the list of errors the error handling converts to standard "Resource not found" MCP error.

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes #2127 
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [ ] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
