### PR TITLE
fix(docs): correct the key_value repo link

### DIFF
--- a/docs/clients/auth/oauth.mdx
+++ b/docs/clients/auth/oauth.mdx
@@ -83,9 +83,9 @@ Upon approval, the OAuth server redirects the user's browser to the local callba
 </Step>
 <Step title="Token Caching">
 The obtained tokens are saved to the configured `token_storage` backend for future use, eliminating the need for repeated browser interactions.
-</Step> 
+</Step>
 <Step title="Authenticated Requests">
-The access token is automatically included in the `Authorization` header for requests to the MCP server. 
+The access token is automatically included in the `Authorization` header for requests to the MCP server.
 </Step>
 <Step title="Refresh Token">
 If the access token expires, the client will automatically use the refresh token to get a new access token.
@@ -125,4 +125,4 @@ async with Client("https://fastmcp.cloud/mcp", auth=oauth) as client:
     await client.ping()
 ```
 
-You can use any `AsyncKeyValue`-compatible backend from the [key-value library](https://github.com/jlowin/key-value) including Redis, DynamoDB, and more. Wrap your storage in `FernetEncryptionWrapper` for encryption.
+You can use any `AsyncKeyValue`-compatible backend from the [key-value library](https://github.com/strawgate/py-key-value) including Redis, DynamoDB, and more. Wrap your storage in `FernetEncryptionWrapper` for encryption.


### PR DESCRIPTION
## Description

This fixes the link to the `key_value` repo from https://github.com/jlowin/fastmcp/commit/5ceafe425c6b9301c6672e41efb8537ff6c0469f

**Contributors Checklist**

- [X] My change closes #2275
- [X] I have followed the repository's development workflow
- [X] I have tested my changes manually and by adding relevant tests
- [X] I have performed all required documentation updates

**Review Checklist**

- [X] I have self-reviewed my changes
- [X] My Pull Request is ready for review

---
