### PR TITLE
Remove uv lockfile monitoring from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
The uv ecosystem creates PRs for lockfile changes, which is noisy - the lockfile updates naturally during development. The pip ecosystem still monitors pyproject.toml constraints, which is the useful part.