### PR TITLE
fix: apply prefix to tool name when mounting servers

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -464,7 +464,12 @@ class FastMCP(Generic[LifespanResultT]):
                 child_tools = await mounted.server.get_tools()
                 for key, tool in child_tools.items():
                     new_key = f"{mounted.prefix}_{key}" if mounted.prefix else key
-                    all_tools[new_key] = tool.model_copy(key=new_key)
+                    all_tools[new_key] = tool.model_copy(
+                        key=new_key,
+                        update={"name": f"{mounted.prefix}_{tool.name}"}
+                        if mounted.prefix
+                        else {},
+                    )
             except Exception as e:
                 logger.warning(
                     f"Failed to get tools from mounted server {mounted.server.name!r}: {e}"
@@ -722,7 +727,9 @@ class FastMCP(Generic[LifespanResultT]):
                     key = tool.key
                     if mounted.prefix:
                         key = f"{mounted.prefix}_{tool.key}"
-                        tool = tool.model_copy(key=key)
+                        tool = tool.model_copy(
+                            key=key, update={"name": f"{mounted.prefix}_{tool.name}"}
+                        )
                     # Later mounted servers override earlier ones
                     all_tools[key] = tool
             except Exception as e:


### PR DESCRIPTION
## problem

when mounting a server with a prefix, the tool's `key` field gets prefixed but the `name` field doesn't. this creates an inconsistency where:

```json
{
  "key": "hue_read_all_lights",
  "name": "read_all_lights"
}
```

this breaks chatmcp UI and other clients that expect `key` and `name` to be consistent when using tools.

## solution

apply the prefix to both `key` and `name` fields when mounting, matching how resources and templates already work:

```python
tool = tool.model_copy(
    key=key,
    update={"name": f"{mounted.prefix}_{tool.name}"}
)
```

this makes tool name prefixing consistent across all component types (tools, resources, templates, prompts).

## example

```python
from fastmcp import FastMCP

# child server
lights = FastMCP("Lights")

@lights.tool
def read_all_lights() -> list[str]:
    return ["light1", "light2"]

# parent server mounts with prefix
hub = FastMCP("Hub")
hub.mount(lights, prefix="hue")

# after fix: both key and name are prefixed
tools = await hub.get_tools()
tool = tools["hue_read_all_lights"]
assert tool.key == "hue_read_all_lights"
assert tool.name == "hue_read_all_lights"  # ✅ now consistent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)