### PR TITLE
Remove deprecated FASTMCP_SERVER_ environment variable prefix

### DIFF
--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -8,11 +8,8 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from platformdirs import user_data_dir
 from pydantic import Field, ImportString, field_validator
-from pydantic.fields import FieldInfo
 from pydantic_settings import (
     BaseSettings,
-    EnvSettingsSource,
-    PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
 from typing_extensions import Self
@@ -31,37 +28,6 @@ TEN_MB_IN_BYTES = 1024 * 1024 * 10
 
 if TYPE_CHECKING:
     from fastmcp.server.auth.auth import AuthProvider
-
-
-class ExtendedEnvSettingsSource(EnvSettingsSource):
-    """
-    A special EnvSettingsSource that allows for multiple env var prefixes to be used.
-
-    Raises a deprecation warning if the old `FASTMCP_SERVER_` prefix is used.
-    """
-
-    def get_field_value(
-        self, field: FieldInfo, field_name: str
-    ) -> tuple[Any, str, bool]:
-        if prefixes := self.config.get("env_prefixes"):
-            for prefix in prefixes:
-                self.env_prefix = prefix
-                env_val, field_key, value_is_complex = super().get_field_value(
-                    field, field_name
-                )
-                if env_val is not None:
-                    if prefix == "FASTMCP_SERVER_":
-                        # Deprecated in 2.8.0
-                        logger.warning(
-                            "Using `FASTMCP_SERVER_` environment variables is deprecated. Use `FASTMCP_` instead.",
-                        )
-                    return env_val, field_key, value_is_complex
-
-        return super().get_field_value(field, field_name)
-
-
-class ExtendedSettingsConfigDict(SettingsConfigDict, total=False):
-    env_prefixes: list[str] | None
 
 
 class ExperimentalSettings(BaseSettings):
@@ -86,8 +52,8 @@ class ExperimentalSettings(BaseSettings):
 class Settings(BaseSettings):
     """FastMCP settings."""
 
-    model_config = ExtendedSettingsConfigDict(
-        env_prefixes=["FASTMCP_", "FASTMCP_SERVER_"],
+    model_config = SettingsConfigDict(
+        env_prefix="FASTMCP_",
         env_file=ENV_FILE,
         extra="ignore",
         env_nested_delimiter="__",
@@ -120,24 +86,6 @@ class Settings(BaseSettings):
                 raise AttributeError(f"Setting {parent_attr} does not exist.")
             settings = getattr(settings, parent_attr)
         setattr(settings, attr, value)
-
-    @classmethod
-    def settings_customise_sources(
-        cls,
-        settings_cls: type[BaseSettings],
-        init_settings: PydanticBaseSettingsSource,
-        env_settings: PydanticBaseSettingsSource,
-        dotenv_settings: PydanticBaseSettingsSource,
-        file_secret_settings: PydanticBaseSettingsSource,
-    ) -> tuple[PydanticBaseSettingsSource, ...]:
-        # can remove this classmethod after deprecated FASTMCP_SERVER_ prefix is
-        # removed
-        return (
-            init_settings,
-            ExtendedEnvSettingsSource(settings_cls),
-            dotenv_settings,
-            file_secret_settings,
-        )
 
     @property
     def settings(self) -> Self:

--- a/tests/deprecated/test_settings.py
+++ b/tests/deprecated/test_settings.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from unittest.mock import patch
 
@@ -302,39 +301,6 @@ class TestDeprecatedServerInitKwargs:
         # This verifies the stacklevel is working as intended (pointing to constructor)
         warning = deprecation_warnings[0]
         assert "server.py" in warning.filename
-
-
-class TestDeprecatedEnvironmentVariables:
-    """Test deprecated environment variable prefixes."""
-
-    def test_fastmcp_server_env_var_deprecation_warning(self, caplog):
-        """Test that FASTMCP_SERVER_ environment variables emit deprecation warnings."""
-        env_var_name = "FASTMCP_SERVER_HOST"
-        original_value = os.environ.get(env_var_name)
-
-        try:
-            os.environ[env_var_name] = "192.168.1.1"
-
-            with caplog_for_fastmcp(caplog):
-                settings = Settings()
-
-            # Check that a warning was logged
-            assert any(
-                "Using `FASTMCP_SERVER_` environment variables is deprecated. Use `FASTMCP_` instead."
-                in record.message
-                for record in caplog.records
-                if record.levelname == "WARNING"
-            )
-
-            # Verify the setting is still applied
-            assert settings.host == "192.168.1.1"
-
-        finally:
-            # Clean up environment variable
-            if original_value is not None:
-                os.environ[env_var_name] = original_value
-            else:
-                os.environ.pop(env_var_name, None)
 
 
 class TestDeprecatedSettingsProperty:


### PR DESCRIPTION
Removes support for the `FASTMCP_SERVER_` environment variable prefix, deprecated in 2.8.0.

Users should use the `FASTMCP_` prefix instead for all FastMCP settings.

**Changes:**
- Removed `ExtendedEnvSettingsSource` class
- Removed `ExtendedSettingsConfigDict` class  
- Updated `Settings.model_config` to use standard `SettingsConfigDict` with `env_prefix="FASTMCP_"`
- Removed `settings_customise_sources` classmethod
- Removed test class `TestDeprecatedEnvironmentVariables`
- Cleaned up unused imports

Closes #2185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified environment variable configuration by consolidating to a single prefix, removing support for multi-prefix configurations.
  * Streamlined internal settings model by eliminating custom environment variable source extensions.

* **Tests**
  * Removed deprecated environment variable tests while maintaining coverage for other deprecated features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->