### PR TITLE
fix: prompt tasks returning mcp.types.PromptMessage now work

### DIFF
--- a/src/fastmcp/server/tasks/converters.py
+++ b/src/fastmcp/server/tasks/converters.py
@@ -123,7 +123,8 @@ async def convert_prompt_result(
     messages: list[mcp.types.PromptMessage] = []
     for msg in raw_value:
         if isinstance(msg, PromptMessage):
-            messages.append(msg.to_mcp())
+            # PromptMessage is imported from mcp.types - use directly
+            messages.append(msg)
         elif isinstance(msg, str):
             messages.append(
                 mcp.types.PromptMessage(

--- a/tests/client/tasks/test_prompt_task_mcp_message.py
+++ b/tests/client/tasks/test_prompt_task_mcp_message.py
@@ -1,0 +1,57 @@
+"""Test prompt task with mcp.types.PromptMessage return values.
+
+Regression test for: PromptMessage object has no attribute 'to_mcp'
+"""
+
+import mcp.types
+
+from fastmcp import FastMCP
+from fastmcp.client import Client
+
+
+async def test_prompt_task_with_mcp_prompt_message():
+    """Prompt task returning mcp.types.PromptMessage should serialize correctly."""
+    mcp_server = FastMCP("test")
+
+    @mcp_server.prompt(task=True)
+    async def greeting(name: str) -> list[mcp.types.PromptMessage]:
+        return [
+            mcp.types.PromptMessage(
+                role="user",
+                content=mcp.types.TextContent(type="text", text=f"Hello {name}"),
+            )
+        ]
+
+    async with Client(mcp_server) as client:
+        task = await client.get_prompt("greeting", {"name": "World"}, task=True)
+        result = await task.result()
+        assert "Hello World" in result.messages[0].content.text  # type: ignore[attr-defined]
+
+
+async def test_prompt_task_with_multiple_mcp_prompt_messages():
+    """Prompt task returning multiple mcp.types.PromptMessage objects."""
+    mcp_server = FastMCP("test")
+
+    @mcp_server.prompt(task=True)
+    async def conversation(topic: str) -> list[mcp.types.PromptMessage]:
+        return [
+            mcp.types.PromptMessage(
+                role="user",
+                content=mcp.types.TextContent(
+                    type="text", text=f"Tell me about {topic}"
+                ),
+            ),
+            mcp.types.PromptMessage(
+                role="assistant",
+                content=mcp.types.TextContent(
+                    type="text", text=f"{topic} is fascinating!"
+                ),
+            ),
+        ]
+
+    async with Client(mcp_server) as client:
+        task = await client.get_prompt("conversation", {"topic": "space"}, task=True)
+        result = await task.result()
+        assert len(result.messages) == 2
+        assert "Tell me about space" in result.messages[0].content.text  # type: ignore[attr-defined]
+        assert "space is fascinating" in result.messages[1].content.text  # type: ignore[attr-defined]


### PR DESCRIPTION
When a prompt function returned `mcp.types.PromptMessage` objects directly and was executed as a task, the result serialization failed with "'PromptMessage' object has no attribute 'to_mcp'".

The task result converter was calling `.to_mcp()` on what it thought was a FastMCP wrapper type, but the import actually pulls in `mcp.types.PromptMessage` directly, which is already the final MCP type. Removed the unnecessary conversion.

```python
@mcp.prompt(task=True)
async def greeting(name: str) -> list[mcp.types.PromptMessage]:
    return [
        mcp.types.PromptMessage(
            role="user",
            content=mcp.types.TextContent(type="text", text=f"Hello {name}"),
        )
    ]

# This now works:
async with Client(mcp) as client:
    task = await client.get_prompt("greeting", {"name": "World"}, task=True)
    result = await task.result()  # Previously failed with 'to_mcp' error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)