### PR TITLE
Update environment vars in uvx transport

### DIFF
--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -748,6 +748,7 @@ class UvxStdioTransport(StdioTransport):
         env: dict[str, str] | None = None
         if env_vars:
             env = os.environ.copy()
+            env.update(env_vars)
 
         super().__init__(
             command="uvx",


### PR DESCRIPTION
## Description
The UvxStdioTransport class is not adding extra environment variables - like e.g. the NpxStdioTransport already does


**Contributors Checklist**

- [x] My change closes #2167
- [ ] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [ ] I have performed all required documentation updates

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
