### PR TITLE
Validate tool names at registration time (SEP-986)

### DIFF
--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -15,9 +15,10 @@ from typing import (
 
 import mcp.types
 import pydantic_core
+from mcp.shared.tool_name_validation import validate_and_warn_tool_name
 from mcp.types import CallToolResult, ContentBlock, Icon, TextContent, ToolAnnotations
 from mcp.types import Tool as MCPTool
-from pydantic import Field, PydanticSchemaGenerationError
+from pydantic import Field, PydanticSchemaGenerationError, model_validator
 from typing_extensions import TypeVar
 
 import fastmcp
@@ -129,6 +130,12 @@ class Tool(FastMCPComponent):
         ToolResultSerializerType | None,
         Field(description="Optional custom serializer for tool results"),
     ] = None
+
+    @model_validator(mode="after")
+    def _validate_tool_name(self) -> Tool:
+        """Validate tool name according to MCP specification (SEP-986)."""
+        validate_and_warn_tool_name(self.name)
+        return self
 
     def enable(self) -> None:
         super().enable()


### PR DESCRIPTION
Tool name validation per SEP-986 now happens immediately when tools are registered, rather than waiting until `list_tools` is called. This gives developers immediate feedback about non-conforming names.

```python
from fastmcp import FastMCP

mcp = FastMCP("demo")

@mcp.tool(name="my invalid tool")  # WARNING logged immediately
def greet():
    return "hello"
```

Validation reuses the SDK's `validate_and_warn_tool_name` from `mcp.shared.tool_name_validation`. Per SEP-986, tool names SHOULD (not MUST) conform to `^[A-Za-z0-9._-]{1,128}$`, so warnings are issued but tools are still created.

Closes #2539