### PR TITLE
Make FASTMCP_SHOW_SERVER_BANNER apply to all server startup methods

### DIFF
--- a/docs/development/upgrade-guide.mdx
+++ b/docs/development/upgrade-guide.mdx
@@ -179,6 +179,15 @@ This applies to all auth providers: `GitHubProvider`, `GoogleProvider`, `AzurePr
 
 The `FastMCPSettings` class has also been simplified - it no longer includes auth-related settings that were previously loaded from environment variables.
 
+### Server Banner Environment Variable Renamed
+
+The environment variable for controlling the server banner has been renamed:
+
+- **Before:** `FASTMCP_SHOW_CLI_BANNER`
+- **After:** `FASTMCP_SHOW_SERVER_BANNER`
+
+This change reflects that the setting now applies to all server startup methods, not just the CLI. The banner is now suppressed when running `python server.py` directly, not just when using `fastmcp run`.
+
 ## v2.14.0
 
 ### OpenAPI Parser Promotion

--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -423,8 +423,10 @@ async def run(
     final_log_level = log_level or config.deployment.log_level
     final_server_args = server_args or config.deployment.args
     # Use CLI override if provided, otherwise use settings
-    # no_banner CLI flag overrides the show_cli_banner setting
-    final_no_banner = no_banner if no_banner else not fastmcp.settings.show_cli_banner
+    # no_banner CLI flag overrides the show_server_banner setting
+    final_no_banner = (
+        no_banner if no_banner else not fastmcp.settings.show_server_banner
+    )
 
     logger.debug(
         "Running server or client",

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -556,14 +556,18 @@ class FastMCP(Generic[LifespanResultT]):
     async def run_async(
         self,
         transport: Transport | None = None,
-        show_banner: bool = True,
+        show_banner: bool | None = None,
         **transport_kwargs: Any,
     ) -> None:
         """Run the FastMCP server asynchronously.
 
         Args:
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
+            show_banner: Whether to display the server banner. If None, uses the
+                FASTMCP_SHOW_SERVER_BANNER setting (default: True).
         """
+        if show_banner is None:
+            show_banner = fastmcp.settings.show_server_banner
         if transport is None:
             transport = "stdio"
         if transport not in {"stdio", "http", "sse", "streamable-http"}:
@@ -586,13 +590,15 @@ class FastMCP(Generic[LifespanResultT]):
     def run(
         self,
         transport: Transport | None = None,
-        show_banner: bool = True,
+        show_banner: bool | None = None,
         **transport_kwargs: Any,
     ) -> None:
         """Run the FastMCP server. Note this is a synchronous function.
 
         Args:
             transport: Transport protocol to use ("http", "stdio", "sse", or "streamable-http")
+            show_banner: Whether to display the server banner. If None, uses the
+                FASTMCP_SHOW_SERVER_BANNER setting (default: True).
         """
 
         anyio.run(

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -320,14 +320,15 @@ class Settings(BaseSettings):
         ),
     ] = False
 
-    show_cli_banner: Annotated[
+    show_server_banner: Annotated[
         bool,
         Field(
             description=inspect.cleandoc(
                 """
-                If True, the server banner will be displayed when running the server via CLI.
-                This setting can be overridden by the --no-banner CLI flag.
-                Set to False via FASTMCP_SHOW_CLI_BANNER=false to suppress the banner.
+                If True, the server banner will be displayed when running the server.
+                This setting can be overridden by the --no-banner CLI flag or by
+                passing show_banner=False to server.run().
+                Set to False via FASTMCP_SHOW_SERVER_BANNER=false to suppress the banner.
                 """
             ),
         ),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -374,8 +374,8 @@ class TestRunCommand:
         assert bound.arguments["project"] == Path("./test-env")
         assert bound.arguments["skip_source"] is True
 
-    def test_show_cli_banner_setting(self):
-        """Test that show_cli_banner setting works with environment variable."""
+    def test_show_server_banner_setting(self):
+        """Test that show_server_banner setting works with environment variable."""
         import os
         from unittest import mock
 
@@ -383,19 +383,19 @@ class TestRunCommand:
 
         # Test default (banner shown)
         settings = Settings()
-        assert settings.show_cli_banner is True
+        assert settings.show_server_banner is True
 
         # Test with env var set to false (banner hidden)
-        with mock.patch.dict(os.environ, {"FASTMCP_SHOW_CLI_BANNER": "false"}):
+        with mock.patch.dict(os.environ, {"FASTMCP_SHOW_SERVER_BANNER": "false"}):
             settings = Settings()
-            assert settings.show_cli_banner is False
+            assert settings.show_server_banner is False
 
         # Test CLI precedence logic (simulated)
-        with mock.patch.dict(os.environ, {"FASTMCP_SHOW_CLI_BANNER": "true"}):
+        with mock.patch.dict(os.environ, {"FASTMCP_SHOW_SERVER_BANNER": "true"}):
             settings = Settings()
             # CLI --no-banner flag would override
             cli_no_banner = True
-            final = cli_no_banner if cli_no_banner else not settings.show_cli_banner
+            final = cli_no_banner if cli_no_banner else not settings.show_server_banner
             assert final is True  # Banner suppressed by CLI flag
 
 


### PR DESCRIPTION
The `FASTMCP_SHOW_CLI_BANNER` setting only worked when using `fastmcp run`. When running servers directly via `python server.py` (calling `mcp.run()`), the env var was ignored.

This PR renames the setting to `FASTMCP_SHOW_SERVER_BANNER` and makes `run()` / `run_async()` respect it. The `show_banner` parameter now defaults to `None`, which resolves to the setting value.

```python
# Now works in all cases:
# FASTMCP_SHOW_SERVER_BANNER=false python server.py
# FASTMCP_SHOW_SERVER_BANNER=false fastmcp run server.py

# Explicit override still works:
mcp.run(show_banner=False)
```