### PR TITLE
Remove redundant None checks from Context methods

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -224,8 +224,6 @@ class Context:
         Returns:
             List of Resource objects available on the server
         """
-        if self.fastmcp is None:
-            raise ValueError("Context is not available outside of a request")
         return await self.fastmcp._list_resources_mcp()
 
     async def list_prompts(self) -> list[MCPPrompt]:
@@ -234,8 +232,6 @@ class Context:
         Returns:
             List of Prompt objects available on the server
         """
-        if self.fastmcp is None:
-            raise ValueError("Context is not available outside of a request")
         return await self.fastmcp._list_prompts_mcp()
 
     async def get_prompt(
@@ -250,8 +246,6 @@ class Context:
         Returns:
             The prompt result
         """
-        if self.fastmcp is None:
-            raise ValueError("Context is not available outside of a request")
         return await self.fastmcp._get_prompt_mcp(name, arguments)
 
     async def read_resource(self, uri: str | AnyUrl) -> list[ReadResourceContents]:
@@ -263,8 +257,6 @@ class Context:
         Returns:
             The resource content as either text or bytes
         """
-        if self.fastmcp is None:
-            raise ValueError("Context is not available outside of a request")
         return await self.fastmcp._read_resource_mcp(uri)
 
     async def log(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -566,7 +566,6 @@ dependencies = [
     { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
     { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "websockets" },
@@ -591,6 +590,7 @@ dev = [
     { name = "pyinstrument" },
     { name = "pyperclip" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-flakefinder" },
@@ -617,7 +617,6 @@ requires-dist = [
     { name = "py-key-value-aio", extras = ["disk", "keyring", "memory"], specifier = ">=0.2.6,<0.3.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.7" },
     { name = "pyperclip", specifier = ">=1.9.0" },
-    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "websockets", specifier = ">=15.0.1" },
@@ -637,6 +636,7 @@ dev = [
     { name = "pyinstrument", specifier = ">=5.0.2" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-flakefinder" },


### PR DESCRIPTION
The `Context.fastmcp` property already handles None checks internally, raising a `RuntimeError` if the FastMCP instance is no longer available. The property is typed to return `FastMCP` (not optional), so accessing `ctx.fastmcp` will either return a valid instance or raise an exception - it can never be None.

This makes the `if self.fastmcp is None` checks in these methods unreachable:
- `list_resources()`
- `list_prompts()`
- `get_prompt()`
- `read_resource()`

```python
@property
def fastmcp(self) -> FastMCP:
    """Get the FastMCP instance."""
    fastmcp = self._fastmcp()
    if fastmcp is None:
        raise RuntimeError("FastMCP instance is no longer available")
    return fastmcp
```

This cleanup improves code clarity by removing defensive checks that can never trigger.

Fixes the outstanding request from PR #2249.