### PR TITLE
Remove test warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,11 @@ fallback-version = "0.0.0"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 # filterwarnings = ["error::DeprecationWarning"]
+filterwarnings = [
+    # Suppress OAuth in-memory token storage warnings in tests
+    # Tests intentionally use ephemeral storage; this warning is for end users
+    "ignore:Using in-memory token storage:UserWarning",
+]
 timeout = 5
 env = [
     "FASTMCP_TEST_MODE=1",

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -94,10 +94,13 @@ async def nested_sse_server():
     from starlette.applications import Starlette
     from starlette.routing import Mount
 
+    from fastmcp.server.http import create_sse_app
     from fastmcp.utilities.http import find_available_port
 
     server = create_test_server()
-    sse_app = server.sse_app(path="/mcp/sse/", message_path="/mcp/messages")
+    sse_app = create_sse_app(
+        server=server, message_path="/mcp/messages", sse_path="/mcp/sse/"
+    )
 
     # Nest the app under multiple mounts to test URL resolution
     inner = Starlette(routes=[Mount("/nest-inner", app=sse_app)])


### PR DESCRIPTION
Removes all warnings from the test suite by addressing two sources of noise:

**Deprecated SSE app creation** - Updated `tests/client/test_sse.py:100` to use `create_sse_app()` directly instead of the deprecated `server.sse_app()` method:

```python
from fastmcp.server.http import create_sse_app

sse_app = create_sse_app(
    server=server, 
    message_path="/mcp/messages", 
    sse_path="/mcp/sse/"
)
```

**OAuth in-memory token storage warnings** - Added pytest warning filter to suppress informational warnings about ephemeral token storage. These warnings are helpful for end users but not relevant in tests, which intentionally use ephemeral storage to avoid leaving artifacts:

```toml
filterwarnings = [
    "ignore:Using in-memory token storage:UserWarning",
]
```

All 229 client tests now pass with zero warnings.