### PR TITLE
Require uvicorn>=0.35 for websockets-sansio support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic[email]>=2.11.7",
     "pyperclip>=1.9.0",
     "py-key-value-aio[disk,keyring,memory]>=0.2.8,<0.3.0",
+    "uvicorn>=0.35",
     "websockets>=15.0.1",
     "jsonschema-path>=0.3.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -593,6 +593,7 @@ dependencies = [
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "uvicorn" },
     { name = "websockets" },
 ]
 
@@ -644,6 +645,7 @@ requires-dist = [
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "rich", specifier = ">=13.9.4" },
+    { name = "uvicorn", specifier = ">=0.35" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
 provides-extras = ["openai"]


### PR DESCRIPTION
Fixes the `KeyError: 'websockets-sansio'` error when running FastMCP servers with HTTP or streamable-HTTP transport.

The `websockets-sansio` protocol was added in uvicorn 0.35, but FastMCP can implicitly get earlier versions of uvicorn from package dependencies. This caused runtime errors when uvicorn tried to load the websocket protocol. We use websockets-sansio because standard websockets leads to a confusing deprecation error. See: https://uvicorn.dev/concepts/websockets/#websockets-sansio-protocol

This PR adds an explicit `uvicorn>=0.35` constraint to ensure the required protocol is available.

Fixes #2299

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to include uvicorn>=0.35.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->