### PR TITLE
Fix dead links to py-key-value repository

### DIFF
--- a/docs/servers/storage-backends.mdx
+++ b/docs/servers/storage-backends.mdx
@@ -142,7 +142,7 @@ The py-key-value-aio library includes additional implementations for various sto
 - **RocksDB** - Embedded high-performance key-value store
 - **Valkey** - Redis-compatible server
 
-For configuration details on these backends, consult the [py-key-value-aio documentation](https://github.com/strawgate/py-key-value-aio).
+For configuration details on these backends, consult the [py-key-value-aio documentation](https://github.com/strawgate/py-key-value).
 
 ## Use Cases in FastMCP
 
@@ -253,7 +253,7 @@ This allows clients to reconnect without re-authenticating after restarts.
 
 ## More Resources
 
-- [py-key-value-aio GitHub](https://github.com/strawgate/py-key-value-aio) - Full library documentation
+- [py-key-value-aio GitHub](https://github.com/strawgate/py-key-value) - Full library documentation
 - [Response Caching Middleware](/servers/middleware#caching-middleware) - Using storage for caching
 - [OAuth Token Security](/deployment/http#oauth-token-security) - Production OAuth configuration
 - [HTTP Deployment](/deployment/http) - Complete deployment guide


### PR DESCRIPTION
Fixes #2216

Updated two broken links in the storage backends documentation that were pointing to `py-key-value-aio` repository, which doesn't exist as a standalone repo. The `py-key-value-aio` package actually lives in the `strawgate/py-key-value` monorepo.

**Changes:**
- docs/servers/storage-backends.mdx:145: Fixed link to py-key-value-aio documentation
- docs/servers/storage-backends.mdx:256: Fixed link to py-key-value-aio GitHub

Generated with [Claude Code](https://claude.ai/code)