### PR TITLE
Consistent decorator-based MCP handler registration

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -303,7 +303,12 @@ class Context:
         Returns:
             The prompt result
         """
-        return await self.fastmcp._get_prompt_mcp(name, arguments)
+        result = await self.fastmcp.render_prompt(name, arguments)
+        if isinstance(result, mcp.types.CreateTaskResult):
+            raise RuntimeError(
+                "Unexpected CreateTaskResult: Context calls should not have task metadata"
+            )
+        return result.to_mcp_prompt_result()
 
     async def read_resource(self, uri: str | AnyUrl) -> list[ResourceContent]:
         """Read a resource by URI.
@@ -314,8 +319,12 @@ class Context:
         Returns:
             List of ResourceContent objects
         """
-        # Context calls don't have task metadata, so always returns list
-        return await self.fastmcp._read_resource_mcp(uri)
+        result = await self.fastmcp.read_resource(str(uri))
+        if isinstance(result, mcp.types.CreateTaskResult):
+            raise RuntimeError(
+                "Unexpected CreateTaskResult: Context calls should not have task metadata"
+            )
+        return result
 
     async def log(
         self,


### PR DESCRIPTION
Handler registration was inconsistent: tools used the SDK's `call_tool()` decorator while resources and prompts used manual `request_handlers[]` registration because the SDK's decorators don't support `CreateTaskResult`.

This PR adds `read_resource()` and `get_prompt()` decorator methods to `LowLevelServer` that handle task metadata extraction, contextvar management, and MCP format conversion. This enables consistent registration:

```python
self._mcp_server.call_tool(validate_input=...)(self._call_tool_mcp)
self._mcp_server.read_resource()(self._read_resource_mcp)
self._mcp_server.get_prompt()(self._get_prompt_mcp)
```

The decorators handle MCP SDK concerns (task metadata, contextvars, result conversion) while the handler methods remain focused on FastMCP-specific logic (error translation). These custom decorators can be removed once the MCP SDK adds native `CreateTaskResult` support for resources and prompts.