### PR TITLE
Fix HTTP transport timeout defaulting to 5 seconds

### DIFF
--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -284,13 +284,13 @@ class StreamableHttpTransport(ClientTransport):
         # need to be forwarded to the remote server.
         headers = get_http_headers() | self.headers
 
-        # Configure timeout if provided (convert timedelta to httpx.Timeout)
+        # Configure timeout if provided, preserving MCP's 30s connect default
         timeout: httpx.Timeout | None = None
         if session_kwargs.get("read_timeout_seconds") is not None:
             read_timeout_seconds = cast(
                 datetime.timedelta, session_kwargs.get("read_timeout_seconds")
             )
-            timeout = httpx.Timeout(read_timeout_seconds.total_seconds())
+            timeout = httpx.Timeout(30.0, read=read_timeout_seconds.total_seconds())
 
         # Create httpx client from factory or use default with MCP-appropriate timeouts
         # create_mcp_http_client uses 30s connect/5min read timeout by default,

--- a/tests/integration_tests/test_timeout_fix.py
+++ b/tests/integration_tests/test_timeout_fix.py
@@ -32,6 +32,7 @@ async def streamable_http_server():
 
 
 @pytest.mark.integration
+@pytest.mark.timeout(15)
 async def test_slow_tool_with_http_transport(streamable_http_server: str):
     """Test that tools taking >5 seconds work correctly with HTTP transport.
 


### PR DESCRIPTION
When `StreamableHttpTransport` was updated to use the new `streamable_http_client` API, the code path for creating an httpx client when no factory is provided used `httpx.AsyncClient()` directly. Without an explicit timeout, httpx defaults to 5 seconds for all operations.

This caused tools taking longer than 5 seconds to fail with a 409 Conflict error as the client's SSE stream would timeout and trigger reconnection logic that conflicts with the existing GET stream.

The fix uses `create_mcp_http_client()` from the MCP SDK which sets appropriate defaults (30s connect, 5min read timeout) and enables `follow_redirects`.

Fixes #2842, fixes #2845