### PR TITLE
Fix redirect URI validation docs to match implementation

### DIFF
--- a/docs/servers/auth/remote-oauth.mdx
+++ b/docs/servers/auth/remote-oauth.mdx
@@ -117,7 +117,7 @@ auth = RemoteAuthProvider(
     token_verifier=token_verifier,
     authorization_servers=[AnyHttpUrl("https://auth.yourcompany.com")],
     base_url="https://api.yourcompany.com",  # Your server base URL
-    # Optional: customize allowed client redirect URIs (defaults to localhost only)
+    # Optional: restrict allowed client redirect URIs (defaults to all for DCR compatibility)
     allowed_client_redirect_uris=["http://localhost:*", "http://127.0.0.1:*"]
 )
 
@@ -204,9 +204,9 @@ WorkOS's support for Dynamic Client Registration makes it particularly well-suit
 <Note>
 `RemoteAuthProvider` also supports the `allowed_client_redirect_uris` parameter for controlling which redirect URIs are accepted from MCP clients during DCR:
 
-- `None` (default): Only localhost patterns allowed
+- `None` (default): All redirect URIs allowed (for DCR compatibility)
 - Custom list: Specify allowed patterns with wildcard support
-- Empty list `[]`: Allow all (not recommended)
+- Empty list `[]`: No redirect URIs allowed
 
 This provides defense-in-depth even though DCR providers typically validate redirect URIs themselves.
 </Note>

--- a/src/fastmcp/server/auth/oauth_proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy.py
@@ -674,8 +674,8 @@ class OAuthProxy(OAuthProvider):
             service_documentation_url: Optional service documentation URL
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 Patterns support wildcards (e.g., "http://localhost:*", "https://*.example.com/*").
-                If None (default), only localhost redirect URIs are allowed.
-                If empty list, all redirect URIs are allowed (not recommended for production).
+                If None (default), all redirect URIs are allowed (for DCR compatibility).
+                If empty list, no redirect URIs are allowed.
                 These are for MCP clients performing loopback redirects, NOT for the upstream OAuth app.
             valid_scopes: List of all the possible valid scopes for a client.
                 These are advertised to clients through the `/.well-known` endpoints. Defaults to `required_scopes` if not provided.

--- a/src/fastmcp/server/auth/oidc_proxy.py
+++ b/src/fastmcp/server/auth/oidc_proxy.py
@@ -249,8 +249,8 @@ class OIDCProxy(OAuthProxy):
             redirect_path: Redirect path configured in upstream OAuth app (defaults to "/auth/callback")
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 Patterns support wildcards (e.g., "http://localhost:*", "https://*.example.com/*").
-                If None (default), only localhost redirect URIs are allowed.
-                If empty list, all redirect URIs are allowed (not recommended for production).
+                If None (default), all redirect URIs are allowed (for DCR compatibility).
+                If empty list, no redirect URIs are allowed.
                 These are for MCP clients performing loopback redirects, NOT for the upstream OAuth app.
             client_storage: Storage backend for OAuth state (client registrations, encrypted tokens).
                 If None, a DiskStore will be created in the data directory (derived from `platformdirs`). The


### PR DESCRIPTION
The docstrings for `allowed_client_redirect_uris` in `OAuthProxy` and `OIDCProxy` incorrectly stated:

- `None` (default) → localhost only
- Empty list `[]` → all URIs allowed

The actual implementation (intentionally, for DCR compatibility) is:

- `None` (default) → all URIs allowed
- Empty list `[]` → no URIs allowed

This updates the docstrings and related documentation to match the implementation.

Thanks to @abrookins for pointing this out.