### PR TITLE
Fix Claude Code installation lock contention in CI workflows

### DIFF
--- a/.github/workflows/martian-issue-triage.yml
+++ b/.github/workflows/martian-issue-triage.yml
@@ -155,6 +155,9 @@ jobs:
           }
           EOF
 
+      - name: Clean up stale Claude locks
+        run: rm -rf ~/.claude/.locks ~/.local/state/claude/locks || true
+
       - name: Run Martian for Issue Triage
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/martian-test-failure.yml
+++ b/.github/workflows/martian-test-failure.yml
@@ -163,6 +163,9 @@ jobs:
           }
           EOF
 
+      - name: Clean up stale Claude locks
+        run: rm -rf ~/.claude/.locks ~/.local/state/claude/locks || true
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -73,6 +73,9 @@ jobs:
           PROMPT_END
           EOF
 
+      - name: Clean up stale Claude locks
+        run: rm -rf ~/.claude/.locks ~/.local/state/claude/locks || true
+
       - name: Run Marvin dedupe command
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -124,6 +124,9 @@ jobs:
           PROMPT_END
           EOF
 
+      - name: Clean up stale Claude locks
+        run: rm -rf ~/.claude/.locks ~/.local/state/claude/locks || true
+
       - name: Run Marvin for Issue Triage
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/marvin.yml
+++ b/.github/workflows/marvin.yml
@@ -56,6 +56,9 @@ jobs:
           app-id: ${{ secrets.MARVIN_APP_ID }}
           private-key: ${{ secrets.MARVIN_APP_PRIVATE_KEY }}
 
+      - name: Clean up stale Claude locks
+        run: rm -rf ~/.claude/.locks ~/.local/state/claude/locks || true
+
       # Marvin Assistant
       - name: Run Marvin
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
Adds a cleanup step before each `claude-code-action` invocation to remove stale lock files that can block installation retries after timeouts.

This addresses a known issue where Claude Code installation can time out and leave behind lock files at `~/.claude/.locks` or `~/.local/state/claude/locks`, causing subsequent retry attempts to fail with:

> "Could not install - another process is currently installing Claude. Please try again in a moment."

See: https://github.com/anthropics/claude-code-action/issues/709

**Affected workflows:** `marvin.yml`, `marvin-label-triage.yml`, `marvin-dedupe-issues.yml`, `martian-issue-triage.yml`, `martian-test-failure.yml`