### PR TITLE
Add smart fallback for missing access token expiry

### DIFF
--- a/src/fastmcp/server/auth/oidc_proxy.py
+++ b/src/fastmcp/server/auth/oidc_proxy.py
@@ -226,6 +226,8 @@ class OIDCProxy(OAuthProxy):
         # Extra parameters
         extra_authorize_params: dict[str, str] | None = None,
         extra_token_params: dict[str, str] | None = None,
+        # Token expiry fallback
+        fallback_access_token_expiry_seconds: int | None = None,
     ) -> None:
         """Initialize the OIDC proxy provider.
 
@@ -272,6 +274,10 @@ class OIDCProxy(OAuthProxy):
                 Example: {"prompt": "consent", "access_type": "offline"}
             extra_token_params: Additional parameters to forward to the upstream token endpoint.
                 Useful for provider-specific parameters during token exchange.
+            fallback_access_token_expiry_seconds: Expiry time to use when upstream provider
+                doesn't return `expires_in` in the token response. If not set, uses smart
+                defaults: 1 hour if a refresh token is available (since we can refresh),
+                or 1 year if no refresh token (for API-key-style tokens like GitHub OAuth Apps).
         """
         if not config_url:
             raise ValueError("Missing required config URL")
@@ -344,6 +350,7 @@ class OIDCProxy(OAuthProxy):
             "token_endpoint_auth_method": token_endpoint_auth_method,
             "require_authorization_consent": require_authorization_consent,
             "consent_csp_policy": consent_csp_policy,
+            "fallback_access_token_expiry_seconds": fallback_access_token_expiry_seconds,
         }
 
         if redirect_path:


### PR DESCRIPTION
GitHub OAuth Apps (and similar providers) issue tokens that never expire and don't return `expires_in` or `refresh_token`. Previously, FastMCP defaulted to 1 hour when `expires_in` was missing, forcing users through re-auth every hour with no way to refresh.

This adds smart defaults based on refresh token availability:
- If `expires_in` provided → use it
- If no `expires_in` but refresh token available → 1 hour (can refresh)
- If no `expires_in` and no refresh token → 1 year (API-key-style)

Users can override with `fallback_access_token_expiry_seconds`:

```python
auth = OAuthProxy(
    # ... existing params ...
    fallback_access_token_expiry_seconds=60 * 60 * 24 * 365,  # 1 year
)
```

Closes #2534