### PR TITLE
fix: apply prefix to tool name when mounting servers

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -464,7 +464,12 @@ class FastMCP(Generic[LifespanResultT]):
                 child_tools = await mounted.server.get_tools()
                 for key, tool in child_tools.items():
                     new_key = f"{mounted.prefix}_{key}" if mounted.prefix else key
-                    all_tools[new_key] = tool.model_copy(key=new_key)
+                    all_tools[new_key] = tool.model_copy(
+                        key=new_key,
+                        update={"name": f"{mounted.prefix}_{tool.name}"}
+                        if mounted.prefix
+                        else {},
+                    )
             except Exception as e:
                 logger.warning(
                     f"Failed to get tools from mounted server {mounted.server.name!r}: {e}"
@@ -722,7 +727,9 @@ class FastMCP(Generic[LifespanResultT]):
                     key = tool.key
                     if mounted.prefix:
                         key = f"{mounted.prefix}_{tool.key}"
-                        tool = tool.model_copy(key=key)
+                        tool = tool.model_copy(
+                            key=key, update={"name": f"{mounted.prefix}_{tool.name}"}
+                        )
                     # Later mounted servers override earlier ones
                     all_tools[key] = tool
             except Exception as e:


### PR DESCRIPTION
Fixes inconsistent tool naming when mounting servers with prefixes.

## Problem

When mounting a child server with a prefix, only the internal `key` field was being prefixed, but the `name` field (which is exposed in the manifest and used by FastMCP Cloud) was not. This caused a mismatch where:

- Manifest shows: `{key: 'hue_read_all_lights', name: 'read_all_lights'}`
- FastMCP Cloud UI uses `tool.name` to call tools
- MCP protocol only knows about the prefixed `key`
- Result: Tool execution fails

## Solution

Apply the prefix to both `key` and `name` fields when mounting servers, ensuring consistency across:
1. Internal bookkeeping (`key`)
2. Manifest generation (`name`)
3. MCP protocol (`_list_tools_mcp` uses `key` as `name`)
4. FastMCP Cloud UI (reads `name` from manifest)

## Changes

- Updated `server.py` at 2 locations to prefix both `key` and `name`
- Added comprehensive unit test verifying both fields are prefixed
- Resources and templates already handled this correctly

## Testing

```bash
uv run pytest tests/server/test_mount.py::TestToolNamePrefixing -v
```

All 55 mount tests pass.