### PR TITLE
Fix exclude_args with non-serializable types

### DIFF
--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -354,7 +354,9 @@ Field provides several validation and documentation features:
 
 You can exclude certain arguments from the tool schema shown to the LLM. This is useful for arguments that are injected at runtime (such as `state`, `user_id`, or credentials) and should not be exposed to the LLM or client. Only arguments with default values can be excluded; attempting to exclude a required argument will raise an error.
 
-Example:
+**Note:** `exclude_args` will be deprecated in FastMCP 2.14 in favor of dependency injection with `Depends()` for better lifecycle management and more explicit dependency handling. `exclude_args` will continue to work until then.
+
+Example with `exclude_args`:
 
 ```python
 @mcp.tool(

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1434,7 +1434,9 @@ class FastMCP(Generic[LifespanResultT]):
             tags: Optional set of tags for categorizing the tool
             output_schema: Optional JSON schema for the tool's output
             annotations: Optional annotations about the tool's behavior
-            exclude_args: Optional list of argument names to exclude from the tool schema
+            exclude_args: Optional list of argument names to exclude from the tool schema.
+                Note: `exclude_args` will be deprecated in FastMCP 2.14 in favor of dependency
+                injection with `Depends()` for better lifecycle management.
             meta: Optional meta information about the tool
             enabled: Optional boolean to enable or disable the tool
 
@@ -1485,6 +1487,7 @@ class FastMCP(Generic[LifespanResultT]):
             tool_name = name  # Use keyword name if provided, otherwise None
 
             # Register the tool immediately and return the tool object
+            # Note: Deprecation warning for exclude_args is handled in Tool.from_function
             tool = Tool.from_function(
                 fn,
                 name=tool_name,

--- a/tests/server/test_tool_exclude_args.py
+++ b/tests/server/test_tool_exclude_args.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+from mcp.server.session import ServerSession
 
 from fastmcp import Client, FastMCP
 from fastmcp.tools.tool import Tool
@@ -92,3 +93,32 @@ async def test_tool_functionality_with_exclude_args():
             "create_item", {"name": "test_item", "value": 42}
         )
         assert result.data == {"name": "test_item", "value": 42}
+
+
+async def test_exclude_args_with_non_serializable_type():
+    """Test that exclude_args works even when the excluded parameter type can't be serialized.
+
+    This test ensures that exclude_args works correctly when the excluded parameter
+    has a type that Pydantic cannot serialize (like ServerSession). The bug was that
+    get_cached_typeadapter would try to serialize all parameters before compress_schema
+    could exclude them, causing a PydanticSchemaGenerationError.
+    """
+
+    def my_tool(message: str, session: ServerSession | None = None) -> str:
+        """A tool that takes a non-serializable Session parameter."""
+        return message
+
+    # This should not raise an error even though ServerSession can't be serialized
+    tool = Tool.from_function(
+        my_tool,
+        name="my_tool",
+        exclude_args=["session"],
+    )
+
+    # Verify the tool was created successfully
+    assert tool is not None
+    assert tool.name == "my_tool"
+
+    # Verify the session parameter is excluded from the schema
+    assert "session" not in tool.parameters["properties"]
+    assert "message" in tool.parameters["properties"]


### PR DESCRIPTION
Fixes issue #2431 where `exclude_args` fails when excluded parameters have non-serializable types like `ServerSession`.

The root cause was that `get_cached_typeadapter()` processes all parameters before `compress_schema()` can exclude them, causing Pydantic to fail when trying to serialize non-serializable types.

**Solution:**
- Added `create_function_without_params()` helper to exclude parameters from annotations before Pydantic sees them
- Updated `ParsedFunction.from_function()` to exclude parameters before calling `get_cached_typeadapter()`
- Added test coverage for non-serializable types

**Example:**
```python
from mcp.server.session import ServerSession
from typing import Optional

@mcp.tool(exclude_args=["session"])
def my_tool(message: str, session: Optional[ServerSession] = None) -> str:
    return message
```

This now works correctly - the `session` parameter is excluded before Pydantic tries to serialize it.

Also adds deprecation notice that `exclude_args` will be deprecated in FastMCP 2.14.

---

cc @chrisguidry -- once we merge the new DI framework in 2.14, I think we will deprecate `exclude_args` and recommend using DI to provide values as arguments that the framework will ignore. I dont like having two ways to do it, and the DI system is much richer. But just cc'ing for your awareness.

Closes #2431