### PR TITLE
Add type-prefixed keys for globally unique component identification

### DIFF
--- a/docs/development/upgrade-guide.mdx
+++ b/docs/development/upgrade-guide.mdx
@@ -8,6 +8,29 @@ tag: NEW
 
 This guide provides migration instructions for breaking changes and major updates when upgrading between FastMCP versions.
 
+## v3.0.0
+
+### Component Lookup Method Parameter Names
+
+The server lookup methods now use semantic parameter names instead of generic `key`:
+
+- `FastMCP.get_tool(name=...)` (was `key`)
+- `FastMCP.get_resource(uri=...)` (was `key`)
+- `FastMCP.get_resource_template(uri=...)` (was `key`)
+- `FastMCP.get_prompt(name=...)` (was `key`)
+
+If you were passing arguments positionally, no change is needed. If you were using keyword arguments:
+
+<CodeGroup>
+```python Before
+tool = await mcp.get_tool(key="my_tool")
+```
+
+```python After
+tool = await mcp.get_tool(name="my_tool")
+```
+</CodeGroup>
+
 ## v2.14.0
 
 ### OpenAPI Parser Promotion

--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import pydantic_core
 
@@ -117,6 +117,8 @@ class PromptResult(FastMCPBaseModel):
 
 class Prompt(FastMCPComponent):
     """A prompt template that can be rendered with parameters."""
