### PR TITLE
fix: type narrowing for skills resource contents

### DIFF
--- a/src/fastmcp/utilities/skills.py
+++ b/src/fastmcp/utilities/skills.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import mcp.types
+
 if TYPE_CHECKING:
     from fastmcp.client import Client
 
@@ -101,7 +103,7 @@ async def get_skill_manifest(client: Client, skill_name: str) -> SkillManifest:
         raise ValueError(f"Could not read manifest for skill: {skill_name}")
 
     content = result[0]
-    if hasattr(content, "text"):
+    if isinstance(content, mcp.types.TextResourceContents):
         try:
             manifest_data = json.loads(content.text)
         except json.JSONDecodeError as e:
@@ -197,9 +199,9 @@ async def download_skill(
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Write content
-        if hasattr(content, "text"):
+        if isinstance(content, mcp.types.TextResourceContents):
             file_path.write_text(content.text)
-        elif hasattr(content, "blob"):
+        elif isinstance(content, mcp.types.BlobResourceContents):
             # Handle base64-encoded binary content
             import base64
 


### PR DESCRIPTION
Fixes upgrade checks type errors in skills.py.

### Problem
The upgrade checks workflow was failing on static analysis with type errors in `src/fastmcp/utilities/skills.py`. The type checker couldn't infer that `content.text` is a `str` when using `hasattr()` checks.

### Solution
Replaced `hasattr()` checks with `isinstance()` checks using proper MCP types:
- `isinstance(content, mcp.types.TextResourceContents)`
- `isinstance(content, mcp.types.BlobResourceContents)`

This provides proper type narrowing so the type checker correctly infers that `content.text` is `str` and `content.blob` is `str`.

Fixes #3019

Generated with [Claude Code](https://claude.ai/code)