### PR TITLE
fix: Preserve metadata in FastMCPProvider component wrappers

### DIFF
--- a/src/fastmcp/server/providers/fastmcp_provider.py
+++ b/src/fastmcp/server/providers/fastmcp_provider.py
@@ -86,6 +86,9 @@ class FastMCPProviderTool(Tool):
             tags=tool.tags,
             annotations=tool.annotations,
             task_config=tool.task_config,
+            meta=tool.meta,
+            title=tool.title,
+            icons=tool.icons,
         )
 
     @overload
@@ -183,6 +186,9 @@ class FastMCPProviderResource(Resource):
             tags=resource.tags,
             annotations=resource.annotations,
             task_config=resource.task_config,
+            meta=resource.meta,
+            title=resource.title,
+            icons=resource.icons,
         )
 
     @overload
@@ -249,6 +255,9 @@ class FastMCPProviderPrompt(Prompt):
             arguments=prompt.arguments,
             tags=prompt.tags,
             task_config=prompt.task_config,
+            meta=prompt.meta,
+            title=prompt.title,
+            icons=prompt.icons,
         )
 
     @overload
@@ -350,6 +359,9 @@ class FastMCPProviderResourceTemplate(ResourceTemplate):
             tags=template.tags,
             annotations=template.annotations,
             task_config=template.task_config,
+            meta=template.meta,
+            title=template.title,
+            icons=template.icons,
         )
 
     async def create_resource(self, uri: str, params: dict[str, Any]) -> Resource:


### PR DESCRIPTION
## Description
<!-- 
Please provide a clear and concise description of the changes made in this pull request.

Using AI to generate code? Please include a note in the description with which AI tool you used.
-->

 When mounting FastMCP servers, component metadata (meta, title, icons) was not being forwarded through the provider wrapper classes. This caused MCP Apps to fail rendering in clients like Claude Desktop, since the `meta["ui"]` configuration was lost during composition. 

The fix adds meta, title, and icons forwarding to all four `FastMCPProvider*` wrapper classes: Tool, Resource, Prompt, and ResourceTemplate.

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes #3056 
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
