### PR TITLE
Remove sync notification infrastructure

### DIFF
--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -273,19 +273,10 @@ import mcp.types
 @mcp.tool
 async def custom_tool_management(ctx: Context) -> str:
     """Example of manual notification after custom tool changes."""
-    # In async code, send immediately
     await ctx.send_notification(mcp.types.ToolListChangedNotification())
     await ctx.send_notification(mcp.types.ResourceListChangedNotification())
     await ctx.send_notification(mcp.types.PromptListChangedNotification())
     return "Notifications sent"
-
-
-@mcp.tool
-def sync_tool(ctx: Context) -> str:
-    """Example of notification from sync code."""
-    # In sync code, queue for background sending (~1 second delay)
-    ctx.send_notification_sync(mcp.types.ToolListChangedNotification())
-    return "Notification queued"
 ```
 
 These methods are primarily used internally by FastMCP's automatic notification system and most users will not need to invoke them directly.

--- a/src/fastmcp/server/providers/local_provider.py
+++ b/src/fastmcp/server/providers/local_provider.py
@@ -111,21 +111,6 @@ class LocalProvider(Provider):
         # Unified component storage - keyed by prefixed key (e.g., "tool:name", "resource:uri")
         self._components: dict[str, FastMCPComponent] = {}
 
-    def _send_list_changed_notification(self, component: FastMCPComponent) -> None:
-        """Send a list changed notification for the component type."""
-        from fastmcp.server.context import _current_context
-
-        context = _current_context.get()
-        if context is None:
-            return
-
-        if isinstance(component, Tool):
-            context.send_notification_sync(mcp.types.ToolListChangedNotification())
-        elif isinstance(component, (Resource, ResourceTemplate)):
-            context.send_notification_sync(mcp.types.ResourceListChangedNotification())
-        elif isinstance(component, Prompt):
-            context.send_notification_sync(mcp.types.PromptListChangedNotification())
-
     # =========================================================================
     # Storage methods
     # =========================================================================
@@ -218,7 +203,6 @@ class LocalProvider(Provider):
         self._check_version_mixing(component)
 
         self._components[component.key] = component
-        self._send_list_changed_notification(component)
         return component
 
     def _remove_component(self, key: str) -> None:
@@ -235,7 +219,6 @@ class LocalProvider(Provider):
             raise KeyError(f"Component {key!r} not found")
 
         del self._components[key]
-        self._send_list_changed_notification(component)
 
     def _get_component(self, key: str) -> FastMCPComponent | None:
         """Get a component by its prefixed key.


### PR DESCRIPTION
Removes the synchronous notification system that was used for sending notifications from sync code (like component add/remove operations).

Note: The main motivation here is the realization that most of the things that send notifications, including the legacy enable/disable, did so outside of a session and so there was no client to send notifications to and so we can rip out a lot of this machinery. 

## Changes

- Removed `send_notification_sync()` method from Context
- Removed notification queue (`_notification_queue`) and background flusher infrastructure
- Removed `_send_list_changed_notification()` from LocalProvider (component add/remove no longer sends notifications)
- Removed sync notification tests
- Updated documentation to remove sync notification examples

The async `send_notification()` method remains for async code. Component operations happen outside request sessions, so notifications are no longer needed for these cases.