### PR TITLE
[Draft] Convert BulkToolCaller to middleware

### DIFF
--- a/src/fastmcp/contrib/bulk_tool_caller/bulk_tool_caller.py
+++ b/src/fastmcp/contrib/bulk_tool_caller/bulk_tool_caller.py
@@ -118,9 +118,6 @@ class BulkToolCaller(MCPMixin):
         async with Client(self.connection) as client:
             result = await client.call_tool_mcp(name=tool, arguments=arguments)
 
-            return CallToolRequestResult(
-                tool=tool,
-                arguments=arguments,
-                isError=result.isError,
-                content=result.content,
+            return CallToolRequestResult.from_call_tool_result(
+                result, tool=tool, arguments=arguments
             )

--- a/src/fastmcp/server/middleware/__init__.py
+++ b/src/fastmcp/server/middleware/__init__.py
@@ -1,8 +1,13 @@
+from typing import TYPE_CHECKING
+
 from .middleware import (
     Middleware,
     MiddlewareContext,
     CallNext,
 )
+
+if TYPE_CHECKING:
+    from .bulk_tool_caller import BulkToolCallerMiddleware
 
 
 def __getattr__(name: str):
@@ -11,6 +16,11 @@ def __getattr__(name: str):
 
         return BulkToolCallerMiddleware
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Ensure BulkToolCallerMiddleware shows up in dir() output."""
+    return sorted([*globals().keys(), "BulkToolCallerMiddleware"])
 
 
 __all__ = [

--- a/src/fastmcp/server/middleware/bulk_tool_caller.py
+++ b/src/fastmcp/server/middleware/bulk_tool_caller.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import TextContent
 
 from fastmcp.server.context import Context
 from fastmcp.server.middleware.bulk_tool_caller_types import (
@@ -46,16 +46,15 @@ async def call_tools_bulk(
                 key=tool_call.tool, arguments=tool_call.arguments
             )
 
-            # Convert ToolResult to CallToolResult
-            # Don't set isError - it defaults to None for successful calls
-            call_tool_result = CallToolResult(
-                content=tool_result.content,
-            )
-
-            # Convert to CallToolRequestResult
+            # Convert ToolResult to CallToolRequestResult, preserving all fields
+            # Note: ToolResult doesn't have isError - it's only on CallToolResult
+            # For successful calls, we don't set isError (defaults to None)
             results.append(
-                CallToolRequestResult.from_call_tool_result(
-                    call_tool_result, tool_call.tool, tool_call.arguments
+                CallToolRequestResult(
+                    tool=tool_call.tool,
+                    arguments=tool_call.arguments,
+                    content=tool_result.content,
+                    structuredContent=tool_result.structured_content,
                 )
             )
         except Exception as e:
@@ -111,16 +110,15 @@ async def call_tool_bulk(
                 key=tool, arguments=args
             )
 
-            # Convert ToolResult to CallToolResult
-            # Don't set isError - it defaults to None for successful calls
-            call_tool_result = CallToolResult(
-                content=tool_result.content,
-            )
-
-            # Convert to CallToolRequestResult
+            # Convert ToolResult to CallToolRequestResult, preserving all fields
+            # Note: ToolResult doesn't have isError - it's only on CallToolResult
+            # For successful calls, we don't set isError (defaults to None)
             results.append(
-                CallToolRequestResult.from_call_tool_result(
-                    call_tool_result, tool, args
+                CallToolRequestResult(
+                    tool=tool,
+                    arguments=args,
+                    content=tool_result.content,
+                    structuredContent=tool_result.structured_content,
                 )
             )
         except Exception as e:

--- a/src/fastmcp/server/middleware/bulk_tool_caller_types.py
+++ b/src/fastmcp/server/middleware/bulk_tool_caller_types.py
@@ -36,4 +36,6 @@ class CallToolRequestResult(CallToolResult):
             arguments=arguments,
             isError=result.isError,
             content=result.content,
+            _meta=getattr(result, "_meta", None),
+            structuredContent=getattr(result, "structuredContent", None),
         )

--- a/tests/server/middleware/test_bulk_tool_caller.py
+++ b/tests/server/middleware/test_bulk_tool_caller.py
@@ -29,7 +29,11 @@ def server_with_tools():
 
     @mcp.tool
     async def no_return_tool(arg1: str) -> None:
-        """A simple tool that returns nothing."""
+        """A simple tool that returns nothing.
+
+        Returns:
+            None: This tool does not return any value.
+        """
 
     @mcp.tool
     def add(a: int, b: int) -> int:
@@ -78,7 +82,7 @@ class TestBulkToolCallerMiddleware:
                             "_meta": None,
                         }
                     ],
-                    "structuredContent": None,
+                    "structuredContent": {"result": "value1"},
                     "isError": False,
                     "tool": "echo_tool",
                     "arguments": {"arg1": "value1"},
@@ -110,7 +114,7 @@ class TestBulkToolCallerMiddleware:
                             "_meta": None,
                         }
                     ],
-                    "structuredContent": None,
+                    "structuredContent": {"result": "value1"},
                     "isError": False,
                     "tool": "echo_tool",
                     "arguments": {"arg1": "value1"},
@@ -125,7 +129,7 @@ class TestBulkToolCallerMiddleware:
                             "_meta": None,
                         }
                     ],
-                    "structuredContent": None,
+                    "structuredContent": {"result": "value2"},
                     "isError": False,
                     "tool": "echo_tool",
                     "arguments": {"arg1": "value2"},
@@ -197,7 +201,7 @@ class TestBulkToolCallerMiddleware:
                             "_meta": None,
                         }
                     ],
-                    "structuredContent": None,
+                    "structuredContent": {"result": "value1"},
                     "isError": False,
                     "tool": "echo_tool",
                     "arguments": {"arg1": "value1"},


### PR DESCRIPTION
## Summary

Converts the BulkToolCaller from an MCPMixin-based implementation to a ToolInjectionMiddleware, following the pattern established in #2142. This simplifies usage and aligns with other tool injection middleware like PromptToolMiddleware and ResourceToolMiddleware.

## Changes

- Created `BulkToolCallerMiddleware` extending `ToolInjectionMiddleware`
- Added `bulk_tool_caller_types.py` to avoid circular imports
- Deprecated original `BulkToolCaller` with clear migration guidance
- Maintained backward compatibility by re-exporting types
- Added comprehensive test suite for middleware

## Usage

New approach:
```python
mcp = FastMCP(middleware=[BulkToolCallerMiddleware()])
```

Old approach (deprecated):
```python
bulk_tool_caller = BulkToolCaller()
bulk_tool_caller.register_tools(mcp)
```

Closes #2262

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/jlowin/fastmcp/tree/claude/issue-2262-20251026-1426) | [View job run](https://github.com/jlowin/fastmcp/actions/runs/18819279688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk tool calling: execute multiple tools or repeated calls with varied arguments; middleware exposes call_tools_bulk and call_tool_bulk with configurable error handling.

* **Deprecations**
  * BulkToolCaller class marked deprecated; middleware is the recommended approach. Public request/result types re-exported for backward compatibility.

* **Tests**
  * Comprehensive tests covering success, error handling, tag-filter behavior, no-return tools, and deprecation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->