### PR TITLE
fix: correctly send resource when exchanging code for the upstream to…

### DIFF
--- a/src/fastmcp/server/auth/providers/azure.py
+++ b/src/fastmcp/server/auth/providers/azure.py
@@ -192,21 +192,9 @@ class AzureProvider(OAuthProxy):
         )
         token_endpoint = f"https://{base_authority}/{tenant_id}/oauth2/v2.0/token"
 
-        # Azure requires scopes during token exchange (AADSTS28003 error if missing).
-        # IMPORTANT: Azure only allows ONE resource per token exchange (AADSTS28000),
-        # so we only send the prefixed required_scopes (which are all the same resource).
-        # The returned token can be used to exchange tokens for other resources if needed through OBO flow.
-        token_exchange_scopes = self._prefix_scopes_for_azure(
-            parsed_required_scopes or []
-        )
-        if parsed_additional_scopes:
-            token_exchange_scopes.extend(
-                s for s in parsed_additional_scopes if s in OIDC_SCOPES
-            )
-        token_exchange_scopes = list(dict.fromkeys(token_exchange_scopes))
-        logger.debug("Token exchange scopes: %s", token_exchange_scopes)
-
         # Initialize OAuth proxy with Azure endpoints
+        # Remember there's hooks called, such as _prepare_scopes_for_token_exchange
+        # and _prepare_scopes_for_upstream_refresh
         super().__init__(
             upstream_authorization_endpoint=authorization_endpoint,
             upstream_token_endpoint=token_endpoint,
@@ -221,7 +209,6 @@ class AzureProvider(OAuthProxy):
             jwt_signing_key=jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             valid_scopes=parsed_required_scopes,
-            extra_token_params={"scope": " ".join(token_exchange_scopes)},
         )
 
         authority_info = ""
@@ -332,16 +319,37 @@ class AzureProvider(OAuthProxy):
         # Let parent build the URL with prefixed scopes
         return super()._build_upstream_authorize_url(txn_id, modified_transaction)
 
