### PR TITLE
Fix Windows test timeout and restore parallel testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,12 +48,7 @@ jobs:
         run: uv sync --upgrade
 
       - name: Run tests (excluding integration and client_process)
-        run: |
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process"
-          else
-            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
-          fi
+        run: uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
         shell: bash
 
       - name: Run client process tests separately

--- a/tests/server/auth/test_oauth_consent_flow.py
+++ b/tests/server/auth/test_oauth_consent_flow.py
@@ -691,6 +691,7 @@ class TestConsentPageServerIcon:
             upstream_client_secret="upstream-secret",
             token_verifier=verifier,
             base_url="https://proxy.example.com",
+            client_storage=MemoryStore(),
             jwt_signing_key="test-secret",
         )
 
@@ -763,6 +764,7 @@ class TestConsentPageServerIcon:
             upstream_client_secret="upstream-secret",
             token_verifier=verifier,
             base_url="https://proxy.example.com",
+            client_storage=MemoryStore(),
             jwt_signing_key="test-secret",
         )
 
@@ -830,6 +832,7 @@ class TestConsentPageServerIcon:
             upstream_client_secret="upstream-secret",
             token_verifier=verifier,
             base_url="https://proxy.example.com",
+            client_storage=MemoryStore(),
             jwt_signing_key="test-secret",
         )
 


### PR DESCRIPTION
PR #2368 fixed SQLite locking issues for parallel test execution, but Windows CI tests were still running sequentially and experiencing timeouts. The root cause was that three tests in `TestConsentPageServerIcon` created `OAuthProxy` instances without specifying `client_storage`, causing them to use the default `DiskStore`. Even with isolated `settings.home` directories, SQLite connections weren't being properly cleaned up between tests.

This PR ensures all OAuth consent tests use in-memory storage and restores parallel test execution on Windows for faster CI runs.

```python
# Before: Uses default DiskStore, causes timeout
proxy = OAuthProxy(
    ...,
    jwt_signing_key="test-secret",
)

# After: Explicit MemoryStore, no database locking
proxy = OAuthProxy(
    ...,
    client_storage=MemoryStore(),
    jwt_signing_key="test-secret",
)
```

Fixes #2382