### PR TITLE
Consolidate get_* and _list_* methods into single API

### DIFF
--- a/docs/development/upgrade-guide.mdx
+++ b/docs/development/upgrade-guide.mdx
@@ -72,6 +72,25 @@ tool = await mcp.get_tool(name="my_tool")
 ```
 </CodeGroup>
 
+### Component Listing Methods Return Lists
+
+The `get_tools()`, `get_resources()`, `get_prompts()`, and `get_resource_templates()` methods now return lists instead of dicts:
+
+<CodeGroup>
+```python Before
+tools = await server.get_tools()
+if "my_tool" in tools:
+    tool = tools["my_tool"]
+```
+
+```python After
+tools = await server.get_tools()
+tool = next((t for t in tools if t.name == "my_tool"), None)
+```
+</CodeGroup>
+
+The dict key was redundant since components already have `.name` or `.uri` attributes. Use list comprehensions or `next()` for lookups.
+
 ## v2.14.0
 
 ### OpenAPI Parser Promotion

--- a/src/fastmcp/server/providers/fastmcp_provider.py
+++ b/src/fastmcp/server/providers/fastmcp_provider.py
@@ -481,7 +481,7 @@ class FastMCPProvider(Provider):
         each tool as a FastMCPProviderTool that delegates execution to the
         nested server's middleware.
         """
-        raw_tools = await self.server._list_tools_middleware()
+        raw_tools = await self.server.get_tools(apply_middleware=True)
         return [FastMCPProviderTool.wrap(self.server, t) for t in raw_tools]
 
     async def get_tool(self, name: str) -> Tool | None:
@@ -500,7 +500,7 @@ class FastMCPProvider(Provider):
         each resource as a FastMCPProviderResource that delegates reading to the
         nested server's middleware.
         """
-        raw_resources = await self.server._list_resources_middleware()
+        raw_resources = await self.server.get_resources(apply_middleware=True)
         return [FastMCPProviderResource.wrap(self.server, r) for r in raw_resources]
 
     async def get_resource(self, uri: str) -> Resource | None:
@@ -518,7 +518,7 @@ class FastMCPProvider(Provider):
         Returns FastMCPProviderResourceTemplate instances that create
         FastMCPProviderResources when materialized.
         """
-        raw_templates = await self.server._list_resource_templates_middleware()
+        raw_templates = await self.server.get_resource_templates(apply_middleware=True)
         return [
             FastMCPProviderResourceTemplate.wrap(self.server, t) for t in raw_templates
         ]
@@ -541,7 +541,7 @@ class FastMCPProvider(Provider):
         Returns FastMCPProviderPrompt instances that delegate rendering to the
         wrapped server's middleware.
         """
-        raw_prompts = await self.server._list_prompts_middleware()
+        raw_prompts = await self.server.get_prompts(apply_middleware=True)
         return [FastMCPProviderPrompt.wrap(self.server, p) for p in raw_prompts]
 
     async def get_prompt(self, name: str) -> Prompt | None:

--- a/src/fastmcp/utilities/inspect.py
+++ b/src/fastmcp/utilities/inspect.py
@@ -107,10 +107,10 @@ async def inspect_fastmcp_v2(mcp: FastMCP[Any]) -> FastMCPInfo:
         FastMCPInfo dataclass containing the extracted information
     """
     # Get all components via middleware to respect filtering and preserve metadata
-    tools_list = await mcp._list_tools_middleware()
-    prompts_list = await mcp._list_prompts_middleware()
-    resources_list = await mcp._list_resources_middleware()
-    templates_list = await mcp._list_resource_templates_middleware()
+    tools_list = await mcp.get_tools(apply_middleware=True)
+    prompts_list = await mcp.get_prompts(apply_middleware=True)
+    resources_list = await mcp.get_resources(apply_middleware=True)
+    templates_list = await mcp.get_resource_templates(apply_middleware=True)
 
     # Extract detailed tool information
     tool_infos = []

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -164,7 +164,7 @@ def greet(name: str) -> str:
         server = await source.load_server()
         assert server.name == "TestServer"
         tools = await server.get_tools()
-        assert "greet" in tools
+        assert any(t.name == "greet" for t in tools)
 
     async def test_import_server_with_main_block(self, tmp_path):
         """Test importing server with if __name__ == '__main__' block."""
@@ -186,7 +186,7 @@ if __name__ == "__main__":
         server = await source.load_server()
         assert server.name == "MainServer"
         tools = await server.get_tools()
-        assert "calculate" in tools
+        assert any(t.name == "calculate" for t in tools)
 
     async def test_import_server_standard_names(self, tmp_path):
         """Test automatic detection of standard names (mcp, server, app)."""
@@ -240,7 +240,7 @@ def custom_tool() -> str:
         server = await source.load_server()
         assert server.name == "CustomServer"
         tools = await server.get_tools()
-        assert "custom_tool" in tools
+        assert any(t.name == "custom_tool" for t in tools)
 
     async def test_import_server_no_standard_names_fails(self, tmp_path):
         """Test importing server when no standard names exist fails."""

--- a/tests/cli/test_server_args.py
+++ b/tests/cli/test_server_args.py
@@ -50,7 +50,7 @@ def get_config() -> dict:
 
         # Test the tool works and can access the parsed args
         tools = await server.get_tools()
-        assert "get_config" in tools
+        assert any(t.name == "get_config" for t in tools)
 
     async def test_server_with_no_args(self, tmp_path):
         """Test a server that uses argparse with no arguments (defaults)."""
@@ -131,5 +131,5 @@ mcp = FastMCP(name)
 
         # Verify tools are available
         tools = await server.get_tools()
-        assert "get_status" in tools
-        assert "echo_message" in tools
+        assert any(t.name == "get_status" for t in tools)
+        assert any(t.name == "echo_message" for t in tools)

--- a/tests/contrib/test_component_manager.py
+++ b/tests/contrib/test_component_manager.py
@@ -81,7 +81,7 @@ class TestComponentManagementRoutes:
         # First disable the tool
         mcp.disable(keys=["tool:test_tool"])
         tools = await mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
         # Enable the tool via the HTTP route
         response = client.post("/tools/test_tool/enable")
@@ -91,13 +91,13 @@ class TestComponentManagementRoutes:
 
         # Verify the tool is enabled
         tools = await mcp.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
     async def test_disable_tool_route(self, client, mcp):
         """Test disabling a tool via the HTTP route."""
         # First ensure the tool is enabled
         tools = await mcp.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
         # Disable the tool via the HTTP route
         response = client.post("/tools/test_tool/disable")
@@ -107,14 +107,14 @@ class TestComponentManagementRoutes:
 
         # Verify the tool is disabled
         tools = await mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
     async def test_enable_resource_route(self, client, mcp):
         """Test enabling a resource via the HTTP route."""
         # First disable the resource
         mcp.disable(keys=["resource:data://test_resource"])
         resources = await mcp.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
         # Enable the resource via the HTTP route
         response = client.post("/resources/data://test_resource/enable")
@@ -124,13 +124,13 @@ class TestComponentManagementRoutes:
 
         # Verify the resource is enabled
         resources = await mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_disable_resource_route(self, client, mcp):
         """Test disabling a resource via the HTTP route."""
         # First ensure the resource is enabled
         resources = await mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
         # Disable the resource via the HTTP route
         response = client.post("/resources/data://test_resource/disable")
@@ -140,41 +140,41 @@ class TestComponentManagementRoutes:
 
         # Verify the resource is disabled
         resources = await mcp.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_enable_template_route(self, client, mcp):
         """Test enabling a resource on a mounted server via the parent server's HTTP route."""
         key = "data://test_resource/{id}"
         mcp.disable(keys=["template:data://test_resource/{id}"])
         templates = await mcp.get_resource_templates()
-        assert key not in templates
+        assert not any(t.uri_template == key for t in templates)
         response = client.post("/resources/data://test_resource/{id}/enable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "message": "Enabled resource: data://test_resource/{id}"
         }
         templates = await mcp.get_resource_templates()
-        assert key in templates
+        assert any(t.uri_template == key for t in templates)
 
     async def test_disable_template_route(self, client, mcp):
         """Test disabling a resource on a mounted server via the parent server's HTTP route."""
         key = "data://test_resource/{id}"
         templates = await mcp.get_resource_templates()
-        assert key in templates
+        assert any(t.uri_template == key for t in templates)
         response = client.post("/resources/data://test_resource/{id}/disable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "message": "Disabled resource: data://test_resource/{id}"
         }
         templates = await mcp.get_resource_templates()
-        assert key not in templates
+        assert not any(t.uri_template == key for t in templates)
 
     async def test_enable_prompt_route(self, client, mcp):
         """Test enabling a prompt via the HTTP route."""
         # First disable the prompt
         mcp.disable(keys=["prompt:test_prompt"])
         prompts = await mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
         # Enable the prompt via the HTTP route
         response = client.post("/prompts/test_prompt/enable")
@@ -184,13 +184,13 @@ class TestComponentManagementRoutes:
 
         # Verify the prompt is enabled
         prompts = await mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
     async def test_disable_prompt_route(self, client, mcp):
         """Test disabling a prompt via the HTTP route."""
         # First ensure the prompt is enabled
         prompts = await mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
         # Disable the prompt via the HTTP route
         response = client.post("/prompts/test_prompt/disable")
@@ -200,107 +200,107 @@ class TestComponentManagementRoutes:
 
         # Verify the prompt is disabled
         prompts = await mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
     async def test_enable_tool_route_on_mounted_server(self, client, mounted_mcp):
         """Test enabling a tool on a mounted server via the parent server's HTTP route."""
         # Disable the tool on the sub-server
         mounted_mcp.disable(keys=["tool:mounted_tool"])
         tools = await mounted_mcp.get_tools()
-        assert "mounted_tool" not in tools
+        assert not any(t.name == "mounted_tool" for t in tools)
         # Enable via parent
         response = client.post("/tools/sub_mounted_tool/enable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "Enabled tool: sub_mounted_tool"}
         # Confirm enabled on sub-server
         tools = await mounted_mcp.get_tools()
-        assert "mounted_tool" in tools
+        assert any(t.name == "mounted_tool" for t in tools)
 
     async def test_disable_tool_route_on_mounted_server(self, client, mounted_mcp):
         """Test disabling a tool on a mounted server via the parent server's HTTP route."""
         # Ensure the tool is enabled on the sub-server
         tools = await mounted_mcp.get_tools()
-        assert "mounted_tool" in tools
+        assert any(t.name == "mounted_tool" for t in tools)
         # Disable via parent
         response = client.post("/tools/sub_mounted_tool/disable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "Disabled tool: sub_mounted_tool"}
         # Confirm disabled on sub-server
         tools = await mounted_mcp.get_tools()
-        assert "mounted_tool" not in tools
+        assert not any(t.name == "mounted_tool" for t in tools)
 
     async def test_enable_resource_route_on_mounted_server(self, client, mounted_mcp):
         """Test enabling a resource on a mounted server via the parent server's HTTP route."""
         mounted_mcp.disable(keys=["resource:data://mounted_resource"])
         resources = await mounted_mcp.get_resources()
-        assert "data://mounted_resource" not in resources
+        assert not any(str(r.uri) == "data://mounted_resource" for r in resources)
         response = client.post("/resources/data://sub/mounted_resource/enable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "message": "Enabled resource: data://sub/mounted_resource"
         }
         resources = await mounted_mcp.get_resources()
-        assert "data://mounted_resource" in resources
+        assert any(str(r.uri) == "data://mounted_resource" for r in resources)
 
     async def test_disable_resource_route_on_mounted_server(self, client, mounted_mcp):
         """Test disabling a resource on a mounted server via the parent server's HTTP route."""
         resources = await mounted_mcp.get_resources()
-        assert "data://mounted_resource" in resources
+        assert any(str(r.uri) == "data://mounted_resource" for r in resources)
         response = client.post("/resources/data://sub/mounted_resource/disable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "message": "Disabled resource: data://sub/mounted_resource"
         }
         resources = await mounted_mcp.get_resources()
-        assert "data://mounted_resource" not in resources
+        assert not any(str(r.uri) == "data://mounted_resource" for r in resources)
 
     async def test_enable_template_route_on_mounted_server(self, client, mounted_mcp):
         """Test enabling a resource on a mounted server via the parent server's HTTP route."""
         key = "data://mounted_resource/{id}"
         mounted_mcp.disable(keys=["template:data://mounted_resource/{id}"])
         templates = await mounted_mcp.get_resource_templates()
-        assert key not in templates
+        assert not any(t.uri_template == key for t in templates)
         response = client.post("/resources/data://sub/mounted_resource/{id}/enable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "message": "Enabled resource: data://sub/mounted_resource/{id}"
         }
         templates = await mounted_mcp.get_resource_templates()
-        assert key in templates
+        assert any(t.uri_template == key for t in templates)
 
     async def test_disable_template_route_on_mounted_server(self, client, mounted_mcp):
         """Test disabling a resource on a mounted server via the parent server's HTTP route."""
         key = "data://mounted_resource/{id}"
         templates = await mounted_mcp.get_resource_templates()
-        assert key in templates
+        assert any(t.uri_template == key for t in templates)
         response = client.post("/resources/data://sub/mounted_resource/{id}/disable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "message": "Disabled resource: data://sub/mounted_resource/{id}"
         }
         templates = await mounted_mcp.get_resource_templates()
-        assert key not in templates
+        assert not any(t.uri_template == key for t in templates)
 
     async def test_enable_prompt_route_on_mounted_server(self, client, mounted_mcp):
         """Test enabling a prompt on a mounted server via the parent server's HTTP route."""
         mounted_mcp.disable(keys=["prompt:mounted_prompt"])
         prompts = await mounted_mcp.get_prompts()
-        assert "mounted_prompt" not in prompts
+        assert not any(p.name == "mounted_prompt" for p in prompts)
         response = client.post("/prompts/sub_mounted_prompt/enable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "Enabled prompt: sub_mounted_prompt"}
         prompts = await mounted_mcp.get_prompts()
-        assert "mounted_prompt" in prompts
+        assert any(p.name == "mounted_prompt" for p in prompts)
 
     async def test_disable_prompt_route_on_mounted_server(self, client, mounted_mcp):
         """Test disabling a prompt on a mounted server via the parent server's HTTP route."""
         prompts = await mounted_mcp.get_prompts()
-        assert "mounted_prompt" in prompts
+        assert any(p.name == "mounted_prompt" for p in prompts)
         response = client.post("/prompts/sub_mounted_prompt/disable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "Disabled prompt: sub_mounted_prompt"}
         prompts = await mounted_mcp.get_prompts()
-        assert "mounted_prompt" not in prompts
+        assert not any(p.name == "mounted_prompt" for p in prompts)
 
     def test_enable_nonexistent_tool(self, client):
         """Test enabling a non-existent tool returns 404."""
@@ -391,18 +391,18 @@ class TestAuthComponentManagementRoutes:
         """Test that unauthenticated requests to enable a tool are rejected."""
         self.mcp.disable(keys=["tool:test_tool"])
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
         response = self.client.post("/tools/test_tool/enable")
         assert response.status_code == 401
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
     async def test_authorized_enable_tool(self):
         """Test that authenticated requests to enable a tool are allowed."""
         self.mcp.disable(keys=["tool:test_tool"])
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
         response = self.client.post(
             "/tools/test_tool/enable", headers={"Authorization": "Bearer " + self.token}
@@ -410,22 +410,22 @@ class TestAuthComponentManagementRoutes:
         assert response.status_code == 200
         assert response.json() == {"message": "Enabled tool: test_tool"}
         tools = await self.mcp.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
     async def test_unauthorized_disable_tool(self):
         """Test that unauthenticated requests to disable a tool are rejected."""
         tools = await self.mcp.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
         response = self.client.post("/tools/test_tool/disable")
         assert response.status_code == 401
         tools = await self.mcp.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
     async def test_authorized_disable_tool(self):
         """Test that authenticated requests to disable a tool are allowed."""
         tools = await self.mcp.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
         response = self.client.post(
             "/tools/test_tool/disable",
@@ -434,13 +434,13 @@ class TestAuthComponentManagementRoutes:
         assert response.status_code == 200
         assert response.json() == {"message": "Disabled tool: test_tool"}
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
     async def test_forbidden_enable_tool(self):
         """Test that requests with insufficient scopes are rejected."""
         self.mcp.disable(keys=["tool:test_tool"])
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
         response = self.client.post(
             "/tools/test_tool/enable",
@@ -448,13 +448,13 @@ class TestAuthComponentManagementRoutes:
         )
         assert response.status_code == 403
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
     async def test_authorized_enable_resource(self):
         """Test that authenticated requests to enable a resource are allowed."""
         self.mcp.disable(keys=["resource:data://test_resource"])
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
         response = self.client.post(
             "/resources/data://test_resource/enable",
@@ -463,23 +463,23 @@ class TestAuthComponentManagementRoutes:
         assert response.status_code == 200
         assert response.json() == {"message": "Enabled resource: data://test_resource"}
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_unauthorized_disable_resource(self):
         """Test that unauthenticated requests to disable a resource are rejected."""
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
         response = self.client.post("/resources/data://test_resource/disable")
         assert response.status_code == 401
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_forbidden_enable_resource(self):
         """Test that requests with insufficient scopes are rejected."""
         self.mcp.disable(keys=["resource:data://test_resource"])
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
         response = self.client.post(
             "/resources/data://test_resource/disable",
@@ -487,12 +487,12 @@ class TestAuthComponentManagementRoutes:
         )
         assert response.status_code == 403
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_authorized_disable_resource(self):
         """Test that authenticated requests to disable a resource are allowed."""
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
         response = self.client.post(
             "/resources/data://test_resource/disable",
@@ -501,24 +501,24 @@ class TestAuthComponentManagementRoutes:
         assert response.status_code == 200
         assert response.json() == {"message": "Disabled resource: data://test_resource"}
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_unauthorized_enable_prompt(self):
         """Test that unauthenticated requests to enable a prompt are rejected."""
         self.mcp.disable(keys=["prompt:test_prompt"])
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
         response = self.client.post("/prompts/test_prompt/enable")
         assert response.status_code == 401
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
     async def test_authorized_enable_prompt(self):
         """Test that authenticated requests to enable a prompt are allowed."""
         self.mcp.disable(keys=["prompt:test_prompt"])
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
         response = self.client.post(
             "/prompts/test_prompt/enable",
@@ -527,22 +527,22 @@ class TestAuthComponentManagementRoutes:
         assert response.status_code == 200
         assert response.json() == {"message": "Enabled prompt: test_prompt"}
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
     async def test_unauthorized_disable_prompt(self):
         """Test that unauthenticated requests to disable a prompt are rejected."""
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
         response = self.client.post("/prompts/test_prompt/disable")
         assert response.status_code == 401
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
     async def test_forbidden_disable_prompt(self):
         """Test that requests with insufficient scopes are rejected."""
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
         response = self.client.post(
             "/prompts/test_prompt/disable",
@@ -550,12 +550,12 @@ class TestAuthComponentManagementRoutes:
         )
         assert response.status_code == 403
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
     async def test_authorized_disable_prompt(self):
         """Test that authenticated requests to disable a prompt are allowed."""
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
         response = self.client.post(
             "/prompts/test_prompt/disable",
@@ -564,7 +564,7 @@ class TestAuthComponentManagementRoutes:
         assert response.status_code == 200
         assert response.json() == {"message": "Disabled prompt: test_prompt"}
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
 
 class TestComponentManagerWithPath:
@@ -596,33 +596,33 @@ class TestComponentManagerWithPath:
     async def test_enable_tool_route_with_path(self, client_with_path, mcp_with_path):
         mcp_with_path.disable(keys=["tool:test_tool"])
         tools = await mcp_with_path.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
         response = client_with_path.post("/test/tools/test_tool/enable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "Enabled tool: test_tool"}
         tools = await mcp_with_path.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
     async def test_disable_resource_route_with_path(
         self, client_with_path, mcp_with_path
     ):
         resources = await mcp_with_path.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
         response = client_with_path.post("/test/resources/data://test_resource/disable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "Disabled resource: data://test_resource"}
         resources = await mcp_with_path.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_enable_prompt_route_with_path(self, client_with_path, mcp_with_path):
         mcp_with_path.disable(keys=["prompt:test_prompt"])
         prompts = await mcp_with_path.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
         response = client_with_path.post("/test/prompts/test_prompt/enable")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"message": "Enabled prompt: test_prompt"}
         prompts = await mcp_with_path.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)
 
 
 class TestComponentManagerWithPathAuth:
@@ -670,28 +670,28 @@ class TestComponentManagerWithPathAuth:
     async def test_unauthorized_enable_tool(self):
         self.mcp.disable(keys=["tool:test_tool"])
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
         response = self.client.post("/test/tools/test_tool/enable")
         assert response.status_code == 401
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
     async def test_forbidden_enable_tool(self):
         self.mcp.disable(keys=["tool:test_tool"])
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
         response = self.client.post(
             "/test/tools/test_tool/enable",
             headers={"Authorization": "Bearer " + self.token_without_scopes},
         )
         assert response.status_code == 403
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
 
     async def test_authorized_enable_tool(self):
         self.mcp.disable(keys=["tool:test_tool"])
         tools = await self.mcp.get_tools()
-        assert "test_tool" not in tools
+        assert not any(t.name == "test_tool" for t in tools)
         response = self.client.post(
             "/test/tools/test_tool/enable",
             headers={"Authorization": "Bearer " + self.token},
@@ -699,30 +699,30 @@ class TestComponentManagerWithPathAuth:
         assert response.status_code == 200
         assert response.json() == {"message": "Enabled tool: test_tool"}
         tools = await self.mcp.get_tools()
-        assert "test_tool" in tools
+        assert any(t.name == "test_tool" for t in tools)
 
     async def test_unauthorized_disable_resource(self):
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
         response = self.client.post("/test/resources/data://test_resource/disable")
         assert response.status_code == 401
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_forbidden_disable_resource(self):
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
         response = self.client.post(
             "/test/resources/data://test_resource/disable",
             headers={"Authorization": "Bearer " + self.token_without_scopes},
         )
         assert response.status_code == 403
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_authorized_disable_resource(self):
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" in resources
+        assert any(str(r.uri) == "data://test_resource" for r in resources)
         response = self.client.post(
             "/test/resources/data://test_resource/disable",
             headers={"Authorization": "Bearer " + self.token},
@@ -730,33 +730,33 @@ class TestComponentManagerWithPathAuth:
         assert response.status_code == 200
         assert response.json() == {"message": "Disabled resource: data://test_resource"}
         resources = await self.mcp.get_resources()
-        assert "data://test_resource" not in resources
+        assert not any(str(r.uri) == "data://test_resource" for r in resources)
 
     async def test_unauthorized_enable_prompt(self):
         self.mcp.disable(keys=["prompt:test_prompt"])
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
         response = self.client.post("/test/prompts/test_prompt/enable")
         assert response.status_code == 401
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
     async def test_forbidden_enable_prompt(self):
         self.mcp.disable(keys=["prompt:test_prompt"])
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
         response = self.client.post(
             "/test/prompts/test_prompt/enable",
             headers={"Authorization": "Bearer " + self.token_without_scopes},
         )
         assert response.status_code == 403
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
 
     async def test_authorized_enable_prompt(self):
         self.mcp.disable(keys=["prompt:test_prompt"])
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" not in prompts
+        assert not any(p.name == "test_prompt" for p in prompts)
         response = self.client.post(
             "/test/prompts/test_prompt/enable",
             headers={"Authorization": "Bearer " + self.token},
@@ -764,4 +764,4 @@ class TestComponentManagerWithPathAuth:
         assert response.status_code == 200
         assert response.json() == {"message": "Enabled prompt: test_prompt"}
         prompts = await self.mcp.get_prompts()
-        assert "test_prompt" in prompts
+        assert any(p.name == "test_prompt" for p in prompts)

--- a/tests/deprecated/test_exclude_args.py
+++ b/tests/deprecated/test_exclude_args.py
@@ -19,8 +19,7 @@ async def test_tool_exclude_args():
             pass
         return message
 
-    tools_dict = await mcp.get_tools()
-    tools = list(tools_dict.values())
+    tools = await mcp.get_tools()
     assert len(tools) == 1
     assert "state" not in tools[0].parameters["properties"]
 
@@ -61,8 +60,7 @@ async def test_add_tool_method_exclude_args():
     mcp.add_tool(tool)
 
     # Check tool via public API
-    tools_dict = await mcp.get_tools()
-    tools = list(tools_dict.values())
+    tools = await mcp.get_tools()
     assert len(tools) == 1
     assert "state" not in tools[0].parameters["properties"]
 

--- a/tests/server/providers/openapi/test_performance_comparison.py
+++ b/tests/server/providers/openapi/test_performance_comparison.py
@@ -247,7 +247,7 @@ class TestPerformance:
             "delete_user",
             "search_users",
         }
-        assert set(tools.keys()) == expected_operations
+        assert {t.name for t in tools} == expected_operations
 
     def test_memory_efficiency(self, comprehensive_spec):
         """Test that implementation doesn't significantly increase memory usage."""

--- a/tests/server/providers/test_local_provider.py
+++ b/tests/server/providers/test_local_provider.py
@@ -589,7 +589,7 @@ class TestLocalProviderStandaloneUsage:
         server = FastMCP("Test", providers=[provider])
 
         tools = await server.get_tools()
-        assert "provider_tool" in tools
+        assert any(t.name == "provider_tool" for t in tools)
 
     async def test_server_decorator_and_provider_tools_coexist(self):
         """Test that server decorators and provider tools coexist."""
@@ -606,8 +606,8 @@ class TestLocalProviderStandaloneUsage:
             return "from server"
 
         tools = await server.get_tools()
-        assert "provider_tool" in tools
-        assert "server_tool" in tools
+        assert any(t.name == "provider_tool" for t in tools)
+        assert any(t.name == "server_tool" for t in tools)
 
     async def test_local_provider_first_wins_duplicates(self):
         """Test that LocalProvider tools take precedence over added providers."""
@@ -625,7 +625,7 @@ class TestLocalProviderStandaloneUsage:
 
         # Server's LocalProvider is first, so its tool wins
         tools = await server.get_tools()
-        assert "duplicate_tool" in tools
+        assert any(t.name == "duplicate_tool" for t in tools)
 
         async with Client(server) as client:
             result = await client.call_tool("duplicate_tool", {})

--- a/tests/server/providers/test_local_provider_prompts.py
+++ b/tests/server/providers/test_local_provider_prompts.py
@@ -53,9 +53,9 @@ class TestPromptDecorator:
         def fn() -> str:
             return "Hello, world!"
 
-        prompts_dict = await mcp.get_prompts()
-        assert len(prompts_dict) == 1
-        prompt = prompts_dict["fn"]
+        prompts = await mcp.get_prompts()
+        assert len(prompts) == 1
+        prompt = next(p for p in prompts if p.name == "fn")
         assert prompt.name == "fn"
         content = await prompt.render()
         if not isinstance(content, PromptResult):
@@ -71,7 +71,7 @@ class TestPromptDecorator:
             return "Hello, world!"
 
         prompts = await mcp.get_prompts()
-        assert "fn" in prompts
+        assert any(p.name == "fn" for p in prompts)
 
         async with Client(mcp) as client:
             result = await client.get_prompt("fn")
@@ -86,9 +86,9 @@ class TestPromptDecorator:
         def fn() -> str:
             return "Hello, world!"
 
-        prompts_dict = await mcp.get_prompts()
-        assert len(prompts_dict) == 1
-        prompt = prompts_dict["custom_name"]
+        prompts_list = await mcp.get_prompts()
+        assert len(prompts_list) == 1
+        prompt = next(p for p in prompts_list if p.name == "custom_name")
         assert prompt.name == "custom_name"
         content = await prompt.render()
         if not isinstance(content, PromptResult):
@@ -103,9 +103,9 @@ class TestPromptDecorator:
         def fn() -> str:
             return "Hello, world!"
 
-        prompts_dict = await mcp.get_prompts()
-        assert len(prompts_dict) == 1
-        prompt = prompts_dict["fn"]
+        prompts_list = await mcp.get_prompts()
+        assert len(prompts_list) == 1
+        prompt = next(p for p in prompts_list if p.name == "fn")
         assert prompt.description == "A custom description"
         content = await prompt.render()
         if not isinstance(content, PromptResult):
@@ -120,9 +120,9 @@ class TestPromptDecorator:
         def test_prompt(name: str, greeting: str = "Hello") -> str:
             return f"{greeting}, {name}!"
 
-        prompts_dict = await mcp.get_prompts()
-        assert len(prompts_dict) == 1
-        prompt = prompts_dict["test_prompt"]
+        prompts = await mcp.get_prompts()
+        assert len(prompts) == 1
+        prompt = next(p for p in prompts if p.name == "test_prompt")
         assert prompt.arguments is not None
         assert len(prompt.arguments) == 2
         assert prompt.arguments[0].name == "name"
@@ -233,9 +233,9 @@ class TestPromptDecorator:
         def sample_prompt() -> str:
             return "Hello, world!"
 
-        prompts_dict = await mcp.get_prompts()
-        assert len(prompts_dict) == 1
-        prompt = prompts_dict["sample_prompt"]
+        prompts = await mcp.get_prompts()
+        assert len(prompts) == 1
+        prompt = next(p for p in prompts if p.name == "sample_prompt")
         assert prompt.tags == {"example", "test-tag"}
 
     async def test_prompt_decorator_with_string_name(self):
@@ -248,8 +248,8 @@ class TestPromptDecorator:
             return "Hello from string named prompt!"
 
         prompts = await mcp.get_prompts()
-        assert "string_named_prompt" in prompts
-        assert "my_function" not in prompts
+        assert any(p.name == "string_named_prompt" for p in prompts)
+        assert not any(p.name == "my_function" for p in prompts)
 
         async with Client(mcp) as client:
             result = await client.get_prompt("string_named_prompt")
@@ -270,7 +270,8 @@ class TestPromptDecorator:
         assert isinstance(result_fn, FunctionPrompt)
 
         prompts = await mcp.get_prompts()
-        assert prompts["direct_call_prompt"] is result_fn
+        prompt = next(p for p in prompts if p.name == "direct_call_prompt")
+        assert prompt is result_fn
 
         async with Client(mcp) as client:
             result = await client.get_prompt("direct_call_prompt")
@@ -318,7 +319,7 @@ class TestPromptDecorator:
         def test_prompt(message: str) -> str:
             return f"Response: {message}"
 
-        prompts_dict = await mcp.get_prompts()
-        prompt = prompts_dict["test_prompt"]
+        prompts = await mcp.get_prompts()
+        prompt = next(p for p in prompts if p.name == "test_prompt")
 
         assert prompt.meta == meta_data

--- a/tests/server/providers/test_local_provider_resources.py
+++ b/tests/server/providers/test_local_provider_resources.py
@@ -143,8 +143,7 @@ class TestResourceTemplates:
         def add(x: int, y: int = 10) -> int:
             return x + y
 
-        templates_dict = await mcp.get_resource_templates()
-        templates = list(templates_dict.values())
+        templates = await mcp.get_resource_templates()
         assert len(templates) == 1
         assert templates[0].uri_template == "math://add/{x}"
 
@@ -165,8 +164,7 @@ class TestResourceTemplates:
         def get_data(name: str) -> str:
             return f"Data for {name}"
 
-        templates_dict = await mcp.get_resource_templates()
-        templates = list(templates_dict.values())
+        templates = await mcp.get_resource_templates()
         assert len(templates) == 1
         assert templates[0].uri_template == "resource://{name}/data"
 
@@ -182,8 +180,8 @@ class TestResourceTemplates:
         def template_resource(param: str) -> str:
             return f"Template resource: {param}"
 
-        templates_dict = await mcp.get_resource_templates()
-        template = templates_dict["resource://{param}"]
+        templates = await mcp.get_resource_templates()
+        template = next(t for t in templates if t.uri_template == "resource://{param}")
         assert template.tags == {"template", "test-tag"}
 
     async def test_template_decorator_wildcard_param(self):
@@ -358,8 +356,7 @@ class TestResourceDecorator:
         def get_data() -> str:
             return "Hello, world!"
 
-        resources_dict = await mcp.get_resources()
-        resources = list(resources_dict.values())
+        resources = await mcp.get_resources()
         assert len(resources) == 1
         assert resources[0].name == "custom-data"
 
@@ -375,8 +372,7 @@ class TestResourceDecorator:
         def get_data() -> str:
             return "Hello, world!"
 
-        resources_dict = await mcp.get_resources()
-        resources = list(resources_dict.values())
+        resources = await mcp.get_resources()
         assert len(resources) == 1
         assert resources[0].description == "Data resource"
 
@@ -388,8 +384,7 @@ class TestResourceDecorator:
         def get_data() -> str:
             return "Hello, world!"
 
-        resources_dict = await mcp.get_resources()
-        resources = list(resources_dict.values())
+        resources = await mcp.get_resources()
         assert len(resources) == 1
         assert resources[0].tags == {"example", "test-tag"}
 
@@ -499,8 +494,8 @@ class TestResourceDecorator:
         def get_data() -> str:
             return "Hello, world!"
 
-        resources_dict = await mcp.get_resources()
-        resource = resources_dict["resource://data"]
+        resources = await mcp.get_resources()
+        resource = next(r for r in resources if str(r.uri) == "resource://data")
 
         assert resource.meta == meta_data
 
@@ -568,8 +563,7 @@ class TestTemplateDecorator:
         def get_data(name: str) -> str:
             return f"Data for {name}"
 
-        templates_dict = await mcp.get_resource_templates()
-        templates = list(templates_dict.values())
+        templates = await mcp.get_resource_templates()
         assert len(templates) == 1
         assert templates[0].name == "get_data"
         assert templates[0].uri_template == "resource://{name}/data"
@@ -597,8 +591,7 @@ class TestTemplateDecorator:
         def get_data(name: str) -> str:
             return f"Data for {name}"
 
-        templates_dict = await mcp.get_resource_templates()
-        templates = list(templates_dict.values())
+        templates = await mcp.get_resource_templates()
         assert len(templates) == 1
         assert templates[0].name == "custom-template"
 
@@ -614,8 +607,7 @@ class TestTemplateDecorator:
         def get_data(name: str) -> str:
             return f"Data for {name}"
 
-        templates_dict = await mcp.get_resource_templates()
-        templates = list(templates_dict.values())
+        templates = await mcp.get_resource_templates()
         assert len(templates) == 1
         assert templates[0].description == "Template description"
 
@@ -698,8 +690,8 @@ class TestTemplateDecorator:
         def template_resource(param: str) -> str:
             return f"Template resource: {param}"
 
-        templates_dict = await mcp.get_resource_templates()
-        template = templates_dict["resource://{param}"]
+        templates = await mcp.get_resource_templates()
+        template = next(t for t in templates if t.uri_template == "resource://{param}")
         assert template.tags == {"template", "test-tag"}
 
     async def test_template_decorator_wildcard_param(self):
@@ -709,8 +701,8 @@ class TestTemplateDecorator:
         def template_resource(param: str) -> str:
             return f"Template resource: {param}"
 
-        templates_dict = await mcp.get_resource_templates()
-        template = templates_dict["resource://{param*}"]
+        templates = await mcp.get_resource_templates()
+        template = next(t for t in templates if t.uri_template == "resource://{param*}")
         assert template.uri_template == "resource://{param*}"
         assert template.name == "template_resource"
 
@@ -724,7 +716,9 @@ class TestTemplateDecorator:
         def get_template_data(param: str) -> str:
             return f"Data for {param}"
 
-        templates_dict = await mcp.get_resource_templates()
-        template = templates_dict["resource://{param}/data"]
+        templates = await mcp.get_resource_templates()
+        template = next(
+            t for t in templates if t.uri_template == "resource://{param}/data"
+        )
 
         assert template.meta == meta_data

--- a/tests/server/test_mount.py
+++ b/tests/server/test_mount.py
@@ -40,8 +40,8 @@ class TestBasicMount:
 
         # Get tools from main app, should include sub_app's tools
         tools = await main_app.get_tools()
-        assert "sub_tool" in tools
-        assert "sub_transformed_tool" in tools
+        assert any(t.name == "sub_tool" for t in tools)
+        assert any(t.name == "sub_transformed_tool" for t in tools)
 
         async with Client(main_app) as client:
             result = await client.call_tool("sub_tool", {})
@@ -61,7 +61,7 @@ class TestBasicMount:
 
         # Tool should be accessible with the default separator
         tools = await main_app.get_tools()
-        assert "sub_greet" in tools
+        assert any(t.name == "sub_greet" for t in tools)
 
         # Call the tool
         async with Client(main_app) as client:
@@ -82,7 +82,7 @@ class TestBasicMount:
 
         tools = await main_app.get_tools()
         # With empty prefix, the tool should keep its original name
-        assert "sub_tool" in tools
+        assert any(t.name == "sub_tool" for t in tools)
 
     async def test_mount_with_no_prefix_provided(self):
         """Test mounting without providing a prefix at all."""
@@ -98,7 +98,7 @@ class TestBasicMount:
 
         tools = await main_app.get_tools()
         # Without prefix, the tool should keep its original name
-        assert "sub_tool" in tools
+        assert any(t.name == "sub_tool" for t in tools)
 
         # Call the tool to verify it works
         async with Client(main_app) as client:
@@ -119,7 +119,7 @@ class TestBasicMount:
 
         # Verify tool is accessible with original name
         tools = await main_app.get_tools()
-        assert "sub_tool" in tools
+        assert any(t.name == "sub_tool" for t in tools)
 
         # Test actual functionality
         async with Client(main_app) as client:
@@ -140,7 +140,7 @@ class TestBasicMount:
 
         # Verify resource is accessible with original URI
         resources = await main_app.get_resources()
-        assert "data://config" in resources
+        assert any(str(r.uri) == "data://config" for r in resources)
 
         # Test actual functionality
         async with Client(main_app) as client:
@@ -162,7 +162,7 @@ class TestBasicMount:
 
         # Verify template is accessible with original URI template
         templates = await main_app.get_resource_templates()
-        assert "users://{user_id}/info" in templates
+        assert any(t.uri_template == "users://{user_id}/info" for t in templates)
 
         # Test actual functionality
         async with Client(main_app) as client:
@@ -184,7 +184,7 @@ class TestBasicMount:
 
         # Verify prompt is accessible with original name
         prompts = await main_app.get_prompts()
-        assert "sub_prompt" in prompts
+        assert any(p.name == "sub_prompt" for p in prompts)
 
         # Test actual functionality
         async with Client(main_app) as client:
@@ -215,8 +215,8 @@ class TestMultipleServerMount:
 
         # Check both are accessible
         tools = await main_app.get_tools()
-        assert "weather_get_forecast" in tools
-        assert "news_get_headlines" in tools
+        assert any(t.name == "weather_get_forecast" for t in tools)
+        assert any(t.name == "news_get_headlines" for t in tools)
 
         # Call tools from both mounted servers
         async with Client(main_app) as client:
@@ -242,15 +242,15 @@ class TestMultipleServerMount:
         # Mount first app
         main_app.mount(first_app, "api")
         tools = await main_app.get_tools()
-        assert "api_first_tool" in tools
+        assert any(t.name == "api_first_tool" for t in tools)
 
         # Mount second app with same prefix
         main_app.mount(second_app, "api")
         tools = await main_app.get_tools()
 
         # Both apps' tools should be accessible (new behavior)
-        assert "api_first_tool" in tools
-        assert "api_second_tool" in tools
+        assert any(t.name == "api_first_tool" for t in tools)
+        assert any(t.name == "api_second_tool" for t in tools)
 
     @pytest.mark.skipif(
         sys.platform == "win32", reason="Windows asyncio networking timeouts."
@@ -593,7 +593,7 @@ class TestDynamicChanges:
 
         # Initially, there should be no tools from sub_app
         tools = await main_app.get_tools()
-        assert not any(key.startswith("sub_") for key in tools)
+        assert not any(t.name.startswith("sub_") for t in tools)
 
         # Add a tool to the sub-app after mounting
         @sub_app.tool
@@ -602,7 +602,7 @@ class TestDynamicChanges:
 
         # The tool should be accessible through the main app
         tools = await main_app.get_tools()
-        assert "sub_dynamic_tool" in tools
+        assert any(t.name == "sub_dynamic_tool" for t in tools)
 
         # Call the dynamically added tool
         async with Client(main_app) as client:
@@ -623,14 +623,14 @@ class TestDynamicChanges:
 
         # Initially, the tool should be accessible
         tools = await main_app.get_tools()
-        assert "sub_temp_tool" in tools
+        assert any(t.name == "sub_temp_tool" for t in tools)
 
         # Remove the tool from sub_app using public API
         sub_app.remove_tool("temp_tool")
 
         # The tool should no longer be accessible
         tools = await main_app.get_tools()
-        assert "sub_temp_tool" not in tools
+        assert not any(t.name == "sub_temp_tool" for t in tools)
 
 
 class TestResourcesAndTemplates:
@@ -650,7 +650,7 @@ class TestResourcesAndTemplates:
 
         # Resource should be accessible through main app
         resources = await main_app.get_resources()
-        assert "data://data/users" in resources
+        assert any(str(r.uri) == "data://data/users" for r in resources)
 
         # Check that resource can be accessed
         async with Client(main_app) as client:
@@ -672,7 +672,7 @@ class TestResourcesAndTemplates:
 
         # Template should be accessible through main app
         templates = await main_app.get_resource_templates()
-        assert "users://api/{user_id}/profile" in templates
+        assert any(t.uri_template == "users://api/{user_id}/profile" for t in templates)
 
         # Check template instantiation
         async with Client(main_app) as client:
@@ -697,7 +697,7 @@ class TestResourcesAndTemplates:
 
         # Resource should be accessible through main app
         resources = await main_app.get_resources()
-        assert "data://data/config" in resources
+        assert any(str(r.uri) == "data://data/config" for r in resources)
 
         # Check access to the resource
         async with Client(main_app) as client:
@@ -724,7 +724,7 @@ class TestPrompts:
 
         # Prompt should be accessible through main app
         prompts = await main_app.get_prompts()
-        assert "assistant_greeting" in prompts
+        assert any(p.name == "assistant_greeting" for p in prompts)
 
         # Render the prompt
         async with Client(main_app) as client:
@@ -747,7 +747,7 @@ class TestPrompts:
 
         # Prompt should be accessible through main app
         prompts = await main_app.get_prompts()
-        assert "assistant_farewell" in prompts
+        assert any(p.name == "assistant_farewell" for p in prompts)
 
         # Render the prompt
         async with Client(main_app) as client:
@@ -777,7 +777,7 @@ class TestProxyServer:
 
         # Tool should be accessible through main app
         tools = await main_app.get_tools()
-        assert "proxy_get_data" in tools
+        assert any(t.name == "proxy_get_data" for t in tools)
 
         # Call the tool
         async with Client(main_app) as client:
@@ -803,7 +803,7 @@ class TestProxyServer:
 
         # Tool should be accessible through main app via proxy
         tools = await main_app.get_tools()
-        assert "proxy_dynamic_data" in tools
+        assert any(t.name == "proxy_dynamic_data" for t in tools)
 
         # Call the tool
         async with Client(main_app) as client:
@@ -1021,10 +1021,12 @@ class TestResourceUriPrefixing:
         resources = await main_app.get_resources()
 
         # Should have prefixed key (using path format: resource://prefix/resource_name)
-        assert "resource://prefix/my_resource" in resources
+        assert any(str(r.uri) == "resource://prefix/my_resource" for r in resources)
 
         # The resource name should NOT be prefixed (only URI is prefixed)
-        resource = resources["resource://prefix/my_resource"]
+        resource = next(
+            r for r in resources if str(r.uri) == "resource://prefix/my_resource"
+        )
         assert resource.name == "my_resource"
 
     async def test_resource_template_uri_prefixing(self):
@@ -1045,10 +1047,14 @@ class TestResourceUriPrefixing:
         templates = await main_app.get_resource_templates()
 
         # Should have prefixed key (using path format: resource://prefix/template_uri)
-        assert "resource://prefix/user/{user_id}" in templates
+        assert any(
+            t.uri_template == "resource://prefix/user/{user_id}" for t in templates
+        )
 
         # The template name should NOT be prefixed (only URI template is prefixed)
-        template = templates["resource://prefix/user/{user_id}"]
+        template = next(
+            t for t in templates if t.uri_template == "resource://prefix/user/{user_id}"
+        )
         assert template.name == "user_template"
 
 
@@ -1393,9 +1399,9 @@ class TestToolNameOverrides:
 
         # Server introspection shows transformed names
         tools = await main.get_tools()
-        assert "custom_name" in tools
-        assert "original_tool" not in tools
-        assert "prefix_original_tool" not in tools
+        assert any(t.name == "custom_name" for t in tools)
+        assert not any(t.name == "original_tool" for t in tools)
+        assert not any(t.name == "prefix_original_tool" for t in tools)
 
         # Client-facing API shows the same transformed names
         async with Client(main) as client:
@@ -1514,7 +1520,7 @@ class TestComponentServicePrefixLess:
 
         # Initially the tool is enabled
         tools = await main_app.get_tools()
-        assert "my_tool" in tools
+        assert any(t.name == "my_tool" for t in tools)
 
         # Disable and re-enable via ComponentService
         service = ComponentService(main_app)
@@ -1522,13 +1528,13 @@ class TestComponentServicePrefixLess:
         assert tool is not None
         # Verify tool is now disabled
         tools = await main_app.get_tools()
-        assert "my_tool" not in tools
+        assert not any(t.name == "my_tool" for t in tools)
 
         tool = await service._enable_tool("my_tool")
         assert tool is not None
         # Verify tool is now enabled
         tools = await main_app.get_tools()
-        assert "my_tool" in tools
+        assert any(t.name == "my_tool" for t in tools)
 
     async def test_enable_resource_prefixless_mount(self):
         """Test enabling a resource on a prefix-less mounted server."""
@@ -1550,13 +1556,13 @@ class TestComponentServicePrefixLess:
         assert resource is not None
         # Verify resource is now disabled
         resources = await main_app.get_resources()
-        assert "data://test" not in resources
+        assert not any(str(r.uri) == "data://test" for r in resources)
 
         resource = await service._enable_resource("data://test")
         assert resource is not None
         # Verify resource is now enabled
         resources = await main_app.get_resources()
-        assert "data://test" in resources
+        assert any(str(r.uri) == "data://test" for r in resources)
 
     async def test_enable_prompt_prefixless_mount(self):
         """Test enabling a prompt on a prefix-less mounted server."""
@@ -1578,10 +1584,10 @@ class TestComponentServicePrefixLess:
         assert prompt is not None
         # Verify prompt is now disabled
         prompts = await main_app.get_prompts()
-        assert "my_prompt" not in prompts
+        assert not any(p.name == "my_prompt" for p in prompts)
 
         prompt = await service._enable_prompt("my_prompt")
         assert prompt is not None
         # Verify prompt is now enabled
         prompts = await main_app.get_prompts()
-        assert "my_prompt" in prompts
+        assert any(p.name == "my_prompt" for p in prompts)

--- a/tests/server/test_tool_annotations.py
+++ b/tests/server/test_tool_annotations.py
@@ -23,8 +23,7 @@ async def test_tool_annotations_in_tool_manager():
         return message
 
     # Check internal tool objects directly
-    tools_dict = await mcp.get_tools()
-    tools = list(tools_dict.values())
+    tools = await mcp.get_tools()
     assert len(tools) == 1
     assert tools[0].annotations is not None
     assert tools[0].annotations.title == "Echo Tool"
@@ -126,8 +125,7 @@ async def test_direct_tool_annotations_in_tool_manager():
         return {"modified": True, **data}
 
     # Check internal tool objects directly
-    tools_dict = await mcp.get_tools()
-    tools = list(tools_dict.values())
+    tools = await mcp.get_tools()
     assert len(tools) == 1
     assert tools[0].annotations is not None
     assert tools[0].annotations.title == "Direct Tool"
@@ -186,8 +184,7 @@ async def test_add_tool_method_annotations():
     mcp.add_tool(tool)
 
     # Check internal tool objects directly
-    tools_dict = await mcp.get_tools()
-    tools = list(tools_dict.values())
+    tools = await mcp.get_tools()
     assert len(tools) == 1
     assert tools[0].annotations is not None
     assert tools[0].annotations.title == "Create Item"

--- a/tests/server/test_tool_transformation.py
+++ b/tests/server/test_tool_transformation.py
@@ -13,11 +13,11 @@ async def test_tool_transformation_in_tool_manager():
 
     mcp.add_tool_transformation("echo", ToolTransformConfig(name="echo_transformed"))
 
-    tools_dict = await mcp.get_tools()
-    tools = list(tools_dict.values())
+    tools = await mcp.get_tools()
     assert len(tools) == 1
-    assert "echo_transformed" in tools_dict
-    assert tools_dict["echo_transformed"].name == "echo_transformed"
+    assert any(t.name == "echo_transformed" for t in tools)
+    tool = next(t for t in tools if t.name == "echo_transformed")
+    assert tool.name == "echo_transformed"
 
 
 async def test_transformed_tool_filtering():
@@ -29,14 +29,14 @@ async def test_transformed_tool_filtering():
         """Echo back the message provided."""
         return message
 
-    tools = list(await mcp._list_tools_middleware())
+    tools = await mcp.get_tools(apply_middleware=True)
     assert len(tools) == 0
 
     mcp.add_tool_transformation(
         "echo", ToolTransformConfig(name="echo_transformed", tags={"enabled_tools"})
     )
 
-    tools = list(await mcp._list_tools_middleware())
+    tools = await mcp.get_tools(apply_middleware=True)
     assert len(tools) == 1
 
 

--- a/v3-notes/get-methods-consolidation.md
+++ b/v3-notes/get-methods-consolidation.md
@@ -1,0 +1,69 @@
+# Consolidating get_* and _list_* Methods
+
+This document captures the design decision to consolidate component listing methods in FastMCP 3.0.
+
+## Problem
+
+The server had parallel implementations for listing components:
+- `get_tools()` / `_list_tools()`
+- `get_resources()` / `_list_resources()`
+- `get_prompts()` / `_list_prompts()`
+- `get_resource_templates()` / `_list_resource_templates()`
+
+These were nearly identical but with subtle differences in dedup keys, logging, and return types. The `_list_*` methods were internal and used by the MCP protocol handlers, while `get_*` methods were the public API.
+
+## Solution
+
+`get_*` is now the canonical method. The `_list_*` methods were deleted entirely.
+
+```python
+async def get_tools(self, *, apply_middleware: bool = False) -> list[Tool]:
+    """Canonical method for listing tools."""
+    if apply_middleware:
+        # Apply middleware chain (for MCP protocol handlers)
+        mw_context = MiddlewareContext(...)
+        return await self._apply_middleware(
+            context=mw_context,
+            call_next=lambda context: self.get_tools(apply_middleware=False)
+        )
+
+    # Core implementation: query providers, dedupe, filter visibility
+    ...
+```
+
+## Key Changes
+
+### Return Type: dict → list
+
+The dict return type was removed because the key was redundant—components already have `.name` or `.uri` attributes.
+
+```python
+# Before
+tools = await server.get_tools()
+tool = tools["my_tool"]
+
+# After
+tools = await server.get_tools()
+tool = next(t for t in tools if t.name == "my_tool")
+```
+
+### Middleware via Parameter
+
+The `apply_middleware=True` parameter applies the middleware chain. This replaces the separate `_list_*_middleware()` methods.
+
+Callers:
+- MCP protocol handlers: `get_tools(apply_middleware=True)`
+- Direct access: `get_tools()` (default False)
+
+## Benefits
+
+1. **Single source of truth** - One method, not two
+2. **Consistent behavior** - Same dedup key, same visibility filtering
+3. **Clearer API** - Public method with explicit middleware opt-in
+4. **Less code** - Deleted ~200 lines of duplicate implementation
+
+## Implementation Files
+
+- `src/fastmcp/server/server.py` - Canonical `get_*` methods
+- `src/fastmcp/server/providers/fastmcp_provider.py` - Uses `apply_middleware=True`
+- `src/fastmcp/utilities/inspect.py` - Uses `apply_middleware=True`


### PR DESCRIPTION
The server had parallel implementations for listing components: `get_tools()` returned a dict indexed by name, while `_list_tools()` returned a list deduplicated by key. These were nearly identical with subtle differences in dedup logic and error handling.

This consolidates them into a single canonical method with an optional middleware parameter:

```python
# Direct access (default) - no middleware
tools = await server.get_tools()

# With middleware chain - used by MCP handlers and mounted servers
tools = await server.get_tools(apply_middleware=True)
```

**Breaking change:** `get_tools()`, `get_resources()`, `get_prompts()`, and `get_resource_templates()` now return `list` instead of `dict`. The dict key was redundant since components already have `.name` or `.uri` attributes.

```python
# Before
tools = await server.get_tools()
if "my_tool" in tools:
    tool = tools["my_tool"]

# After
tools = await server.get_tools()
tool = next((t for t in tools if t.name == "my_tool"), None)
```