+    def _prepare_scopes_for_token_exchange(self, scopes: list[str]) -> list[str]:
+        """Prepare scopes for Azure authorization code exchange.
+
+        Azure requires scopes during token exchange (AADSTS28003 error if missing).
+        Azure only allows ONE resource per token request (AADSTS28000), so we only
+        include scopes for this API plus OIDC scopes.
+
+        Args:
+            scopes: Scopes from the authorization request (unprefixed)
+
+        Returns:
+            List of scopes for Azure token endpoint
+        """
+        # Prefix scopes for this API
+        prefixed_scopes = self._prefix_scopes_for_azure(scopes or [])
+
+        # Add OIDC scopes only (not other API scopes) to avoid AADSTS28000
+        if self.additional_authorize_scopes:
+            prefixed_scopes.extend(
+                s for s in self.additional_authorize_scopes if s in OIDC_SCOPES
+            )
+
+        deduplicated = list(dict.fromkeys(prefixed_scopes))
+        logger.debug("Token exchange scopes: %s", deduplicated)
+        return deduplicated
+
     def _prepare_scopes_for_upstream_refresh(self, scopes: list[str]) -> list[str]:
         """Prepare scopes for Azure token refresh.
 
-        Azure requires:
-        1. Fully-qualified custom scopes (e.g., "api://xxx/read" not "read")
-        2. Microsoft Graph scopes (e.g., "User.Read", "openid") sent as-is
-        3. Additional scopes from provider config (additional_authorize_scopes)
-
-        This method transforms base client scopes for Azure while keeping them
-        unprefixed in storage to prevent accumulation.
+        Azure requires fully-qualified scopes and only allows ONE resource per
+        token request (AADSTS28000). We include scopes for this API plus OIDC scopes.
 
         Args:
             scopes: Base scopes from RefreshToken (unprefixed, e.g., ["read"])
@@ -352,22 +360,19 @@ class AzureProvider(OAuthProxy):
         logger.debug("Base scopes from storage: %s", scopes)
 
         # Filter out any additional_authorize_scopes that may have been stored
-        # (they shouldn't be in storage, but clean them up if they are)
         additional_scopes_set = set(self.additional_authorize_scopes or [])
         base_scopes = [s for s in scopes if s not in additional_scopes_set]
 
-        # Prefix base scopes with identifier_uri for Azure using shared helper
+        # Prefix base scopes with identifier_uri for Azure
         prefixed_scopes = self._prefix_scopes_for_azure(base_scopes)
 
-        # Add additional scopes (Graph + OIDC) for the Azure request
-        # These are NOT stored in RefreshToken, only sent to Azure
+        # Add OIDC scopes only (not other API scopes) to avoid AADSTS28000
         if self.additional_authorize_scopes:
-            prefixed_scopes.extend(self.additional_authorize_scopes)
+            prefixed_scopes.extend(
+                s for s in self.additional_authorize_scopes if s in OIDC_SCOPES
+            )
 
-        # Deduplicate while preserving order (in case older tokens have duplicates)
-        # Use dict.fromkeys() for O(n) deduplication with order preservation
         deduplicated_scopes = list(dict.fromkeys(prefixed_scopes))
-
         logger.debug("Scopes for Azure token endpoint: %s", deduplicated_scopes)
         return deduplicated_scopes
 

--- a/tests/server/auth/providers/test_azure.py
+++ b/tests/server/auth/providers/test_azure.py
@@ -438,7 +438,11 @@ class TestAzureProvider:
         assert len(result) == 2
 
     def test_prepare_scopes_for_upstream_refresh_with_additional_scopes(self):
-        """Test that additional_authorize_scopes are added during token refresh."""
+        """Test that only OIDC scopes from additional_authorize_scopes are added.
+
+        Azure only allows ONE resource per token request (AADSTS28000), so
+        non-OIDC scopes like User.Read are excluded from refresh requests.
+        """
         provider = AzureProvider(
             client_id="test_client",
             client_secret="test_secret",
@@ -447,7 +451,7 @@ class TestAzureProvider:
             identifier_uri="api://my-api",
             required_scopes=["read"],
             additional_authorize_scopes=[
-                "User.Read",
+                "User.Read",  # Not OIDC - excluded
                 "openid",
                 "profile",
                 "offline_access",
@@ -455,16 +459,16 @@ class TestAzureProvider:
             jwt_signing_key="test-secret",
         )
 
-        # Base scopes should be prefixed, additional scopes appended
+        # Base scopes should be prefixed, only OIDC scopes appended
         result = provider._prepare_scopes_for_upstream_refresh(["read", "write"])
 
         assert "api://my-api/read" in result
         assert "api://my-api/write" in result
-        assert "User.Read" in result
+        assert "User.Read" not in result  # Not OIDC, excluded
         assert "openid" in result
         assert "profile" in result
         assert "offline_access" in result
-        assert len(result) == 6
+        assert len(result) == 5
 
     def test_prepare_scopes_for_upstream_refresh_filters_duplicate_additional_scopes(
         self,
@@ -482,16 +486,17 @@ class TestAzureProvider:
         )
 
         # If additional scopes were accidentally stored, they should be filtered
-        # to prevent accumulation
+        # User.Read is not OIDC so won't be added
         result = provider._prepare_scopes_for_upstream_refresh(
             ["read", "User.Read", "openid"]
         )
 
-        # Should have: api://my-api/read (prefixed) + User.Read + openid (added once)
+        # Should have: api://my-api/read (prefixed) + openid (OIDC, added once)
+        # User.Read is filtered from storage AND not added (not OIDC)
         assert "api://my-api/read" in result
-        assert result.count("User.Read") == 1
+        assert "User.Read" not in result  # Not OIDC
         assert result.count("openid") == 1
-        assert len(result) == 3
+        assert len(result) == 2
 
     def test_prepare_scopes_for_upstream_refresh_mixed_scopes(self):
         """Test mixed scenario with both prefixed and unprefixed scopes."""
@@ -502,7 +507,7 @@ class TestAzureProvider:
             base_url="https://myserver.com",
             identifier_uri="api://my-api",
             required_scopes=["read"],
-            additional_authorize_scopes=["User.Read"],
+            additional_authorize_scopes=["openid"],  # OIDC scope
             jwt_signing_key="test-secret",
         )
 
@@ -514,7 +519,7 @@ class TestAzureProvider:
         assert "api://my-api/read" in result
         assert "api://other-api/admin" in result  # Already prefixed, unchanged
         assert "api://my-api/write" in result
-        assert "User.Read" in result
+        assert "openid" in result
         assert len(result) == 4
 
     def test_prepare_scopes_for_upstream_refresh_scope_with_slash(self):
@@ -552,12 +557,12 @@ class TestAzureProvider:
             jwt_signing_key="test-secret",
         )
 
-        # Empty scopes should still add additional_authorize_scopes
+        # Empty scopes should still add OIDC scopes (not User.Read)
         result = provider._prepare_scopes_for_upstream_refresh([])
 
-        assert "User.Read" in result
+        assert "User.Read" not in result  # Not OIDC
         assert "openid" in result
-        assert len(result) == 2
+        assert len(result) == 1  # Only openid (the only OIDC scope)
 
     def test_prepare_scopes_for_upstream_refresh_no_additional_scopes(self):
         """Test behavior when no additional_authorize_scopes are configured."""
@@ -587,21 +592,21 @@ class TestAzureProvider:
             base_url="https://myserver.com",
             identifier_uri="api://my-api",
             required_scopes=["read"],
-            additional_authorize_scopes=["User.Read", "openid"],
+            additional_authorize_scopes=["openid", "profile"],  # OIDC scopes only
             jwt_signing_key="test-secret",
         )
 
-        # Test with duplicate base scopes and duplicate additional scopes
+        # Test with duplicate base scopes
         result = provider._prepare_scopes_for_upstream_refresh(
-            ["read", "write", "read", "User.Read", "openid"]
+            ["read", "write", "read", "openid"]
         )
 
-        # Should have deduplicated results in order
+        # Should have deduplicated results in order (User.Read filtered, openid added once)
         assert result == [
             "api://my-api/read",
             "api://my-api/write",
-            "User.Read",
             "openid",
+            "profile",
         ]
         assert len(result) == 4
 
@@ -813,11 +818,12 @@ class TestAzureTokenExchangeScopes:
     """Tests for Azure provider's token exchange scope handling.
 
     Azure requires scopes to be sent during the authorization code exchange.
