### PR TITLE
feat(contrib): Add compensation annotation discovery

### DIFF
--- a/src/fastmcp/contrib/compensation_annotations/__init__.py
+++ b/src/fastmcp/contrib/compensation_annotations/__init__.py
@@ -1,0 +1,41 @@
+"""Compensation annotation discovery for MCP tools.
+
+This module provides utilities to discover compensation pairs from MCP tool schemas
+using the `x-compensation-pair` annotation convention. Compensation pairs define
+relationships between tools that create resources and tools that undo those creations.
+
+Example:
+    >>> from fastmcp import FastMCP
+    >>> from fastmcp.contrib.compensation_annotations import discover_compensation_pairs
+    >>>
+    >>> mcp = FastMCP("MyServer")
+    >>>
+    >>> @mcp.tool(annotations={"x-compensation-pair": "delete_item"})
+    ... def add_item(name: str) -> dict:
+    ...     return {"id": "123", "name": name}
+    >>>
+    >>> @mcp.tool
+    ... def delete_item(item_id: str) -> dict:
+    ...     return {"deleted": item_id}
+    >>>
+    >>> # Discover compensation pairs from tool schemas
+    >>> pairs = discover_compensation_pairs(mcp._tool_manager.tools.values())
+    >>> # Returns: {"add_item": "delete_item"}
+
+Supported annotation locations:
+    - `annotations["x-compensation-pair"]` (recommended)
+    - `inputSchema["x-compensation-pair"]`
+    - Top-level schema `x-compensation-pair`
+"""
+
+from fastmcp.contrib.compensation_annotations.parser import (
+    discover_compensation_pairs,
+    parse_mcp_schema,
+    validate_mcp_schema,
+)
+
+__all__ = [
+    "discover_compensation_pairs",
+    "parse_mcp_schema",
+    "validate_mcp_schema",
+]

