### PR TITLE
Fix prompt return type documentation

### DIFF
--- a/docs/servers/prompts.mdx
+++ b/docs/servers/prompts.mdx
@@ -38,11 +38,14 @@ def ask_about_topic(topic: str) -> str:
     """Generates a user message asking for an explanation of a topic."""
     return f"Can you please explain the concept of '{topic}'?"
 
-# Prompt returning a specific message type
+# Prompt returning multiple messages
 @mcp.prompt
-def generate_code_request(language: str, task_description: str) -> Message:
-    """Generates a user message requesting code generation."""
-    return Message(f"Write a {language} function that performs the following task: {task_description}")
+def generate_code_request(language: str, task_description: str) -> list[Message]:
+    """Generates a conversation for code generation."""
+    return [
+        Message(f"Write a {language} function that performs the following task: {task_description}"),
+        Message("I'll help you write that function.", role="assistant"),
+    ]
 ```
 
 **Key Concepts:**

--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -242,10 +242,9 @@ class Prompt(FastMCPComponent):
         """Create a Prompt from a function.
 
         The function can return:
-        - A string (converted to a message)
-        - A Message object
-        - A dict (converted to a message)
-        - A sequence of any of the above
+        - str: wrapped as single user Message
+        - list[Message | str]: converted to list[Message]
+        - PromptResult: used directly
         """
         return FunctionPrompt.from_function(
             fn=fn,
@@ -385,10 +384,9 @@ class FunctionPrompt(Prompt):
         """Create a Prompt from a function.
 
         The function can return:
-        - A string (converted to a message)
-        - A Message object
-        - A dict (converted to a message)
-        - A sequence of any of the above
+        - str: wrapped as single user Message
+        - list[Message | str]: converted to list[Message]
+        - PromptResult: used directly
         """
 
         func_name = name or getattr(fn, "__name__", None) or fn.__class__.__name__


### PR DESCRIPTION
The documentation example for prompts showed returning a single `Message` object with `-> Message`, but this is not a supported return type. The `convert_result` method only handles:

- `str` → wrapped as single user Message
- `list[Message | str]` → converted to list[Message]  
- `PromptResult` → passed through

A single `Message` would raise `TypeError: Prompt must return str, list[Message], or PromptResult`.

Updated the example to return `list[Message]` which demonstrates the multi-message capability, and corrected the docstrings in `Prompt.from_function` and `FunctionPrompt.from_function` to match the actual supported types.