### PR TITLE
Add version badge for DebugTokenVerifier

### DIFF
--- a/docs/servers/auth/token-verification.mdx
+++ b/docs/servers/auth/token-verification.mdx
@@ -212,6 +212,8 @@ Static token verification stores tokens as plain text and should never be used i
 
 ### Debug/Custom Token Verification
 
+<VersionBadge version="2.13.1" />
+
 The `DebugTokenVerifier` provides maximum flexibility for testing and special cases where standard token verification isn't applicable. It delegates validation to a user-provided callable, making it useful for prototyping, testing scenarios, or handling opaque tokens without introspection endpoints.
 
 ```python


### PR DESCRIPTION
Adds version badge for 2.13.1 to the DebugTokenVerifier section in the token verification documentation.

Closes #2388

Generated with [Claude Code](https://claude.ai/code)