### PR TITLE
Do not run windows tests in parallel

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,12 @@ jobs:
         run: uv sync --upgrade
 
       - name: Run tests (excluding integration and client_process)
-        run: uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process"
+          else
+            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
+          fi
         shell: bash
 
       - name: Run client process tests separately


### PR DESCRIPTION
Windows tests keep crashing, this runs them sequentially 🐢 