### PR TITLE
Remove deprecated run_streamable_http_async method

### DIFF
--- a/docs/python-sdk/fastmcp-server-server.mdx
+++ b/docs/python-sdk/fastmcp-server-server.mdx
@@ -723,12 +723,6 @@ Create a Starlette app using the specified HTTP transport.
 - A Starlette application configured with the specified transport
 
 
-#### `run_streamable_http_async` <sup><a href="https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/server/server.py#L2184" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
-
-```python
-run_streamable_http_async(self, host: str | None = None, port: int | None = None, log_level: str | None = None, path: str | None = None, uvicorn_config: dict[str, Any] | None = None) -> None
-```
-
 #### `mount` <sup><a href="https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/server/server.py#L2209" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -2182,31 +2182,6 @@ class FastMCP(Generic[LifespanResultT]):
                 middleware=middleware,
             )
 
-    async def run_streamable_http_async(
-        self,
-        host: str | None = None,
-        port: int | None = None,
-        log_level: str | None = None,
-        path: str | None = None,
-        uvicorn_config: dict[str, Any] | None = None,
-    ) -> None:
-        # Deprecated since 2.3.2
-        if fastmcp.settings.deprecation_warnings:
-            warnings.warn(
-                "The run_streamable_http_async method is deprecated (as of 2.3.2). "
-                "Use run_http_async instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        await self.run_http_async(
-            transport="http",
-            host=host,
-            port=port,
-            log_level=log_level,
-            path=path,
-            uvicorn_config=uvicorn_config,
-        )
-
     def mount(
         self,
         server: FastMCP[LifespanResultT],

--- a/tests/deprecated/test_deprecated.py
+++ b/tests/deprecated/test_deprecated.py
@@ -70,24 +70,6 @@ async def test_run_sse_async_deprecation_warning():
         assert call_kwargs.get("transport") == "sse"
 
 
-async def test_run_streamable_http_async_deprecation_warning():
-    """Test that run_streamable_http_async raises a deprecation warning."""
-    server = FastMCP("TestServer")
-
-    # Use patch to avoid actually running the server
-    with patch.object(server, "run_http_async", new_callable=AsyncMock) as mock_run:
-        with pytest.warns(
-            DeprecationWarning,
-            match="The run_streamable_http_async method is deprecated",
-        ):
-            await server.run_streamable_http_async()
-
-        # Verify the mock was called with the right transport
-        mock_run.assert_called_once()
-        call_kwargs = mock_run.call_args.kwargs
-        assert call_kwargs.get("transport") == "http"
-
-
 def test_http_app_with_sse_transport():
     """Test that http_app with SSE transport works (no warning)."""
     server = FastMCP("TestServer")


### PR DESCRIPTION
Removes the deprecated `run_streamable_http_async()` method from FastMCP (deprecated in 2.3.2). Users should migrate to `run_http_async()` instead.

Fixes #2191