### PR TITLE
Remove TaskConfig and client from root exports

### DIFF
--- a/docs/servers/tasks.mdx
+++ b/docs/servers/tasks.mdx
@@ -69,7 +69,8 @@ For fine-grained control over task execution behavior, use `TaskConfig` instead 
 | `"required"` | Error: task required | Executes as background task |
 
 ```python
-from fastmcp import FastMCP, TaskConfig
+from fastmcp import FastMCP
+from fastmcp.server.tasks import TaskConfig
 
 mcp = FastMCP("MyServer")
 

--- a/src/fastmcp/__init__.py
+++ b/src/fastmcp/__init__.py
@@ -14,7 +14,6 @@ if settings.log_enabled:
 
 from fastmcp.server.server import FastMCP
 from fastmcp.server.context import Context
-from fastmcp.server.tasks.config import TaskConfig
 import fastmcp.server
 
 from fastmcp.client import Client
@@ -32,7 +31,5 @@ __all__ = [
     "Client",
     "Context",
     "FastMCP",
-    "TaskConfig",
-    "client",
     "settings",
 ]

--- a/tests/server/tasks/test_task_config_modes.py
+++ b/tests/server/tasks/test_task_config_modes.py
@@ -8,9 +8,10 @@ Tests that the server correctly enforces task execution modes:
 
 import pytest
 
-from fastmcp import FastMCP, TaskConfig
+from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.exceptions import ToolError
+from fastmcp.server.tasks import TaskConfig
 
 
 class TestTaskConfigNormalization:

--- a/tests/server/tasks/test_task_mount.py
+++ b/tests/server/tasks/test_task_mount.py
@@ -10,9 +10,10 @@ import asyncio
 import pytest
 from docket import Docket
 
-from fastmcp import FastMCP, TaskConfig
+from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.server.dependencies import CurrentDocket, CurrentFastMCP
+from fastmcp.server.tasks import TaskConfig
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Removes `TaskConfig` and `client` from the root `__all__` exports to encourage more explicit imports.

`TaskConfig` should now be imported from its public API:
```python
from fastmcp.server.tasks import TaskConfig
```

The `client` module remains accessible via explicit import (`from fastmcp import client`) but is no longer included in `from fastmcp import *` exports.

All documentation and tests have been updated to use the correct import paths.