### PR TITLE
Fix middleware example: add context parameter to call_next()

### DIFF
--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -210,8 +210,8 @@ class UserAuthMiddleware(Middleware):
         # Middleware stores user info in context state
         context.fastmcp_context.set_state("user_id", "user_123")
         context.fastmcp_context.set_state("permissions", ["read", "write"])
-        
-        return await call_next()
+
+        return await call_next(context)
 
 @mcp.tool
 async def secure_operation(data: str, ctx: Context) -> str:


### PR DESCRIPTION
Fixes #2207

The middleware example in the Context State Management documentation was missing the `context` parameter when calling `call_next()`, which caused a runtime error when users tried to use the example code.

### Changes
- Updated `docs/servers/context.mdx` to pass `context` to `call_next(context)`
- Verified all other middleware examples in docs are correct

🤖 Generated with [Claude Code](https://claude.ai/code)