### PR TITLE
Dereference $ref in tool schemas for MCP client compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "uvicorn>=0.35",
     "websockets>=15.0.1",
     "jsonschema-path>=0.3.4",
+    "jsonref>=1.1.0",
 ]
 
 requires-python = ">=3.10"

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -34,7 +34,7 @@ import fastmcp
 from fastmcp.server.dependencies import without_injected_parameters
 from fastmcp.server.tasks.config import TaskConfig, TaskMeta
 from fastmcp.utilities.components import FastMCPComponent
-from fastmcp.utilities.json_schema import compress_schema, resolve_root_ref
+from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import (
     Audio,
@@ -685,10 +685,6 @@ class ParsedFunction:
                     output_schema = base_schema
 
                 output_schema = compress_schema(output_schema, prune_titles=True)
-
-                # Resolve root-level $ref to meet MCP spec requirement for type: object
-                # Self-referential Pydantic models generate schemas with $ref at root
-                output_schema = resolve_root_ref(output_schema)
 
             except PydanticSchemaGenerationError as e:
                 if "_UnserializableType" not in str(e):

--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -680,7 +680,7 @@ class TransformedTool(Tool):
 
         if parent_defs:
             schema["$defs"] = parent_defs
-            schema = compress_schema(schema, prune_defs=True)
+            schema = compress_schema(schema)
 
         # Create forwarding function that closes over everything it needs
         async def _forward(**kwargs: Any):
@@ -863,7 +863,7 @@ class TransformedTool(Tool):
 
         if merged_defs:
             result["$defs"] = merged_defs
-            result = compress_schema(result, prune_defs=True)
+            result = compress_schema(result)
 
         return result
 

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -201,18 +201,15 @@ class TestToolFromFunction:
                 "description": "Create a new user.",
                 "tags": set(),
                 "parameters": {
-                    "$defs": {
-                        "UserInput": {
+                    "properties": {
+                        "user": {
                             "properties": {
                                 "name": {"type": "string"},
                                 "age": {"type": "integer"},
                             },
                             "required": ["name", "age"],
                             "type": "object",
-                        }
-                    },
-                    "properties": {
-                        "user": {"$ref": "#/$defs/UserInput"},
+                        },
                         "flag": {"type": "boolean"},
                     },
                     "required": ["user", "flag"],

--- a/tests/utilities/openapi/test_schemas.py
+++ b/tests/utilities/openapi/test_schemas.py
@@ -580,8 +580,8 @@ class TestEdgeCases:
             len(properties) > 0
         )  # Should have some properties from one of the content types
 
-    def test_oneof_reference_preserved(self):
-        """Test that schemas referenced in oneOf are preserved."""
+    def test_oneof_reference_dereferenced(self):
+        """Test that schemas referenced in oneOf are dereferenced."""
 
         schema = {
             "type": "object",
@@ -594,14 +594,14 @@ class TestEdgeCases:
 
         result = compress_schema(schema)
 
-        # TestSchema should be preserved (referenced in oneOf)
-        assert "TestSchema" in result["$defs"]
+        # $defs should be removed (all refs dereferenced)
+        assert "$defs" not in result
 
-        # UnusedSchema should be removed
-        assert "UnusedSchema" not in result["$defs"]
+        # TestSchema should be inlined in oneOf
+        assert result["properties"]["data"]["oneOf"] == [{"type": "string"}]
 
-    def test_anyof_reference_preserved(self):
-        """Test that schemas referenced in anyOf are preserved."""
+    def test_anyof_reference_dereferenced(self):
+        """Test that schemas referenced in anyOf are dereferenced."""
 
         schema = {
             "type": "object",
@@ -614,11 +614,14 @@ class TestEdgeCases:
 
         result = compress_schema(schema)
 
-        assert "TestSchema" in result["$defs"]
-        assert "UnusedSchema" not in result["$defs"]
+        # $defs should be removed (all refs dereferenced)
+        assert "$defs" not in result
 
-    def test_allof_reference_preserved(self):
-        """Test that schemas referenced in allOf are preserved."""
+        # TestSchema should be inlined in anyOf
+        assert result["properties"]["data"]["anyOf"] == [{"type": "string"}]
+
+    def test_allof_reference_dereferenced(self):
+        """Test that schemas referenced in allOf are dereferenced."""
 
         schema = {
             "type": "object",
@@ -631,5 +634,8 @@ class TestEdgeCases:
 
         result = compress_schema(schema)
 
-        assert "TestSchema" in result["$defs"]
-        assert "UnusedSchema" not in result["$defs"]
+        # $defs should be removed (all refs dereferenced)
+        assert "$defs" not in result
+
+        # TestSchema should be inlined in allOf
+        assert result["properties"]["data"]["allOf"] == [{"type": "string"}]

--- a/tests/utilities/test_json_schema.py
+++ b/tests/utilities/test_json_schema.py
@@ -1,17 +1,9 @@
 from fastmcp.utilities.json_schema import (
     _prune_param,
     compress_schema,
+    dereference_refs,
     resolve_root_ref,
 )
-
-# Wrapper for backward compatibility with tests
-
-
-def _prune_additional_properties(schema):
-    """Wrapper for compress_schema that only prunes additionalProperties: false."""
-    return compress_schema(
-        schema, prune_defs=False, prune_additional_properties=True, prune_titles=False
-    )
 
 
 class TestPruneParam:
@@ -55,32 +47,28 @@ class TestPruneParam:
         assert "required" not in result
 
 
-class TestPruneUnusedDefs:
-    """Tests for unused definition pruning (via compress_schema)."""
+class TestDereferenceRefs:
+    """Tests for the dereference_refs function."""
 
-    def test_removes_unreferenced_defs(self):
-        """Test that unreferenced definitions are removed."""
+    def test_dereferences_simple_ref(self):
+        """Test that simple $ref is dereferenced."""
         schema = {
             "properties": {
                 "foo": {"$ref": "#/$defs/foo_def"},
             },
             "$defs": {
                 "foo_def": {"type": "string"},
-                "unused_def": {"type": "integer"},
             },
         }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
+        result = dereference_refs(schema)
 
-        assert "foo_def" in result["$defs"]
-        assert "unused_def" not in result["$defs"]
+        # $ref should be inlined
+        assert result["properties"]["foo"] == {"type": "string"}
+        # $defs should be removed
+        assert "$defs" not in result
 
-    def test_nested_references_kept(self):
-        """Test that definitions referenced via nesting are kept."""
+    def test_dereferences_nested_refs(self):
+        """Test that nested $refs are dereferenced."""
         schema = {
             "properties": {
                 "foo": {"$ref": "#/$defs/foo_def"},
@@ -91,209 +79,58 @@ class TestPruneUnusedDefs:
                     "properties": {"nested": {"$ref": "#/$defs/nested_def"}},
                 },
                 "nested_def": {"type": "string"},
-                "unused_def": {"type": "integer"},
             },
         }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
-        assert "foo_def" in result["$defs"]
-        assert "nested_def" in result["$defs"]
-        assert "unused_def" not in result["$defs"]
+        result = dereference_refs(schema)
 
-    def test_nested_references_removed(self):
-        """Test that definitions referenced via nesting in unused defs are removed."""
-        schema = {
-            "properties": {},
-            "$defs": {
-                "foo_def": {
-                    "type": "object",
-                    "properties": {"nested": {"$ref": "#/$defs/nested_def"}},
-                },
-                "nested_def": {"type": "string"},
-            },
-        }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
+        # All refs should be inlined
+        assert result["properties"]["foo"]["properties"]["nested"] == {"type": "string"}
+        # $defs should be removed
         assert "$defs" not in result
 
-    def test_nested_references_with_recursion_kept(self):
-        """Test that definitions with recursion referenced via nesting are kept."""
+    def test_falls_back_for_circular_refs(self):
+        """Test that circular references fall back to resolve_root_ref."""
         schema = {
-            "properties": {
-                "foo": {"$ref": "#/$defs/foo_def"},
-            },
             "$defs": {
-                "foo_def": {
+                "Node": {
                     "type": "object",
-                    "properties": {"nested": {"$ref": "#/$defs/foo_def"}},
-                },
-                "unused_def": {"type": "integer"},
+                    "properties": {
+                        "children": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/Node"},
+                        }
+                    },
+                }
             },
+            "$ref": "#/$defs/Node",
         }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
-        assert "foo_def" in result["$defs"]
-        assert "unused_def" not in result["$defs"]
+        result = dereference_refs(schema)
 
-    def test_nested_references_with_recursion_removed(self):
-        """Test that definitions with recursion referenced via nesting in unused defs are removed."""
-        schema = {
-            "properties": {},
-            "$defs": {
-                "foo_def": {
-                    "type": "object",
-                    "properties": {"nested": {"$ref": "#/$defs/foo_def"}},
-                },
-            },
-        }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
-        assert "$defs" not in result
-
-    def test_multiple_nested_references_with_recursion_kept(self):
-        """Test that definitions with multiple levels of recursion referenced via nesting are kept."""
-        schema = {
-            "properties": {
-                "foo": {"$ref": "#/$defs/foo_def"},
-            },
-            "$defs": {
-                "foo_def": {
-                    "type": "object",
-                    "properties": {"nested": {"$ref": "#/$defs/nested_def"}},
-                },
-                "nested_def": {
-                    "type": "object",
-                    "properties": {"nested": {"$ref": "#/$defs/foo_def"}},
-                },
-                "unused_def": {"type": "integer"},
-            },
-        }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
-        assert "foo_def" in result["$defs"]
-        assert "nested_def" in result["$defs"]
-        assert "unused_def" not in result["$defs"]
-
-    def test_multiple_nested_references_with_recursion_removed(self):
-        """Test that definitions with multiple levels of recursion referenced via nesting in unused defs are removed."""
-        schema = {
-            "properties": {},
-            "$defs": {
-                "foo_def": {
-                    "type": "object",
-                    "properties": {"nested": {"$ref": "#/$defs/nested_def"}},
-                },
-                "nested_def": {
-                    "type": "object",
-                    "properties": {"nested": {"$ref": "#/$defs/foo_def"}},
-                },
-            },
-        }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
-        assert "$defs" not in result
-
-    def test_array_references_kept(self):
-        """Test that definitions referenced in array items are kept."""
-        schema = {
-            "properties": {
-                "items": {"type": "array", "items": {"$ref": "#/$defs/item_def"}},
-            },
-            "$defs": {
-                "item_def": {"type": "string"},
-                "unused_def": {"type": "integer"},
-            },
-        }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
-        assert "item_def" in result["$defs"]
-        assert "unused_def" not in result["$defs"]
-
-    def test_removes_defs_field_when_empty(self):
-        """Test that $defs field is removed when all definitions are unused."""
-        schema = {
-            "properties": {
-                "foo": {"type": "string"},
-            },
-            "$defs": {
-                "unused_def": {"type": "integer"},
-            },
-        }
-        result = compress_schema(
-            schema,
-            prune_defs=True,
-            prune_additional_properties=False,
-            prune_titles=False,
-        )
-        assert "$defs" not in result
-
-
-class TestPruneAdditionalProperties:
-    """Tests for the _prune_additional_properties function."""
-
-    def test_removes_when_false(self):
-        """Test that additionalProperties is removed when it's false."""
-        schema = {
-            "type": "object",
-            "properties": {"foo": {"type": "string"}},
-            "additionalProperties": False,
-        }
-        result = _prune_additional_properties(schema)
-        assert "additionalProperties" not in result
-
-    def test_keeps_when_true(self):
-        """Test that additionalProperties is kept when it's true."""
-        schema = {
-            "type": "object",
-            "properties": {"foo": {"type": "string"}},
-            "additionalProperties": True,
-        }
-        result = _prune_additional_properties(schema)
-        assert "additionalProperties" in result
-        assert result["additionalProperties"] is True
-
-    def test_keeps_when_object(self):
-        """Test that additionalProperties is kept when it's an object schema."""
-        schema = {
-            "type": "object",
-            "properties": {"foo": {"type": "string"}},
-            "additionalProperties": {"type": "string"},
-        }
-        result = _prune_additional_properties(schema)
-        assert "additionalProperties" in result
-        assert result["additionalProperties"] == {"type": "string"}
+        # Should fall back to resolve_root_ref behavior
+        # Root should be resolved but nested refs preserved
+        assert result.get("type") == "object"
+        assert "$defs" in result  # $defs preserved for circular refs
 
 
 class TestCompressSchema:
     """Tests for the compress_schema function."""
+
+    def test_dereferences_by_default(self):
+        """Test that compress_schema dereferences $refs by default."""
+        schema = {
+            "properties": {
+                "foo": {"$ref": "#/$defs/foo_def"},
+            },
+            "$defs": {
+                "foo_def": {"type": "string"},
+            },
+        }
+        result = compress_schema(schema)
+
+        # $ref should be inlined
+        assert result["properties"]["foo"] == {"type": "string"}
+        # $defs should be removed
+        assert "$defs" not in result
 
     def test_prune_params(self):
         """Test pruning parameters with compress_schema."""
@@ -308,38 +145,6 @@ class TestCompressSchema:
         result = compress_schema(schema, prune_params=["foo", "baz"])
         assert result["properties"] == {"bar": {"type": "integer"}}
         assert result["required"] == ["bar"]
-
-    def test_prune_defs(self):
-        """Test pruning unused definitions with compress_schema."""
-        schema = {
-            "properties": {
-                "foo": {"$ref": "#/$defs/foo_def"},
-                "bar": {"type": "integer"},
-            },
-            "$defs": {
-                "foo_def": {"type": "string"},
-                "unused_def": {"type": "number"},
-            },
-        }
-        result = compress_schema(schema)
-        assert "foo_def" in result["$defs"]
-        assert "unused_def" not in result["$defs"]
-
-    def test_disable_prune_defs(self):
-        """Test disabling pruning of unused definitions."""
-        schema = {
-            "properties": {
-                "foo": {"$ref": "#/$defs/foo_def"},
-                "bar": {"type": "integer"},
-            },
-            "$defs": {
-                "foo_def": {"type": "string"},
-                "unused_def": {"type": "number"},
-            },
-        }
-        result = compress_schema(schema, prune_defs=False)
-        assert "foo_def" in result["$defs"]
-        assert "unused_def" in result["$defs"]
 
     def test_pruning_additional_properties(self):
         """Test pruning additionalProperties when False."""
@@ -382,8 +187,8 @@ class TestCompressSchema:
         assert "remove" not in result["properties"]
         # Check that required list was updated
         assert result["required"] == ["keep"]
-        # Check that unused definitions were removed
-        assert "$defs" not in result  # Both defs should be gone
+        # Check that $defs was removed (dereferenced)
+        assert "$defs" not in result
         # Check that additionalProperties was removed
         assert "additionalProperties" not in result
 

--- a/uv.lock
+++ b/uv.lock
@@ -689,6 +689,7 @@ dependencies = [
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "httpx" },
+    { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
@@ -745,6 +746,7 @@ requires-dist = [
     { name = "cyclopts", specifier = ">=4.0.0" },
     { name = "exceptiongroup", specifier = ">=1.2.2" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "jsonref", specifier = ">=1.1.0" },
     { name = "jsonschema-path", specifier = ">=0.3.4" },
     { name = "mcp", specifier = ">=1.24.0,<2.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.102.0" },
@@ -1098,6 +1100,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
     { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
     { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Some MCP clients (like VS Code Copilot) don't properly handle `$ref` in tool input schemas. When Pydantic generates schemas for Enum types, it uses `$defs` with `$ref` pointers:

```json
{
  "$defs": {"Category": {"enum": ["food", "transport"], "type": "string"}},
  "properties": {"category": {"$ref": "#/$defs/Category"}}
}
```

VS Code Copilot appears to strip `$defs` before sending to Claude, leaving dangling `$ref` pointers that cause tool calls to fail.

This PR dereferences all `$ref` entries in `compress_schema()` using `jsonref`, producing clean inlined schemas:

```json
{
  "properties": {"category": {"enum": ["food", "transport"], "type": "string"}}
}
```

Self-referencing schemas (which can't be fully dereferenced) fall back to `resolve_root_ref()` for MCP spec compliance.

### Background

We previously closed PRs #1192 and #1641 which proposed similar solutions. Our position was that FastMCP's obligation is MCP spec compliance, not working around individual client bugs. However, this issue has persisted for a long time across multiple popular clients (Claude Desktop, VS Code Copilot) that are otherwise excellent. The tradeoff is minimal—slightly larger schemas due to inlining—with no functional compromise. Given how widespread and long-standing this is, it feels reasonable to make this accommodation.

Closes #2807, closes #1193, fixes #2236