### PR TITLE
Prefix Docket function names to avoid collisions in multi-mount setups

### DIFF
--- a/src/fastmcp/server/tasks/handlers.py
+++ b/src/fastmcp/server/tasks/handlers.py
@@ -99,9 +99,10 @@ async def handle_tool_as_task(
         # Don't let notification failures break task creation
         await ctx.session.send_notification(notification)  # type: ignore[arg-type]
 
-    # Queue function to Docket (result storage via execution_ttl)
+    # Queue function to Docket by name (result storage via execution_ttl)
+    # Use tool.key which matches what was registered - prefixed for mounted tools
     await docket.add(
-        tool.fn,  # type: ignore[attr-defined]
+        tool.key,
         key=task_key,
     )(**arguments)
 
@@ -204,9 +205,10 @@ async def handle_prompt_as_task(
     with suppress(Exception):
         await ctx.session.send_notification(notification)  # type: ignore[arg-type]
 
-    # Queue function to Docket (result storage via execution_ttl)
+    # Queue function to Docket by name (result storage via execution_ttl)
+    # Use prompt.key which matches what was registered - prefixed for mounted prompts
     await docket.add(
-        prompt.fn,  # type: ignore[attr-defined]
+        prompt.key,
         key=task_key,
     )(**(arguments or {}))
 
@@ -307,19 +309,20 @@ async def handle_resource_as_task(
     with suppress(Exception):
         await ctx.session.send_notification(notification)  # type: ignore[arg-type]
 
-    # Queue function to Docket (result storage via execution_ttl)
+    # Queue function to Docket by name (result storage via execution_ttl)
+    # Use resource.name which matches what was registered - prefixed for mounted resources
     # For templates, extract URI params and pass them to the function
     from fastmcp.resources.template import FunctionResourceTemplate, match_uri_template
 
     if isinstance(resource, FunctionResourceTemplate):
         params = match_uri_template(uri, resource.uri_template) or {}
         await docket.add(
-            resource.fn,  # type: ignore[attr-defined]
+            resource.name,
             key=task_key,
         )(**params)
     else:
         await docket.add(
-            resource.fn,  # type: ignore[attr-defined]
+            resource.name,
             key=task_key,
         )()
 


### PR DESCRIPTION
When multiple servers with task-enabled tools are mounted into a parent, their functions were all registered with Docket using `fn.__name__`. This meant two mounted servers each having a function named `add` would both register under `"add"`, with the second overwriting the first.

Now mounted functions use prefixed names matching their client-facing tool names (e.g., `c1_add`, `c2_add`). Root server functions still use their original names with no prefix.

```python
child1 = FastMCP("child1")
child2 = FastMCP("child2")

@child1.tool(task=True)
async def process(value: int) -> int:
    return value * 2

@child2.tool(task=True)
async def process(value: int) -> int:
    return value * 3

parent = FastMCP("parent")
parent.mount(child1, prefix="c1")
parent.mount(child2, prefix="c2")

# Both execute their own implementation correctly
# c1_process -> 20, c2_process -> 30
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)