### PR TITLE
fix: preserve exception propagation through transport cleanup

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -16,7 +16,7 @@ import httpx
 import mcp.types
 import pydantic_core
 from exceptiongroup import catch
-from mcp import ClientSession
+from mcp import ClientSession, McpError
 from mcp.types import (
     CancelTaskRequest,
     CancelTaskRequestParams,
@@ -514,7 +514,8 @@ class Client(Generic[ClientTransportT]):
                         raise RuntimeError(
                             "Session task completed without exception but connection failed"
                         )
-                    if isinstance(exception, httpx.HTTPStatusError):
+                    # Preserve specific exception types that clients may want to handle
+                    if isinstance(exception, httpx.HTTPStatusError | McpError):
                         raise exception
                     raise RuntimeError(
                         f"Client failed to connect: {exception}"


### PR DESCRIPTION
When exceptions occur during client initialization (e.g., `McpError` from server middleware), they were being swallowed and converted to "generator didn't yield" errors. This specifically affected in-memory transport where the server lifespan (including Docket's background worker context managers) is nested inside the client's task group - the complex cleanup chain was suppressing exceptions.

**Root cause:** anyio task groups suppress exceptions when `cancel_scope.cancel()` is called during cleanup.

**Fix:** Capture exceptions before task group cleanup and re-raise them after the task group exits cleanly:

```python
exception_to_raise: BaseException | None = None
async with anyio.create_task_group() as tg:
    try:
        async with ClientSession(...) as session:
            yield session
    except BaseException as e:
        exception_to_raise = e
    finally:
        tg.cancel_scope.cancel()

if exception_to_raise is not None:
    raise exception_to_raise
```

Also preserves `McpError` type in `_connect()` so callers can catch protocol-level errors:

```python
async with Client(server) as client:
    ...
# Now raises McpError instead of RuntimeError wrapping McpError
```

Relevant to fixing https://github.com/jlowin/fastmcp/pull/2531