### PR TITLE
Skip parallel MCP config test on Windows

### DIFF
--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -243,6 +243,10 @@ async def test_multi_client(tmp_path: Path):
         assert result_2.data == 3
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win32"),
+    reason="Windows has process lifecycle issues with parallel stdio subprocess calls",
+)
 async def test_multi_client_parallel_calls(tmp_path: Path):
     server_script = inspect.cleandoc("""
         from fastmcp import FastMCP


### PR DESCRIPTION
The `test_multi_client_parallel_calls` test spawns multiple Python subprocesses and runs 40 concurrent `list_tools()` calls via stdio. This consistently times out on Windows CI due to slower subprocess/stdio performance.

The adjacent `test_multi_client_lifespan` test already has the same Windows skip for similar reasons. This adds the skipif marker to match.