### PR TITLE
Use platformdirs for settings.home

### DIFF
--- a/examples/memory.py
+++ b/examples/memory.py
@@ -14,7 +14,6 @@ import math
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Annotated, Any, Self
 
 import asyncpg
@@ -24,6 +23,7 @@ from pgvector.asyncpg import register_vector  # Import register_vector
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent
 
+import fastmcp
 from fastmcp import FastMCP
 
 MAX_DEPTH = 5
@@ -45,9 +45,9 @@ mcp = FastMCP(
 )
 
 DB_DSN = "postgresql://postgres:postgres@localhost:54320/memory_db"
-# reset memory with rm ~/.fastmcp/{USER}/memory/*
+# reset memory by deleting the profile directory
 PROFILE_DIR = (
-    Path.home() / ".fastmcp" / os.environ.get("USER", "anon") / "memory"
+    fastmcp.settings.home / os.environ.get("USER", "anon") / "memory"
 ).resolve()
 PROFILE_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "httpx>=0.28.1",
     "mcp>=1.17.0,<2.0.0",
     "openapi-pydantic>=0.5.1",
+    "platformdirs>=4.0.0",
     "rich>=13.9.4",
     "cyclopts>=3.0.0",
     "authlib>=1.5.2",

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -6,6 +6,7 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
+from platformdirs import user_data_dir
 from pydantic import Field, ImportString, field_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import (
@@ -150,7 +151,7 @@ class Settings(BaseSettings):
         )
         return self
 
-    home: Path = Path.home() / ".fastmcp"
+    home: Path = Path(user_data_dir("fastmcp", appauthor=False))
 
     test_mode: bool = False
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -553,6 +553,7 @@ dependencies = [
     { name = "mcp" },
     { name = "openapi-core" },
     { name = "openapi-pydantic" },
+    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["disk", "memory"] },
     { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
@@ -603,6 +604,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.102.0" },
     { name = "openapi-core", specifier = ">=0.19.5" },
     { name = "openapi-pydantic", specifier = ">=0.5.1" },
+    { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "py-key-value-aio", extras = ["disk", "memory"], specifier = ">=0.2.6,<0.3.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.7" },
     { name = "pyperclip", specifier = ">=1.9.0" },


### PR DESCRIPTION
Switches `settings.home` from `Path.home() / ".fastmcp"` to `platformdirs.user_data_dir("fastmcp")` to follow platform conventions and avoid cluttering the user's home directory.

Platform-specific paths:
- macOS: `~/Library/Application Support/fastmcp`
- Linux: `~/.local/share/fastmcp`
- Windows: `%APPDATA%\fastmcp`

Users can still override via `FASTMCP_HOME` environment variable.