### PR TITLE
Fix documentation to use 'meta' instead of '_meta' for MCP spec field

### DIFF
--- a/docs/clients/prompts.mdx
+++ b/docs/clients/prompts.mdx
@@ -26,8 +26,8 @@ async with client:
         if prompt.arguments:
             print(f"Arguments: {[arg.name for arg in prompt.arguments]}")
         # Access tags and other metadata
-        if hasattr(prompt, '_meta') and prompt._meta:
-            fastmcp_meta = prompt._meta.get('_fastmcp', {})
+        if prompt.meta:
+            fastmcp_meta = prompt.meta.get('_fastmcp', {})
             print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
 
@@ -44,16 +44,16 @@ async with client:
     # Filter prompts by tag
     analysis_prompts = [
         prompt for prompt in prompts 
-        if hasattr(prompt, '_meta') and prompt._meta and
-           prompt._meta.get('_fastmcp', {}) and
-           'analysis' in prompt._meta.get('_fastmcp', {}).get('tags', [])
+        if prompt.meta and
+           prompt.meta.get('_fastmcp', {}) and
+           'analysis' in prompt.meta.get('_fastmcp', {}).get('tags', [])
     ]
     
     print(f"Found {len(analysis_prompts)} analysis prompts")
 ```
 
 <Note>
-The `_meta` field is part of the standard MCP specification. FastMCP servers include tags and other metadata within a `_fastmcp` namespace (e.g., `_meta._fastmcp.tags`) to avoid conflicts with user-defined metadata. This behavior can be controlled with the server's `include_fastmcp_meta` setting - when disabled, the `_fastmcp` namespace won't be included. Other MCP server implementations may not provide this metadata structure.
+The `meta` field is part of the standard MCP specification. FastMCP servers include tags and other metadata within a `_fastmcp` namespace (e.g., `meta._fastmcp.tags`) to avoid conflicts with user-defined metadata. This behavior can be controlled with the server's `include_fastmcp_meta` setting - when disabled, the `_fastmcp` namespace won't be included. Other MCP server implementations may not provide this metadata structure.
 </Note>
 
 ## Using Prompts

--- a/docs/clients/resources.mdx
+++ b/docs/clients/resources.mdx
@@ -35,8 +35,8 @@ async with client:
         print(f"Description: {resource.description}")
         print(f"MIME Type: {resource.mimeType}")
         # Access tags and other metadata
-        if hasattr(resource, '_meta') and resource._meta:
-            fastmcp_meta = resource._meta.get('_fastmcp', {})
+        if resource.meta:
+            fastmcp_meta = resource.meta.get('_fastmcp', {})
             print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
 
@@ -54,8 +54,8 @@ async with client:
         print(f"Name: {template.name}")
         print(f"Description: {template.description}")
         # Access tags and other metadata
-        if hasattr(template, '_meta') and template._meta:
-            fastmcp_meta = template._meta.get('_fastmcp', {})
+        if template.meta:
+            fastmcp_meta = template.meta.get('_fastmcp', {})
             print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
 
@@ -72,16 +72,16 @@ async with client:
     # Filter resources by tag
     config_resources = [
         resource for resource in resources 
-        if hasattr(resource, '_meta') and resource._meta and
-           resource._meta.get('_fastmcp', {}) and
-           'config' in resource._meta.get('_fastmcp', {}).get('tags', [])
+        if resource.meta and
+           resource.meta.get('_fastmcp', {}) and
+           'config' in resource.meta.get('_fastmcp', {}).get('tags', [])
     ]
     
     print(f"Found {len(config_resources)} config resources")
 ```
 
 <Note>
-The `_meta` field is part of the standard MCP specification. FastMCP servers include tags and other metadata within a `_fastmcp` namespace (e.g., `_meta._fastmcp.tags`) to avoid conflicts with user-defined metadata. This behavior can be controlled with the server's `include_fastmcp_meta` setting - when disabled, the `_fastmcp` namespace won't be included. Other MCP server implementations may not provide this metadata structure.
+The `meta` field is part of the standard MCP specification. FastMCP servers include tags and other metadata within a `_fastmcp` namespace (e.g., `meta._fastmcp.tags`) to avoid conflicts with user-defined metadata. This behavior can be controlled with the server's `include_fastmcp_meta` setting - when disabled, the `_fastmcp` namespace won't be included. Other MCP server implementations may not provide this metadata structure.
 </Note>
 
 ## Reading Resources

--- a/docs/clients/tools.mdx
+++ b/docs/clients/tools.mdx
@@ -26,7 +26,7 @@ async with client:
         if tool.inputSchema:
             print(f"Parameters: {tool.inputSchema}")
         # Access tags and other metadata
-        if hasattr(tool, 'meta') and tool.meta:
+        if tool.meta:
             fastmcp_meta = tool.meta.get('_fastmcp', {})
             print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
@@ -44,7 +44,7 @@ async with client:
     # Filter tools by tag
     analysis_tools = [
         tool for tool in tools 
-        if hasattr(tool, 'meta') and tool.meta and
+        if tool.meta and
            tool.meta.get('_fastmcp', {}) and
            'analysis' in tool.meta.get('_fastmcp', {}).get('tags', [])
     ]

