### PR TITLE
Fix keep_alive passthrough in StdioMCPServer.to_transport()

### DIFF
--- a/src/fastmcp/mcp_config.py
+++ b/src/fastmcp/mcp_config.py
@@ -143,6 +143,9 @@ class StdioMCPServer(BaseModel):
     # Execution context
     cwd: str | None = None  # Working directory for command execution
     timeout: int | None = None  # Maximum response time in milliseconds
+    keep_alive: bool | None = (
+        None  # Whether to keep the subprocess alive between connections
+    )
 
     # Metadata
     description: str | None = None  # Human-readable server description
@@ -161,6 +164,7 @@ class StdioMCPServer(BaseModel):
             args=self.args,
             env=self.env,
             cwd=self.cwd,
+            keep_alive=self.keep_alive,
         )
 
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -70,6 +70,37 @@ def test_parse_single_stdio_config():
     assert transport.args == ["hello"]
 
 
+def test_stdio_config_keep_alive_passthrough():
+    """Test that keep_alive parameter is passed through from StdioMCPServer to StdioTransport."""
+    # Test with keep_alive=False
+    server = StdioMCPServer(command="test", keep_alive=False)
+    assert server.keep_alive is False
+    transport = server.to_transport()
+    assert isinstance(transport, StdioTransport)
+    assert transport.keep_alive is False
+
+    # Test with keep_alive=True
+    server = StdioMCPServer(command="test", keep_alive=True)
+    assert server.keep_alive is True
+    transport = server.to_transport()
+    assert isinstance(transport, StdioTransport)
+    assert transport.keep_alive is True
+
+    # Test with keep_alive=None (should default to True in StdioTransport)
+    server = StdioMCPServer(command="test", keep_alive=None)
+    assert server.keep_alive is None
+    transport = server.to_transport()
+    assert isinstance(transport, StdioTransport)
+    assert transport.keep_alive is True  # StdioTransport defaults to True
+
+    # Test with keep_alive not specified (should default to None, then True in StdioTransport)
+    server = StdioMCPServer(command="test")
+    assert server.keep_alive is None
+    transport = server.to_transport()
+    assert isinstance(transport, StdioTransport)
+    assert transport.keep_alive is True  # StdioTransport defaults to True
+
+
 def test_parse_extra_keys():
     config = {
         "mcpServers": {


### PR DESCRIPTION
Fixes a bug where `StdioMCPServer.to_transport()` was not passing through the `keep_alive` parameter to the created `StdioTransport`, causing subprocesses to persist after the Client context manager exits even when `keep_alive=False` was specified.

## Changes

- Added `keep_alive: bool | None = None` field to `StdioMCPServer` class
- Updated `to_transport()` method to pass `keep_alive=self.keep_alive` when creating `StdioTransport`
- Added comprehensive test coverage for the passthrough behavior

## Example

```python
from fastmcp.mcp_config import StdioMCPServer

# Now works correctly - keep_alive is passed through
server = StdioMCPServer(command='test', keep_alive=False)
transport = server.to_transport()
assert transport.keep_alive == False  # ✓ Now correctly False
```

Previously, `transport.keep_alive` would always be `True` regardless of the value set on `StdioMCPServer`.