### PR TITLE
Updated deprecation URL for V3

### DIFF
--- a/src/fastmcp/tools/function_tool.py
+++ b/src/fastmcp/tools/function_tool.py
@@ -193,7 +193,7 @@ class FunctionTool(Tool):
             warnings.warn(
                 "The `exclude_args` parameter is deprecated as of FastMCP 2.14. "
                 "Use dependency injection with `Depends()` instead for better lifecycle management. "
-                "See https://gofastmcp.com/servers/dependencies for examples.",
+                "See https://gofastmcp.com/servers/dependency-injection#using-depends for examples.",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
## Description
[Current main branch](https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/tools/function_tool.py#L196)

This 404s for both the v2 and v3 docs
https://gofastmcp.com/v2/servers/dependencies
https://gofastmcp.com/servers/dependencies

It looks like these URLs should be
V2: https://gofastmcp.com/v2/servers/context#using-depends
V3: https://gofastmcp.com/servers/dependency-injection#using-depends


**Contributors Checklist**
- [X] My change closes #3107 
- [X] I have followed the repository's development workflow
- [X] I have tested my changes manually and by adding relevant tests
- [X] I have performed all required documentation updates

**Review Checklist**
- [X] I have self-reviewed my changes
- [X] My Pull Request is ready for review
