### PR TITLE
Fix timeout=None overriding create_mcp_http_client defaults

### DIFF
--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -306,8 +306,8 @@ class StreamableHttpTransport(ClientTransport):
         else:
             http_client = create_mcp_http_client(
                 headers=headers,
-                timeout=timeout,
                 auth=self.auth,
+                **({"timeout": timeout} if timeout is not None else {}),
             )
 
         # Ensure httpx client is closed after use


### PR DESCRIPTION
Cherry-pick of #2853 for the 2.x release line.

When `timeout` is `None`, passing it explicitly to `create_mcp_http_client()` overrides the function's built-in defaults. Now uses conditional unpacking to preserve defaults when no timeout is specified.