### PR TITLE
Enable background task support for custom component subclasses

### DIFF
--- a/src/fastmcp/resources/resource.py
+++ b/src/fastmcp/resources/resource.py
@@ -6,9 +6,13 @@ import base64
 import inspect
 import warnings
 from collections.abc import Callable
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import mcp.types
+
+if TYPE_CHECKING:
+    from docket import Docket
+    from docket.execution import Execution
 import pydantic
 import pydantic_core
 from mcp.types import Annotations, Icon
@@ -277,6 +281,18 @@ class Resource(FastMCPComponent):
         """The lookup key for this resource. Returns str(uri)."""
         return str(self.uri)
 
+    def register_with_docket(self, docket: Docket) -> None:
+        """Register this resource with docket for background execution."""
+        if self.task_config.mode == "forbidden":
+            return
+        docket.register(self.read, names=[self.key])
+
+    async def add_to_docket(  # type: ignore[override]
+        self, docket: Docket, **kwargs: Any
+    ) -> Execution:
+        """Schedule this resource for background execution via docket."""
+        return await docket.add(self.key, **kwargs)()
+
 
 class FunctionResource(Resource):
     """A resource that defers data loading by wrapping a function.
@@ -292,10 +308,6 @@ class FunctionResource(Resource):
     """
 
     fn: Callable[..., Any]
-    task_config: Annotated[
-        TaskConfig,
-        Field(description="Background task execution configuration (SEP-1686)."),
-    ] = Field(default_factory=lambda: TaskConfig(mode="forbidden"))
 
     @classmethod
     def from_function(
@@ -366,3 +378,13 @@ class FunctionResource(Resource):
 
         # Convert any value to ResourceContent
         return ResourceContent.from_value(result, mime_type=self.mime_type)
+
+    def register_with_docket(self, docket: Docket) -> None:
+        """Register this resource with docket for background execution.
+
+        FunctionResource registers the underlying function, which has the user's
+        Depends parameters for docket to resolve.
+        """
+        if self.task_config.mode == "forbidden":
+            return
+        docket.register(self.fn, names=[self.key])

--- a/tests/server/middleware/test_logging.py
+++ b/tests/server/middleware/test_logging.py
@@ -332,7 +332,7 @@ class TestLoggingMiddleware:
 
         assert get_log_lines(caplog) == snapshot(
             [
-                '{"event": "request_start", "method": "test_method", "source": "client", "payload": "{\\"name\\":\\"tmpl\\",\\"title\\":null,\\"description\\":null,\\"icons\\":null,\\"tags\\":[],\\"meta\\":null,\\"enabled\\":true,\\"uri_template\\":\\"tmpl://{id}\\",\\"mime_type\\":\\"text/plain\\",\\"parameters\\":{\\"id\\":{\\"type\\":\\"string\\"}},\\"annotations\\":null}", "payload_type": "ResourceTemplate"}',
+                '{"event": "request_start", "method": "test_method", "source": "client", "payload": "{\\"name\\":\\"tmpl\\",\\"title\\":null,\\"description\\":null,\\"icons\\":null,\\"tags\\":[],\\"meta\\":null,\\"enabled\\":true,\\"task_config\\":{\\"mode\\":\\"forbidden\\"},\\"uri_template\\":\\"tmpl://{id}\\",\\"mime_type\\":\\"text/plain\\",\\"parameters\\":{\\"id\\":{\\"type\\":\\"string\\"}},\\"annotations\\":null}", "payload_type": "ResourceTemplate"}',
                 '{"event": "request_success", "method": "test_method", "source": "client", "duration_ms": 0.02}',
             ]
         )


### PR DESCRIPTION
Custom `Tool`, `Resource`, `ResourceTemplate`, and `Prompt` subclasses can now support background task execution. Previously, only decorator-based components (`@mcp.tool(task=True)`) could use docket.

Each component now encapsulates its docket integration via two methods:

- `register_with_docket(docket)` - Registers the component with docket, checking `task_config` internally
- `add_to_docket(docket, ...)` - Handles component-specific calling conventions for scheduling execution

Custom subclasses enable task support by setting `task_config`:

```python
from fastmcp.tools import Tool, ToolResult
from fastmcp.server.tasks import TaskConfig

class MyCustomTool(Tool):
    task_config = TaskConfig(mode="optional")

    async def run(self, arguments: dict) -> ToolResult:
        ...
```

The `task_config` field has been elevated to `FastMCPComponent` (default: `mode="forbidden"`), so all components inherit it.