--- a/src/fastmcp/contrib/compensation_annotations/example.py
+++ b/src/fastmcp/contrib/compensation_annotations/example.py
@@ -1,0 +1,128 @@
+"""Example: Compensation Annotations with FastMCP.
+
+This example demonstrates how to use compensation annotations to declare
+relationships between tools that create resources and tools that undo them.
+
+Run this example:
+    python -m fastmcp.contrib.compensation_annotations.example
+"""
+
+import asyncio
+
+from fastmcp import FastMCP
+from fastmcp.contrib.compensation_annotations import (
+    discover_compensation_pairs,
+    parse_mcp_schema,
+    validate_mcp_schema,
+)
+
+# Create a FastMCP server with compensation-annotated tools
+mcp = FastMCP("Booking Server")
+
+
+@mcp.tool(
+    annotations={
+        "x-compensation-pair": "cancel_flight",
+        "x-action-type": "create",
+    }
+)
+def book_flight(destination: str, date: str) -> dict:
+    """Book a flight to a destination."""
+    return {
+        "booking_id": "FL-12345",
+        "destination": destination,
+        "date": date,
+        "status": "confirmed",
+    }
+
+
+@mcp.tool(annotations={"x-action-type": "delete"})
+def cancel_flight(booking_id: str) -> dict:
+    """Cancel a flight booking."""
+    return {
+        "booking_id": booking_id,
+        "status": "cancelled",
+    }
+
+
+@mcp.tool(
+    annotations={
+        "x-compensation-pair": "cancel_hotel",
+        "x-action-type": "create",
+    }
+)
+def book_hotel(hotel_name: str, check_in: str, check_out: str) -> dict:
+    """Book a hotel room."""
+    return {
+        "reservation_id": "HT-67890",
+        "hotel": hotel_name,
+        "check_in": check_in,
+        "check_out": check_out,
+        "status": "confirmed",
+    }
+
+
+@mcp.tool(annotations={"x-action-type": "delete"})
+def cancel_hotel(reservation_id: str) -> dict:
+    """Cancel a hotel reservation."""
+    return {
+        "reservation_id": reservation_id,
+        "status": "cancelled",
+    }
+
+
+@mcp.tool(annotations={"x-action-type": "read"})
+def get_bookings() -> list:
+    """Get all current bookings."""
+    return [
+        {"type": "flight", "id": "FL-12345"},
+        {"type": "hotel", "id": "HT-67890"},
+    ]
+
+
+async def main() -> None:
+    """Demonstrate compensation annotation discovery."""
+    print("=" * 60)
+    print("Compensation Annotations Example")
+    print("=" * 60)
+
+    # Get all tools from the server (async method)
+    tools_dict = await mcp.get_tools()
+    tools = list(tools_dict.values())
+    print(f"\nRegistered tools: {[t.name for t in tools]}")
+
+    # Discover compensation pairs
+    pairs = discover_compensation_pairs(tools)
+    print("\nDiscovered compensation pairs:")
+    for tool_name, comp_tool in pairs.items():
+        print(f"  {tool_name} -> {comp_tool}")
+
+    # Validate individual schemas
+    print("\nSchema validation:")
+    for tool in tools:
+        schema = {
+            "name": tool.name,
+            "annotations": (
+                tool.annotations.model_dump(exclude_none=True)
+                if tool.annotations and hasattr(tool.annotations, "model_dump")
+                else {}
+            ),
+            "inputSchema": tool.parameters,
+        }
+        errors = validate_mcp_schema(schema)
+        status = "valid" if not errors else f"errors: {errors}"
+        print(f"  {tool.name}: {status}")
+
+    # Parse a single schema
+    print("\nParsing individual schema:")
+    example_schema = {
+        "name": "add_item",
+        "annotations": {"x-compensation-pair": "delete_item"},
+    }
+    result = parse_mcp_schema(example_schema)
+    print(f"  parse_mcp_schema({example_schema})")
+    print(f"  -> {result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/fastmcp/contrib/compensation_annotations/parser.py
+++ b/src/fastmcp/contrib/compensation_annotations/parser.py
@@ -1,0 +1,260 @@
+"""Compensation annotation parsing for MCP tool schemas.
+
+This module provides functions to parse MCP tool schemas and discover
+compensation pairs from the `x-compensation-pair` annotation.
+
+Compensation pairs define relationships between tools that create resources
+and tools that undo those creations, enabling automatic rollback in
+transactional agent workflows.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastmcp.utilities.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from fastmcp.tools.tool import Tool
+
+logger = get_logger(__name__)
+
+
+def parse_mcp_schema(schema: dict[str, Any]) -> tuple[str, str] | None:
+    """Extract compensation pair from an MCP tool schema.
+
+    Searches for `x-compensation-pair` in multiple locations within the schema:
+    1. `annotations["x-compensation-pair"]` (recommended)
+    2. `inputSchema["x-compensation-pair"]`
+    3. Top-level `x-compensation-pair`
+
+    Args:
+        schema: MCP tool schema dictionary with at least a "name" field.
+
+    Returns:
+        Tuple of (tool_name, compensation_tool_name) if found, None otherwise.
+
+    Example:
+        >>> schema = {
+        ...     "name": "book_flight",
+        ...     "annotations": {"x-compensation-pair": "cancel_flight"}
+        ... }
+        >>> parse_mcp_schema(schema)
+        ('book_flight', 'cancel_flight')
+
+        >>> schema = {"name": "get_status"}  # No compensation
+        >>> parse_mcp_schema(schema)
+        None
+    """
+    tool_name = schema.get("name")
+    if not tool_name:
+        return None
+
+    # Check annotations (recommended location)
+    annotations = schema.get("annotations", {})
+    if isinstance(annotations, dict):
+        comp_pair = annotations.get("x-compensation-pair")
+        if comp_pair and isinstance(comp_pair, str):
+            return (tool_name, comp_pair)
+
+    # Check inputSchema for x-compensation-pair
+    input_schema = schema.get("inputSchema", {})
+    if isinstance(input_schema, dict):
+        comp_pair = input_schema.get("x-compensation-pair")
+        if comp_pair and isinstance(comp_pair, str):
+            return (tool_name, comp_pair)
+
+    # Check top-level x-compensation-pair
+    comp_pair = schema.get("x-compensation-pair")
+    if comp_pair and isinstance(comp_pair, str):
+        return (tool_name, comp_pair)
+
+    return None
+
+
+def discover_compensation_pairs(
+    tools: Iterable[Tool] | Iterable[dict[str, Any]],
+) -> dict[str, str]:
+    """Discover compensation pairs from a collection of tools.
+
+    Scans tool schemas for `x-compensation-pair` annotations and returns
+    a mapping of tool names to their compensation tool names.
+
+    Args:
+        tools: Iterable of FastMCP Tool objects or raw schema dictionaries.
+
+    Returns:
+        Dictionary mapping tool names to their compensation tool names.
+
+    Example:
+        >>> from fastmcp import FastMCP
+        >>> mcp = FastMCP("Server")
+        >>>
+        >>> @mcp.tool(annotations={"x-compensation-pair": "cancel_flight"})
+        ... def book_flight(dest: str) -> dict:
+        ...     return {"booking_id": "123"}
+        >>>
+        >>> @mcp.tool(annotations={"x-compensation-pair": "cancel_hotel"})
+        ... def book_hotel(hotel: str) -> dict:
+        ...     return {"reservation_id": "456"}
+        >>>
+        >>> pairs = discover_compensation_pairs(mcp._tool_manager.tools.values())
+        >>> # Returns: {"book_flight": "cancel_flight", "book_hotel": "cancel_hotel"}
+    """
+    pairs: dict[str, str] = {}
+
+    for tool in tools:
+        schema = _get_tool_schema(tool)
+        if schema:
+            result = parse_mcp_schema(schema)
+            if result:
+                tool_name, comp_tool = result
+                pairs[tool_name] = comp_tool
+                logger.debug(
+                    f"Discovered compensation pair: {tool_name} -> {comp_tool}"
+                )
+
+    return pairs
+
+
+def _get_tool_schema(tool: Any) -> dict[str, Any] | None:
+    """Extract a schema dictionary from a tool object.
+
+    Supports:
+    - Raw schema dictionaries (passed through)
+    - FastMCP Tool objects
+    - Objects with name/get_input_schema protocol
+    - LangChain-style tools with args_schema
+
+    Args:
+        tool: A tool object or schema dictionary.
+
+    Returns:
+        Schema dictionary or None if extraction fails.
+    """
+    if isinstance(tool, dict):
+        return tool
+
+    # FastMCP Tool object
+    if (
+        hasattr(tool, "name")
+        and hasattr(tool, "parameters")
+        and hasattr(tool, "annotations")
+    ):
+        annotations_dict: dict[str, Any] = {}
+        if tool.annotations is not None:
+            # ToolAnnotations is a Pydantic model, convert to dict
+            if hasattr(tool.annotations, "model_dump"):
+                annotations_dict = tool.annotations.model_dump(exclude_none=True)
+            elif hasattr(tool.annotations, "dict"):
+                annotations_dict = tool.annotations.dict(exclude_none=True)
+            elif isinstance(tool.annotations, dict):
+                annotations_dict = tool.annotations
+            # Also include any extra fields that might be in the annotations
+            if hasattr(tool.annotations, "__dict__"):
+                for key, value in tool.annotations.__dict__.items():
+                    if not key.startswith("_") and value is not None:
+                        annotations_dict[key] = value
+
+        return {
+            "name": tool.name,
+            "description": getattr(tool, "description", ""),
+            "inputSchema": tool.parameters,
+            "annotations": annotations_dict,
+        }
+
+    # Generic protocol: name + get_input_schema
+    if hasattr(tool, "name") and hasattr(tool, "get_input_schema"):
+        try:
+            return {
+                "name": tool.name,
+                "description": getattr(tool, "description", ""),
+                "inputSchema": tool.get_input_schema(),
+            }
+        except Exception:
+            pass
+
+    # LangChain-style tool with args_schema
+    if hasattr(tool, "name") and hasattr(tool, "args_schema"):
+        try:
+            args_schema = tool.args_schema
+            if args_schema and hasattr(args_schema, "model_json_schema"):
+                return {
+                    "name": tool.name,
+                    "description": getattr(tool, "description", ""),
+                    "inputSchema": args_schema.model_json_schema(),
+                }
+            elif args_schema and hasattr(args_schema, "schema"):
+                return {
+                    "name": tool.name,
+                    "description": getattr(tool, "description", ""),
+                    "inputSchema": args_schema.schema(),
+                }
+        except Exception:
+            pass
+
+    return None
+
+
+def validate_mcp_schema(schema: dict[str, Any]) -> list[str]:
+    """Validate an MCP tool schema for compensation annotation correctness.
+
+    Checks that:
+    1. Schema has the required "name" field
+    2. The name is a non-empty string
+    3. If `x-compensation-pair` is declared, it's a valid non-empty string
+
+    Args:
+        schema: MCP tool schema dictionary to validate.
+
+    Returns:
+        List of validation error messages. Empty list if valid.
+
+    Example:
+        >>> schema = {"name": "add_item", "annotations": {"x-compensation-pair": ""}}
+        >>> errors = validate_mcp_schema(schema)
+        >>> # Returns: ["Field 'x-compensation-pair' must be a non-empty string"]
+    """
+    errors: list[str] = []
+
+    # Check required name field
+    if "name" not in schema:
+        errors.append("Missing required field: name")
+        return errors
+
+    tool_name = schema["name"]
+    if not isinstance(tool_name, str) or not tool_name:
+        errors.append("Field 'name' must be a non-empty string")
+
+    # Validate x-compensation-pair in annotations
+    annotations = schema.get("annotations", {})
+    if isinstance(annotations, dict):
+        comp_pair = annotations.get("x-compensation-pair")
+        if comp_pair is not None:
+            if not isinstance(comp_pair, str) or not comp_pair:
+                errors.append(
+                    "Field 'x-compensation-pair' in annotations must be a non-empty string"
+                )
+
+    # Validate x-compensation-pair in inputSchema
+    input_schema = schema.get("inputSchema")
+    if input_schema is not None:
+        if not isinstance(input_schema, dict):
+            errors.append("Field 'inputSchema' must be an object")
+        else:
+            comp_pair = input_schema.get("x-compensation-pair")
+            if comp_pair is not None:
+                if not isinstance(comp_pair, str) or not comp_pair:
+                    errors.append(
+                        "Field 'x-compensation-pair' in inputSchema must be a non-empty string"
+                    )
+
+    # Validate top-level x-compensation-pair
+    comp_pair = schema.get("x-compensation-pair")
+    if comp_pair is not None:
+        if not isinstance(comp_pair, str) or not comp_pair:
+            errors.append("Field 'x-compensation-pair' must be a non-empty string")
+
+    return errors

--- a/tests/contrib/test_compensation_annotations.py
+++ b/tests/contrib/test_compensation_annotations.py
@@ -1,0 +1,307 @@
+"""Tests for compensation annotation discovery."""
+
+from fastmcp import FastMCP
+from fastmcp.contrib.compensation_annotations import (
+    discover_compensation_pairs,
+    parse_mcp_schema,
+    validate_mcp_schema,
+)
+
+
+class TestParseMcpSchema:
+    """Tests for parse_mcp_schema function."""
+
+    def test_parse_from_annotations(self):
+        """Parse compensation pair from annotations field."""
+        schema = {
+            "name": "book_flight",
+            "annotations": {"x-compensation-pair": "cancel_flight"},
+        }
+        result = parse_mcp_schema(schema)
+        assert result == ("book_flight", "cancel_flight")
+
+    def test_parse_from_input_schema(self):
+        """Parse compensation pair from inputSchema field."""
+        schema = {
+            "name": "add_item",
+            "inputSchema": {
+                "type": "object",
+                "x-compensation-pair": "delete_item",
+            },
+        }
+        result = parse_mcp_schema(schema)
+        assert result == ("add_item", "delete_item")
+
+    def test_parse_from_top_level(self):
+        """Parse compensation pair from top-level field."""
+        schema = {
+            "name": "create_user",
+            "x-compensation-pair": "delete_user",
+        }
+        result = parse_mcp_schema(schema)
+        assert result == ("create_user", "delete_user")
+
+    def test_annotations_takes_precedence(self):
+        """Annotations field takes precedence over inputSchema."""
+        schema = {
+            "name": "add_item",
+            "annotations": {"x-compensation-pair": "remove_item"},
+            "inputSchema": {"x-compensation-pair": "delete_item"},
+        }
+        result = parse_mcp_schema(schema)
+        # annotations is checked first
+        assert result == ("add_item", "remove_item")
+
+    def test_returns_none_without_compensation(self):
+        """Returns None when no compensation pair is declared."""
+        schema = {
+            "name": "get_status",
+            "description": "Get current status",
+        }
+        result = parse_mcp_schema(schema)
+        assert result is None
+
+    def test_returns_none_without_name(self):
+        """Returns None when schema has no name."""
+        schema = {
+            "annotations": {"x-compensation-pair": "cancel_flight"},
+        }
+        result = parse_mcp_schema(schema)
+        assert result is None
+
+    def test_ignores_non_string_compensation(self):
+        """Ignores non-string compensation pair values."""
+        schema = {
+            "name": "add_item",
+            "annotations": {"x-compensation-pair": 123},
+        }
+        result = parse_mcp_schema(schema)
+        assert result is None
+
+    def test_ignores_empty_string_compensation(self):
+        """Ignores empty string compensation pair values."""
+        schema = {
+            "name": "add_item",
+            "annotations": {"x-compensation-pair": ""},
+        }
+        result = parse_mcp_schema(schema)
+        assert result is None
+
+
+class TestDiscoverCompensationPairs:
+    """Tests for discover_compensation_pairs function."""
+
+    def test_discover_from_dict_schemas(self):
+        """Discover pairs from raw schema dictionaries."""
+        tools = [
+            {
+                "name": "book_flight",
+                "annotations": {"x-compensation-pair": "cancel_flight"},
+            },
+            {"name": "cancel_flight"},
+            {
+                "name": "book_hotel",
+                "annotations": {"x-compensation-pair": "cancel_hotel"},
+            },
+        ]
+        pairs = discover_compensation_pairs(tools)
+        assert pairs == {
+            "book_flight": "cancel_flight",
+            "book_hotel": "cancel_hotel",
+        }
+
+    def test_discover_empty_list(self):
+        """Returns empty dict for empty tool list."""
+        pairs = discover_compensation_pairs([])
+        assert pairs == {}
+
+    def test_discover_no_compensation_tools(self):
+        """Returns empty dict when no tools have compensation."""
+        tools = [
+            {"name": "get_status"},
+            {"name": "list_items"},
+        ]
+        pairs = discover_compensation_pairs(tools)
+        assert pairs == {}
+
+    async def test_discover_from_fastmcp_tools(self):
+        """Discover pairs from FastMCP Tool objects."""
+        mcp = FastMCP("TestServer")
+
+        @mcp.tool(annotations={"x-compensation-pair": "delete_item"})
+        def add_item(name: str) -> dict:
+            return {"id": "123"}
+
+        @mcp.tool
+        def delete_item(item_id: str) -> dict:
+            return {"deleted": True}
+
+        @mcp.tool(annotations={"x-compensation-pair": "cancel_task"})
+        def create_task(title: str) -> dict:
+            return {"task_id": "456"}
+
+        tools_dict = await mcp.get_tools()
+        tools = list(tools_dict.values())
+        pairs = discover_compensation_pairs(tools)
+
+        assert "add_item" in pairs
+        assert pairs["add_item"] == "delete_item"
+        assert "create_task" in pairs
+        assert pairs["create_task"] == "cancel_task"
+        # delete_item has no compensation pair
+        assert "delete_item" not in pairs
+
+
+class TestValidateMcpSchema:
+    """Tests for validate_mcp_schema function."""
+
+    def test_valid_schema(self):
+        """Valid schema returns no errors."""
+        schema = {
+            "name": "add_item",
+            "annotations": {"x-compensation-pair": "delete_item"},
+        }
+        errors = validate_mcp_schema(schema)
+        assert errors == []
+
+    def test_valid_schema_without_compensation(self):
+        """Schema without compensation is valid."""
+        schema = {
+            "name": "get_status",
+            "description": "Get status",
+        }
+        errors = validate_mcp_schema(schema)
+        assert errors == []
+
+    def test_missing_name(self):
+        """Missing name field is an error."""
+        schema = {
+            "annotations": {"x-compensation-pair": "delete_item"},
+        }
+        errors = validate_mcp_schema(schema)
+        assert "Missing required field: name" in errors
+
+    def test_empty_name(self):
+        """Empty name string is an error."""
+        schema = {
+            "name": "",
+            "annotations": {"x-compensation-pair": "delete_item"},
+        }
+        errors = validate_mcp_schema(schema)
+        assert "Field 'name' must be a non-empty string" in errors
+
+    def test_non_string_name(self):
+        """Non-string name is an error."""
+        schema = {
+            "name": 123,
+        }
+        errors = validate_mcp_schema(schema)
+        assert "Field 'name' must be a non-empty string" in errors
+
+    def test_empty_compensation_in_annotations(self):
+        """Empty compensation pair in annotations is an error."""
+        schema = {
+            "name": "add_item",
+            "annotations": {"x-compensation-pair": ""},
+        }
+        errors = validate_mcp_schema(schema)
+        assert (
+            "Field 'x-compensation-pair' in annotations must be a non-empty string"
+            in errors
+        )
+
+    def test_non_string_compensation_in_annotations(self):
+        """Non-string compensation pair in annotations is an error."""
+        schema = {
+            "name": "add_item",
+            "annotations": {"x-compensation-pair": 123},
+        }
+        errors = validate_mcp_schema(schema)
+        assert (
+            "Field 'x-compensation-pair' in annotations must be a non-empty string"
+            in errors
+        )
+
+    def test_empty_compensation_in_input_schema(self):
+        """Empty compensation pair in inputSchema is an error."""
+        schema = {
+            "name": "add_item",
+            "inputSchema": {"x-compensation-pair": ""},
+        }
+        errors = validate_mcp_schema(schema)
+        assert (
+            "Field 'x-compensation-pair' in inputSchema must be a non-empty string"
+            in errors
+        )
+
+    def test_non_dict_input_schema(self):
+        """Non-dict inputSchema is an error."""
+        schema = {
+            "name": "add_item",
+            "inputSchema": "not a dict",
+        }
+        errors = validate_mcp_schema(schema)
+        assert "Field 'inputSchema' must be an object" in errors
+
+    def test_multiple_errors(self):
+        """Multiple validation errors are reported."""
+        schema = {
+            "name": "",
+            "annotations": {"x-compensation-pair": ""},
+            "inputSchema": "invalid",
+        }
+        errors = validate_mcp_schema(schema)
+        assert len(errors) >= 2
+
+
+class TestIntegration:
+    """Integration tests with FastMCP server."""
+
+    async def test_full_workflow(self):
+        """Test complete workflow: create server, add tools, discover pairs."""
+        mcp = FastMCP("BookingServer")
+
+        @mcp.tool(
+            annotations={
+                "x-compensation-pair": "cancel_flight",
+                "x-action-type": "create",
+            }
+        )
+        def book_flight(destination: str) -> dict:
+            return {"booking_id": "FL-123", "destination": destination}
+
+        @mcp.tool(annotations={"x-action-type": "delete"})
+        def cancel_flight(booking_id: str) -> dict:
+            return {"cancelled": booking_id}
+
+        @mcp.tool(
+            annotations={
+                "x-compensation-pair": "cancel_hotel",
+                "x-action-type": "create",
+            }
+        )
+        def book_hotel(hotel: str) -> dict:
+            return {"reservation_id": "HT-456", "hotel": hotel}
+
+        @mcp.tool(annotations={"x-action-type": "delete"})
+        def cancel_hotel(reservation_id: str) -> dict:
+            return {"cancelled": reservation_id}
+
+        @mcp.tool(annotations={"x-action-type": "read"})
+        def get_bookings() -> list:
+            return []
+
+        # Discover compensation pairs
+        tools_dict = await mcp.get_tools()
+        tools = list(tools_dict.values())
+        pairs = discover_compensation_pairs(tools)
+
+        # Verify expected pairs
+        assert len(pairs) == 2
+        assert pairs["book_flight"] == "cancel_flight"
+        assert pairs["book_hotel"] == "cancel_hotel"
+
+        # Verify non-compensatable tools are not included
+        assert "cancel_flight" not in pairs
+        assert "cancel_hotel" not in pairs
+        assert "get_bookings" not in pairs


### PR DESCRIPTION
## Summary
- Adds `fastmcp.contrib.compensation_annotations` module
- Provides utilities to discover compensation pairs from MCP tool schemas
- Supports `x-compensation-pair` annotation convention

Closes #2626

## Motivation
Tools that create resources often need corresponding "undo" tools. This module standardizes discovering these pairs from tool annotations, enabling libraries like [react-agent-compensation](https://pypi.org/project/react-agent-compensation/) to automatically configure rollback behavior.

## Example
```python
from fastmcp import FastMCP
from fastmcp.contrib.compensation_annotations import discover_compensation_pairs

mcp = FastMCP("MyServer")

@mcp.tool(annotations={"x-compensation-pair": "delete_item"})
def add_item(name: str) -> dict:
    return {"id": "123"}

@mcp.tool
def delete_item(item_id: str) -> dict:
    return {"deleted": True}

# Discover pairs
tools = await mcp.get_tools()
pairs = discover_compensation_pairs(tools.values())
# {"add_item": "delete_item"}
```

## Test plan
- [x] Unit tests for all public functions (23 tests)
- [x] Tests pass with `uv run pytest tests/contrib/test_compensation_annotations.py`
- [x] Linting passes with `uv run ruff check`
- [x] Type checking passes with `uv run ty check`