### PR TITLE
Bump pydocket to 0.17.2 (memory leak fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40.0"]
 openai = ["openai>=1.102.0"]
-tasks = ["pydocket>=0.17.2b3"]
+tasks = ["pydocket>=0.17.2"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "py-key-value-aio", extras = ["disk", "keyring", "memory"], specifier = ">=0.3.0,<0.4.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.7" },
-    { name = "pydocket", marker = "extra == 'tasks'", specifier = ">=0.17.2b3" },
+    { name = "pydocket", marker = "extra == 'tasks'", specifier = ">=0.17.2" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "rich", specifier = ">=13.9.4" },
@@ -1918,7 +1918,7 @@ wheels = [
 
 [[package]]
 name = "pydocket"
-version = "0.17.2b3"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
@@ -1934,9 +1934,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/fd/b2789629c35bc08074a223725738d2d8fe4df4b4eefe5ed8c5ad3668430e/pydocket-0.17.2b3.tar.gz", hash = "sha256:08c94837fe45494b1b442f7248ffeaf33c043786e7c14770c8320d666244e067", size = 329299, upload-time = "2026-01-26T01:53:38.112Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/17/1fb6309e40bbee999c5d881b8213a1078968412d855e064a9a94cfb9eeef/pydocket-0.17.2.tar.gz", hash = "sha256:8f02c68952701eb1b3a70d439b76392d15f1eb9568d0bde6a69997ea5c79c89f", size = 329829, upload-time = "2026-01-26T16:07:56.217Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/da/0fe46d7aa3a6084c3715c462d9b16dffca18092fac0eec7d9299d7b46a83/pydocket-0.17.2b3-py3-none-any.whl", hash = "sha256:f54ab37ded42120201d22faad1acbfee53cc413bb35fe2064d557ff8007f9fb9", size = 91656, upload-time = "2026-01-26T01:53:36.518Z" },
+    { url = "https://files.pythonhosted.org/packages/53/74/4c9b70753d5721165047e6428ac239ca083118474794deaca5a27d0ab212/pydocket-0.17.2-py3-none-any.whl", hash = "sha256:f43743b84b4e3d614d99b0cad2deebab028104c217745406ecf9e1efb8926e04", size = 91628, upload-time = "2026-01-26T16:07:55.018Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps pydocket to >=0.17.2 to address a memory leak in the `memory://` docket broker that affected fastmcp task execution.

The leak was caused by cancelled tasks accumulating in memory and was fixed in [chrisguidry/docket#300](https://github.com/chrisguidry/docket/pull/300).

🤖 Generated with [Claude Code](https://claude.ai/code)