### PR TITLE
fix(OpenAPIParser): Fix missing $defs for response schemas in experimental OpenAPI parser

### DIFF
--- a/src/fastmcp/experimental/utilities/openapi/parser.py
+++ b/src/fastmcp/experimental/utilities/openapi/parser.py
@@ -653,9 +653,7 @@ class OpenAPIParser(
                     )
 
         return {
-            name: all_schemas[name]
-            for name in needed_schemas
-            if name in all_schemas
+            name: all_schemas[name] for name in needed_schemas if name in all_schemas
         }
 
     def parse(self) -> list[HTTPRoute]:


### PR DESCRIPTION
## Description
`_extract_output_schema_dependencies` was overly aggressive in pruning and could miss nested `$refs`.

As a result, certain referenced definitions were dropped from `$defs` even though they were still referenced (e.g. via `anyOf` / `allOf` chains), so the final JSON Schema contained `$refs` pointing to definitions that no longer existed, causing `PointerToNowhere`-validation errors.

By walking every response schema recursively with `_extract_schema_dependencies`, the original intention of pruning the schema is preserved, while collecting all `$ref`’d definition names.

**Contributors Checklist**
- [X] My change closes #2397
- [X] I have followed the repository's development workflow
- [X] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
- [X] I have self-reviewed my changes
- [X] My Pull Request is ready for review

---
