### PR TITLE
Add version badge for run_server_async in tests docs

### DIFF
--- a/docs/development/tests.mdx
+++ b/docs/development/tests.mdx
@@ -4,6 +4,8 @@ description: "Testing patterns and requirements for FastMCP"
 icon: vial
 ---
 
+import { VersionBadge } from "/snippets/version-badge.mdx"
+
 Good tests are the foundation of reliable software. In FastMCP, we treat tests as first-class documentation that demonstrates how features work while protecting against regressions. Every new capability needs comprehensive tests that demonstrate correctness.
 
 ## FastMCP Tests
@@ -300,6 +302,8 @@ async def test_database_tool():
 While in-memory testing covers most unit testing needs, you'll occasionally need to test actual network transports like HTTP or SSE. FastMCP provides two approaches: in-process async servers using AnyIO task groups (preferred), and separate subprocess servers (for special cases).
 
 #### In-Process Network Testing (Preferred)
+
+<VersionBadge version="2.13.0" />
 
 For most network transport tests, use `run_server_async` with AnyIO task groups. This runs the server as a task in the same process, providing fast, deterministic tests with full debugger support:
 


### PR DESCRIPTION
This PR adds a version badge to the tests documentation to indicate that `run_server_async` is only available in version 2.13.0.

This addresses the issue where the docs were documenting an unreleased feature without clearly marking it as such, which confused users working with the stable release (2.12.5).

Fixes #2228

Generated with [Claude Code](https://claude.ai/code)