### PR TITLE
Pin MCP under 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "exceptiongroup>=1.2.2",
     "httpx>=0.28.1",
-    "mcp>=1.24.0",
+    "mcp>=1.24.0,<2.0",
     "openapi-pydantic>=0.5.1",
     "platformdirs>=4.0.0",
     "pydocket>=0.16.3",
@@ -181,4 +181,3 @@ extend-select = [
 
 [tool.codespell]
 ignore-words-list = "asend,shttp,te"
-


### PR DESCRIPTION
This pin must have been relaxed during the 11/25/25 updates. Pins the MCP SDK under 2.0