### PR TITLE
Revert "Enable parallel tests on Windows"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,13 @@ jobs:
         run: uv sync --upgrade
 
       - name: Run tests (excluding integration and client_process)
-        run: uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" -v
+          else
+            uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
+          fi
+        shell: bash
 
       - name: Run client process tests separately
         run: uv run pytest --inline-snapshot=disable tests -m "client_process" -x


### PR DESCRIPTION
Reverts jlowin/fastmcp#2715

<img width="672" height="500" alt="image" src="https://github.com/user-attachments/assets/20ee48cf-dfa3-44e7-bb5c-4c741d556bf9" />

Windows tests continue to fail with intermittent worker crashes.