### PR TITLE
Let FastMCPError propagate from dependencies

### DIFF
--- a/src/fastmcp/server/dependencies.py
+++ b/src/fastmcp/server/dependencies.py
@@ -21,6 +21,7 @@ from mcp.server.auth.provider import (
 from mcp.server.lowlevel.server import request_ctx
 from starlette.requests import Request
 
+from fastmcp.exceptions import FastMCPError
 from fastmcp.server.auth import AccessToken
 from fastmcp.server.http import _current_http_request
 from fastmcp.utilities.types import is_class_member_of_type
@@ -188,6 +189,10 @@ async def _resolve_fastmcp_dependencies(
                         resolved[parameter] = await stack.enter_async_context(
                             dependency
                         )
+                    except FastMCPError:
+                        # Let FastMCPError subclasses (ToolError, ResourceError, etc.)
+                        # propagate unchanged so they can be handled appropriately
+                        raise
                     except Exception as error:
                         fn_name = getattr(fn, "__name__", repr(fn))
                         raise RuntimeError(


### PR DESCRIPTION
When a dependency raises ToolError or other FastMCPError subclasses, they
were getting wrapped in RuntimeError with a generic "Failed to resolve
dependency" message. This made it hard to use ToolError for validation
in dependencies.

Now FastMCPError subclasses propagate unchanged, matching the pattern
used elsewhere in the codebase.

Closes #2633

🤖 Generated with [Claude Code](https://claude.com/claude-code)