### PR TITLE
Fix google scope example

### DIFF
--- a/src/fastmcp/server/auth/providers/google.py
+++ b/src/fastmcp/server/auth/providers/google.py
@@ -79,7 +79,7 @@ class GoogleTokenVerifier(TokenVerifier):
         """Initialize the Google token verifier.
 
         Args:
-            required_scopes: Required OAuth scopes (e.g., ['openid', 'email'])
+            required_scopes: Required OAuth scopes (e.g., ['openid', 'https://www.googleapis.com/auth/userinfo.email'])
             timeout_seconds: HTTP request timeout
         """
         super().__init__(required_scopes=required_scopes)


### PR DESCRIPTION
Google requires full URI scopes, not e.g. "email" like other auth providers. The Google provider docstring used "email" however, leading to confusion. Closes #1917