### PR TITLE
Fix unawaited coroutine warning and treat as test error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ filterwarnings = [
     # Suppress OAuth in-memory token storage warnings in tests
     # Tests intentionally use ephemeral storage; this warning is for end users
     "ignore:Using in-memory token storage:UserWarning",
+    # Treat unawaited coroutine warnings as errors - these are almost always bugs
+    "error:coroutine .* was never awaited:RuntimeWarning",
+    "error:Exception ignored in.*coroutine:pytest.PytestUnraisableExceptionWarning",
 ]
 timeout = 5
 env = [

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -686,6 +686,8 @@ class Client(Generic[ClientTransportT]):
 
         # If session task already failed, raise immediately
         if session_task.done():
+            # Close the coroutine to avoid "was never awaited" warning
+            coro.close()
             exc = session_task.exception()
             if exc:
                 raise exc


### PR DESCRIPTION
When `_await_with_session_monitoring` detects that the session task is already done, it raises immediately without closing the passed coroutine. This causes "coroutine was never awaited" warnings during test teardown.

**Fix:** Call `coro.close()` before raising to properly clean up the coroutine.

**Prevention:** Add pytest filterwarnings to treat unawaited coroutine warnings as errors so future occurrences will fail tests rather than emit warnings.

```python
# pyproject.toml
filterwarnings = [
    "error:coroutine .* was never awaited:RuntimeWarning",
    "error:Exception ignored in.*coroutine:pytest.PytestUnraisableExceptionWarning",
]
```