### PR TITLE
Enable parallel tests on Windows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,13 +51,7 @@ jobs:
         run: uv sync --upgrade
 
       - name: Run tests (excluding integration and client_process)
-        run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" -v
-          else
-            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
-          fi
-        shell: bash
+        run: uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
 
       - name: Run client process tests separately
         run: uv run pytest --inline-snapshot=disable tests -m "client_process" -x


### PR DESCRIPTION
Now that the problematic stdio subprocess tests are skipped on Windows, perhaps we can re-enable parallel test execution. (#2714, #2711)