### PR TITLE
Configure Marvin to auto-create PRs and label issues

### DIFF
--- a/.github/workflows/marvin.yml
+++ b/.github/workflows/marvin.yml
@@ -75,5 +75,5 @@ jobs:
               "env": {
                 "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}"
               },
-              "customInstructions": "When you complete work on an issue, ALWAYS create a pull request using the mcp__github__create_pull_request tool instead of just posting a link. After creating the PR, add the 'marvin-pr' label to the original issue using mcp__github__update_issue. Follow the PR message guidelines in CLAUDE.md."
+              "customInstructions": "When you complete work on an issue: (1) You MUST create a pull request using the mcp__github__create_pull_request tool instead of posting a link, and (2) You MUST add the 'marvin-pr' label to the original issue using mcp__github__update_issue. Even if PR creation fails and you post a link instead, you MUST still add the 'marvin-pr' label. Follow the PR message guidelines in CLAUDE.md."
             }


### PR DESCRIPTION
Currently when Marvin completes work on an issue, it creates a branch and posts a GitHub link for manual PR creation. This adds friction and makes it hard to track which issues have pending work.

This change adds custom instructions to the Marvin workflow telling it to:

1. **Auto-create PRs**: Use `mcp__github__create_pull_request` instead of posting links
2. **Label issues**: Add the "marvin-pr" label to issues after completing work, even if PR creation fails

Now you can filter issues by the "marvin-pr" label to see which ones have pending PRs from Marvin.

```yaml
"customInstructions": "When you complete work on an issue: (1) You MUST create a pull request using the mcp__github__create_pull_request tool instead of posting a link, and (2) You MUST add the 'marvin-pr' label to the original issue using mcp__github__update_issue. Even if PR creation fails and you post a link instead, you MUST still add the 'marvin-pr' label. Follow the PR message guidelines in CLAUDE.md."
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration with enhanced procedural directives for automated pull request creation and issue labeling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->