### PR TITLE
Make CORS opt-in via middleware parameter

### DIFF
--- a/docs/deployment/http.mdx
+++ b/docs/deployment/http.mdx
@@ -145,6 +145,59 @@ middleware = [
 http_app = mcp.http_app(middleware=middleware)
 ```
 
+### CORS for Browser-Based Clients
+
+<Tip>
+Most MCP clients, including those that you access through a browser like ChatGPT or Claude, don't need CORS configuration. Only enable CORS if you're working with an MCP client that connects directly from a browser, such as debugging tools or inspectors.
+</Tip>
+
+CORS (Cross-Origin Resource Sharing) is needed when JavaScript running in a web browser connects directly to your MCP server. This is different from using an LLM through a browser—in that case, the browser connects to the LLM service, and the LLM service connects to your MCP server (no CORS needed).
+
+Browser-based MCP clients that need CORS include:
+
+- **MCP Inspector** - Browser-based debugging tool for testing MCP servers
+- **Custom browser-based MCP clients** - If you're building a web app that directly connects to MCP servers
+
+For these scenarios, add CORS middleware with the specific headers required for MCP protocol:
+
+```python
+from fastmcp import FastMCP
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+
+mcp = FastMCP("MyServer")
+
+# Configure CORS for browser-based clients
+middleware = [
+    Middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # Allow all origins; use specific origins for security
+        allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+        allow_headers=[
+            "mcp-protocol-version",
+            "mcp-session-id",
+            "Authorization",
+            "Content-Type",
+        ],
+        expose_headers=["mcp-session-id"],
+    )
+]
+
+app = mcp.http_app(middleware=middleware)
+```
+
+**Key configuration details:**
+
+- **`allow_origins`**: Specify exact origins (e.g., `["http://localhost:3000"]`) rather than `["*"]` for production deployments
+- **`allow_headers`**: Must include `mcp-protocol-version`, `mcp-session-id`, and `Authorization` (for authenticated servers)
+- **`expose_headers`**: Must include `mcp-session-id` so JavaScript can read the session ID from responses and send it in subsequent requests
+
+Without `expose_headers=["mcp-session-id"]`, browsers will receive the session ID but JavaScript won't be able to access it, causing session management to fail.
+
+<Warning>
+**Production Security**: Never use `allow_origins=["*"]` in production. Specify the exact origins of your browser-based clients. Using wildcards exposes your server to unauthorized access from any website.
+</Warning>
+
 ## Integration with Web Frameworks
 
 If you already have a web application running, you can add MCP capabilities by mounting a FastMCP server as a sub-application. This allows you to expose MCP tools alongside your existing API endpoints, sharing the same domain and infrastructure. The MCP server becomes just another route in your application, making it easy to manage and deploy.

--- a/tests/server/http/test_http_auth_middleware.py
+++ b/tests/server/http/test_http_auth_middleware.py
@@ -1,6 +1,5 @@
 import pytest
 from mcp.server.auth.middleware.bearer_auth import RequireAuthMiddleware
-from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
@@ -27,8 +26,10 @@ class TestStreamableHTTPAppResourceMetadataURL:
         )
         return provider
 
-    def test_auth_endpoint_wrapped_with_cors_middleware(self, bearer_auth_provider):
-        """Test that auth-protected endpoints are wrapped with CORS middleware."""
+    def test_auth_endpoint_wrapped_with_require_auth_middleware(
+        self, bearer_auth_provider
+    ):
+        """Test that auth-protected endpoints use RequireAuthMiddleware."""
         server = FastMCP(name="TestServer")
 
         app = create_streamable_http_app(
@@ -39,13 +40,11 @@ class TestStreamableHTTPAppResourceMetadataURL:
 
         route = next(r for r in app.routes if isinstance(r, Route) and r.path == "/mcp")
 
-        # When auth is enabled, endpoint should be wrapped with CORSMiddleware
-        assert isinstance(route.endpoint, CORSMiddleware)
-        # Verify allowed methods include OPTIONS for CORS preflight
-        assert "OPTIONS" in route.methods
+        # When auth is enabled, endpoint should use RequireAuthMiddleware
+        assert isinstance(route.endpoint, RequireAuthMiddleware)
 
     def test_auth_endpoint_has_correct_methods(self, rsa_key_pair):
-        """Test that auth-protected endpoints have correct HTTP methods including OPTIONS."""
+        """Test that auth-protected endpoints have correct HTTP methods."""
         provider = JWTVerifier(
             public_key=rsa_key_pair.public_key,
             issuer="https://issuer",
@@ -60,14 +59,14 @@ class TestStreamableHTTPAppResourceMetadataURL:
         )
         route = next(r for r in app.routes if isinstance(r, Route) and r.path == "/mcp")
 
-        # Verify CORSMiddleware is applied
-        assert isinstance(route.endpoint, CORSMiddleware)
-        # Verify methods include GET, POST, DELETE, OPTIONS for streamable-http
-        expected_methods = {"GET", "POST", "DELETE", "OPTIONS"}
+        # Verify RequireAuthMiddleware is applied
+        assert isinstance(route.endpoint, RequireAuthMiddleware)
+        # Verify methods include GET, POST, DELETE for streamable-http
+        expected_methods = {"GET", "POST", "DELETE"}
         assert expected_methods.issubset(set(route.methods))
 
-    def test_no_auth_provider_mounts_without_cors_middleware(self, rsa_key_pair):
-        """Test that endpoints without auth are not wrapped with CORS middleware."""
+    def test_no_auth_provider_mounts_without_middleware(self, rsa_key_pair):
+        """Test that endpoints without auth are not wrapped with middleware."""
         server = FastMCP(name="TestServer")
         app = create_streamable_http_app(
             server=server,
@@ -75,32 +74,8 @@ class TestStreamableHTTPAppResourceMetadataURL:
             auth=None,
         )
         route = next(r for r in app.routes if isinstance(r, Route) and r.path == "/mcp")
-        # Without auth, no CORSMiddleware or RequireAuthMiddleware should be applied
-        assert not isinstance(route.endpoint, CORSMiddleware)
+        # Without auth, no RequireAuthMiddleware should be applied
         assert not isinstance(route.endpoint, RequireAuthMiddleware)
-
-    def test_options_request_succeeds_with_auth(self, bearer_auth_provider):
-        """Test that OPTIONS requests to /mcp succeed even when auth is required."""
-        server = FastMCP(name="TestServer")
-        app = create_streamable_http_app(
-            server=server,
-            streamable_http_path="/mcp",
-            auth=bearer_auth_provider,
-        )
-
-        # Test OPTIONS request with proper CORS preflight headers
-        with TestClient(app) as client:
-            response = client.options(
-                "/mcp",
-                headers={
-                    "Origin": "http://localhost:3000",
-                    "Access-Control-Request-Method": "POST",
-                },
-            )
-            assert response.status_code == 200
-            # Verify CORS headers are present
-            assert "access-control-allow-origin" in response.headers
-            assert "access-control-allow-methods" in response.headers
 
     def test_authenticated_requests_still_require_auth(self, bearer_auth_provider):
         """Test that actual requests (not OPTIONS) still require authentication."""


### PR DESCRIPTION
Most MCP clients (Claude Desktop, CLI tools, server-side applications) don't run in browsers and don't need CORS configuration. Only browser-based MCP clients like Inspector require CORS headers. Automatically wrapping authenticated endpoints with CORS meant shipping broad defaults (`allow_origins=["*"]`) that most users don't need and shouldn't use in production.

This makes CORS opt-in by removing automatic CORSMiddleware wrapping and documenting how users can add CORS when needed via the existing `middleware` parameter. Users get full control over CORS configuration and only enable it when actually connecting from browser-based clients.

**For browser-based clients (like MCP Inspector):**

```python
from starlette.middleware import Middleware
from starlette.middleware.cors import CORSMiddleware

middleware = [
    Middleware(
        CORSMiddleware,
        allow_origins=["http://localhost:3000"],  # Specific origins
        allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
        allow_headers=["mcp-protocol-version", "mcp-session-id", "Authorization"],
        expose_headers=["mcp-session-id"],  # Critical for session persistence
    )
]

app = mcp.http_app(middleware=middleware)
```

The key insight: `expose_headers=["mcp-session-id"]` is required for browsers to read the session ID from responses and send it on subsequent requests. Without this, session management fails after the first request.

Closes #2139