### PR TITLE
Add docs-broken-links command and fix docstring markdown parsing

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ typecheck:
 docs:
     cd docs && npx --yes mint@latest dev
 
+# Check for broken links in documentation
+docs-broken-links:
+    cd docs && npx --yes mint@latest install && npx --yes mint@latest broken-links
+
 # Generate API reference documentation for all modules
 api-ref-all:
     uvx --with-editable . --refresh-package mdxify mdxify@latest --all --root-module fastmcp --anchor-name "Python SDK" --exclude fastmcp.contrib

--- a/src/fastmcp/server/elicitation.py
+++ b/src/fastmcp/server/elicitation.py
@@ -94,7 +94,7 @@ class ElicitationJsonSchema(GenerateJsonSchema):
     def enum_schema(self, schema: core_schema.EnumSchema) -> JsonSchemaValue:
         """Generate inline enum schema.
 
-        Always generates enum pattern: {"enum": [value, ...]}
+        Always generates enum pattern: `{"enum": [value, ...]}`
         Titled enums are handled separately via dict-based syntax in ctx.elicit().
         """
         # Get the base schema from parent - always use simple enum pattern
@@ -134,12 +134,12 @@ def parse_elicit_response_type(response_type: Any) -> ElicitConfig:
 
     Supports multiple syntaxes:
     - None: Empty object schema, expect empty response
-    - dict: {"low": {"title": "..."}} -> single-select titled enum
+    - dict: `{"low": {"title": "..."}}` -> single-select titled enum
     - list patterns:
-        - [["a", "b"]] -> multi-select untitled
-        - [{"low": {...}}] -> multi-select titled
-        - ["a", "b"] -> single-select untitled
-    - list[X] type annotation: multi-select with type
+        - `[["a", "b"]]` -> multi-select untitled
+        - `[{"low": {...}}]` -> multi-select titled
+        - `["a", "b"]` -> single-select untitled
+    - `list[X]` type annotation: multi-select with type
     - Scalar types (bool, int, float, str, Literal, Enum): single value
     - Other types (dataclass, BaseModel): use directly
     """

--- a/src/fastmcp/server/tasks/keys.py
+++ b/src/fastmcp/server/tasks/keys.py
@@ -1,7 +1,7 @@
 """Task key management for SEP-1686 background tasks.
 
 Task keys encode security scoping and metadata in the Docket key format:
-    {session_id}:{client_task_id}:{task_type}:{component_identifier}
+    `{session_id}:{client_task_id}:{task_type}:{component_identifier}`
 
 This format provides:
 - Session-based security scoping (prevents cross-session access)
@@ -20,7 +20,7 @@ def build_task_key(
 ) -> str:
     """Build Docket task key with embedded metadata.
 
-    Format: {session_id}:{client_task_id}:{task_type}:{component_identifier}
+    Format: `{session_id}:{client_task_id}:{task_type}:{component_identifier}`
 
     The component_identifier is URI-encoded to handle special characters (colons, slashes, etc.).
 
@@ -55,12 +55,10 @@ def parse_task_key(task_key: str) -> dict[str, str]:
 
     Examples:
         >>> parse_task_key("session123:task456:tool:my_tool")
-        {'session_id': 'session123', 'client_task_id': 'task456',
-         'task_type': 'tool', 'component_identifier': 'my_tool'}
+        `{'session_id': 'session123', 'client_task_id': 'task456', 'task_type': 'tool', 'component_identifier': 'my_tool'}`
 
         >>> parse_task_key("session123:task456:resource:file%3A%2F%2Fdata.txt")
-        {'session_id': 'session123', 'client_task_id': 'task456',
-         'task_type': 'resource', 'component_identifier': 'file://data.txt'}
+        `{'session_id': 'session123', 'client_task_id': 'task456', 'task_type': 'resource', 'component_identifier': 'file://data.txt'}`
     """
     parts = task_key.split(":", 3)
     if len(parts) != 4:


### PR DESCRIPTION
Adds a new `just docs-broken-links` command to check for broken links in documentation and fixes markdown parsing errors in auto-generated SDK docs.

**Changes:**
- Add `docs-broken-links` command to justfile that runs `mint broken-links` after installing dependencies
- Fix docstring markdown parsing errors in `elicitation.py` and `tasks/keys.py` by wrapping JSON/dict syntax in backticks
- Add instructions to CLAUDE.md about running `just api-ref-all` and `just docs-broken-links` before pushing

The broken links check catches both markdown parsing errors (from docstrings that don't convert properly during `api-ref-all`) and actual dead links. This helps prevent invalid markdown from being committed to the repository.

**Example usage:**
```bash
just api-ref-all        # Regenerate SDK docs
just docs-broken-links  # Verify no parsing errors or broken links
```