### PR TITLE
Skip label triage for Dependabot PRs

### DIFF
--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   label-issue-or-pr:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Dependabot PRs don't need AI-powered triage - they're formulaic dependency bumps. This skips the workflow entirely rather than burning API tokens on self-explanatory PRs.