### PR TITLE
Add OCI integration to docs navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -199,8 +199,9 @@
                   "integrations/descope",
                   "integrations/discord",
                   "integrations/github",
-                  "integrations/scalekit",
                   "integrations/google",
+                  "integrations/oci",
+                  "integrations/scalekit",
                   "integrations/workos"
                 ]
               },


### PR DESCRIPTION
Adds the OCI IAM integration page to the Authentication section in docs.json. The page existed but wasn't included in the navigation (#2389)