### PR TITLE
Add enable_rich_logging setting to disable rich formatting

### DIFF
--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -195,6 +195,18 @@ class Settings(BaseSettings):
 
     docket: DocketSettings = DocketSettings()
 
+    enable_rich_logging: Annotated[
+        bool,
+        Field(
+            description=inspect.cleandoc(
+                """
+                If True, will use rich formatting for log output. If False,
+                will use standard Python logging without rich formatting.
+                """
+            )
+        ),
+    ] = True
+
     enable_rich_tracebacks: Annotated[
         bool,
         Field(

--- a/src/fastmcp/utilities/logging.py
+++ b/src/fastmcp/utilities/logging.py
@@ -57,6 +57,18 @@ def configure_logging(
     logger.propagate = False
     logger.setLevel(level)
 
+    # Remove any existing handlers to avoid duplicates on reconfiguration
+    for hdlr in logger.handlers[:]:
+        logger.removeHandler(hdlr)
+
+    # Use standard logging handlers if rich logging is disabled
+    if not fastmcp.settings.enable_rich_logging:
+        # Create a standard StreamHandler for stderr
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        logger.addHandler(handler)
+        return
+
     # Configure the handler for normal logs
     handler = RichHandler(
         console=Console(stderr=True),
@@ -90,10 +102,6 @@ def configure_logging(
     traceback_handler.setFormatter(formatter)
 
     traceback_handler.addFilter(lambda record: record.exc_info is not None)
-
-    # Remove any existing handlers to avoid duplicates on reconfiguration
-    for hdlr in logger.handlers[:]:
-        logger.removeHandler(hdlr)
 
     logger.addHandler(handler)
     logger.addHandler(traceback_handler)


### PR DESCRIPTION
## Summary

Adds a new `enable_rich_logging` setting that allows users to disable all rich formatting in logs. When disabled, FastMCP uses standard Python logging without rich formatting.

## Changes

- Added `enable_rich_logging` setting to `settings.py` (defaults to `True`)
- Modified `configure_logging()` to use `StreamHandler` when rich logging is disabled
- Added tests for both enabled and disabled states

## Usage

```python
# Via environment variable
FASTMCP_ENABLE_RICH_LOGGING=false

# Via Python code
import fastmcp
fastmcp.settings.enable_rich_logging = False
```

Closes #2892

----

Generated with [Claude Code](https://claude.ai/code)