### PR TITLE
Add server version to banner

### DIFF
--- a/src/fastmcp/utilities/cli.py
+++ b/src/fastmcp/utilities/cli.py
@@ -217,7 +217,10 @@ def log_server_banner(server: FastMCP[Any]) -> None:
     info_table.add_column(style="cyan", justify="left")  # Label column
     info_table.add_column(style="dim", justify="left")  # Value column
 
-    info_table.add_row("🖥", "Server:", Text(server.name, style="dim"))
+    server_info = server.name
+    if server.version:
+        server_info += f", {server.version}"
+    info_table.add_row("🖥", "Server:", Text(server_info, style="dim"))
     info_table.add_row("🚀", "Deploy free:", "https://fastmcp.cloud")
 
     # Create panel with logo, title, and information using Group


### PR DESCRIPTION
## Description

Add the server version, if set, to the banner.

I considered separate line, but at a glance that _could_ be confused for the FastMCP version, and the banner looks quite nice and minimal as-is.

**Contributors Checklist**

- [x] My change closes #3075
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review