### PR TITLE
Add exc_info=True to inspect command error logging

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -772,6 +772,7 @@ async def inspect(
                 "server_spec": server_spec,
                 "error": str(e),
             },
+            exc_info=True,
         )
         console.print(f"[bold red]✗[/bold red] Failed to inspect server: {e}")
         sys.exit(1)


### PR DESCRIPTION
When the `fastmcp inspect` command fails during server loading (missing dependencies, import errors, syntax errors), only the error message is logged without the stack trace. This makes debugging difficult because you can't see where in the code the error occurred.

Adding `exc_info=True` to the error logger includes the full stack trace, showing:
- Exact file and line number where the error occurred
- Complete call stack leading to the error  
- Chained exceptions

This is particularly valuable for inspect because it loads server modules dynamically through complex import chains and dependency resolution.

**Example:**

Without `exc_info=True`:
```
ERROR Failed to inspect server: ModuleNotFoundError: No module named 'foo'
```

With `exc_info=True`:
```
ERROR Failed to inspect server: ModuleNotFoundError: No module named 'foo'
Traceback (most recent call last):
  File "server.py", line 3, in <module>
    import foo
ModuleNotFoundError: No module named 'foo'
```

Fixes #2231

🤖 Generated with [Claude Code](https://claude.com/claude-code)