### PR TITLE
Add v3 breaking changes notice to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@
 >
 > **For production MCP applications, install FastMCP:** `pip install fastmcp`
 
+> [!Important]
+> FastMCP 3.0 is in development and may include breaking changes. To avoid unexpected issues, pin your dependency to v2: `fastmcp<3`
+
 ---
 
 **FastMCP is the standard framework for building MCP applications**, providing the fastest path from idea to production.

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -23,6 +23,10 @@ Alternatively, you can install it directly with `pip` or `uv pip`:
     ```
 </CodeGroup>
 
+<Warning>
+**FastMCP 3.0** is in development and may include breaking changes. To avoid unexpected issues, pin your dependency to v2: `fastmcp<3`
+</Warning>
+
 ### Verify Installation
 
 To verify that FastMCP is installed correctly, you can run the following command:

--- a/docs/getting-started/welcome.mdx
+++ b/docs/getting-started/welcome.mdx
@@ -35,7 +35,6 @@ if __name__ == "__main__":
     mcp.run()
 ```
 
-
 ## Beyond Basic MCP
 
 FastMCP pioneered Python MCP development, and FastMCP 1.0 was incorporated into the [official MCP SDK](https://github.com/modelcontextprotocol/python-sdk) in 2024.
@@ -45,6 +44,10 @@ FastMCP pioneered Python MCP development, and FastMCP 1.0 was incorporated into 
 Ready to build? Start with our [installation guide](/getting-started/installation) or jump straight to the [quickstart](/getting-started/quickstart).
 
 FastMCP is made with 💙 by [Prefect](https://www.prefect.io/).
+
+<Warning>
+**FastMCP 3.0** is in development and may include breaking changes. To avoid unexpected issues, pin your dependency to v2: `fastmcp<3`
+</Warning>
 
 ## What is MCP?
 


### PR DESCRIPTION
Adds a notice to the README and docs welcome page advising users to pin `fastmcp<3` to avoid unexpected issues as FastMCP 3.0 development proceeds.