### PR TITLE
docs: document expanded reload behavior and restructure beta sections

### DIFF
--- a/docs/development/v3-notes/v3-features.mdx
+++ b/docs/development/v3-notes/v3-features.mdx
@@ -4,7 +4,31 @@ title: v3.0 Feature Tracking
 
 This document tracks major features in FastMCP v3.0 for release notes preparation.
 
-## Provider-Based Architecture
+## 3.0.0beta2
+
+### CLI: Expanded Reload File Watching
+
+The `--reload` flag now watches a comprehensive set of file types, making it suitable for MCP apps with frontend bundles ([#3028](https://github.com/jlowin/fastmcp/pull/3028)). Previously limited to `.py` files, it now watches JavaScript, TypeScript, HTML, CSS, config files, and media assets.
+
+### CLI: fastmcp install stdio
+
+The new `fastmcp install stdio` command generates full `uv run` commands for running FastMCP servers over stdio ([#3032](https://github.com/jlowin/fastmcp/pull/3032)).
+
+```bash
+# Generate command for a server
+fastmcp install stdio server.py
+
+# Outputs:
+# uv run --directory /path/to/project fastmcp run server.py
+```
+
+The command automatically detects the project directory and generates the appropriate `uv run` invocation, making it easy to integrate FastMCP servers with MCP clients.
+
+---
+
+## 3.0.0beta1
+
+### Provider-Based Architecture
 
 v3.0 introduces a provider-based component system that replaces v2's static-only registration ([#2622](https://github.com/jlowin/fastmcp/pull/2622)). Providers dynamically source tools, resources, templates, and prompts at runtime.
 
@@ -201,7 +225,7 @@ Documentation: `docs/servers/transforms/resources-as-tools.mdx`, `docs/servers/t
 
 ---
 
-## Session-Scoped State
+### Session-Scoped State
 
 v3.0 changes context state from request-scoped to session-scoped. State now persists across multiple tool calls within the same MCP session.
 
@@ -232,7 +256,7 @@ Documentation: `docs/servers/context.mdx`
 
 ---
 
-## Visibility System
+### Visibility System
 
 Components can be enabled/disabled using the visibility system. Each `enable()` or `disable()` call adds a stateless Visibility transform that marks components via internal metadata. Later transforms override earlier ones.
 
@@ -263,7 +287,7 @@ Works at both server and provider level. Supports:
 - **Override semantics**: Later transforms override earlier marks (enable after disable = enabled)
 - **Transform ordering**: Visibility transforms are injected at the point you call them, so component state is known
 
-### Per-Session Visibility
+#### Per-Session Visibility
 
 Server-level visibility changes affect all connected clients. For per-session control, use `Context` methods that apply rules only to the current session ([#2917](https://github.com/jlowin/fastmcp/pull/2917)):
 
@@ -304,7 +328,7 @@ Documentation: `docs/servers/visibility.mdx`
 
 ---
 
-## Component Versioning
+### Component Versioning
 
 v3.0 introduces versioning support for tools, resources, and prompts. Components can declare a version, and when multiple versions of the same component exist, the highest version is automatically exposed to clients.
 
@@ -422,11 +446,11 @@ The `@` is always present (even for unversioned components) to enable unambiguou
 
 ---
 
-## Type-Safe Canonical Results
+### Type-Safe Canonical Results
 
 v3.0 introduces type-safe result classes that provide explicit control over component responses while supporting MCP runtime metadata: `ToolResult` ([#2736](https://github.com/jlowin/fastmcp/pull/2736)), `ResourceResult` ([#2734](https://github.com/jlowin/fastmcp/pull/2734)), and `PromptResult` ([#2738](https://github.com/jlowin/fastmcp/pull/2738)).
 
-### ToolResult
+#### ToolResult
 
 `ToolResult` (`src/fastmcp/tools/tool.py:79`) provides structured tool responses:
 
@@ -447,7 +471,7 @@ Fields:
 - `structured_content`: Dict matching tool's output schema
 - `meta`: Runtime metadata passed to MCP as `_meta`
 
-### ResourceResult
+#### ResourceResult
 
 `ResourceResult` (`src/fastmcp/resources/resource.py:117`) provides structured resource responses:
 
@@ -467,7 +491,7 @@ def get_items() -> ResourceResult:
 
 Accepts strings, bytes, or `list[ResourceContent]` for flexible content handling.
 
-### PromptResult
+#### PromptResult
 
 `PromptResult` (`src/fastmcp/prompts/prompt.py:109`) provides structured prompt responses:
 
@@ -487,7 +511,7 @@ def conversation() -> PromptResult:
 
 ---
 
-## Background Tasks (SEP-1686)
+### Background Tasks (SEP-1686)
 
 v3.0 implements MCP SEP-1686 for background task execution via Docket integration.
 
@@ -520,7 +544,7 @@ Requires Docket server for task scheduling and result polling.
 
 ---
 
-## Decorators Return Functions
+### Decorators Return Functions
 
 v3.0 changes what decorators (`@tool`, `@resource`, `@prompt`) return ([#2856](https://github.com/jlowin/fastmcp/pull/2856)). Decorators now return the original function unchanged, rather than transforming it into a component object.
 
@@ -552,7 +576,7 @@ Environment variable: `FASTMCP_DECORATOR_MODE=object`
 
 ---
 
-## CLI Auto-Reload
+### CLI Auto-Reload
 
 The `--reload` flag enables file watching with automatic server restarts for development ([#2816](https://github.com/jlowin/fastmcp/pull/2816)).
 
@@ -581,7 +605,7 @@ fastmcp dev server.py  # Includes --reload by default
 
 ---
 
-## Component Authorization
+### Component Authorization
 
 v3.0 introduces callable-based authorization for tools, resources, and prompts ([#2855](https://github.com/jlowin/fastmcp/pull/2855)).
 
@@ -634,7 +658,7 @@ STDIO transport bypasses all auth checks (no OAuth concept).
 
 ---
 
-## MCP Apps (SDK Compatibility)
+### MCP Apps (SDK Compatibility)
 
 v3.0 adds Phase 1 support for [MCP Apps](https://modelcontextprotocol.io/specification/2025-06-18/server/apps) — the spec extension that lets MCP servers deliver interactive UIs via sandboxed iframes. Phase 1 is SDK compatibility only: extension negotiation, typed UI metadata on tools and resources, and the `ui://` resource scheme. No component DSL, renderer, or `FastMCPApp` class yet — those are future phases.
 
@@ -698,7 +722,7 @@ Implementation: `src/fastmcp/server/apps.py` (models and constants), with integr
 
 ---
 
-## FileSystemProvider
+### FileSystemProvider
 
 v3.0 introduces `FileSystemProvider`, a fundamentally different approach to organizing MCP servers. Instead of importing a server instance and decorating functions with `@server.tool`, you use standalone decorators in separate files and let the provider discover them.
 
@@ -736,7 +760,7 @@ Documentation: [FileSystemProvider](/servers/providers/filesystem)
 
 ---
 
-## SkillsProvider
+### SkillsProvider
 
 v3.0 introduces `SkillsProvider` for exposing agent skills as MCP resources ([#2944](https://github.com/jlowin/fastmcp/pull/2944)). Skills are directories containing instructions and supporting files that teach AI assistants how to perform tasks—used by Claude Code, Cursor, VS Code Copilot, and other AI coding tools.
 
@@ -779,7 +803,7 @@ Documentation: [Skills Provider](/servers/providers/skills)
 
 ---
 
-## OpenTelemetry Tracing
+### OpenTelemetry Tracing
 
 v3.0 adds OpenTelemetry instrumentation for observability into server and client operations ([#2869](https://github.com/jlowin/fastmcp/pull/2869)).
 
@@ -807,7 +831,7 @@ Documentation: [Telemetry](/servers/telemetry)
 
 ---
 
-## Pagination
+### Pagination
 
 v3.0 adds pagination support for list operations when servers expose many components ([#2903](https://github.com/jlowin/fastmcp/pull/2903)).
 
@@ -833,7 +857,7 @@ Documentation: [Pagination](/servers/pagination)
 
 ---
 
-## Composable Lifespans
+### Composable Lifespans
 
 Lifespans can be combined with the `|` operator for modular setup/teardown ([#2828](https://github.com/jlowin/fastmcp/pull/2828)):
 
@@ -874,7 +898,7 @@ Documentation: [Lifespan](/servers/lifespan)
 
 ---
 
-## Tool Timeout
+### Tool Timeout
 
 Tools can limit foreground execution time with a `timeout` parameter ([#2872](https://github.com/jlowin/fastmcp/pull/2872)):
 
@@ -891,7 +915,7 @@ Note: This timeout applies to foreground execution only. Background tasks (`task
 
 ---
 
-## PingMiddleware
+### PingMiddleware
 
 Sends periodic server-to-client pings to keep long-lived connections alive ([#2838](https://github.com/jlowin/fastmcp/pull/2838)):
 
@@ -907,7 +931,7 @@ The middleware starts a background ping task on first message from each session,
 
 ---
 
-## Context.transport Property
+### Context.transport Property
 
 Tools can detect which transport is active ([#2850](https://github.com/jlowin/fastmcp/pull/2850)):
 
@@ -927,7 +951,7 @@ Returns `Literal["stdio", "sse", "streamable-http"]` when running, or `None` out
 
 ---
 
-## Automatic Threadpool for Sync Functions
+### Automatic Threadpool for Sync Functions
 
 Synchronous tools, resources, and prompts now automatically run in a threadpool, preventing event loop blocking during concurrent requests ([#2865](https://github.com/jlowin/fastmcp/pull/2865)):
 
@@ -944,7 +968,7 @@ Three concurrent calls now execute in parallel (~10s) rather than sequentially (
 
 ---
 
-## CLI Update Notifications
+### CLI Update Notifications
 
 The CLI notifies users when a newer FastMCP version is available on PyPI ([#2840](https://github.com/jlowin/fastmcp/pull/2840)).
 
@@ -957,11 +981,11 @@ The CLI notifies users when a newer FastMCP version is available on PyPI ([#2840
 
 ---
 
-## Deprecated Features
+### Deprecated Features
 
 These emit deprecation warnings but continue to work.
 
-### Mount Prefix Parameter
+#### Mount Prefix Parameter
 
 The `prefix` parameter for `mount()` renamed to `namespace`:
 
@@ -973,7 +997,7 @@ main.mount(subserver, prefix="api")
 main.mount(subserver, namespace="api")
 ```
 
-### Tag Filtering Init Parameters
+#### Tag Filtering Init Parameters
 
 `FastMCP(include_tags=..., exclude_tags=...)` deprecated. Use `enable()`/`disable()` methods:
 
@@ -986,11 +1010,11 @@ mcp = FastMCP("server")
 mcp.disable(tags={"internal"})
 ```
 
-### Tool Serializer Parameter
+#### Tool Serializer Parameter
 
 The `tool_serializer` parameter on `FastMCP` is deprecated. Return `ToolResult` for explicit serialization control.
 
-### Tool Transformation Methods
+#### Tool Transformation Methods
 
 `add_tool_transformation()`, `remove_tool_transformation()`, and `tool_transformations` constructor parameter are deprecated. Use `add_transform(ToolTransform({...}))` instead:
 
@@ -1005,13 +1029,13 @@ mcp.add_transform(ToolTransform({"name": config}))
 
 ---
 
-## Breaking Changes
+### Breaking Changes
 
-### WSTransport Removed
+#### WSTransport Removed
 
 The deprecated `WSTransport` client transport has been removed ([#2826](https://github.com/jlowin/fastmcp/pull/2826)). Use `StreamableHttpTransport` instead.
 
-### Decorators Return Functions
+#### Decorators Return Functions
 
 Decorators (`@tool`, `@resource`, `@prompt`) now return the original function instead of component objects. Code that treats the decorated function as a `FunctionTool`, `FunctionResource`, or `FunctionPrompt` will break.
 
@@ -1035,7 +1059,7 @@ greet("World")                   # "Hello, World!"
 
 Set `FASTMCP_DECORATOR_MODE=object` or `fastmcp.settings.decorator_mode = "object"` for v2 behavior.
 
-### Component Enable/Disable Moved to Server/Provider
+#### Component Enable/Disable Moved to Server/Provider
 
 The `enabled` field and `enable()`/`disable()` methods removed from component objects:
 
@@ -1048,7 +1072,7 @@ tool.disable()
 server.disable(names={"my_tool"}, components=["tool"])
 ```
 
-### Component Lookup Methods
+#### Component Lookup Methods
 
 Server lookup and listing methods have updated signatures:
 
@@ -1065,7 +1089,7 @@ tools = await server.get_tools()
 tool = next((t for t in tools if t.name == "my_tool"), None)
 ```
 
-### Prompt Return Types
+#### Prompt Return Types
 
 Prompt functions now use `Message` instead of `mcp.types.PromptMessage`:
 
@@ -1085,7 +1109,7 @@ def my_prompt() -> Message:
     return Message("Hello")  # role defaults to "user"
 ```
 
-### Auth Provider Environment Variables Removed
+#### Auth Provider Environment Variables Removed
 
 Auth providers no longer auto-load from environment variables ([#2752](https://github.com/jlowin/fastmcp/pull/2752)):
 
@@ -1103,13 +1127,13 @@ auth = GitHubProvider(
 
 See `docs/development/v3-notes/auth-provider-env-vars.mdx` for rationale.
 
-### Server Banner Environment Variable
+#### Server Banner Environment Variable
 
 `FASTMCP_SHOW_CLI_BANNER` → `FASTMCP_SHOW_SERVER_BANNER` ([#2771](https://github.com/jlowin/fastmcp/pull/2771))
 
 Now applies to all server startup methods, not just the CLI.
 
-### Context State Methods Are Async
+#### Context State Methods Are Async
 
 `ctx.set_state()` and `ctx.get_state()` are now async and session-scoped:
 


### PR DESCRIPTION
Add documentation for PR #3028 (expanded file watching) and #3032 (fastmcp install stdio) in a new 3.0.0beta2 section. All existing features are now properly grouped under 3.0.0beta1 with appropriate header levels.

Closes #3029

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/jlowin/fastmcp/actions/runs/21523228674) | [Branch](https://github.com/jlowin/fastmcp/tree/claude/issue-3029-20260130-1640