### PR TITLE
Remove trailing slashes from MCP endpoint URLs

### DIFF
--- a/docs/deployment/http.mdx
+++ b/docs/deployment/http.mdx
@@ -45,7 +45,7 @@ Run your server with a simple Python command:
 python server.py
 ```
 
-Your server is now accessible at `http://localhost:8000/mcp/` (or use your server's actual IP address for remote access).
+Your server is now accessible at `http://localhost:8000/mcp` (or use your server's actual IP address for remote access).
 
 This approach is ideal when you want to get online quickly with minimal configuration. It's perfect for internal tools, development environments, or simple deployments where you don't need advanced server features. The built-in server handles all the HTTP details, letting you focus on your MCP implementation.
 
@@ -72,7 +72,7 @@ Run with any ASGI server - here's an example with Uvicorn:
 uvicorn app:app --host 0.0.0.0 --port 8000
 ```
 
-Your server is accessible at the same URL: `http://localhost:8000/mcp/` (or use your server's actual IP address for remote access).
+Your server is accessible at the same URL: `http://localhost:8000/mcp` (or use your server's actual IP address for remote access).
 
 The ASGI approach shines in production environments where you need reliability and performance. You can run multiple worker processes to handle concurrent requests, add custom middleware for logging or monitoring, integrate with existing deployment pipelines, or mount your MCP server as part of a larger application.
 
@@ -293,7 +293,7 @@ api.mount("/mcp", mcp.http_app())
 # Run with: uvicorn app:api --host 0.0.0.0 --port 8000
 ```
 
-Your existing API remains at `http://localhost:8000/api/` while MCP is available at `http://localhost:8000/mcp/`.
+Your existing API remains at `http://localhost:8000/api` while MCP is available at `http://localhost:8000/mcp`.
 
 ## Mounting Authenticated Servers
 

--- a/docs/deployment/running-server.mdx
+++ b/docs/deployment/running-server.mdx
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     mcp.run(transport="http", host="127.0.0.1", port=8000)
 ```
 
-Your server is now accessible at `http://localhost:8000/mcp/`. This URL is the MCP endpoint that clients will connect to. HTTP transport enables:
+Your server is now accessible at `http://localhost:8000/mcp`. This URL is the MCP endpoint that clients will connect to. HTTP transport enables:
 - Network accessibility
 - Multiple concurrent clients
 - Integration with web infrastructure

--- a/docs/integrations/auth0.mdx
+++ b/docs/integrations/auth0.mdx
@@ -132,7 +132,7 @@ import asyncio
 
 async def main():
     # The client will automatically handle Auth0 OAuth flows
-    async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
+    async with Client("http://localhost:8000/mcp", auth="oauth") as client:
         # First-time connection will open Auth0 login in your browser
         print("✓ Authenticated with Auth0!")
 

--- a/docs/integrations/authkit.mdx
+++ b/docs/integrations/authkit.mdx
@@ -70,7 +70,7 @@ from fastmcp import Client
 import asyncio
 
 async def main():
-    async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
+    async with Client("http://localhost:8000/mcp", auth="oauth") as client:
         assert await client.ping()
 
 if __name__ == "__main__":

--- a/docs/integrations/aws-cognito.mdx
+++ b/docs/integrations/aws-cognito.mdx
@@ -170,7 +170,7 @@ import asyncio
 
 async def main():
     # The client will automatically handle AWS Cognito OAuth
-    async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
+    async with Client("http://localhost:8000/mcp", auth="oauth") as client:
         # First-time connection will open AWS Cognito login in your browser
         print("✓ Authenticated with AWS Cognito!")
 

--- a/docs/integrations/azure.mdx
+++ b/docs/integrations/azure.mdx
@@ -185,7 +185,7 @@ import asyncio
 
 async def main():
     # The client will automatically handle Azure OAuth
-    async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
+    async with Client("http://localhost:8000/mcp", auth="oauth") as client:
         # First-time connection will open Azure login in your browser
         print("✓ Authenticated with Azure!")
         

--- a/docs/integrations/descope.mdx
+++ b/docs/integrations/descope.mdx
@@ -93,7 +93,7 @@ from fastmcp import Client
 import asyncio
 
 async def main():
-    async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
+    async with Client("http://localhost:8000/mcp", auth="oauth") as client:
         assert await client.ping()
 
 if __name__ == "__main__":

--- a/docs/integrations/fastapi.mdx
+++ b/docs/integrations/fastapi.mdx
@@ -366,7 +366,7 @@ combined_app = FastAPI(
 
 # Now you have:
 # - Regular API: http://localhost:8000/products
-# - LLM-friendly MCP: http://localhost:8000/mcp/
+# - LLM-friendly MCP: http://localhost:8000/mcp
 # Both served from the same FastAPI application!
 ```
 

--- a/docs/integrations/github.mdx
+++ b/docs/integrations/github.mdx
@@ -114,7 +114,7 @@ import asyncio
 
 async def main():
     # The client will automatically handle GitHub OAuth
-    async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
+    async with Client("http://localhost:8000/mcp", auth="oauth") as client:
         # First-time connection will open GitHub login in your browser
         print("✓ Authenticated with GitHub!")
         

--- a/docs/integrations/google.mdx
+++ b/docs/integrations/google.mdx
@@ -125,7 +125,7 @@ import asyncio
 
 async def main():
     # The client will automatically handle Google OAuth
-    async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
+    async with Client("http://localhost:8000/mcp", auth="oauth") as client:
         # First-time connection will open Google login in your browser
         print("✓ Authenticated with Google!")
         

--- a/docs/tutorials/rest-api.mdx
+++ b/docs/tutorials/rest-api.mdx
@@ -103,7 +103,7 @@ from fastmcp import Client
 
 async def main():
     # Connect to the MCP server we just created
-    async with Client("http://127.0.0.1:8000/mcp/") as client:
+    async with Client("http://127.0.0.1:8000/mcp") as client:
         
         # List the tools that were automatically generated
         tools = await client.list_tools()


### PR DESCRIPTION
The default MCP endpoint is `/mcp` (no trailing slash), but docs were showing client URLs with trailing slashes like `http://localhost:8000/mcp/`. This mismatch causes 307 redirects that break OAuth flows.

**Before:**
```python
async with Client("http://localhost:8000/mcp/", auth="oauth") as client:
```

**After:**
```python
async with Client("http://localhost:8000/mcp", auth="oauth") as client:
```

Fixes #2273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated endpoint URL examples across deployment and integration guides for consistent path formatting.
  * Added documentation for remote deployment capabilities in HTTP transport features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->