### PR TITLE
Configure ty to fail on warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,9 @@ python-version = "3.10"
 # Some code uses `# ty: ignore[invalid-argument-type]` for this limitation.
 # TODO: Remove these ignores once ty supports union narrowing
 
+[tool.ty.terminal]
+error-on-warning = true
+
 [tool.ruff.lint]
 fixable = ["ALL"]
 ignore = [

--- a/tests/server/auth/providers/test_supabase.py
+++ b/tests/server/auth/providers/test_supabase.py
@@ -135,10 +135,11 @@ class TestSupabaseProvider:
         )
 
         assert provider.auth_route == "custom/auth/route"
+        assert isinstance(provider.token_verifier, JWTVerifier)
         assert (
             provider.token_verifier.jwks_uri
             == "https://abc123.supabase.co/custom/auth/route/.well-known/jwks.json"
-        )  # type: ignore[attr-defined]
+        )
 
     def test_custom_auth_route_trailing_slash(self):
         provider = SupabaseProvider(


### PR DESCRIPTION
Enables `error-on-warning = true` in `[tool.ty.terminal]` so ty exits with code 1 when warnings are emitted. This catches type issues earlier in CI rather than letting them accumulate.

Fixed the one existing warning by adding an `isinstance` check before accessing `jwks_uri` on the token verifier.