### PR TITLE
fix: broaden combine_lifespans type to accept Mapping return types

### DIFF
--- a/src/fastmcp/utilities/lifespan.py
+++ b/src/fastmcp/utilities/lifespan.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from typing import Any, TypeVar
 
@@ -10,7 +10,7 @@ AppT = TypeVar("AppT")
 
 
 def combine_lifespans(
-    *lifespans: Callable[[AppT], AbstractAsyncContextManager[dict[str, Any] | None]],
+    *lifespans: Callable[[AppT], AbstractAsyncContextManager[Mapping[str, Any] | None]],
 ) -> Callable[[AppT], AbstractAsyncContextManager[dict[str, Any]]]:
     """Combine multiple lifespans into a single lifespan.
 


### PR DESCRIPTION
## Summary

Broadens the type annotation in `combine_lifespans` from `dict[str, Any]` to `Mapping[str, Any]`, enabling compatibility with Starlette's `Lifespan` type.

Fixes #3004

## Problem

When using `combine_lifespans` with Starlette apps:

```python
from starlette.applications import Starlette
from fastmcp import FastMCP
from fastmcp.utilities.lifespan import combine_lifespans

mcp = FastMCP("Test")
mcp_app = mcp.http_app(path="/mcp")

app = Starlette(routes=[], lifespan=combine_lifespans(mcp_app.lifespan))
```

Type checkers report:

> Argument of type "Lifespan[Starlette]" cannot be assigned to parameter of type "Callable[[Starlette], AbstractAsyncContextManager[dict[str, Any] | None]]"

This happens because Starlette's `Lifespan` returns `Mapping[str, Any]`, not `dict[str, Any]`.

## Solution

Changed the type annotation from `dict[str, Any] | None` to `Mapping[str, Any] | None`. This is backwards compatible because `dict` is a subtype of `Mapping`.

## Changes

- `src/fastmcp/utilities/lifespan.py`: Added `Mapping` import and updated type annotation
- `tests/server/test_server_lifespan.py`: Added test for Mapping return type compatibility

## Testing

- All existing `TestCombineLifespans` tests pass
- Added new test `test_combine_lifespans_with_mapping_return_type` that verifies Mapping compatibility
- Type checker (`ty check`) passes
- Prek checks pass