### PR TITLE
Use ergonomic provider initialization pattern

### DIFF
--- a/examples/providers/sqlite/server.py
+++ b/examples/providers/sqlite/server.py
@@ -101,10 +101,8 @@ class SQLiteToolProvider(Provider):
         )
 
 
-mcp = FastMCP("DynamicToolsServer")
-
 provider = SQLiteToolProvider(db_path=str(DB_PATH))
-mcp.add_provider(provider)
+mcp = FastMCP("DynamicToolsServer", providers=[provider])
 
 
 @mcp.tool

--- a/src/fastmcp/server/openapi/server.py
+++ b/src/fastmcp/server/openapi/server.py
@@ -8,9 +8,7 @@ This class is deprecated. Use FastMCP with OpenAPIProvider instead:
 
     client = httpx.AsyncClient(base_url="https://api.example.com")
     provider = OpenAPIProvider(openapi_spec=spec, client=client)
-
-    mcp = FastMCP("My API Server")
-    mcp.add_provider(provider)
+    mcp = FastMCP("My API Server", providers=[provider])
 """
 
 from __future__ import annotations
@@ -55,9 +53,7 @@ class FastMCPOpenAPI(FastMCP):
 
         client = httpx.AsyncClient(base_url="https://api.example.com")
         provider = OpenAPIProvider(openapi_spec=spec, client=client)
-
-        mcp = FastMCP("API Server")
-        mcp.add_provider(provider)
+        mcp = FastMCP("API Server", providers=[provider])
         ```
     """
 
@@ -94,8 +90,7 @@ class FastMCPOpenAPI(FastMCP):
         warnings.warn(
             "FastMCPOpenAPI is deprecated. Use FastMCP with OpenAPIProvider instead:\n"
             "    provider = OpenAPIProvider(openapi_spec=spec, client=client)\n"
-            "    mcp = FastMCP('name')\n"
-            "    mcp.add_provider(provider)",
+            "    mcp = FastMCP('name', providers=[provider])",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/fastmcp/server/providers/openapi/__init__.py
+++ b/src/fastmcp/server/providers/openapi/__init__.py
@@ -10,9 +10,7 @@ Example:
 
     client = httpx.AsyncClient(base_url="https://api.example.com")
     provider = OpenAPIProvider(openapi_spec=spec, client=client)
-
-    mcp = FastMCP("API Server")
-    mcp.add_provider(provider)
+    mcp = FastMCP("API Server", providers=[provider])
     ```
 """
 

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -2788,9 +2788,7 @@ class FastMCP(Generic[LifespanResultT]):
             tags=tags,
             timeout=timeout,
         )
-        server = cls(name=name, **settings)
-        server.add_provider(provider)
-        return server
+        return cls(name=name, providers=[provider], **settings)
 
     @classmethod
     def from_fastapi(
@@ -2847,9 +2845,7 @@ class FastMCP(Generic[LifespanResultT]):
             tags=tags,
             timeout=timeout,
         )
-        server = cls(name=server_name, **settings)
-        server.add_provider(provider)
-        return server
+        return cls(name=server_name, providers=[provider], **settings)
 
     @classmethod
     def as_proxy(


### PR DESCRIPTION
The FastMCP constructor already accepts a `providers` kwarg, but examples and convenience methods were using a less ergonomic three-step pattern. This updates them to use the cleaner approach.

**Before:**
```python
provider = OpenAPIProvider(openapi_spec=spec, client=client)
mcp = FastMCP("API Server")
mcp.add_provider(provider)
```

**After:**
```python
provider = OpenAPIProvider(openapi_spec=spec, client=client)
mcp = FastMCP("API Server", providers=[provider])
```

Changes apply to:
- SQLite provider example
- OpenAPI provider documentation
- `FastMCP.from_openapi()` and `FastMCP.from_fastapi()` convenience methods