### PR TITLE
Fix query-only resource templates not matching URIs without query strings

### DIFF
--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -236,7 +236,7 @@ class ResourceManager:
         # Then check templates (local and mounted) only if not found in concrete resources
         templates = await self.get_resource_templates()
         for template_key in templates:
-            if match_uri_template(uri_str, template_key):
+            if match_uri_template(uri_str, template_key) is not None:
                 return True
 
         return False

--- a/tests/resources/test_resource_manager.py
+++ b/tests/resources/test_resource_manager.py
@@ -647,6 +647,31 @@ class TestQueryOnlyTemplates:
         content = await manager.read_resource("data://items?format=xml&limit=20")
         assert content == "Data in xml (limit: 20)"
 
+    async def test_has_resource_with_query_only_template(self):
+        """Test that has_resource() works with query-only templates.
+
+        Regression test for bug where empty parameter dict {} was treated as falsy,
+        causing has_resource() to return False for query-only templates when no
+        query string was provided.
+        """
+        manager = ResourceManager()
+
+        def get_config(format: str = "json") -> str:
+            return f"Config in {format} format"
+
+        template = ResourceTemplate.from_function(
+            fn=get_config,
+            uri_template="data://config{?format}",
+            name="config",
+        )
+        manager.add_template(template)
+
+        # Should find resource without query param (uses default)
+        assert await manager.has_resource("data://config")
+
+        # Should also find resource with query param
+        assert await manager.has_resource("data://config?format=xml")
+
 
 class TestResourceErrorHandling:
     """Test error handling in the ResourceManager."""


### PR DESCRIPTION
## Description

Resource templates with only query parameters (no path parameters) weren't matching URIs when the query string was omitted, even though the query parameters had default values. A template like `data://config{?format}` would fail to match `data://config`, incorrectly raising `NotFoundError`.

This happened because `match_uri_template()` returns an empty `dict` when a template matches but extracts no parameters. Two places in `ResourceManager` used walrus operator truthiness checks that treated `{}` as falsy, causing valid matches to be skipped.

```python
# Before (bug)
if params := match_uri_template(uri_str, key): ...
    # {} is falsy, so this block is skipped!

# After (fixed)
if (params := match_uri_template(uri_str, key)) is not None: ...
    # {} is truthy with 'is not None', so this block executes
```

Example:

```python
from fastmcp import FastMCP, Client

mcp = FastMCP()

@mcp.resource("data://config{?format}")
def get_config(format: str = "json") -> str:
    return f"Config in {format} format"

async with Client(mcp) as client:
    # Now works - uses default format="json"
    result = await client.read_resource("data://config")

    # Also works - overrides with format="xml"
    result = await client.read_resource("data://config?format=xml")
```

Templates with at least one path parameter were unaffected because the params dict was never empty.

**Edit**: CodeRabbit AI code review identified a third location with the same bug in `has_resource()` at line 239. Added test coverage and applied the same fix to ensure `has_resource()` correctly identifies query-only templates.

_Generated with OpenCode and Claude Sonnet 4.5_

**Contributors Checklist**

- [x] My change closes #2322
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened template matching checks to avoid false-positive matches and ensure parameters are preserved when a match exists.

* **Tests**
  * Added test coverage for templates using only query parameters (defaults, overrides, multiple params).
  * Note: an identical test class was unintentionally duplicated in the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->