### PR TITLE
Fix: resolve root-level $ref in outputSchema for MCP spec compliance

### DIFF
--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -33,7 +33,7 @@ import fastmcp
 from fastmcp.server.dependencies import without_injected_parameters
 from fastmcp.server.tasks.config import TaskConfig
 from fastmcp.utilities.components import FastMCPComponent
-from fastmcp.utilities.json_schema import compress_schema
+from fastmcp.utilities.json_schema import compress_schema, resolve_root_ref
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import (
     Audio,
@@ -635,6 +635,10 @@ class ParsedFunction:
                     output_schema = base_schema
 
                 output_schema = compress_schema(output_schema, prune_titles=True)
+
+                # Resolve root-level $ref to meet MCP spec requirement for type: object
+                # Self-referential Pydantic models generate schemas with $ref at root
+                output_schema = resolve_root_ref(output_schema)
 
             except PydanticSchemaGenerationError as e:
                 if "_UnserializableType" not in str(e):


### PR DESCRIPTION
## Summary
- Fixes issue where self-referential Pydantic models generate outputSchema with $ref at root level
- MCP specification requires outputSchema to have "type": "object" at root level
- Added resolve_root_ref() function to inline referenced definitions while preserving $defs for nested references

## Test plan
- [x] Added unit tests for resolve_root_ref function
- [x] Added integration tests for self-referential Pydantic models
- [x] All existing tests pass

Closes #2455

🤖 Generated with Claude Code