### PR TITLE
Update example MCP version in installation docs

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Installation
+description: Install FastMCP and verify your setup
 icon: arrow-down-to-line
 ---
 ## Install FastMCP


### PR DESCRIPTION
The installation documentation example was showing an outdated MCP version (1.12.4). Updated to 1.25.0 to match the current supported version.