### PR TITLE
Remove deprecated Context.get_http_request method

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
-import warnings
 import weakref
 from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
@@ -39,8 +38,6 @@ from pydantic.networks import AnyUrl
 from starlette.requests import Request
 from typing_extensions import TypeVar
 
-import fastmcp.server.dependencies
-from fastmcp import settings
 from fastmcp.server.elicitation import (
     AcceptedElicitation,
     CancelledElicitation,
@@ -637,21 +634,6 @@ class Context:
         else:
             # This should never happen, but handle it just in case
             raise ValueError(f"Unexpected elicitation action: {result.action}")
-
-    def get_http_request(self) -> Request:
-        """Get the active starlette request."""
-
-        # Deprecated in 2.2.11
-        if settings.deprecation_warnings:
-            warnings.warn(
-                "Context.get_http_request() is deprecated and will be removed in a future version. "
-                "Use get_http_request() from fastmcp.server.dependencies instead. "
-                "See https://gofastmcp.com/servers/context#http-requests for more details.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        return fastmcp.server.dependencies.get_http_request()
 
     def set_state(self, key: str, value: Any) -> None:
         """Set a value in the context state."""

--- a/tests/server/test_context.py
+++ b/tests/server/test_context.py
@@ -1,67 +1,13 @@
-import warnings
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from mcp.types import ModelPreferences
-from starlette.requests import Request
 
 from fastmcp.server.context import (
     Context,
     _parse_model_preferences,
 )
 from fastmcp.server.server import FastMCP
-
-
-class TestContextDeprecations:
-    def test_get_http_request_deprecation_warning(self):
-        """Test that using Context.get_http_request() raises a deprecation warning."""
-        # Create a mock FastMCP instance
-        mock_fastmcp = MagicMock()
-        context = Context(fastmcp=mock_fastmcp)
-
-        # Patch the dependency function to return a mock request
-        mock_request = MagicMock(spec=Request)
-        with patch(
-            "fastmcp.server.dependencies.get_http_request", return_value=mock_request
-        ):
-            # Check that the deprecation warning is raised
-            with pytest.warns(
-                DeprecationWarning, match="Context.get_http_request\\(\\) is deprecated"
-            ):
-                request = context.get_http_request()
-
-            # Verify the function still works and returns the request
-            assert request is mock_request
-
-    def test_get_http_request_deprecation_message(self):
-        """Test that the deprecation warning has the correct message with guidance."""
-        # Create a mock FastMCP instance
-        mock_fastmcp = MagicMock()
-        context = Context(fastmcp=mock_fastmcp)
-
-        # Patch the dependency function to return a mock request
-        mock_request = MagicMock(spec=Request)
-        with patch(
-            "fastmcp.server.dependencies.get_http_request", return_value=mock_request
-        ):
-            # Capture and check the specific warning message
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                context.get_http_request()
-
-                assert len(w) == 1
-                warning = w[0]
-                assert issubclass(warning.category, DeprecationWarning)
-                assert "Context.get_http_request() is deprecated" in str(
-                    warning.message
-                )
-                assert (
-                    "Use get_http_request() from fastmcp.server.dependencies instead"
-                    in str(warning.message)
-                )
-                assert "https://gofastmcp.com/servers/context#http-requests" in str(
-                    warning.message
-                )
 
 
 @pytest.fixture


### PR DESCRIPTION
Removes the deprecated `Context.get_http_request()` method, deprecated in 2.2.11.

Users should use `get_http_request()` from `fastmcp.server.dependencies` instead.

**Changes:**
- Removed `Context.get_http_request()` method
- Removed `TestContextDeprecations` test class  
- Cleaned up unused imports (`warnings` from context.py)

Closes #2194