### PR TITLE
Add OIDCProxy to auth module exports

### DIFF
--- a/src/fastmcp/server/auth/__init__.py
+++ b/src/fastmcp/server/auth/__init__.py
@@ -7,6 +7,7 @@ from .auth import (
 )
 from .providers.jwt import JWTVerifier, StaticTokenVerifier
 from .oauth_proxy import OAuthProxy
+from .oidc_proxy import OIDCProxy
 
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "JWTVerifier",
     "OAuthProvider",
     "OAuthProxy",
+    "OIDCProxy",
     "RemoteAuthProvider",
     "StaticTokenVerifier",
     "TokenVerifier",


### PR DESCRIPTION
Fixes #2298

Adds the missing `OIDCProxy` import and export to the auth module's `__init__.py` file. This allows users to import `OIDCProxy` directly from `fastmcp.server.auth` instead of requiring the full path `fastmcp.server.auth.oidc_proxy.OIDCProxy`.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenID Connect authentication proxy functionality is now available as part of the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->