### PR TITLE
Add execution field to base Tool class

### DIFF
--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -133,6 +133,10 @@ class Tool(FastMCPComponent):
         ToolAnnotations | None,
         Field(description="Additional annotations about the tool"),
     ] = None
+    execution: Annotated[
+        ToolExecution | None,
+        Field(description="Task execution configuration (SEP-1686)"),
+    ] = None
     serializer: Annotated[
         ToolResultSerializerType | None,
         Field(description="Optional custom serializer for tool results"),
@@ -182,7 +186,7 @@ class Tool(FastMCPComponent):
             outputSchema=overrides.get("outputSchema", self.output_schema),
             icons=overrides.get("icons", self.icons),
             annotations=overrides.get("annotations", self.annotations),
-            execution=overrides.get("execution"),
+            execution=overrides.get("execution", self.execution),
             _meta=overrides.get(
                 "_meta", self.get_meta(include_fastmcp_meta=include_fastmcp_meta)
             ),


### PR DESCRIPTION
The base Tool class now has an optional `execution` field for storing task execution metadata (SEP-1686). This lets gateways/proxies preserve execution info when forwarding tools from backends - previously this metadata was lost because Tool had no way to store it.

When a gateway receives tools from a backend with `execution` metadata (e.g., `taskSupport: "optional"`), it can now store that in a `Tool` object and have it survive the round-trip through `to_mcp_tool()`.

```python
# Gateway can now preserve execution metadata from backends
tool = Tool(
    name="backend_tool",
    parameters={...},
    execution=ToolExecution(taskSupport="optional"),
)

# Metadata preserved when converting back to MCP
mcp_tool = tool.to_mcp_tool()
assert mcp_tool.execution.taskSupport == "optional"
```

FunctionTool continues to derive execution from `task_config` as before - this only affects the base `Tool` class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)