### PR TITLE
Fix OAuth client to preserve full URL path for metadata discovery

### DIFF
--- a/tests/client/auth/test_oauth_client.py
+++ b/tests/client/auth/test_oauth_client.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from fastmcp.client import Client
+from fastmcp.client.auth import OAuth
 from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.server.auth.auth import ClientRegistrationOptions
 from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
@@ -124,3 +125,49 @@ async def test_oauth_server_metadata_discovery(streamable_http_server: str):
         # The endpoints should be properly formed URLs
         assert metadata["authorization_endpoint"].startswith(server_base_url)
         assert metadata["token_endpoint"].startswith(server_base_url)
+
+
+class TestOAuthClientUrlHandling:
+    """Tests for OAuth client URL handling (issue #2573)."""
+
+    def test_oauth_preserves_full_url_with_path(self):
+        """OAuth client should preserve the full MCP URL including path components.
+
+        This is critical for servers hosted under path-based endpoints like
+        mcp.example.com/server1/v1.0/mcp where OAuth metadata discovery needs
+        the full path to find the correct .well-known endpoints.
+        """
+        mcp_url = "https://mcp.example.com/server1/v1.0/mcp"
+        oauth = OAuth(mcp_url=mcp_url)
+
+        # The full URL should be preserved for OAuth discovery
+        assert oauth.context.server_url == mcp_url
+
+        # The stored mcp_url should match
+        assert oauth.mcp_url == mcp_url
+
+    def test_oauth_preserves_root_url(self):
+        """OAuth client should work correctly with root-level URLs."""
+        mcp_url = "https://mcp.example.com"
+        oauth = OAuth(mcp_url=mcp_url)
+
+        assert oauth.context.server_url == mcp_url
+        assert oauth.mcp_url == mcp_url
+
+    def test_oauth_normalizes_trailing_slash(self):
+        """OAuth client should normalize trailing slashes for consistency."""
+        mcp_url_with_slash = "https://mcp.example.com/api/mcp/"
+        oauth = OAuth(mcp_url=mcp_url_with_slash)
+
+        # Trailing slash should be stripped
+        expected = "https://mcp.example.com/api/mcp"
+        assert oauth.context.server_url == expected
+        assert oauth.mcp_url == expected
+
+    def test_oauth_token_storage_uses_full_url(self):
+        """Token storage should use the full URL to separate tokens per endpoint."""
+        mcp_url = "https://mcp.example.com/server1/v1.0/mcp"
+        oauth = OAuth(mcp_url=mcp_url)
+
+        # Token storage should key by the full URL, not just the host
+        assert oauth.token_storage_adapter._server_url == mcp_url


### PR DESCRIPTION
The OAuth client was stripping path components from MCP server URLs, breaking metadata discovery for servers hosted under path-based endpoints like `mcp.example.com/server1/v1.0/mcp`.

The fix preserves the full URL when initializing `OAuthClientProvider`, enabling proper path-aware discovery per RFC 8414/9728. The MCP SDK already handles fallback to root-level `.well-known` endpoints when path-based discovery fails, so this works for both configurations.

```python
# Before: path was stripped, discovery only tried root
OAuth(mcp_url="https://mcp.example.com/api/v1/mcp")
# -> server_url = "https://mcp.example.com"  # broken

# After: full path preserved, discovery tries path first then root
OAuth(mcp_url="https://mcp.example.com/api/v1/mcp")
# -> server_url = "https://mcp.example.com/api/v1/mcp"  # correct
```

Closes #2573, Closes #2419