### PR TITLE
Let FastMCPError propagate unchanged from managers

### DIFF
--- a/src/fastmcp/prompts/prompt_manager.py
+++ b/src/fastmcp/prompts/prompt_manager.py
@@ -7,7 +7,7 @@ from typing import Any
 from mcp import GetPromptResult
 
 from fastmcp import settings
-from fastmcp.exceptions import NotFoundError, PromptError
+from fastmcp.exceptions import FastMCPError, NotFoundError, PromptError
 from fastmcp.prompts.prompt import FunctionPrompt, Prompt, PromptResult
 from fastmcp.settings import DuplicateBehavior
 from fastmcp.utilities.logging import get_logger
@@ -107,9 +107,8 @@ class PromptManager:
         try:
             messages = await prompt.render(arguments)
             return GetPromptResult(description=prompt.description, messages=messages)
-        except PromptError as e:
-            logger.exception(f"Error rendering prompt {name!r}")
-            raise e
+        except FastMCPError:
+            raise
         except Exception as e:
             logger.exception(f"Error rendering prompt {name!r}")
             if self.mask_error_details:

--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -10,7 +10,7 @@ from typing import Any
 from pydantic import AnyUrl
 
 from fastmcp import settings
-from fastmcp.exceptions import NotFoundError, ResourceError
+from fastmcp.exceptions import FastMCPError, NotFoundError, ResourceError
 from fastmcp.resources.resource import Resource
 from fastmcp.resources.template import (
     ResourceTemplate,
@@ -268,10 +268,9 @@ class ResourceManager:
                         uri_str,
                         params=params,
                     )
-                # Pass through ResourceErrors as-is
-                except ResourceError as e:
-                    logger.error(f"Error creating resource from template: {e}")
-                    raise e
+                # Pass through FastMCPErrors as-is
+                except FastMCPError:
+                    raise
                 # Handle other exceptions
                 except Exception as e:
                     logger.error(f"Error creating resource from template: {e}")
@@ -299,10 +298,9 @@ class ResourceManager:
             try:
                 return await resource.read()
 
-            # raise ResourceErrors as-is
-            except ResourceError as e:
-                logger.exception(f"Error reading resource {uri_str!r}")
-                raise e
+            # raise FastMCPErrors as-is
+            except FastMCPError:
+                raise
 
             # Handle other exceptions
             except Exception as e:
@@ -322,11 +320,8 @@ class ResourceManager:
                 try:
                     resource = await template.create_resource(uri_str, params=params)
                     return await resource.read()
-                except ResourceError as e:
-                    logger.exception(
-                        f"Error reading resource from template {uri_str!r}"
-                    )
-                    raise e
+                except FastMCPError:
+                    raise
                 except Exception as e:
                     logger.exception(
                         f"Error reading resource from template {uri_str!r}"

--- a/src/fastmcp/tools/tool_manager.py
+++ b/src/fastmcp/tools/tool_manager.py
@@ -8,7 +8,7 @@ from mcp.types import ToolAnnotations
 from pydantic import ValidationError
 
 from fastmcp import settings
-from fastmcp.exceptions import NotFoundError, ToolError
+from fastmcp.exceptions import FastMCPError, NotFoundError, ToolError
 from fastmcp.settings import DuplicateBehavior
 from fastmcp.tools.tool import Tool, ToolResult
 from fastmcp.tools.tool_transform import (
@@ -158,12 +158,10 @@ class ToolManager:
         tool = await self.get_tool(key)
         try:
             return await tool.run(arguments)
-        except ValidationError as e:
-            logger.exception(f"Error validating tool {key!r}: {e}")
-            raise e
-        except ToolError as e:
-            logger.exception(f"Error calling tool {key!r}")
-            raise e
+        except FastMCPError:
+            raise
+        except ValidationError:
+            raise
         except Exception as e:
             logger.exception(f"Error calling tool {key!r}")
             if self.mask_error_details:


### PR DESCRIPTION
Previously, managers only re-raised their specific error types (e.g., `ToolError` in ToolManager, `ResourceError` in ResourceManager). This meant that other `FastMCPError` subclasses like `fastmcp.exceptions.ValidationError` would get wrapped, losing their original message.

Now all managers catch `FastMCPError` (the base class) and re-raise it unchanged, allowing any FastMCP error type to propagate with its original message intact.

```python
from fastmcp import FastMCP
from fastmcp.server import Context
from fastmcp.exceptions import ValidationError

mcp = FastMCP()

@mcp.tool
def validate(ctx: Context) -> str:
    raise ValidationError("Invalid input format")
    
# Error message is now "Invalid input format", not wrapped in "Error calling tool..."
```