### PR TITLE
Switch to `logger.exception` for `fastmcp run/inspect`

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -502,9 +502,8 @@ async def run(
             process = subprocess.run(cmd, check=True, env=env)
             sys.exit(process.returncode)
         except subprocess.CalledProcessError as e:
-            logger.error(
+            logger.exception(
                 f"Failed to run: {e}",
-                exc_info=True,
                 extra={
                     "server_spec": server_spec,
                     "error": str(e),
@@ -527,9 +526,8 @@ async def run(
                 skip_source=skip_source,
             )
         except Exception as e:
-            logger.error(
+            logger.exception(
                 f"Failed to run: {e}",
-                exc_info=True,
                 extra={
                     "server_spec": server_spec,
                     "error": str(e),
@@ -768,13 +766,12 @@ async def inspect(
             console.print(formatted_json.decode("utf-8"))
 
     except Exception as e:
-        logger.error(
+        logger.exception(
             f"Failed to inspect server: {e}",
             extra={
                 "server_spec": server_spec,
                 "error": str(e),
             },
-            exc_info=True,
         )
         console.print(f"[bold red]✗[/bold red] Failed to inspect server: {e}")
         sys.exit(1)


### PR DESCRIPTION
This prior [PR](https://github.com/jlowin/fastmcp/pull/2232) added `exc_info=True` to the error handling in `fastmcp inspect ...`. 

With similar motivation, this PR switches the `logger.error` -> `logger.exception` for the `fastmcp run` command (and also adds it to the inspect command). This makes it 100% clear where the error is coming from, where as before there was not even a file or line number, making this difficult to debug.

### Example
```python
# server.py
import asyncio
from fastmcp import FastMCP

mcp = FastMCP("Demo 🚀")

@mcp.tool
def add(a: int, b: int) -> int:
    """Add two numbers"""
    return a + b

asyncio.run(mcp.run())
```

### Before
<img width="1287" height="111" alt="Screenshot 2025-10-28 at 10 22 08 AM" src="https://github.com/user-attachments/assets/c60cc1cf-d312-447e-bffe-626165cba067" />


### Now
<img width="1265" height="485" alt="Screenshot 2025-10-28 at 10 21 58 AM" src="https://github.com/user-attachments/assets/07eb58b9-496b-4715-89ab-63973b5bbdae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting to consistently include full stack traces when CLI operations fail, providing clearer diagnostic information for troubleshooting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->