### PR TITLE
Add base_authority parameter to AzureProvider for Azure Government support

### DIFF
--- a/docs/integrations/azure.mdx
+++ b/docs/integrations/azure.mdx
@@ -128,6 +128,7 @@ auth_provider = AzureProvider(
     # Optional: request additional upstream scopes in the authorize request
     # additional_authorize_scopes=["User.Read", "offline_access", "openid", "email"],
     # redirect_path="/auth/callback"                  # Default value, customize if needed
+    # base_authority="login.microsoftonline.us"      # For Azure Government (default: login.microsoftonline.com)
 )
 
 mcp = FastMCP(name="Azure Secured App", auth=auth_provider)
@@ -314,6 +315,15 @@ Comma-, space-, or JSON-separated list of additional scopes to include in the au
 
 <ParamField path="FASTMCP_SERVER_AUTH_AZURE_IDENTIFIER_URI" default="api://{client_id}">
 Application ID URI used to prefix scopes during authorization.
+</ParamField>
+
+<ParamField path="FASTMCP_SERVER_AUTH_AZURE_BASE_AUTHORITY" default="login.microsoftonline.com">
+Azure authority base URL. Override this to use Azure Government:
+
+- `login.microsoftonline.com` - Azure Public Cloud (default)
+- `login.microsoftonline.us` - Azure Government
+
+This setting affects all Azure OAuth endpoints (authorization, token, issuer, JWKS).
 </ParamField>
 </Card>
 


### PR DESCRIPTION
Adds `base_authority` parameter to `AzureProvider` to allow overriding the Azure authority endpoint. This enables support for Azure Government (`login.microsoftonline.us`) and other Azure clouds.

The parameter defaults to `login.microsoftonline.com` for backward compatibility. When set to `login.microsoftonline.us`, all Azure OAuth endpoints (authorization, token, issuer, JWKS) use the Azure Government endpoints.

Example usage:

```python
auth = AzureProvider(
    client_id="your-client-id",
    client_secret="your-client-secret",
    tenant_id="your-tenant-id",
    required_scopes=["read", "write"],
    base_authority="login.microsoftonline.us",  # For Azure Government
    base_url="http://localhost:8000",
)
```

Fixes #2301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Government cloud deployment via configurable authority base URL parameter.

* **Documentation**
  * Updated Azure integration documentation with base authority configuration options and examples for public and government clouds.

* **Tests**
  * Added comprehensive test coverage for authority configuration scenarios, including Azure Government and environment variable overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->