### PR TITLE
bug fix in `fastmcp install claude-code`

### DIFF
--- a/src/fastmcp/cli/install/claude_code.py
+++ b/src/fastmcp/cli/install/claude_code.py
@@ -127,7 +127,7 @@ def install_claude_code(
     # Build claude mcp add command
     cmd_parts = [claude_cmd, "mcp", "add", name]
 
-    # Add environment variables if specified (before the name and command)
+    # Add environment variables if specified
     if env_vars:
         for key, value in env_vars.items():
             cmd_parts.extend(["-e", f"{key}={value}"])


### PR DESCRIPTION
Calling the CLI like below command doesn't end up working: 

```
fastmcp install claude-code "$SERVER_FILE" \
    --python 3.12 \
    --env "DOCS_DIR=$DOCS_DIR" \
    --env "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
    --with fastmcp \
    --with anthropic \
    --with click
```

It errors out like: 

```
Failed to install 'foo-mcp' in Claude Code: Invalid environment variable format: foo-mcp, environment variables should be added as: -e KEY1=value1 
-e KEY2=value2
```

The fix was simply ensuring that the claude code mcp command gets mcp name directly.

## Description
<!-- 
Please provide a clear and concise description of the changes made in this pull request.

Using AI to generate code? Please include a note in the description with which AI tool you used.
-->

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [ ] My change closes #(issue number)
- [ ] I have followed the repository's development workflow
- [x] I have tested my changes manually
- [ ] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
