### PR TITLE
Fix base_url fallback when url is not set (backport #2776)

### DIFF
--- a/src/fastmcp/server/openapi/components.py
+++ b/src/fastmcp/server/openapi/components.py
@@ -64,10 +64,8 @@ class OpenAPITool(Tool):
         try:
             # Get base URL from client
             base_url = (
-                str(self._client.base_url)
-                if hasattr(self._client, "base_url") and self._client.base_url
-                else "http://localhost"
-            )
+                str(self._client.base_url) if hasattr(self._client, "base_url") else ""
+            ) or "http://localhost"
 
             # Get Headers from client
             cli_headers = (

--- a/tests/server/openapi/test_comprehensive.py
+++ b/tests/server/openapi/test_comprehensive.py
@@ -498,6 +498,38 @@ class TestOpenAPIComprehensive:
             assert "123" in str(request.url)
             assert "users/123" in str(request.url)
 
+    async def test_request_uses_localhost_fallback_when_no_base_url(
+        self, comprehensive_openapi_spec
+    ):
+        """Test that tool uses localhost fallback when client has no base_url."""
+        mock_client = Mock(spec=httpx.AsyncClient)
+        mock_client.base_url = httpx.URL("")  # Empty URL, same as httpx default
+        mock_client.headers = None
+
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": 123,
+            "name": "Test User",
+            "email": "test@example.com",
+        }
+        mock_response.raise_for_status = Mock()
+
+        mock_client.send = AsyncMock(return_value=mock_response)
+
+        server = FastMCPOpenAPI(
+            openapi_spec=comprehensive_openapi_spec,
+            client=mock_client,
+        )
+
+        async with Client(server) as mcp_client:
+            await mcp_client.call_tool("get_user", {"id": 123})
+
+        # Verify request was made to localhost fallback
+        mock_client.send.assert_called_once()
+        request = mock_client.send.call_args[0][0]
+        assert str(request.url).startswith("http://localhost")
+
     async def test_complex_request_with_body_and_parameters(
         self, comprehensive_openapi_spec
     ):


### PR DESCRIPTION
Backport of #2776 for 2.14.2 release.

When `httpx.AsyncClient` is created without a `base_url`, it defaults to `httpx.URL("")`. This URL is truthy but stringifies to an empty string, causing requests to fail instead of falling back to `http://localhost`.

```python
# Before: httpx.URL("") is truthy, so this returns ""
base_url = str(url) if url else "http://localhost"

# After: "" is falsy, so this returns "http://localhost"
base_url = str(url) or "http://localhost"
```

Closes #2775