### PR TITLE
Add Python 3.13 to Ubuntu CI tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.10"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.13"
       fail-fast: false
     timeout-minutes: 10
 


### PR DESCRIPTION
Expands CI test coverage to include Python 3.13 on Ubuntu while maintaining existing 3.10 coverage across all platforms.

The test matrix now runs:
- Ubuntu: Python 3.10 and 3.13  
- Windows: Python 3.10

This ensures compatibility with the latest Python release while preserving our baseline support.