### PR TITLE
Harden install commands against special characters

### DIFF
--- a/src/fastmcp/cli/install/claude_code.py
+++ b/src/fastmcp/cli/install/claude_code.py
@@ -1,5 +1,6 @@
 """Claude Code integration for FastMCP install using Cyclopts."""
 
+import shlex
 import shutil
 import subprocess
 import sys
@@ -124,8 +125,8 @@ def install_claude_code(
     # Build the full command
     full_command = env_config.build_command(["fastmcp", "run", server_spec])
 
-    # Build claude mcp add command
-    cmd_parts = [claude_cmd, "mcp", "add", name]
+    # Build claude mcp add command (escape name to prevent shell injection)
+    cmd_parts = [claude_cmd, "mcp", "add", shlex.quote(name)]
 
     # Add environment variables if specified
     if env_vars:

--- a/src/fastmcp/cli/install/gemini_cli.py
+++ b/src/fastmcp/cli/install/gemini_cli.py
@@ -1,5 +1,6 @@
 """Gemini CLI integration for FastMCP install using Cyclopts."""
 
+import shlex
 import shutil
 import subprocess
 import sys
@@ -129,8 +130,8 @@ def install_gemini_cli(
         for key, value in env_vars.items():
             cmd_parts.extend(["-e", f"{key}={value}"])
 
-    # Add server name and command
-    cmd_parts.extend([name, full_command[0], "--"])
+    # Add server name and command (escape name to prevent shell injection)
+    cmd_parts.extend([shlex.quote(name), full_command[0], "--"])
     cmd_parts.extend(full_command[1:])
 
     try:


### PR DESCRIPTION
Apply shell escaping to server names in claude-code and gemini-cli install commands to prevent issues with special characters.