### PR TITLE
Allow marvin-context-protocol bot in label triage workflow

### DIFF
--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -135,6 +135,7 @@ jobs:
           prompt: ${{ steps.triage-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
           allowed_non_write_users: "*"
+          allowed_bots: "marvin-context-protocol"
           claude_args: |
             --allowedTools Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__get_pull_request_files
           settings: |


### PR DESCRIPTION
The label triage workflow was failing because `claude-code-action` blocks bot-initiated workflows by default. When a PR is opened, the `marvin-context-protocol[bot]` token triggers the workflow, which was being rejected with:

> Workflow initiated by non-human actor: marvin-context-protocol (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

The `allowed_non_write_users: "*"` setting only applies to human users without write access—it doesn't cover bots. Adding `allowed_bots: "marvin-context-protocol"` explicitly permits this bot to trigger the workflow.

See e.g. https://github.com/jlowin/fastmcp/actions/runs/21139594024/job/60789943971?pr=2932