### PR TITLE
Fix Prefect website URL in docs footer

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,7 @@
     "socials": {
       "discord": "https://discord.gg/uu8dJCgttd",
       "github": "https://github.com/jlowin/fastmcp",
-      "website": "https://prefect.ai",
+      "website": "https://www.prefect.io",
       "x": "https://x.com/fastmcp"
     }
   },


### PR DESCRIPTION
Port of #2701 to release/2.x branch.

The link in the footer was broken.