### PR TITLE
Fix Chrome CSP blocking OAuth consent form with custom protocol redirects

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy.py
@@ -365,9 +365,19 @@ def create_consent_html(
     )
 
     # Need to allow form-action for form submission
-    # Explicitly allow https: and http: schemes (not wildcard) to work with Chrome
-    # when redirect chains end in custom protocol schemes like cursor://
-    csp_policy = "default-src 'none'; style-src 'unsafe-inline'; img-src https:; base-uri 'none'; form-action https: http:"
+    # Chrome requires explicit scheme declarations in CSP form-action when redirect chains
+    # end in custom protocol schemes (e.g., cursor://). Parse redirect_uri to include its scheme.
+    parsed_redirect = urlparse(redirect_uri)
+    redirect_scheme = parsed_redirect.scheme.lower()
+
+    # Build form-action directive with standard schemes plus custom protocol if present
+    form_action_schemes = ["https:", "http:"]
+    if redirect_scheme and redirect_scheme not in ("http", "https"):
+        # Custom protocol scheme (e.g., cursor:, vscode:, etc.)
+        form_action_schemes.append(f"{redirect_scheme}:")
+
+    form_action_directive = " ".join(form_action_schemes)
+    csp_policy = f"default-src 'none'; style-src 'unsafe-inline'; img-src https:; base-uri 'none'; form-action {form_action_directive}"
 
     return create_page(
         content=content,


### PR DESCRIPTION
Fixes #2302

Chrome blocks OAuth consent form submissions when redirect chains terminate in custom protocol schemes like `cursor://`. The CSP `form-action *` directive doesn't match custom protocols in Chrome's implementation, causing form submissions to be blocked even though the form itself submits to HTTPS.

The fix dynamically extracts the scheme from the redirect URI and includes it explicitly in the CSP directive. For a redirect URI like `cursor://anysphere.cursor-mcp/oauth/callback`, the CSP becomes `form-action https: http: cursor:` instead of `form-action *`, allowing Chrome to validate the entire redirect chain.

```python
# Parse redirect URI and include custom protocol scheme in CSP
parsed_redirect = urlparse(redirect_uri)
redirect_scheme = parsed_redirect.scheme.lower()
form_action_schemes = ["https:", "http:"]
if redirect_scheme and redirect_scheme not in ("http", "https"):
    form_action_schemes.append(f"{redirect_scheme}:")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened consent page security by tightening form submission policies: form-action now allows only explicit schemes derived from the redirect target (plus standard http/https), removing the previous wildcard to reduce unsafe submissions and improve browser compatibility and redirect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->