### PR TITLE
Use pip instead of uv pip in upgrade instructions

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -129,7 +129,7 @@ def version(
             console.print(
                 f"[bold]🎉 FastMCP update available:[/bold] [green]{newer_version}[/green]"
             )
-            console.print("[dim]Run: uv pip install --upgrade fastmcp[/dim]")
+            console.print("[dim]Run: pip install --upgrade fastmcp[/dim]")
 
 
 @app.command

--- a/src/fastmcp/utilities/cli.py
+++ b/src/fastmcp/utilities/cli.py
@@ -267,7 +267,7 @@ def log_server_banner(server: FastMCP[Any]) -> None:
             ("🎉 Update available: ", "bold"),
             (newer_version, "bold green"),
         )
-        update_line2 = Text("Run: uv pip install --upgrade fastmcp", style="dim")
+        update_line2 = Text("Run: pip install --upgrade fastmcp", style="dim")
         update_notice = Panel(
             Group(Align.center(update_line1), Align.center(update_line2)),
             border_style="blue",


### PR DESCRIPTION
Follow-up to #2839. The upgrade message was using `uv pip install` which assumes users are using uv. Changed to just `pip install` for tool-agnostic guidance that works for all users.