--- a/docs/integrations/openapi.mdx
+++ b/docs/integrations/openapi.mdx
@@ -324,7 +324,7 @@ mcp = FastMCP.from_openapi(
 
 #### OpenAPI Tags in Client Meta
 
-FastMCP automatically includes OpenAPI tags from your specification in the component's metadata. These tags are available to MCP clients through the `_meta._fastmcp.tags` field, allowing clients to filter and organize components based on the original OpenAPI tagging:
+FastMCP automatically includes OpenAPI tags from your specification in the component's metadata. These tags are available to MCP clients through the `meta._fastmcp.tags` field, allowing clients to filter and organize components based on the original OpenAPI tagging:
 
 <CodeGroup>
 ```json {5} OpenAPI spec with tags
@@ -344,9 +344,9 @@ FastMCP automatically includes OpenAPI tags from your specification in the compo
 async with client:
     tools = await client.list_tools()
     for tool in tools:
-        if hasattr(tool, '_meta') and tool._meta:
+        if tool.meta:
             # OpenAPI tags are now available in _fastmcp namespace!
-            fastmcp_meta = tool._meta.get('_fastmcp', {})
+            fastmcp_meta = tool.meta.get('_fastmcp', {})
             openapi_tags = fastmcp_meta.get('tags', [])
             if 'users' in openapi_tags:
                 print(f"Found user-related tool: {tool.name}")

--- a/docs/servers/prompts.mdx
+++ b/docs/servers/prompts.mdx
@@ -107,7 +107,7 @@ def data_analysis_prompt(
 <ParamField body="meta" type="dict[str, Any] | None">
   <VersionBadge version="2.11.0" />
 
-  Optional meta information about the prompt. This data is passed through to the MCP client as the `_meta` field of the client-side prompt object and can be used for custom metadata, versioning, or other application-specific purposes.
+  Optional meta information about the prompt. This data is passed through to the MCP client as the `meta` field of the client-side prompt object and can be used for custom metadata, versioning, or other application-specific purposes.
 </ParamField>
 </Card>
 
@@ -241,7 +241,7 @@ def code_review(code: str) -> PromptResult:
 
 **`description`** - Optional description of the prompt result. If not provided, defaults to the prompt's docstring.
 
-**`meta`** - Optional metadata dictionary that will be included in the MCP response's `_meta` field. Use this for runtime metadata like categorization, priority, or other client-specific data.
+**`meta`** - Optional metadata dictionary that will be included in the MCP response's `meta` field. Use this for runtime metadata like categorization, priority, or other client-specific data.
 
 <Note>
 The `meta` field in `PromptResult` is for runtime metadata specific to this render response. This is separate from the `meta` parameter in `@mcp.prompt(meta={...})`, which provides static metadata about the prompt definition itself (returned when listing prompts).

--- a/docs/servers/resources.mdx
+++ b/docs/servers/resources.mdx
@@ -128,7 +128,7 @@ def get_application_status() -> dict:
 <ParamField body="meta" type="dict[str, Any] | None">
   <VersionBadge version="2.11.0" />
   
-  Optional meta information about the resource. This data is passed through to the MCP client as the `_meta` field of the client-side resource object and can be used for custom metadata, versioning, or other application-specific purposes.
+  Optional meta information about the resource. This data is passed through to the MCP client as the `meta` field of the client-side resource object and can be used for custom metadata, versioning, or other application-specific purposes.
 </ParamField>
 </Card>
 
@@ -170,7 +170,7 @@ def get_widget() -> ResourceContent:
 
 **`mime_type`** - Optional MIME type for the content. Defaults to `"text/plain"` for string content and `"application/octet-stream"` for binary content.
 
-**`meta`** - Optional metadata dictionary that will be included in the MCP response's `_meta` field. Use this for runtime metadata like Content Security Policy headers, caching hints, or other client-specific data.
+**`meta`** - Optional metadata dictionary that will be included in the MCP response's `meta` field. Use this for runtime metadata like Content Security Policy headers, caching hints, or other client-specific data.
 
 ```python
 # Binary content with metadata

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -112,7 +112,7 @@ def search_products_implementation(query: str, category: str | None = None) -> l
 <ParamField body="meta" type="dict[str, Any] | None">
   <VersionBadge version="2.11.0" />
   
-  Optional meta information about the tool. This data is passed through to the MCP client as the `_meta` field of the client-side tool object and can be used for custom metadata, versioning, or other application-specific purposes.
+  Optional meta information about the tool. This data is passed through to the MCP client as the `meta` field of the client-side tool object and can be used for custom metadata, versioning, or other application-specific purposes.
 </ParamField>
 </Card>
 


### PR DESCRIPTION
The MCP specification uses `meta` as the field name, not `_meta`. While the Python SDK's Pydantic models use `_meta` as a serialization alias, the Python attribute is `meta`. This PR updates all documentation to consistently refer to `meta` when discussing the MCP specification and uses `meta` in code examples.

Additionally removes unnecessary `hasattr` checks from meta field examples, since `meta` is a standard field on MCP SDK objects (it's just optional/None).

**Changes:**
- Updated server docs to say "passed through as the `meta` field" instead of "`_meta` field"
- Updated client docs to say "The `meta` field is part of the standard MCP specification" 
- Fixed code examples to use `.meta` instead of `._meta`
- Removed `hasattr` checks from meta field examples

**Example:**
```python
# Before
if hasattr(resource, '_meta') and resource._meta:
    fastmcp_meta = resource._meta.get('_fastmcp', {})

# After  
if resource.meta:
    fastmcp_meta = resource.meta.get('_fastmcp', {})
```