### PR TITLE
fix: use MCP spec error code -32002 for resource not found

### DIFF
--- a/src/fastmcp/server/mixins/mcp_operations.py
+++ b/src/fastmcp/server/mixins/mcp_operations.py
@@ -336,9 +336,15 @@ class MCPOperationsMixin:
                 return result
             return result.to_mcp_result(uri)
         except DisabledError as e:
-            raise NotFoundError(f"Unknown resource: {str(uri)!r}") from e
-        except NotFoundError:
-            raise
+            raise McpError(
+                mcp.types.ErrorData(
+                    code=-32002, message=f"Resource not found: {str(uri)!r}"
+                )
+            ) from e
+        except NotFoundError as e:
+            raise McpError(
+                mcp.types.ErrorData(code=-32002, message=f"Resource not found: {e}")
+            ) from e
 
     async def _get_prompt_mcp(
         self, name: str, arguments: dict[str, Any] | None


### PR DESCRIPTION
FastMCP was returning error code `-32001` for "resource not found" errors, but the MCP spec defines `-32002` as the correct code for this case. Fixes #3038.

The fix applies at two layers: the protocol boundary in `_read_resource_mcp` now wraps `NotFoundError`/`DisabledError` in `McpError(code=-32002)` directly, so the correct code reaches clients regardless of middleware configuration. The `ErrorHandlingMiddleware` also now checks `context.method` to distinguish resource operations from tool/prompt operations — resources get `-32002`, everything else stays at `-32001`.

As a side effect, the middleware no longer says "Resource not found" for tool or prompt not-found errors (which was always misleading) — those now say "Not found".

Closes #3038