### PR TITLE
docs: use --prerelease=explicit for install instructions

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -12,13 +12,13 @@ FastMCP 3.0 is currently in beta. Install by specifying the version explicitly.
 </Note>
 
 ```bash
-pip install fastmcp==3.0.0b1
+uv add "fastmcp>=3.0.0b1" --prerelease=explicit
 ```
 
-If you plan to use FastMCP in a uv-managed project, you can add it as a dependency with:
+Or with pip:
 
 ```bash
-uv add fastmcp --prerelease=allow
+pip install "fastmcp>=3.0.0b1" --pre
 ```
 
 ### Optional Dependencies
@@ -26,7 +26,7 @@ uv add fastmcp --prerelease=allow
 FastMCP provides optional extras for specific features. For example, to install the background tasks extra:
 
 ```bash
-pip install "fastmcp[tasks]==3.0.0b1"
+uv add "fastmcp[tasks]>=3.0.0b1" --prerelease=explicit
 ```
 
 See [Background Tasks](/servers/tasks) for details on the task system.

--- a/docs/servers/tasks.mdx
+++ b/docs/servers/tasks.mdx
@@ -43,9 +43,7 @@ MCP background tasks are different: they're **protocol-native**. This means MCP 
 <VersionBadge version="3.0.0" /> Background tasks require the `tasks` extra:
 
 ```bash
-pip install "fastmcp[tasks]==3.0.0b1"
-# or with uv
-uv add "fastmcp[tasks]" --prerelease=allow
+uv add "fastmcp[tasks]>=3.0.0b1" --prerelease=explicit
 ```
 
 Add `task=True` to any tool, resource, resource template, or prompt decorator. This marks the component as capable of background execution.


### PR DESCRIPTION
Using `--prerelease=allow` when installing fastmcp can pull in prerelease versions of dependencies like httpx. httpx 1.0.dev* removes `TransportError` which breaks httpx-sse, which breaks mcp imports.

`--prerelease=explicit` only allows prereleases for packages explicitly requested with a prerelease specifier (like `fastmcp>=3.0a0`), keeping dependencies on stable versions.

```bash
# before (could install httpx==1.0.dev3)
uv add fastmcp --prerelease=allow

# after (installs httpx==0.28.1 stable)
uv add "fastmcp>=3.0a0" --prerelease=explicit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)