### PR TITLE
Use consistent refresh_ttl for JTI mapping store

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy.py
@@ -1576,7 +1576,7 @@ class OAuthProxy(OAuthProvider):
         )
 
         # Store new refresh token JTI mapping with aligned expiry
-        refresh_ttl = new_refresh_expires_in or 60 * 60 * 24 * 30
+        # (reuse refresh_ttl calculated above for upstream token store)
         await self._jti_mapping_store.put(
             key=new_refresh_jti,
             value=JTIMapping(


### PR DESCRIPTION
During the token refresh flow, the JTI mapping TTL was calculated with a simpler fallback than the upstream token store TTL. If `new_refresh_expires_in` was None but `refresh_token_expires_at` existed with a value > 30 days, the JTI mapping would use a 30-day default while the upstream token store used the actual expiry.

This could cause auth failures after 30 days if the JTI mapping expired before the upstream token it referenced.

Now both use the same `refresh_ttl` calculation.