### PR TITLE
Expose InitializeResult to middleware

### DIFF
--- a/src/fastmcp/server/middleware/middleware.py
+++ b/src/fastmcp/server/middleware/middleware.py
@@ -150,8 +150,8 @@ class Middleware:
     async def on_initialize(
         self,
         context: MiddlewareContext[mt.InitializeRequest],
-        call_next: CallNext[mt.InitializeRequest, None],
-    ) -> None:
+        call_next: CallNext[mt.InitializeRequest, mt.InitializeResult | None],
+    ) -> mt.InitializeResult | None:
         return await call_next(context)
 
     async def on_call_tool(


### PR DESCRIPTION
The MCP SDK's `ServerSession._received_request()` handles initialize requests by calling `responder.respond(InitializeResult)` directly, which sends the response to the write stream and returns `None`. This meant middleware could only see the initialize *request*, never the *response*.

This PR wraps `responder.respond()` to capture the `InitializeResult` before it's sent, then returns it through the middleware chain. Now middleware like `LoggingMiddleware` can access and log the server's capabilities during initialization.

```python
class ResponseCapturingMiddleware(Middleware):
    async def on_initialize(
        self,
        context: MiddlewareContext[mt.InitializeRequest],
        call_next: CallNext[mt.InitializeRequest, mt.InitializeResult | None],
    ) -> mt.InitializeResult | None:
        result = await call_next(context)
        # result is now the InitializeResult, not None
        print(f"Server: {result.serverInfo.name}")
        print(f"Capabilities: {result.capabilities}")
        return result
```

Fixes #2504