### PR TITLE
Fix rate limit detection during teardown phase

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -56,9 +56,9 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
 
-    # Only process actual failures during the call phase, not xfails
+    # Only process actual failures during the call or teardown phase, not xfails
     if (
-        report.when == "call"
+        report.when in ("call", "teardown")
         and report.failed
         and not hasattr(report, "wasxfail")
         and item.module.__name__ == "tests.integration_tests.test_github_mcp_remote"


### PR DESCRIPTION
When GitHub API rate limits (429) occur during integration tests, the existing conftest.py hook converts failures to skips. However, 429 errors that surface during async context manager cleanup (`__aexit__`) were not being caught because the hook only processed the "call" phase.

This adds the "teardown" phase to the check, catching rate limit errors that appear during cleanup and properly converting them to skipped tests.