### PR TITLE
Remove unused include_tags/exclude_tags settings

### DIFF
--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -327,31 +327,6 @@ class Settings(BaseSettings):
         ),
     ] = None
 
-    include_tags: Annotated[
-        set[str] | None,
-        Field(
-            description=inspect.cleandoc(
-                """
-                If provided, only components that match these tags will be
-                exposed to clients. A component is considered to match if ANY of
-                its tags match ANY of the tags in the set.
-                """
-            ),
-        ),
-    ] = None
-    exclude_tags: Annotated[
-        set[str] | None,
-        Field(
-            description=inspect.cleandoc(
-                """
-                If provided, components that match these tags will be excluded
-                from the server. A component is considered to match if ANY of
-                its tags match ANY of the tags in the set.
-                """
-            ),
-        ),
-    ] = None
-
     include_fastmcp_meta: Annotated[
         bool,
         Field(


### PR DESCRIPTION
These settings in `Settings` were never wired up to anything—nothing reads `fastmcp.settings.include_tags` or `fastmcp.settings.exclude_tags`. The actual deprecation is on `FastMCP.__init__()` parameters, which is tracked in #2755.