-    The provider sets extra_token_params with properly prefixed scopes.
+    The provider overrides _prepare_scopes_for_token_exchange to return
+    properly prefixed scopes.
     """
 
-    def test_extra_token_params_set_with_prefixed_scopes(self):
-        """Test that extra_token_params contains prefixed scopes."""
+    def test_prepare_scopes_returns_prefixed_scopes(self):
+        """Test that _prepare_scopes_for_token_exchange returns prefixed scopes."""
         provider = AzureProvider(
             client_id="test_client",
             client_secret="test_secret",
@@ -828,13 +834,13 @@ class TestAzureTokenExchangeScopes:
             jwt_signing_key="test-secret",
         )
 
-        assert "scope" in provider._extra_token_params
-        scope_str = provider._extra_token_params["scope"]
-        assert "api://my-api/read" in scope_str
-        assert "api://my-api/write" in scope_str
+        scopes = provider._prepare_scopes_for_token_exchange(["read", "write"])
+        assert len(scopes) > 0
+        assert "api://my-api/read" in scopes
+        assert "api://my-api/write" in scopes
 
-    def test_extra_token_params_includes_additional_oidc_scopes(self):
-        """Test that extra_token_params includes OIDC scopes from additional_authorize_scopes."""
+    def test_prepare_scopes_includes_additional_oidc_scopes(self):
+        """Test that _prepare_scopes_for_token_exchange includes OIDC scopes."""
         provider = AzureProvider(
             client_id="test_client",
             client_secret="test_secret",
@@ -846,20 +852,21 @@ class TestAzureTokenExchangeScopes:
             jwt_signing_key="test-secret",
         )
 
-        scope_str = provider._extra_token_params["scope"]
-        assert "api://my-api/read" in scope_str
-        assert "openid" in scope_str
-        assert "profile" in scope_str
-        assert "offline_access" in scope_str
+        scopes = provider._prepare_scopes_for_token_exchange(["read"])
+        assert len(scopes) > 0
+        assert "api://my-api/read" in scopes
+        assert "openid" in scopes
+        assert "profile" in scopes
+        assert "offline_access" in scopes
 
-    def test_extra_token_params_excludes_other_api_scopes(self):
+    def test_prepare_scopes_excludes_other_api_scopes(self):
         """Test token exchange excludes other API scopes (Azure AADSTS28000).
 
         Azure only allows ONE resource per token exchange. Other API scopes
         are requested during authorization but excluded from token exchange.
         """
         provider = AzureProvider(
-            client_id="a29c5d50-182d-4daf-a6e3-511766907bc5",
+            client_id="00000000-1111-2222-3333-444444444444",
             client_secret="test_secret",
             tenant_id="test-tenant",
             base_url="https://myserver.com",
@@ -868,26 +875,25 @@ class TestAzureTokenExchangeScopes:
                 "openid",
                 "profile",
                 "offline_access",
-                "api://eca032c0-13c6-452e-ad93-4588d580cd8f/user_impersonation",
-                "api://404bb359-314a-47a9-84fe-cdeae262c621/user_impersonation",
+                "api://aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/user_impersonation",
+                "api://11111111-2222-3333-4444-555555555555/user_impersonation",
             ],
             jwt_signing_key="test-secret",
         )
 
-        scope_str = provider._extra_token_params["scope"]
+        scopes = provider._prepare_scopes_for_token_exchange(["user_impersonation"])
+        assert len(scopes) > 0
         # Primary API scope should be prefixed with the provider's identifier_uri
-        assert (
-            "api://a29c5d50-182d-4daf-a6e3-511766907bc5/user_impersonation" in scope_str
-        )
+        assert "api://00000000-1111-2222-3333-444444444444/user_impersonation" in scopes
         # OIDC scopes should be included
-        assert "openid" in scope_str
-        assert "profile" in scope_str
-        assert "offline_access" in scope_str
+        assert "openid" in scopes
+        assert "profile" in scopes
+        assert "offline_access" in scopes
         # Other API scopes should NOT be included (Azure multi-resource limitation)
-        assert "api://eca032c0" not in scope_str
-        assert "api://404bb359" not in scope_str
+        assert not any("api://aaaaaaaa" in s for s in scopes)
+        assert not any("api://11111111" in s for s in scopes)
 
-    def test_extra_token_params_deduplicates_scopes(self):
+    def test_prepare_scopes_deduplicates_scopes(self):
         """Test that duplicate scopes are deduplicated."""
         provider = AzureProvider(
             client_id="test_client",
@@ -900,7 +906,42 @@ class TestAzureTokenExchangeScopes:
             jwt_signing_key="test-secret",
         )
 
-        scope_str = provider._extra_token_params["scope"]
+        # Pass a scope that will be prefixed to match one in additional_authorize_scopes
+        scopes = provider._prepare_scopes_for_token_exchange(["read"])
+        assert len(scopes) > 0
         # Should be deduplicated - api://my-api/read appears only once
-        assert scope_str.count("api://my-api/read") == 1
-        assert "openid" in scope_str
+        assert scopes.count("api://my-api/read") == 1
+        assert "openid" in scopes
+
+    def test_extra_token_params_does_not_contain_scope(self):
+        """Test that extra_token_params doesn't contain scope to avoid TypeError.
+
+        Previously, Azure provider set extra_token_params={"scope": ...} during init.
+        This caused a TypeError in exchange_refresh_token because it passes both
+        scope=... AND **self._extra_token_params, resulting in:
+        "got multiple values for keyword argument 'scope'"
+
+        The fix uses the _prepare_scopes_for_token_exchange hook instead.
+        """
+        provider = AzureProvider(
+            client_id="test_client",
+            client_secret="test_secret",
+            tenant_id="test-tenant",
+            base_url="https://myserver.com",
+            identifier_uri="api://my-api",
+            required_scopes=["read", "write"],
+            additional_authorize_scopes=["openid", "profile", "offline_access"],
+            jwt_signing_key="test-secret",
+        )
+
+        # extra_token_params should NOT contain "scope" to avoid TypeError during refresh
+        assert "scope" not in provider._extra_token_params
+
+        # Instead, scopes should be provided via the hook methods
+        exchange_scopes = provider._prepare_scopes_for_token_exchange(["read", "write"])
+        assert len(exchange_scopes) > 0
+
+        refresh_scopes = provider._prepare_scopes_for_upstream_refresh(
+            ["read", "write"]
+        )
+        assert len(refresh_scopes) > 0


### PR DESCRIPTION
As explained [here](https://github.com/jlowin/fastmcp/pull/2918#issuecomment-3806239082), if an MCP server wants to use OBO flow for multiple resources, and use consent flow, this does not work today. 

This PR fixes this by correctly sending the correct scopes when exchanging auth code for the upstream token. 

Note: Tests have been written by Claude Sonnet4.5 and reviewed by codex and gemini. 

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes [comment](https://github.com/jlowin/fastmcp/pull/2918#issuecomment-3806239082)
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
