### PR TITLE
Add maturity warnings for py-key-value backends

### DIFF
--- a/docs/clients/auth/oauth.mdx
+++ b/docs/clients/auth/oauth.mdx
@@ -126,3 +126,7 @@ async with Client("https://fastmcp.cloud/mcp", auth=oauth) as client:
 ```
 
 You can use any `AsyncKeyValue`-compatible backend from the [key-value library](https://github.com/strawgate/py-key-value) including Redis, DynamoDB, and more. Wrap your storage in `FernetEncryptionWrapper` for encryption.
+
+<Note>
+When selecting a storage backend, review the [py-key-value documentation](https://github.com/strawgate/py-key-value) to understand the maturity level and limitations of your chosen backend. Some backends may be in preview or have constraints that affect production suitability.
+</Note>

--- a/docs/servers/storage-backends.mdx
+++ b/docs/servers/storage-backends.mdx
@@ -143,6 +143,10 @@ The py-key-value-aio library includes additional implementations for various sto
 
 For configuration details on these backends, consult the [py-key-value-aio documentation](https://github.com/strawgate/py-key-value).
 
+<Warning>
+Before using these backends in production, review the [py-key-value documentation](https://github.com/strawgate/py-key-value) to understand the maturity level and limitations of your chosen backend. Some backends may be in preview or have specific constraints that make them unsuitable for production use.
+</Warning>
+
 ## Use Cases in FastMCP
 
 ### Server-Side OAuth Token Storage


### PR DESCRIPTION
Adds warning notes to documentation directing users to review py-key-value documentation for backend maturity and limitations before production use.

Changes:
- `docs/servers/storage-backends.mdx`: Added Warning callout after alternative backends list
- `docs/clients/auth/oauth.mdx`: Added Note callout for token storage backend selection

Fixes #2310

----
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added informational notes about backend maturity and production readiness considerations.
  * Added warnings regarding backend limitations and production suitability for key-value storage options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->