### PR TITLE
Redesign OAuth consent screen for better UX

### DIFF
--- a/src/fastmcp/utilities/ui.py
+++ b/src/fastmcp/utilities/ui.py
@@ -111,15 +111,23 @@ BUTTON_STYLES = """
 # Info box / message box styles
 INFO_BOX_STYLES = """
     .info-box {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
+        background: #f0f9ff;
+        border: 1px solid #bae6fd;
         border-radius: 0.5rem;
-        padding: 0.875rem;
-        margin: 1.25rem 0;
-        font-size: 0.875rem;
-        color: #6b7280;
-        font-family: 'SF Mono', 'Monaco', 'Consolas', 'Courier New', monospace;
+        padding: 1rem;
+        margin-bottom: 1.5rem;
         text-align: left;
+        font-size: 0.9375rem;
+        line-height: 1.5;
+        color: #374151;
+    }
+
+    .info-box p {
+        margin-bottom: 0.5rem;
+    }
+
+    .info-box p:last-child {
+        margin-bottom: 0;
     }
 
     .info-box.centered {
@@ -133,8 +141,20 @@ INFO_BOX_STYLES = """
     }
 
     .info-box strong {
-        color: #111827;
+        color: #0ea5e9;
         font-weight: 600;
+    }
+
+    .info-box .server-name-link {
+        color: #0ea5e9;
+        text-decoration: underline;
+        font-weight: 600;
+        cursor: pointer;
+        transition: opacity 0.15s;
+    }
+
+    .info-box .server-name-link:hover {
+        opacity: 0.8;
     }
 
     .warning-box {
@@ -236,10 +256,11 @@ DETAIL_BOX_STYLES = """
 
     .detail-label {
         font-weight: 600;
-        min-width: 140px;
+        min-width: 160px;
         color: #6b7280;
         font-size: 0.875rem;
         flex-shrink: 0;
+        padding-right: 1rem;
     }
 
     .detail-value {
@@ -249,6 +270,72 @@ DETAIL_BOX_STYLES = """
         color: #111827;
         word-break: break-all;
         overflow-wrap: break-word;
+    }
+"""
+
+# Redirect section styles (for OAuth redirect URI box)
+REDIRECT_SECTION_STYLES = """
+    .redirect-section {
+        background: #fffbeb;
+        border: 1px solid #fcd34d;
+        border-radius: 0.5rem;
+        padding: 1rem;
+        margin-bottom: 1.5rem;
+        text-align: left;
+    }
+
+    .redirect-section .label {
+        font-size: 0.875rem;
+        color: #6b7280;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        display: block;
+    }
+
+    .redirect-section .value {
+        font-family: 'SF Mono', 'Monaco', 'Consolas', 'Courier New', monospace;
+        font-size: 0.875rem;
+        color: #111827;
+        word-break: break-all;
+        margin-top: 0.25rem;
+    }
+"""
+
+# Collapsible details styles
+DETAILS_STYLES = """
+    details {
+        margin-bottom: 1.5rem;
+        text-align: left;
+    }
+
+    summary {
+        cursor: pointer;
+        font-size: 0.875rem;
+        color: #6b7280;
+        font-weight: 600;
+        list-style: none;
+        padding: 0.5rem;
+        border-radius: 0.25rem;
+    }
+
+    summary:hover {
+        background: #f9fafb;
+    }
+
+    summary::marker {
+        display: none;
+    }
+
+    summary::before {
+        content: "▶";
+        display: inline-block;
+        margin-right: 0.5rem;
+        transition: transform 0.2s;
+        font-size: 0.75rem;
+    }
+
+    details[open] summary::before {
+        transform: rotate(90deg);
     }
 """
 


### PR DESCRIPTION
We've received feedback that Confused Deputy OAuth consent screens can be intimidating for non-technical users, especially when displaying technical details like redirect URIs, client IDs, and requested scopes. This PR tweaks the design with the goal of maintaining MCP security best practices while being accessible to all users. Relates to request in #2139

## Old
<img width="712" height="756" alt="image" src="https://github.com/user-attachments/assets/dee8f524-0c46-46a7-9f95-cab262f5cd46" />

## New
<img width="737" height="713" alt="image" src="https://github.com/user-attachments/assets/f6b719aa-950b-4579-bbe8-d2f2a6f1b798" />