+
+    KEY_PREFIX: ClassVar[str] = "prompt"
 
     arguments: list[PromptArgument] | None = Field(
         default=None, description="Arguments that can be passed to the prompt"

--- a/src/fastmcp/resources/resource.py
+++ b/src/fastmcp/resources/resource.py
@@ -6,7 +6,7 @@ import base64
 import inspect
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar
 
 import mcp.types
 
@@ -136,6 +136,8 @@ class ResourceContent(pydantic.BaseModel):
 
 class Resource(FastMCPComponent):
     """Base class for all resources."""
+
+    KEY_PREFIX: ClassVar[str] = "resource"
 
     model_config = ConfigDict(validate_default=True)
 
@@ -300,8 +302,8 @@ class Resource(FastMCPComponent):
 
     @property
     def key(self) -> str:
-        """The lookup key for this resource. Returns str(uri)."""
-        return str(self.uri)
+        """The globally unique lookup key for this resource."""
+        return self.make_key(str(self.uri))
 
     def register_with_docket(self, docket: Docket) -> None:
         """Register this resource with docket for background execution."""

--- a/src/fastmcp/resources/template.py
+++ b/src/fastmcp/resources/template.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import parse_qs, unquote
 
 import mcp.types
@@ -96,6 +96,8 @@ def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
 
 class ResourceTemplate(FastMCPComponent):
     """A template for dynamically creating resources."""
+
+    KEY_PREFIX: ClassVar[str] = "template"
 
     uri_template: str = Field(
         description="URI template with parameters (e.g. weather://{city}/current)"
@@ -265,8 +267,8 @@ class ResourceTemplate(FastMCPComponent):
 
     @property
     def key(self) -> str:
-        """The lookup key for this template. Returns uri_template."""
-        return self.uri_template
+        """The globally unique lookup key for this template."""
+        return self.make_key(self.uri_template)
 
     def register_with_docket(self, docket: Docket) -> None:
         """Register this template with docket for background execution."""

--- a/src/fastmcp/server/providers/base.py
+++ b/src/fastmcp/server/providers/base.py
@@ -30,27 +30,13 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
 from typing import Literal
 
 from fastmcp.prompts.prompt import Prompt
 from fastmcp.resources.resource import Resource
 from fastmcp.resources.template import ResourceTemplate
 from fastmcp.tools.tool import Tool
-
-
-@dataclass
-class TaskComponents:
-    """Collection of components eligible for background task execution.
-
-    Used by get_tasks() to return components for Docket registration.
-    Components must implement register_with_docket() and add_to_docket().
-    """
-
-    tools: Sequence[Tool] = ()
-    resources: Sequence[Resource] = ()
-    templates: Sequence[ResourceTemplate] = ()
-    prompts: Sequence[Prompt] = ()
+from fastmcp.utilities.components import FastMCPComponent
 
 
 class Provider:
@@ -239,11 +225,37 @@ class Provider:
         prompts = await self.list_prompts()
         return next((p for p in prompts if p.name == name), None)
 
+    async def get_component(
+        self, key: str
+    ) -> Tool | Resource | ResourceTemplate | Prompt | None:
+        """Get a component by its prefixed key.
+
+        Args:
+            key: The prefixed key (e.g., "tool:name", "resource:uri", "template:uri").
+
+        Returns:
+            The component if found, or None to continue searching other providers.
+        """
+        # Default implementation: iterate through all components and match by key
+        for tool in await self.list_tools():
+            if tool.key == key:
+                return tool
+        for resource in await self.list_resources():
+            if resource.key == key:
+                return resource
+        for template in await self.list_resource_templates():
+            if template.key == key:
+                return template
+        for prompt in await self.list_prompts():
+            if prompt.key == key:
+                return prompt
+        return None
+
     # -------------------------------------------------------------------------
     # Task registration
     # -------------------------------------------------------------------------
 
-    async def get_tasks(self) -> TaskComponents:
+    async def get_tasks(self) -> Sequence[FastMCPComponent]:
         """Return components that should be registered as background tasks.
 
         Override to customize which components are task-eligible.
@@ -257,34 +269,28 @@ class Provider:
         from fastmcp.resources.template import FunctionResourceTemplate
         from fastmcp.tools.tool import FunctionTool
 
-        all_tools = await self.list_tools()
-        all_resources = await self.list_resources()
-        all_templates = await self.list_resource_templates()
-        all_prompts = await self.list_prompts()
+        components: list[FastMCPComponent] = []
 
-        return TaskComponents(
-            tools=[
-                t
-                for t in all_tools
-                if isinstance(t, FunctionTool) and t.task_config.supports_tasks()
-            ],
-            resources=[
-                r
-                for r in all_resources
-                if isinstance(r, FunctionResource) and r.task_config.supports_tasks()
-            ],
-            templates=[
-                t
-                for t in all_templates
-                if isinstance(t, FunctionResourceTemplate)
+        for t in await self.list_tools():
+            if isinstance(t, FunctionTool) and t.task_config.supports_tasks():
+                components.append(t)
+
+        for r in await self.list_resources():
+            if isinstance(r, FunctionResource) and r.task_config.supports_tasks():
+                components.append(r)
+
+        for t in await self.list_resource_templates():
+            if (
+                isinstance(t, FunctionResourceTemplate)
                 and t.task_config.supports_tasks()
-            ],
-            prompts=[
-                p
-                for p in all_prompts
-                if isinstance(p, FunctionPrompt) and p.task_config.supports_tasks()
-            ],
-        )
+            ):
+                components.append(t)
+
+        for p in await self.list_prompts():
+            if isinstance(p, FunctionPrompt) and p.task_config.supports_tasks():
+                components.append(p)
+
+        return components
 
     # -------------------------------------------------------------------------
     # Lifecycle methods

--- a/src/fastmcp/server/providers/openapi/provider.py
+++ b/src/fastmcp/server/providers/openapi/provider.py
@@ -11,7 +11,7 @@ from jsonschema_path import SchemaPath
 
 from fastmcp.prompts import Prompt
 from fastmcp.resources import Resource, ResourceTemplate
-from fastmcp.server.providers.base import Provider, TaskComponents
+from fastmcp.server.providers.base import Provider
 from fastmcp.server.providers.openapi.components import (
     OpenAPIResource,
     OpenAPIResourceTemplate,
@@ -27,6 +27,7 @@ from fastmcp.server.providers.openapi.routing import (
     _determine_route_type,
 )
 from fastmcp.tools.tool import Tool
+from fastmcp.utilities.components import FastMCPComponent
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.openapi import (
     HTTPRoute,
@@ -378,6 +379,6 @@ class OpenAPIProvider(Provider):
         """Return empty list - OpenAPI doesn't create prompts."""
         return []
 
-    async def get_tasks(self) -> TaskComponents:
-        """Return empty TaskComponents - OpenAPI components don't support tasks."""
-        return TaskComponents()
+    async def get_tasks(self) -> Sequence[FastMCPComponent]:
+        """Return empty list - OpenAPI components don't support tasks."""
+        return []

--- a/src/fastmcp/server/providers/proxy.py
+++ b/src/fastmcp/server/providers/proxy.py
@@ -39,7 +39,7 @@ from fastmcp.resources import Resource, ResourceTemplate
 from fastmcp.resources.resource import ResourceContent
 from fastmcp.server.context import Context
 from fastmcp.server.dependencies import get_context
-from fastmcp.server.providers.base import Provider, TaskComponents
+from fastmcp.server.providers.base import Provider
 from fastmcp.server.server import FastMCP
 from fastmcp.server.tasks.config import TaskConfig
 from fastmcp.tools.tool import Tool, ToolResult
@@ -47,7 +47,7 @@ from fastmcp.tools.tool_transform import (
     ToolTransformConfig,
     apply_transformations_to_tools,
 )
-from fastmcp.utilities.components import MirroredComponent
+from fastmcp.utilities.components import FastMCPComponent, MirroredComponent
 from fastmcp.utilities.logging import get_logger
 
 if TYPE_CHECKING:
@@ -541,14 +541,14 @@ class ProxyProvider(Provider):
     # Task methods
     # -------------------------------------------------------------------------
 
-    async def get_tasks(self) -> TaskComponents:
-        """Return empty TaskComponents since proxy components don't support tasks.
+    async def get_tasks(self) -> Sequence[FastMCPComponent]:
+        """Return empty list since proxy components don't support tasks.
 
         Override the base implementation to avoid calling list_tools() during
         server lifespan initialization, which would open the client before any
         context is set. All Proxy* components have task_config.mode="forbidden".
         """
-        return TaskComponents()
+        return []
 
     # lifespan() uses default implementation (empty context manager)
     # because client cleanup is handled per-request

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -8,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ClassVar,
     Generic,
     TypeAlias,
     get_type_hints,
@@ -125,6 +126,8 @@ class ToolResult:
 
 class Tool(FastMCPComponent):
     """Internal tool registration info."""
+
+    KEY_PREFIX: ClassVar[str] = "tool"
 
     parameters: Annotated[
         dict[str, Any], Field(description="JSON schema for tool parameters")

--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -927,17 +927,20 @@ def apply_transformations_to_tools(
 ) -> dict[str, Tool]:
     """Apply a list of transformations to a list of tools. Tools that do not have any transformations
     are left unchanged.
+
+    Note: tools dict is keyed by prefixed key (e.g., "tool:my_tool"),
+    but transformations are keyed by tool name (e.g., "my_tool").
     """
 
     transformed_tools: dict[str, Tool] = {}
 
-    for tool_name, tool in tools.items():
-        if transformation := transformations.get(tool_name):
-            transformed_tools[transformation.name or tool_name] = transformation.apply(
-                tool
-            )
+    for tool_key, tool in tools.items():
+        # Look up transformation by tool name, not prefixed key
+        if transformation := transformations.get(tool.name):
+            transformed = transformation.apply(tool)
+            transformed_tools[transformed.key] = transformed
             continue
 
-        transformed_tools[tool_name] = tool
+        transformed_tools[tool_key] = tool
 
     return transformed_tools

--- a/src/fastmcp/utilities/inspect.py
+++ b/src/fastmcp/utilities/inspect.py
@@ -119,7 +119,7 @@ async def inspect_fastmcp_v2(mcp: FastMCP[Any]) -> FastMCPInfo:
     # Extract detailed tool information
     tool_infos = []
     for tool in tools_list:
-        mcp_tool = tool.to_mcp_tool(name=tool.key)
+        mcp_tool = tool.to_mcp_tool(name=tool.name)
         tool_infos.append(
             ToolInfo(
                 key=tool.key,
@@ -165,7 +165,7 @@ async def inspect_fastmcp_v2(mcp: FastMCP[Any]) -> FastMCPInfo:
         resource_infos.append(
             ResourceInfo(
                 key=resource.key,
-                uri=resource.key,
+                uri=str(resource.uri),
                 name=resource.name,
                 description=resource.description,
                 mime_type=resource.mime_type,
@@ -188,7 +188,7 @@ async def inspect_fastmcp_v2(mcp: FastMCP[Any]) -> FastMCPInfo:
         template_infos.append(
             TemplateInfo(
                 key=template.key,
-                uri_template=template.key,
+                uri_template=template.uri_template,
                 name=template.name,
                 description=template.description,
                 mime_type=template.mime_type,

--- a/tests/server/providers/test_local_provider.py
+++ b/tests/server/providers/test_local_provider.py
@@ -35,8 +35,8 @@ class TestLocalProviderStorage:
         )
         provider.add_tool(tool)
 
-        assert "test_tool" in provider._tools
-        assert provider._tools["test_tool"] is tool
+        assert "tool:test_tool" in provider._components
+        assert provider._components["tool:test_tool"] is tool
 
     def test_add_multiple_tools(self):
         """Test adding multiple tools."""
@@ -55,8 +55,8 @@ class TestLocalProviderStorage:
         provider.add_tool(tool1)
         provider.add_tool(tool2)
 
-        assert "tool1" in provider._tools
-        assert "tool2" in provider._tools
+        assert "tool:tool1" in provider._components
+        assert "tool:tool2" in provider._components
 
     def test_remove_tool(self):
         """Test removing a tool from LocalProvider."""
@@ -70,7 +70,7 @@ class TestLocalProviderStorage:
         provider.add_tool(tool)
         provider.remove_tool("test_tool")
 
-        assert "test_tool" not in provider._tools
+        assert "tool:test_tool" not in provider._components
 
     def test_remove_nonexistent_tool_raises(self):
         """Test that removing a nonexistent tool raises KeyError."""
@@ -87,7 +87,7 @@ class TestLocalProviderStorage:
         def test_resource() -> str:
             return "content"
 
-        assert "resource://test" in provider._resources
+        assert "resource:resource://test" in provider._components
 
     def test_remove_resource(self):
         """Test removing a resource from LocalProvider."""
@@ -99,7 +99,7 @@ class TestLocalProviderStorage:
 
         provider.remove_resource("resource://test")
 
-        assert "resource://test" not in provider._resources
+        assert "resource:resource://test" not in provider._components
 
     def test_add_template(self):
         """Test adding a resource template to LocalProvider."""
@@ -109,7 +109,7 @@ class TestLocalProviderStorage:
         def template_fn(id: str) -> str:
             return f"Resource {id}"
 
-        assert "resource://{id}" in provider._templates
+        assert "template:resource://{id}" in provider._components
 
     def test_remove_template(self):
         """Test removing a resource template from LocalProvider."""
@@ -121,7 +121,7 @@ class TestLocalProviderStorage:
 
         provider.remove_template("resource://{id}")
 
-        assert "resource://{id}" not in provider._templates
+        assert "template:resource://{id}" not in provider._components
 
     def test_add_prompt(self):
         """Test adding a prompt to LocalProvider."""
@@ -133,7 +133,7 @@ class TestLocalProviderStorage:
         )
         provider.add_prompt(prompt)
 
-        assert "test_prompt" in provider._prompts
+        assert "prompt:test_prompt" in provider._components
 
     def test_remove_prompt(self):
         """Test removing a prompt from LocalProvider."""
@@ -146,7 +146,7 @@ class TestLocalProviderStorage:
         provider.add_prompt(prompt)
         provider.remove_prompt("test_prompt")
 
-        assert "test_prompt" not in provider._prompts
+        assert "prompt:test_prompt" not in provider._components
 
 
 class TestLocalProviderInterface:
@@ -304,8 +304,8 @@ class TestLocalProviderDecorators:
         def my_tool(x: int) -> int:
             return x * 2
 
-        assert "my_tool" in provider._tools
-        assert provider._tools["my_tool"].name == "my_tool"
+        assert "tool:my_tool" in provider._components
+        assert provider._components["tool:my_tool"].name == "my_tool"
 
     def test_tool_decorator_with_parens(self):
         """Test @provider.tool() with empty parentheses."""
@@ -315,7 +315,7 @@ class TestLocalProviderDecorators:
         def my_tool(x: int) -> int:
             return x * 2
 
-        assert "my_tool" in provider._tools
+        assert "tool:my_tool" in provider._components
 
     def test_tool_decorator_with_name_kwarg(self):
         """Test @provider.tool(name='custom')."""
@@ -325,8 +325,8 @@ class TestLocalProviderDecorators:
         def my_tool(x: int) -> int:
             return x * 2
 
-        assert "custom_name" in provider._tools
-        assert "my_tool" not in provider._tools
+        assert "tool:custom_name" in provider._components
+        assert "tool:my_tool" not in provider._components
 
     def test_tool_decorator_with_description(self):
         """Test @provider.tool(description='...')."""
@@ -336,7 +336,7 @@ class TestLocalProviderDecorators:
         def my_tool(x: int) -> int:
             return x * 2
 
-        assert provider._tools["my_tool"].description == "Custom description"
+        assert provider._components["tool:my_tool"].description == "Custom description"
 
     def test_tool_direct_call(self):
         """Test provider.tool(fn, name='...')."""
@@ -347,7 +347,7 @@ class TestLocalProviderDecorators:
 
         provider.tool(my_tool, name="direct_tool")
 
-        assert "direct_tool" in provider._tools
+        assert "tool:direct_tool" in provider._components
 
     async def test_tool_decorator_execution(self):
         """Test that decorated tools execute correctly."""
@@ -371,7 +371,7 @@ class TestLocalProviderDecorators:
         def my_resource() -> str:
             return "test content"
 
-        assert "resource://test" in provider._resources
+        assert "resource:resource://test" in provider._components
 
     def test_resource_decorator_with_name(self):
         """Test @provider.resource with custom name."""
@@ -381,7 +381,7 @@ class TestLocalProviderDecorators:
         def my_resource() -> str:
             return "test content"
 
-        assert provider._resources["resource://test"].name == "custom_name"
+        assert provider._components["resource:resource://test"].name == "custom_name"
 
     async def test_resource_decorator_execution(self):
         """Test that decorated resources execute correctly."""
@@ -405,7 +405,7 @@ class TestLocalProviderDecorators:
         def my_prompt() -> str:
             return "A prompt"
 
-        assert "my_prompt" in provider._prompts
+        assert "prompt:my_prompt" in provider._components
 
     def test_prompt_decorator_with_parens(self):
         """Test @provider.prompt() with empty parentheses."""
@@ -415,7 +415,7 @@ class TestLocalProviderDecorators:
         def my_prompt() -> str:
             return "A prompt"
 
-        assert "my_prompt" in provider._prompts
+        assert "prompt:my_prompt" in provider._components
 
     def test_prompt_decorator_with_name(self):
         """Test @provider.prompt(name='custom')."""
@@ -425,8 +425,8 @@ class TestLocalProviderDecorators:
         def my_prompt() -> str:
             return "A prompt"
 
-        assert "custom_prompt" in provider._prompts
-        assert "my_prompt" not in provider._prompts
+        assert "prompt:custom_prompt" in provider._components
+        assert "prompt:my_prompt" not in provider._components
 
 
 class TestLocalProviderToolTransformations:
@@ -510,8 +510,8 @@ class TestLocalProviderTaskRegistration:
             return x
 
         tasks = await provider.get_tasks()
-        assert len(tasks.tools) == 1
-        assert tasks.tools[0].name == "background_tool"
+        assert len(tasks) == 1
+        assert tasks[0].name == "background_tool"
 
     async def test_get_tasks_filters_forbidden_tools(self):
         """Test that get_tasks excludes tools with forbidden task mode."""
@@ -522,7 +522,7 @@ class TestLocalProviderTaskRegistration:
             return x
 
         tasks = await provider.get_tasks()
-        assert len(tasks.tools) == 0
+        assert len(tasks) == 0
 
     async def test_get_tasks_includes_custom_tool_subclasses(self):
         """Test that custom Tool subclasses are included in get_tasks."""
@@ -538,8 +538,8 @@ class TestLocalProviderTaskRegistration:
         provider.add_tool(CustomTool(name="custom", description="Custom tool"))
 
         tasks = await provider.get_tasks()
-        assert len(tasks.tools) == 1
-        assert tasks.tools[0].name == "custom"
+        assert len(tasks) == 1
+        assert tasks[0].name == "custom"
 
 
 class TestLocalProviderStandaloneUsage:

--- a/tests/server/tasks/test_custom_subclass_tasks.py
+++ b/tests/server/tasks/test_custom_subclass_tasks.py
@@ -122,10 +122,10 @@ async def test_custom_tool_registers_with_docket():
 
     tool.register_with_docket(mock_docket)
 
-    # Should register self.run with docket
+    # Should register self.run with docket using prefixed key
     mock_docket.register.assert_called_once()
     call_args = mock_docket.register.call_args
-    assert call_args[1]["names"] == ["test"]
+    assert call_args[1]["names"] == ["tool:test"]
 
 
 async def test_custom_tool_forbidden_does_not_register():


### PR DESCRIPTION
Component keys are now globally unique by including a type prefix. This eliminates any possibility of key collisions between different component types.

```python
from fastmcp import FastMCP
from fastmcp.tools import Tool

mcp = FastMCP("Server")

@mcp.tool
def greet(name: str) -> str:
    return f"Hello, {name}!"

# Keys are now prefixed by type
tool = await mcp.get_tool("greet")
print(tool.key)  # "tool:greet"

# Direct lookup by prefixed key
component = await mcp.get_component("tool:greet")

# Class method to construct keys
Tool.make_key("greet")  # "tool:greet"
```

Key prefixes:
- `tool:` for tools
- `prompt:` for prompts  
- `resource:` for resources
- `template:` for resource templates

LocalProvider now uses unified `_components` dict storage. `get_tasks()` returns a flat `Sequence[FastMCPComponent]` instead of the previous `TaskComponents` dataclass. Subclasses of `FastMCPComponent` that don't define `KEY_PREFIX` will emit a warning.

Closes #2703