### PR TITLE
Fix decorator error messages to link to correct doc pages

### DIFF
--- a/src/fastmcp/prompts/function_prompt.py
+++ b/src/fastmcp/prompts/function_prompt.py
@@ -387,7 +387,7 @@ def prompt(
     if isinstance(name_or_fn, classmethod):
         raise TypeError(
             "To decorate a classmethod, use @classmethod above @prompt. "
-            "See https://gofastmcp.com/servers/tools#using-with-methods"
+            "See https://gofastmcp.com/servers/prompts#using-with-methods"
         )
 
     def create_prompt(

--- a/src/fastmcp/server/providers/local_provider.py
+++ b/src/fastmcp/server/providers/local_provider.py
@@ -727,7 +727,7 @@ class LocalProvider(Provider):
                     f"            ...\n\n"
                     f"    obj = MyClass()\n"
                     f"    mcp.add_resource(obj.{fn_name})\n\n"
-                    f"See https://gofastmcp.com/servers/tools#using-with-methods"
+                    f"See https://gofastmcp.com/servers/resources#using-with-methods"
                 )
 
             if fastmcp.settings.decorator_mode == "object":
@@ -869,7 +869,7 @@ class LocalProvider(Provider):
         if isinstance(name_or_fn, classmethod):
             raise TypeError(
                 "To decorate a classmethod, use @classmethod above @prompt. "
-                "See https://gofastmcp.com/servers/tools#using-with-methods"
+                "See https://gofastmcp.com/servers/prompts#using-with-methods"
             )
 
         def decorate_and_register(
@@ -892,7 +892,7 @@ class LocalProvider(Provider):
                     f"            ...\n\n"
                     f"    obj = MyClass()\n"
                     f"    mcp.add_prompt(obj.{fn_name})\n\n"
-                    f"See https://gofastmcp.com/servers/tools#using-with-methods"
+                    f"See https://gofastmcp.com/servers/prompts#using-with-methods"
                 )
 
             resolved_task: bool | TaskConfig = task if task is not None else False


### PR DESCRIPTION
Error messages for `@prompt` and `@resource` decorators were incorrectly linking to the tools documentation page. Now each decorator type links to its own "Using with Methods" section:

- `@tool` errors → `/servers/tools#using-with-methods`
- `@resource` errors → `/servers/resources#using-with-methods`
- `@prompt` errors → `/servers/prompts#using-with-methods`