### PR TITLE
feat: Continue install support

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -218,6 +218,7 @@
                   "integrations/chatgpt",
                   "integrations/claude-code",
                   "integrations/claude-desktop",
+                  "integrations/continue",
                   "integrations/cursor",
                   "integrations/gemini-cli",
                   "integrations/mcp-json-configuration"

--- a/docs/integrations/continue.mdx
+++ b/docs/integrations/continue.mdx
@@ -1,0 +1,187 @@
+---
+title: Continue 🤝 FastMCP
+sidebarTitle: Continue
+description: Install and use FastMCP servers in Continue
+icon: message-code
+---
+
+import { VersionBadge } from "/snippets/version-badge.mdx"
+import { LocalFocusTip } from "/snippets/local-focus.mdx"
+
+<LocalFocusTip />
+
+Continue is an open-source AI code assistant that supports MCP servers, allowing you to extend Continue's agent with custom tools, resources, and prompts from your FastMCP servers.
+
+<Info>
+For detailed information about Continue's MCP implementation and configuration options, see the [Continue MCP documentation](https://docs.continue.dev/customize/deep-dives/mcp).
+</Info>
+
+## Requirements
+
+This integration uses STDIO transport to run your FastMCP server locally. Continue MCP servers work in agent mode and are configured using YAML block files in the `~/.continue/mcpServers` directory.
+
+## Create a Server
+
+The examples in this guide will use the following simple dice-rolling server, saved as `server.py`.
+
+```python server.py
+import random
+from fastmcp import FastMCP
+
+mcp = FastMCP(name="Dice Roller")
+
+@mcp.tool
+def roll_dice(n_dice: int) -> list[int]:
+    """Roll `n_dice` 6-sided dice and return the results."""
+    return [random.randint(1, 6) for _ in range(n_dice)]
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+## Install the Server
+
+### FastMCP CLI
+
+The easiest way to install a FastMCP server in Continue is using the `fastmcp install continue` command. This automatically handles the configuration and dependency management.
+
+```bash
+fastmcp install continue server.py
+```
+
+The install command supports the same `file.py:object` notation as the `run` command. If no object is specified, it will automatically look for a FastMCP server object named `mcp`, `server`, or `app` in your file:
+
+```bash
+# These are equivalent if your server object is named 'mcp'
+fastmcp install continue server.py
+fastmcp install continue server.py:mcp
+
+# Use explicit object name if your server has a different name
+fastmcp install continue server.py:my_custom_server
+```
+
+The command creates a YAML block file in `~/.continue/mcpServers/` named after your server (e.g., `my-server.yaml`). After installation, restart Continue to load the new server.
+
+#### Dependencies
+
+FastMCP offers multiple ways to manage dependencies for your Continue servers:
+
+**Individual packages**: Use the `--with` flag to specify packages your server needs. You can use this flag multiple times:
+
+```bash
+fastmcp install continue server.py --with pandas --with requests
+```
+
+**Requirements file**: For projects with a `requirements.txt` file, use `--with-requirements` to install all dependencies at once:
+
+```bash
+fastmcp install continue server.py --with-requirements requirements.txt
+```
+
+**Editable packages**: When developing local packages, use `--with-editable` to install them in editable mode:
+
+```bash
+fastmcp install continue server.py --with-editable ./my-local-package
+```
+
+You can also use a `fastmcp.json` configuration file:
+
+```json fastmcp.json
+{
+  "$schema": "https://gofastmcp.com/public/schemas/fastmcp.json/v1.json",
+  "source": {
+    "path": "server.py",
+    "entrypoint": "mcp"
+  },
+  "environment": {
+    "dependencies": ["pandas", "requests"]
+  }
+}
+```
+
+Then install it:
+
+```bash
+fastmcp install continue fastmcp.json
+```
+
+#### Python Version and Project Configuration
+
+Control your server's Python environment with these options:
+
+**Python version**: Use `--python` to specify which Python version your server should use. This is essential when your server requires specific Python features:
+
+```bash
+fastmcp install continue server.py --python 3.11
+```
+
+**Project directory**: Use `--project` to run your server within a specific project context. This ensures `uv` discovers all project configuration files and uses the correct virtual environment:
+
+```bash
+fastmcp install continue server.py --project /path/to/my-project
+```
+
+#### Environment Variables
+
+<Warning>
+Continue runs servers in a completely isolated environment with no access to your shell environment or locally installed applications. You must explicitly pass any environment variables your server needs.
+</Warning>
+
+If your server needs environment variables (like API keys), you must include them:
+
+```bash
+fastmcp install continue server.py --name "Weather Server" \
+  --env API_KEY=your-api-key \
+  --env DEBUG=true
+```
+
+Or load them from a `.env` file:
+
+```bash
+fastmcp install continue server.py --name "Weather Server" --env-file .env
+```
+
+<Warning>
+**`uv` must be installed and available in your system PATH**. Continue runs in its own isolated environment and needs `uv` to manage dependencies.
+</Warning>
+
+## Using the Server
+
+Once your server is installed and Continue is restarted, you can start using your FastMCP server with Continue's AI agent.
+
+<Note>
+MCP servers only work in **agent mode** in Continue. Make sure to switch to agent mode before testing your server.
+</Note>
+
+Try asking Continue something like:
+
+> "Roll some dice for me"
+
+Continue will automatically detect your `roll_dice` tool and use it to fulfill your request.
+
+The AI assistant can now access all the tools, resources, and prompts you've defined in your FastMCP server.
+
+## Manual Configuration
+
+For manual configuration or advanced use cases, you can create YAML block files directly in `~/.continue/mcpServers/`. Continue uses a composable block schema where each file contains an `mcpServers` array:
+
+```yaml dice-roller.yaml
+name: dice-roller
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: dice-roller
+    type: stdio
+    command: uv
+    args:
+      - run
+      - --with
+      - fastmcp
+      - fastmcp
+      - run
+      - path/to/your/server.py
+    env:  # Optional
+      API_KEY: your-api-key
+```
+
+For detailed information about Continue's YAML block schema, configuration options, and remote server setup, see the [Continue MCP documentation](https://docs.continue.dev/customize/deep-dives/mcp).

--- a/docs/integrations/mcp-json-configuration.mdx
+++ b/docs/integrations/mcp-json-configuration.mdx
@@ -9,7 +9,7 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 <VersionBadge version="2.10.3" />
 
-FastMCP can generate standard MCP JSON configuration files that work with any MCP-compatible client including Claude Desktop, VS Code, Cursor, and other applications that support the Model Context Protocol.
+FastMCP can generate standard MCP JSON configuration files that work with any MCP-compatible client including Claude Desktop, Continue, VS Code, Cursor, and other applications that support the Model Context Protocol.
 
 ## MCP JSON Configuration Standard
 
@@ -71,6 +71,7 @@ An object containing environment variables to set when launching the server. All
 This format is widely adopted across the MCP ecosystem:
 
 - **Claude Desktop**: Uses `~/.claude/claude_desktop_config.json`
+- **Continue**: Uses `~/.continue/mcpServers/*.yaml` (YAML format with JSON content)
 - **Cursor**: Uses `~/.cursor/mcp.json`
 - **VS Code**: Uses workspace `.vscode/mcp.json`
 - **Other clients**: Many MCP-compatible applications follow this standard
@@ -78,7 +79,12 @@ This format is widely adopted across the MCP ecosystem:
 ## Overview
 
 <Note>
-**For the best experience, use FastMCP's first-class integrations:** [`fastmcp install claude-code`](/integrations/claude-code), [`fastmcp install claude-desktop`](/integrations/claude-desktop), or [`fastmcp install cursor`](/integrations/cursor). Use MCP JSON generation for advanced use cases and unsupported clients.
+  **For the best experience, use FastMCP's first-class integrations:** [`fastmcp
+  install claude-code`](/integrations/claude-code), [`fastmcp install
+  claude-desktop`](/integrations/claude-desktop), [`fastmcp install
+  continue`](/integrations/continue), or [`fastmcp install
+  cursor`](/integrations/cursor). Use MCP JSON generation for advanced use cases
+  and unsupported clients.
 </Note>
 
 The `fastmcp install mcp-json` command generates configuration in the standard `mcpServers` format used across the MCP ecosystem. This is useful when:

--- a/src/fastmcp/cli/install/__init__.py
+++ b/src/fastmcp/cli/install/__init__.py
@@ -4,6 +4,7 @@ import cyclopts
 
 from .claude_code import claude_code_command
 from .claude_desktop import claude_desktop_command
+from .continue_client import continue_command
 from .cursor import cursor_command
 from .gemini_cli import gemini_cli_command
 from .mcp_json import mcp_json_command
@@ -17,6 +18,7 @@ install_app = cyclopts.App(
 # Register each command from its respective module
 install_app.command(claude_code_command, name="claude-code")
 install_app.command(claude_desktop_command, name="claude-desktop")
+install_app.command(continue_command, name="continue")
 install_app.command(cursor_command, name="cursor")
 install_app.command(gemini_cli_command, name="gemini-cli")
 install_app.command(mcp_json_command, name="mcp-json")

--- a/src/fastmcp/cli/install/continue_client.py
+++ b/src/fastmcp/cli/install/continue_client.py
@@ -1,0 +1,214 @@
+"""Continue integration for FastMCP install using Cyclopts."""
+
+import sys
+from pathlib import Path
+from typing import Annotated, Any
+
+import cyclopts
+import yaml
+from rich import print
+
+from fastmcp.utilities.logging import get_logger
+from fastmcp.utilities.mcp_server_config.v1.environments.uv import UVEnvironment
+
+from .shared import process_common_args
+
+logger = get_logger(__name__)
+
+
+def get_continue_mcp_servers_dir() -> Path:
+    """Get the platform-agnostic Continue mcpServers directory.
+
+    Returns:
+        Path to the global ~/.continue/mcpServers directory
+    """
+    home = Path.home()
+    return home / ".continue" / "mcpServers"
+
+
+def convert_env_to_continue_format(
+    env_vars: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Convert environment variables to Continue's YAML format.
+
+    Continue stores actual environment variable values directly in the YAML.
+    Returns None for empty dict to match Continue's schema.
+    """
+    if not env_vars:
+        return None
+    return env_vars
+
+
+def install_continue(
+    file: Path,
+    server_object: str | None,
+    name: str,
+    *,
+    with_editable: list[Path] | None = None,
+    with_packages: list[str] | None = None,
+    env_vars: dict[str, str] | None = None,
+    python_version: str | None = None,
+    with_requirements: Path | None = None,
+    project: Path | None = None,
+) -> bool:
+    """Install FastMCP server in Continue.
+
+    Args:
+        file: Path to the server file
+        server_object: Optional server object name (for :object suffix)
+        name: Name for the server in Continue
+        with_editable: Optional list of directories to install in editable mode
+        with_packages: Optional list of additional packages to install
+        env_vars: Optional dictionary of environment variables
+        python_version: Optional Python version to use
+        with_requirements: Optional requirements file to install from
+        project: Optional project directory to run within
+
+    Returns:
+        True if installation was successful, False otherwise
+    """
+    mcp_servers_dir = get_continue_mcp_servers_dir()
+    mcp_servers_dir.mkdir(parents=True, exist_ok=True)
+    config_file = mcp_servers_dir / f"{name}.yaml"
+
+    env_config = UVEnvironment(
+        python=python_version,
+        dependencies=(with_packages or []) + ["fastmcp"],
+        requirements=with_requirements,
+        project=project,
+        editable=with_editable,
+    )
+
+    if server_object:
+        server_spec = f"{file.resolve()}:{server_object}"
+    else:
+        server_spec = str(file.resolve())
+
+    full_command = env_config.build_command(["fastmcp", "run", server_spec])
+
+    server_config: dict[str, Any] = {
+        "name": name,
+        "type": "stdio",
+        "command": full_command[0],
+    }
+
+    if len(full_command) > 1:
+        server_config["args"] = full_command[1:]
+
+    if env_vars:
+        server_config["env"] = convert_env_to_continue_format(env_vars)
+
+    if project:
+        server_config["cwd"] = str(project)
+
+    # Continue requires block schema format with mcpServers array even for individual files
+    block_config: dict[str, Any] = {
+        "name": name,
+        "version": "0.0.1",
+        "schema": "v1",
+        "mcpServers": [server_config],
+    }
+
+    try:
+        with open(config_file, "w") as f:
+            yaml.dump(block_config, f, default_flow_style=False, sort_keys=False)
+
+        print(
+            f"[green]Successfully installed '{name}' to Continue[/green]\n"
+            f"[blue]Config file: {config_file}[/blue]"
+        )
+        return True
+    except Exception as e:
+        print(f"[red]Failed to install server: {e}[/red]")
+        return False
+
+
+async def continue_command(
+    server_spec: str,
+    *,
+    server_name: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--name", "-n"],
+            help="Custom name for the server in Continue",
+        ),
+    ] = None,
+    with_editable: Annotated[
+        list[Path] | None,
+        cyclopts.Parameter(
+            "--with-editable",
+            help="Directory with pyproject.toml to install in editable mode (can be used multiple times)",
+            negative="",
+        ),
+    ] = None,
+    with_packages: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(
+            "--with",
+            help="Additional packages to install (can be used multiple times)",
+            negative="",
+        ),
+    ] = None,
+    env_vars: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(
+            "--env",
+            help="Environment variables in KEY=VALUE format (can be used multiple times)",
+            negative="",
+        ),
+    ] = None,
+    env_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(
+            "--env-file",
+            help="Load environment variables from .env file",
+        ),
+    ] = None,
+    python: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            "--python",
+            help="Python version to use (e.g., 3.10, 3.11)",
+        ),
+    ] = None,
+    with_requirements: Annotated[
+        Path | None,
+        cyclopts.Parameter(
+            "--with-requirements",
+            help="Requirements file to install dependencies from",
+        ),
+    ] = None,
+    project: Annotated[
+        Path | None,
+        cyclopts.Parameter(
+            "--project",
+            help="Run the command within the given project directory",
+        ),
+    ] = None,
+) -> None:
+    """Install an MCP server in Continue.
+
+    Args:
+        server_spec: Python file to install, optionally with :object suffix
+    """
+    with_editable = with_editable or []
+    with_packages = with_packages or []
+    env_vars = env_vars or []
+    file, server_object, name, with_packages, env_dict = await process_common_args(
+        server_spec, server_name, with_packages, env_vars, env_file
+    )
+
+    success = install_continue(
+        file=file,
+        server_object=server_object,
+        name=name,
+        with_editable=with_editable,
+        with_packages=with_packages,
+        env_vars=env_dict,
+        python_version=python,
+        with_requirements=with_requirements,
+        project=project,
+    )
+
+    if not success:
+        sys.exit(1)

--- a/tests/cli/test_continue_client.py
+++ b/tests/cli/test_continue_client.py
@@ -1,0 +1,385 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from fastmcp.cli.install.continue_client import (
+    continue_command,
+    convert_env_to_continue_format,
+    get_continue_mcp_servers_dir,
+    install_continue,
+)
+
+
+class TestContinueClientDirectories:
+    """Test Continue directory handling."""
+
+    def test_get_continue_mcp_servers_dir(self):
+        """Test getting the Continue mcpServers directory path."""
+        mcp_dir = get_continue_mcp_servers_dir()
+        assert mcp_dir == Path.home() / ".continue" / "mcpServers"
+
+
+class TestEnvConversion:
+    """Test environment variable conversion."""
+
+    def test_convert_env_to_continue_format_none(self):
+        """Test conversion with None env vars."""
+        result = convert_env_to_continue_format(None)
+        assert result is None
+
+    def test_convert_env_to_continue_format_empty(self):
+        """Test conversion with empty env vars."""
+        result = convert_env_to_continue_format({})
+        # Empty dict is treated as None to match Continue's schema
+        assert result is None
+
+    def test_convert_env_to_continue_format_with_values(self):
+        """Test conversion with actual env vars."""
+        env_vars = {"API_KEY": "test-key", "DEBUG": "true"}
+        result = convert_env_to_continue_format(env_vars)
+        assert result == env_vars
+
+
+class TestInstallContinueClient:
+    """Test Continue client installation functionality."""
+
+    def test_install_continue_success(self, tmp_path):
+        """Test successful Continue client installation."""
+        # Mock the home directory
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            result = install_continue(
+                file=Path("/path/to/server.py"),
+                server_object=None,
+                name="test-server",
+            )
+
+            assert result is True
+
+            # Verify the YAML file was created
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+            assert config_file.exists()
+
+            # Verify the YAML content follows Continue block schema
+            with open(config_file) as f:
+                yaml_content = yaml.safe_load(f)
+
+            # Block metadata
+            assert yaml_content["name"] == "test-server"
+            assert yaml_content["version"] == "0.0.1"
+            assert yaml_content["schema"] == "v1"
+            assert "mcpServers" in yaml_content
+            assert isinstance(yaml_content["mcpServers"], list)
+            assert len(yaml_content["mcpServers"]) == 1
+            
+            # Server config within mcpServers array
+            server_config = yaml_content["mcpServers"][0]
+            assert server_config["name"] == "test-server"
+            assert server_config["type"] == "stdio"
+            assert server_config["command"] == "uv"
+            assert "args" in server_config
+            assert "run" in server_config["args"]
+            assert "fastmcp" in server_config["args"]
+            assert "/path/to/server.py" in " ".join(server_config["args"])
+
+    def test_install_continue_with_packages(self, tmp_path):
+        """Test Continue client installation with additional packages."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            result = install_continue(
+                file=Path("/path/to/server.py"),
+                server_object="app",
+                name="test-server",
+                with_packages=["numpy", "pandas"],
+                env_vars={"API_KEY": "test"},
+            )
+
+            assert result is True
+
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+            with open(config_file) as f:
+                yaml_content = yaml.safe_load(f)
+
+            server_config = yaml_content["mcpServers"][0]
+            # Check that all packages are included
+            assert server_config["name"] == "test-server"
+            assert server_config["type"] == "stdio"
+            args_str = " ".join(server_config["args"])
+            assert "--with" in args_str
+            assert "numpy" in args_str
+            assert "pandas" in args_str
+            assert "fastmcp" in args_str
+            assert "server.py:app" in args_str
+            assert server_config["env"] == {"API_KEY": "test"}
+
+    def test_install_continue_with_editable(self, tmp_path):
+        """Test Continue client installation with editable package."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        editable_path = Path.cwd() / "local" / "package"
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            result = install_continue(
+                file=Path("/path/to/server.py"),
+                server_object="custom_app",
+                name="test-server",
+                with_editable=[editable_path],
+            )
+
+            assert result is True
+
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+            with open(config_file) as f:
+                yaml_content = yaml.safe_load(f)
+
+            server_config = yaml_content["mcpServers"][0]
+            assert "--with-editable" in server_config["args"]
+            # Check that the path was resolved (should be absolute)
+            editable_idx = server_config["args"].index("--with-editable") + 1
+            resolved_path = server_config["args"][editable_idx]
+            assert Path(resolved_path).is_absolute()
+            assert "server.py:custom_app" in " ".join(server_config["args"])
+
+    def test_install_continue_with_python_version(self, tmp_path):
+        """Test Continue client installation with specific Python version."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            result = install_continue(
+                file=Path("/path/to/server.py"),
+                server_object=None,
+                name="test-server",
+                python_version="3.11",
+            )
+
+            assert result is True
+
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+            with open(config_file) as f:
+                yaml_content = yaml.safe_load(f)
+
+            server_config = yaml_content["mcpServers"][0]
+            assert "--python" in server_config["args"]
+            assert "3.11" in server_config["args"]
+
+    def test_install_continue_with_requirements(self, tmp_path):
+        """Test Continue client installation with requirements file."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        requirements_file = tmp_path / "requirements.txt"
+        requirements_file.write_text("numpy\npandas\n")
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            result = install_continue(
+                file=Path("/path/to/server.py"),
+                server_object=None,
+                name="test-server",
+                with_requirements=requirements_file,
+            )
+
+            assert result is True
+
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+            with open(config_file) as f:
+                yaml_content = yaml.safe_load(f)
+
+            server_config = yaml_content["mcpServers"][0]
+            assert "--with-requirements" in server_config["args"]
+            assert str(requirements_file) in server_config["args"]
+
+    def test_install_continue_with_project(self, tmp_path):
+        """Test Continue client installation with project directory."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        project_dir = tmp_path / "my_project"
+        project_dir.mkdir()
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            result = install_continue(
+                file=Path("/path/to/server.py"),
+                server_object=None,
+                name="test-server",
+                project=project_dir,
+            )
+
+            assert result is True
+
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+            with open(config_file) as f:
+                yaml_content = yaml.safe_load(f)
+
+            server_config = yaml_content["mcpServers"][0]
+            # Project is passed to uv command args
+            assert "--project" in server_config["args"]
+            assert str(project_dir) in server_config["args"]
+            # And also set as cwd in the YAML config
+            assert server_config["cwd"] == str(project_dir)
+
+    def test_install_continue_yaml_format(self, tmp_path):
+        """Test that the YAML file follows Continue's block schema."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            install_continue(
+                file=Path("/path/to/server.py"),
+                server_object=None,
+                name="test-server",
+            )
+
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+
+            # Verify it's valid YAML following Continue block schema
+            yaml_data = yaml.safe_load(config_file.read_text())
+            assert isinstance(yaml_data, dict)
+            
+            # Block metadata fields
+            assert "name" in yaml_data
+            assert yaml_data["name"] == "test-server"
+            assert "version" in yaml_data
+            assert "schema" in yaml_data
+            assert "mcpServers" in yaml_data
+            assert isinstance(yaml_data["mcpServers"], list)
+            assert len(yaml_data["mcpServers"]) == 1
+            
+            # Server config within mcpServers array
+            server_config = yaml_data["mcpServers"][0]
+            assert "name" in server_config
+            assert server_config["name"] == "test-server"
+            assert "type" in server_config
+            assert server_config["type"] == "stdio"
+            assert "command" in server_config
+            assert server_config["command"] == "uv"
+            
+            # Optional fields
+            if "args" in server_config:
+                assert isinstance(server_config["args"], list)
+            if "env" in server_config:
+                assert isinstance(server_config["env"], dict)
+
+    def test_install_continue_creates_directory(self, tmp_path):
+        """Test that installation creates the mcpServers directory if it doesn't exist."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        mcp_servers_dir = mock_home / ".continue" / "mcpServers"
+        assert not mcp_servers_dir.exists()
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            result = install_continue(
+                file=Path("/path/to/server.py"),
+                server_object=None,
+                name="test-server",
+            )
+
+            assert result is True
+            assert mcp_servers_dir.exists()
+            assert mcp_servers_dir.is_dir()
+
+    def test_install_continue_no_env_no_cwd(self, tmp_path):
+        """Test that env and cwd are not included when not provided."""
+        mock_home = tmp_path / "mock_home"
+        mock_home.mkdir()
+
+        with patch("fastmcp.cli.install.continue_client.Path.home", return_value=mock_home):
+            install_continue(
+                file=Path("/path/to/server.py"),
+                server_object=None,
+                name="test-server",
+            )
+
+            config_file = mock_home / ".continue" / "mcpServers" / "test-server.yaml"
+            yaml_data = yaml.safe_load(config_file.read_text())
+            server_config = yaml_data["mcpServers"][0]
+            
+            # Optional fields should not be present when not provided
+            assert "env" not in server_config
+            assert "cwd" not in server_config
+
+
+class TestContinueClientCommand:
+    """Test the Continue client CLI command."""
+
+    @patch("fastmcp.cli.install.continue_client.install_continue")
+    @patch("fastmcp.cli.install.continue_client.process_common_args")
+    async def test_continue_command_basic(self, mock_process_args, mock_install):
+        """Test basic Continue client command execution."""
+        mock_process_args.return_value = (
+            Path("server.py"),
+            None,
+            "test-server",
+            [],
+            {},
+        )
+        mock_install.return_value = True
+
+        with patch("sys.exit") as mock_exit:
+            await continue_command("server.py")
+
+        mock_install.assert_called_once_with(
+            file=Path("server.py"),
+            server_object=None,
+            name="test-server",
+            with_editable=[],
+            with_packages=[],
+            env_vars={},
+            python_version=None,
+            with_requirements=None,
+            project=None,
+        )
+        mock_exit.assert_not_called()
+
+    @patch("fastmcp.cli.install.continue_client.install_continue")
+    @patch("fastmcp.cli.install.continue_client.process_common_args")
+    async def test_continue_command_with_options(self, mock_process_args, mock_install):
+        """Test Continue client command with all options."""
+        mock_process_args.return_value = (
+            Path("server.py"),
+            "app",
+            "my-server",
+            ["numpy"],
+            {"API_KEY": "test"},
+        )
+        mock_install.return_value = True
+
+        await continue_command(
+            "server.py",
+            server_name="my-server",
+            with_packages=["numpy"],
+            env_vars=["API_KEY=test"],
+            python="3.11",
+        )
+
+        mock_install.assert_called_once()
+        call_kwargs = mock_install.call_args[1]
+        assert call_kwargs["python_version"] == "3.11"
+
+    @patch("fastmcp.cli.install.continue_client.install_continue")
+    @patch("fastmcp.cli.install.continue_client.process_common_args")
+    async def test_continue_command_failure(self, mock_process_args, mock_install):
+        """Test Continue client command when installation fails."""
+        mock_process_args.return_value = (
+            Path("server.py"),
+            None,
+            "test-server",
+            [],
+            {},
+        )
+        mock_install.return_value = False
+
+        with pytest.raises(SystemExit) as exc_info:
+            await continue_command("server.py")
+
+        assert isinstance(exc_info.value, SystemExit)
+        assert exc_info.value.code == 1
+        assert exc_info.value.code == 1


### PR DESCRIPTION
Adds support for fastmcp install continue, which installs configuration to a user's global `.continue/mcpServers` in Continue's native YAML format

## Description
<!-- 
Please provide a clear and concise description of the changes made in this pull request.

Using AI to generate code? Please include a note in the description with which AI tool you used.
-->

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes #2258
- [ ] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
