### PR TITLE
Adopt streamable_http_client API from MCP SDK

### DIFF
--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -304,10 +304,11 @@ class StreamableHttpTransport(ClientTransport):
         else:
             http_client = httpx.AsyncClient(**httpx_client_kwargs)
 
-        async with streamable_http_client(
-            self.url,
-            http_client=http_client,
-        ) as transport:
+        # Ensure httpx client is closed after use
+        async with (
+            http_client,
+            streamable_http_client(self.url, http_client=http_client) as transport,
+        ):
             read_stream, write_stream, get_session_id = transport
             self._get_session_id_cb = get_session_id
             async with ClientSession(


### PR DESCRIPTION
Adopts the new `streamable_http_client` API from the MCP Python SDK while maintaining backward compatibility.

## Changes

- **Updated import**: Switched from deprecated `streamablehttp_client` to `streamable_http_client`
- **Factory to client conversion**: Converts `httpx_client_factory` to `httpx.AsyncClient` instances before passing to the new API
- **Backward compatibility**: Continues accepting factories (needed for OAuth) but converts them at the SDK boundary
- **Deprecation warning**: Added warning for `sse_read_timeout` parameter which is no longer supported by the new API

## Implementation Details

The new API accepts `httpx.AsyncClient` directly instead of factories. FastMCP maintains its factory-based API for OAuth compatibility, creating clients from factories only when calling the MCP SDK:

```python
# FastMCP still accepts factories
transport = StreamableHttpTransport(
    url="https://api.example.com/mcp",
    httpx_client_factory=lambda **kwargs: httpx.AsyncClient(verify=False, **kwargs)
)

# Internally converts to client for new API
http_client = self.httpx_client_factory(**httpx_client_kwargs)
async with streamable_http_client(self.url, http_client=http_client) as transport:
    ...
```

Closes #2594