### PR TITLE
Refactor task module: rename protocol.py to requests.py and reduce redundancy

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -606,7 +606,7 @@ class FastMCP(Generic[LifespanResultT]):
             ServerResult,
         )
 
-        from fastmcp.server.tasks.protocol import (
+        from fastmcp.server.tasks.requests import (
             tasks_cancel_handler,
             tasks_get_handler,
             tasks_list_handler,

--- a/src/fastmcp/server/tasks/config.py
+++ b/src/fastmcp/server/tasks/config.py
@@ -15,6 +15,11 @@ from typing import Any, Literal
 # Task execution modes per SEP-1686 / MCP ToolExecution.taskSupport
 TaskMode = Literal["forbidden", "optional", "required"]
 
+# Default values for task metadata (single source of truth)
+DEFAULT_POLL_INTERVAL = timedelta(seconds=5)  # Default poll interval
+DEFAULT_POLL_INTERVAL_MS = int(DEFAULT_POLL_INTERVAL.total_seconds() * 1000)
+DEFAULT_TTL_MS = 60_000  # Default TTL in milliseconds
+
 
 @dataclass
 class TaskConfig:
@@ -47,7 +52,7 @@ class TaskConfig:
     """
 
     mode: TaskMode = "optional"
-    poll_interval: timedelta = timedelta(seconds=5)
+    poll_interval: timedelta = DEFAULT_POLL_INTERVAL
 
     @classmethod
     def from_bool(cls, value: bool) -> TaskConfig:

--- a/src/fastmcp/server/tasks/subscriptions.py
+++ b/src/fastmcp/server/tasks/subscriptions.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from docket.execution import ExecutionState
 from mcp.types import TaskStatusNotification, TaskStatusNotificationParams
 
-from fastmcp.server.tasks.protocol import DOCKET_TO_MCP_STATE
+from fastmcp.server.tasks.requests import DOCKET_TO_MCP_STATE
 from fastmcp.utilities.logging import get_logger
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Improves clarity and reduces duplication in the task module by renaming `protocol.py` → `requests.py` and consolidating Redis lookup logic.

## Changes

**Renamed for clarity:**
- `src/fastmcp/server/tasks/protocol.py` → `requests.py`
- More descriptive: these handlers process MCP task **requests** (tasks/get, tasks/result, tasks/cancel, tasks/list)

**Consolidated constants:**
- Moved `DEFAULT_POLL_INTERVAL_MS` and `DEFAULT_TTL_MS` to `config.py`
- `DEFAULT_POLL_INTERVAL_MS` is now derived from `DEFAULT_POLL_INTERVAL` instead of duplicated
- Updated `TaskConfig` to reference the constant

**Reduced redundancy:**
- Extracted `_lookup_task_execution()` helper function
- Eliminates ~50 lines of duplicated Redis lookup code across handlers
- Performance improvement: uses `redis.mget()` for single round-trip instead of 3 separate gets

All 198 task tests pass.