### PR TITLE
Support VersionSpec in enable/disable for range-based filtering

### DIFF
--- a/src/fastmcp/server/providers/base.py
+++ b/src/fastmcp/server/providers/base.py
@@ -511,7 +511,7 @@ class Provider:
         *,
         names: set[str] | None = None,
         keys: set[str] | None = None,
-        version: str | None = None,
+        version: VersionSpec | None = None,
         tags: set[str] | None = None,
         components: list[Literal["tool", "resource", "template", "prompt"]]
         | None = None,
@@ -529,7 +529,8 @@ class Provider:
         Args:
             names: Component names or URIs to enable.
             keys: Component keys to enable (e.g., {"tool:my_tool@v1"}).
-            version: Component version to enable.
+            version: Component version spec to enable (e.g., VersionSpec(eq="v1") or
+                VersionSpec(gte="v2")). Unversioned components will not match.
             tags: Enable components with these tags.
             components: Component types to include (e.g., ["tool", "prompt"]).
             only: If True, ONLY enable matching components (allowlist mode).
@@ -559,7 +560,7 @@ class Provider:
         *,
         names: set[str] | None = None,
         keys: set[str] | None = None,
-        version: str | None = None,
+        version: VersionSpec | None = None,
         tags: set[str] | None = None,
         components: list[Literal["tool", "resource", "template", "prompt"]]
         | None = None,
@@ -573,7 +574,8 @@ class Provider:
         Args:
             names: Component names or URIs to disable.
             keys: Component keys to disable (e.g., {"tool:my_tool@v1"}).
-            version: Component version to disable.
+            version: Component version spec to disable (e.g., VersionSpec(eq="v1") or
+                VersionSpec(gte="v2")). Unversioned components will not match.
             tags: Disable components with these tags.
             components: Component types to include (e.g., ["tool", "prompt"]).
 

--- a/src/fastmcp/server/transforms/enabled.py
+++ b/src/fastmcp/server/transforms/enabled.py
@@ -64,7 +64,7 @@ class Enabled(Transform):
         *,
         names: set[str] | None = None,
         keys: set[str] | None = None,
-        version: str | None = None,
+        version: VersionSpec | None = None,
         tags: frozenset[str] | None = None,
         components: frozenset[str] | None = None,
         match_all: bool = False,
@@ -75,7 +75,8 @@ class Enabled(Transform):
             enabled: If True, mark matching as enabled; if False, mark as disabled.
             names: Component names or URIs to match.
             keys: Component keys to match (e.g., {"tool:my_tool@v1"}).
-            version: Component version to match.
+            version: Component version spec to match. Unversioned components (version=None)
+                will NOT match a version spec.
             tags: Tags to match (component must have at least one).
             components: Component types to match (e.g., frozenset({"tool", "prompt"})).
             match_all: If True, matches all components regardless of other criteria.
@@ -160,7 +161,10 @@ class Enabled(Transform):
                 return False
 
         # Check version if specified
-        if self.version is not None and component.version != self.version:
+        # Note: match_none=False means unversioned components don't match a version spec
+        if self.version is not None and not self.version.matches(
+            component.version, match_none=False
+        ):
             return False
 
         # Check tags if specified (component must have at least one matching tag)

--- a/src/fastmcp/utilities/versions.py
+++ b/src/fastmcp/utilities/versions.py
@@ -42,18 +42,21 @@ class VersionSpec:
     lt: str | None = None
     eq: str | None = None
 
-    def matches(self, version: str | None) -> bool:
+    def matches(self, version: str | None, *, match_none: bool = True) -> bool:
         """Check if a version matches this spec.
 
         Args:
             version: The version to check, or None for unversioned.
+            match_none: Whether unversioned (None) components match. Defaults to True
+                for backward compatibility with retrieval operations. Set to False
+                when filtering (e.g., enable/disable) to exclude unversioned components
+                from version-specific rules.
 
         Returns:
             True if the version matches the spec.
         """
         if version is None:
-            # Unversioned components always match
-            return True
+            return match_none
 
         if self.eq is not None:
             return version == self.eq


### PR DESCRIPTION
Adds support for version range matching in `enable()` and `disable()` methods by accepting `VersionSpec` instead of plain strings.

## Changes

The `version` parameter in `enable()`/`disable()` now accepts `VersionSpec` for flexible version filtering:

```python
from fastmcp import FastMCP
from fastmcp.utilities.versions import VersionSpec

mcp = FastMCP("Server")

# Exact version
mcp.disable(names={"my_tool"}, version=VersionSpec(eq="v2"))

# Version range (>= v2)
mcp.disable(names={"my_tool"}, version=VersionSpec(gte="v2"))

# Version range (>= v1 and < v3)
mcp.disable(names={"my_tool"}, version=VersionSpec(gte="v1", lt="v3"))
```

## Unversioned Components

Components without a version (`version=None`) will **not** match a `VersionSpec`. This prevents accidentally disabling unversioned components when targeting specific versions:

```python
# Only disables v2+, leaves unversioned untouched
mcp.disable(names={"tool_a"}, version=VersionSpec(gte="v2"))
```

## Implementation

- Added `match_none` parameter to `VersionSpec.matches()` (defaults to `True` for backward compatibility)
- Updated `Enabled` transform to use `VersionSpec` and call `matches(match_none=False)`
- Updated `enable()`/`disable()` signatures to accept `VersionSpec | None`
- Added comprehensive tests for version range matching

Part of #2910