### PR TITLE
Remove deprecated WSTransport

### DIFF
--- a/docs/development/upgrade-guide.mdx
+++ b/docs/development/upgrade-guide.mdx
@@ -10,6 +10,10 @@ This guide provides migration instructions for breaking changes and major update
 
 ## v3.0.0
 
+### WSTransport Removed
+
+The deprecated `WSTransport` client transport has been removed. Use `StreamableHttpTransport` instead.
+
 ### Provider Architecture
 
 FastMCP v3 introduces a unified provider architecture for sourcing components. All tools, resources, and prompts now flow through providers:

--- a/docs/development/v3-notes/v3-features.mdx
+++ b/docs/development/v3-notes/v3-features.mdx
@@ -304,6 +304,10 @@ The `tool_serializer` parameter on `FastMCP` is deprecated. Return `ToolResult` 
 
 ## Breaking Changes
 
+### WSTransport Removed
+
+The deprecated `WSTransport` client transport has been removed. Use `StreamableHttpTransport` instead.
+
 ### Component Enable/Disable Moved to Server/Provider
 
 The `enabled` field and `enable()`/`disable()` methods removed from component objects:

--- a/src/fastmcp/client/__init__.py
+++ b/src/fastmcp/client/__init__.py
@@ -1,18 +1,17 @@
+from .auth import OAuth, BearerAuth
 from .client import Client
 from .transports import (
     ClientTransport,
-    WSTransport,
+    FastMCPTransport,
+    NodeStdioTransport,
+    NpxStdioTransport,
+    PythonStdioTransport,
     SSETransport,
     StdioTransport,
-    PythonStdioTransport,
-    NodeStdioTransport,
-    UvxStdioTransport,
-    UvStdioTransport,
-    NpxStdioTransport,
-    FastMCPTransport,
     StreamableHttpTransport,
+    UvStdioTransport,
+    UvxStdioTransport,
 )
-from .auth import OAuth, BearerAuth
 
 __all__ = [
     "BearerAuth",
@@ -28,5 +27,4 @@ __all__ = [
     "StreamableHttpTransport",
     "UvStdioTransport",
     "UvxStdioTransport",
-    "WSTransport",
 ]

--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -119,45 +119,6 @@ class ClientTransport(abc.ABC):
             raise ValueError("This transport does not support auth")
 
 
-class WSTransport(ClientTransport):
-    """Transport implementation that connects to an MCP server via WebSockets."""
-
-    def __init__(self, url: str | AnyUrl):
-        # we never really used this transport, so it can be removed at any time
-        if fastmcp.settings.deprecation_warnings:
-            warnings.warn(
-                "WSTransport is a deprecated MCP transport and will be removed in a future version. Use StreamableHttpTransport instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if isinstance(url, AnyUrl):
-            url = str(url)
-        if not isinstance(url, str) or not url.startswith("ws"):
-            raise ValueError("Invalid WebSocket URL provided.")
-        self.url = url
-
-    @contextlib.asynccontextmanager
-    async def connect_session(
-        self, **session_kwargs: Unpack[SessionKwargs]
-    ) -> AsyncIterator[ClientSession]:
-        try:
-            from mcp.client.websocket import websocket_client
-        except ImportError as e:
-            raise ImportError(
-                "The websocket transport is not available. Please install fastmcp[websockets] or install the websockets package manually."
-            ) from e
-
-        async with websocket_client(self.url) as transport:
-            read_stream, write_stream = transport
-            async with ClientSession(
-                read_stream, write_stream, **session_kwargs
-            ) as session:
-                yield session
-
-    def __repr__(self) -> str:
-        return f"<WebSocketTransport(url='{self.url}')>"
-
-
 class SSETransport(ClientTransport):
     """Transport implementation that connects to an MCP server via Server-Sent Events."""
 


### PR DESCRIPTION
WSTransport was deprecated and directed users to StreamableHttpTransport. It was never widely used and had no tests. This removes it from the client module and documents the removal in the v3 upgrade guide.