### PR TITLE
Fix base_url fallback when url is not set

### DIFF
--- a/src/fastmcp/server/providers/openapi/components.py
+++ b/src/fastmcp/server/providers/openapi/components.py
@@ -108,11 +108,7 @@ class OpenAPITool(Tool):
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
         """Execute the HTTP request using RequestDirector."""
         try:
-            base_url = (
-                str(self._client.base_url)
-                if self._client.base_url
-                else "http://localhost"
-            )
+            base_url = str(self._client.base_url) or "http://localhost"
 
             # Build the request using RequestDirector
             request = self._director.build(self._route, arguments, base_url)


### PR DESCRIPTION
## Description

When httpx.AsyncClient is created without a base_url, it defaults to `httpx.URL("")`. The original code checked `if self._client.base_url` to determine whether to use the fallback, but `httpx.URL("")` is truthy even though it stringifies to an empty string. This caused requests to be made to `""` instead of `"http://localhost/"`.

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes #2775 
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
