### PR TITLE
docs: Add AWS Cognito resource server requirement and CORS guidance

### DIFF
--- a/docs/deployment/http.mdx
+++ b/docs/deployment/http.mdx
@@ -280,6 +280,14 @@ OAuth specifications (RFC 8414 and RFC 9728) require discovery metadata to be ac
 Follow the configuration instructions below to set up mounting correctly.
 </Warning>
 
+<Warning>
+**CORS Middleware Conflicts:**
+
+If you're integrating FastMCP into an existing application with its own CORS middleware, be aware that layering CORS middleware can cause conflicts (such as 404 errors on `.well-known` routes or OPTIONS requests).
+
+FastMCP and the MCP SDK already handle CORS for OAuth routes. If you need CORS on your own application routes, consider using the sub-app pattern: mount FastMCP and your routes as separate apps, each with their own middleware, rather than adding application-wide CORS middleware.
+</Warning>
+
 ### Route Types
 
 OAuth-protected MCP servers expose two categories of routes:

--- a/docs/integrations/aws-cognito.mdx
+++ b/docs/integrations/aws-cognito.mdx
@@ -86,21 +86,19 @@ Set up AWS Cognito user pool with an app client to get the credentials needed fo
     </Tip>
 </Step>
 
-<Step title="Pick Up AWS Cognito Domain">
-    Navigate to **"Branding" → "Domain"** in the side navigation to find or configure Your AWS Cognito domain:
+<Step title="Configure Resource Server">
+    AWS Cognito requires a resource server entry to support OAuth with protected resources. Without this, token exchange will fail with an `invalid_grant` error.
 
-    **Option 1: Use Auto-Generated Domain**
-    - If AWS has already created a domain automatically, note the **domain prefix** (the part before `.auth.region.amazoncognito.com`)
-    - This prefix is what you'll use in your FastMCP configuration
+    Navigate to **"Branding" → "Domain"** in the side navigation, then:
 
-    **Option 2: Create a Custom Domain Prefix**
-    - If no domain exists or you want a better name, delete the existing domain and create a new one using the **"Actions"** menu
-    - Under **"Domain"** → **"Cognito domain"** in the **"Create Cognito domain"** dialog, enter a meaningful prefix (e.g., `my-app`) that is available in the AWS region you are in
-    - Just note the **domain prefix** you entered (e.g., `my-fastmcp-app`) - this is what you'll use in your FastMCP configuration
+    1. Click **"Create resource server"**
+    2. **Resource server name**: Enter a descriptive name (e.g., `My MCP Server`)
+    3. **Resource server identifier**: Enter your MCP endpoint URL exactly as it will be accessed (e.g., `http://localhost:8000/mcp` for development, or `https://your-server.com/mcp` for production)
+    4. Click **"Create resource server"**
 
-    <Info>
-    The FastMCP AWS Cognito provider automatically constructs the full domain from your prefix and region, simplifying configuration.
-    </Info>
+    <Warning>
+    The resource server identifier must exactly match your `base_url + mcp_path`. For the default configuration with `base_url="http://localhost:8000"` and `path="/mcp"`, use `http://localhost:8000/mcp`.
+    </Warning>
 </Step>
 
 <Step title="Save Your Credentials">
@@ -109,7 +107,6 @@ Set up AWS Cognito user pool with an app client to get the credentials needed fo
     - **User Pool ID**: Format like `eu-central-1_XXXXXXXXX`
     - **Client ID**: Your application's client identifier
     - **Client Secret**: Generated client secret (keep secure)
-    - **Domain Prefix**: The prefix of Your AWS Cognito domain
     - **AWS Region**: Where Your AWS Cognito user pool is located
 
     <Tip>

--- a/docs/integrations/fastapi.mdx
+++ b/docs/integrations/fastapi.mdx
@@ -407,6 +407,12 @@ app.mount("/mcp", mcp.http_app())  # Session manager won't initialize
 
 If you're mounting an authenticated MCP server under a path prefix, see [Mounting Authenticated Servers](/deployment/http#mounting-authenticated-servers) for important OAuth routing considerations.
 
+### CORS Middleware
+
+If your FastAPI app uses `CORSMiddleware` and you're mounting an OAuth-protected FastMCP server, avoid adding application-wide CORS middleware. FastMCP and the MCP SDK already handle CORS for OAuth routes, and layering CORS middleware can cause conflicts (such as 404 errors on `.well-known` routes or OPTIONS requests).
+
+If you need CORS on your own FastAPI routes, use the sub-app pattern: mount your API and FastMCP as separate apps, each with their own middleware, rather than adding top-level `CORSMiddleware` to the combined application.
+
 ### Combining Lifespans
 
 If your FastAPI app already has a lifespan (for database connections, startup tasks, etc.), you can't simply replace it with the MCP lifespan. Instead, you need to create a new lifespan function that manages both contexts. This ensures that both your app's initialization logic and the MCP server's session manager run properly:


### PR DESCRIPTION
Related to #2139

This PR updates documentation based on lessons from a user's deep dive into AWS Cognito OAuth integration. The user discovered two critical setup requirements that weren't documented:

## AWS Cognito Resource Server Requirement

AWS Cognito requires a resource server entry for OAuth with protected resources. Without it, token exchange fails with `invalid_grant`. Added new Step 6 to AWS Cognito docs explaining:
- How to create resource server in Cognito console
- Resource identifier must match MCP endpoint URL (`base_url + mcp_path`)
- Example: `http://localhost:8000/mcp`

Also removed Step 6 (domain prefix) since FastMCP doesn't use it in configuration.

## CORS Middleware Conflicts

When mounting OAuth-protected servers into existing applications, layering CORS middleware causes conflicts (404s on `.well-known` routes, OPTIONS failures). Added warnings to HTTP deployment and FastAPI integration docs noting:
- FastMCP/MCP SDK already handle CORS for OAuth routes
- Recommend sub-app pattern if CORS needed on user routes
- Brief, practical guidance without overcomplicating