### PR TITLE
fix: set pytest-asyncio default fixture loop scope to function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ fallback-version = "0.0.0"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 # filterwarnings = ["error::DeprecationWarning"]
 filterwarnings = [
     # Suppress OAuth in-memory token storage warnings in tests


### PR DESCRIPTION
Fixes a warning from newer pytest-asyncio versions that requires explicitly setting the event loop scope for async fixtures.

Sets `asyncio_default_fixture_loop_scope = "function"` in pytest configuration to resolve the deprecation warning.