### PR TITLE
Clean up cancelled connection startup

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -6,7 +6,7 @@ import datetime
 import secrets
 import uuid
 import weakref
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Generic, Literal, TypeVar, cast, overload
@@ -506,7 +506,35 @@ class Client(Generic[ClientTransportT]):
                 self._session_state.session_task = asyncio.create_task(
                     self._session_runner()
                 )
-                await self._session_state.ready_event.wait()
+                try:
+                    await self._session_state.ready_event.wait()
+                except asyncio.CancelledError:
+                    # Cancellation during initial connection startup can leave the
+                    # background session task running because __aexit__ is never invoked
+                    # when __aenter__ is cancelled. Since we hold the session lock here
+                    # and we know we started the session task, it's safe to tear it down
+                    # without impacting other active contexts.
+                    session_task = self._session_state.session_task
+                    if session_task is not None:
+                        # Request a graceful stop if the runner has already reached
+                        # its stop_event wait.
+                        self._session_state.stop_event.set()
+                        session_task.cancel()
+                        # Preserve the original cancellation.
+                        with suppress(asyncio.CancelledError, Exception):
+                            await asyncio.shield(session_task)
+
+                    # Reset session state so future callers can reconnect cleanly.
+                    self._session_state.session_task = None
+                    self._session_state.session = None
+                    self._session_state.initialize_result = None
+                    self._session_state.nesting_counter = 0
+
+                    # Preserve the original cancellation.
+                    with suppress(asyncio.CancelledError, Exception):
+                        await asyncio.shield(self.transport.close())
+
+                    raise
 
                 if self._session_state.session_task.done():
                     exception = self._session_state.session_task.exception()


### PR DESCRIPTION
## Description
This change handles `CancelledError` inside `_connect()` only when the current call started a new session task (under the session lock), then tears down the partial session and resets state. It also adds regression tests for cancelled entry cleanup and for a cancelled concurrent waiter that must not close an already-active session.

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes #2613 
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
