### PR TITLE
Fix --reload port conflict when using explicit port

### DIFF
--- a/src/fastmcp/cli/run.py
+++ b/src/fastmcp/cli/run.py
@@ -372,7 +372,8 @@ async def run_with_reload(
                 stdin=None,
                 stdout=None,
                 stderr=None,
-                start_new_session=True,
+                # Own process group so _terminate_process can kill the whole tree
+                start_new_session=sys.platform != "win32",
             )
 
             # Watch for either: file changes OR process death


### PR DESCRIPTION
When `fastmcp run --reload --port 8002` detects a file change, the old server process needs to fully release the port before the new one starts. The reload mechanism was calling `process.kill()` (SIGKILL) on just the direct child, but when the command is wrapped with `uv run`, the actual server is a grandchild — SIGKILL kills `uv`, the server becomes an orphan still holding the port, and the new process gets "address already in use."

The fix puts the subprocess in its own process group (`start_new_session=True`) and sends SIGTERM to the entire group on reload, giving all processes in the tree a chance to shut down gracefully and release ports. Falls back to SIGKILL after 3 seconds if needed.