### PR TITLE
Remove overly restrictive MIME type validation from Resource

### DIFF
--- a/src/fastmcp/resources/resource.py
+++ b/src/fastmcp/resources/resource.py
@@ -42,7 +42,6 @@ class Resource(FastMCPComponent):
     mime_type: str = Field(
         default="text/plain",
         description="MIME type of the resource content",
-        pattern=r"^[a-zA-Z0-9]+/[a-zA-Z0-9\-+.]+$",
     )
     annotations: Annotated[
         Annotations | None,


### PR DESCRIPTION
The `Resource.mime_type` field had a regex pattern that was stricter than RFC 2045, rejecting valid MIME types like `text/plain; charset="utf-8"`. This removes the pattern constraint to accept all valid MIME type strings.

```python
# Previously rejected, now accepted:
Resource(uri="file:///test.txt", mime_type='text/plain; charset="utf-8"')
```