### PR TITLE
Updated deprecation URL for V2

### DIFF
--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -323,7 +323,7 @@ class FunctionTool(Tool):
             warnings.warn(
                 "The `exclude_args` parameter is deprecated as of FastMCP 2.14. "
                 "Use dependency injection with `Depends()` instead for better lifecycle management. "
-                "See https://gofastmcp.com/servers/context#using-depends for examples.",
+                "See https://gofastmcp.com/v2/servers/context#using-depends for examples.",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
## Description
[Current Release/V2.x branch](https://github.com/jlowin/fastmcp/blob/release/2.x/src/fastmcp/tools/tool.py#L326)

Not sure of the etiquette for multiple PRs against a single issue to resolve different versions.

Docs for this deprecation don't align for V2 or V3:

For V2 this should be https://gofastmcp.com/v2/servers/context#using-depends and V3 this has moved to https://gofastmcp.com/servers/dependency-injection#using-depends 

Similar to https://github.com/jlowin/fastmcp/pull/3108 raised for V3 but I figured it may be a good idea to backprop it to V2.

**Contributors Checklist**

- [X] My change closes #3108 
- [X] I have followed the repository's development workflow
- [X] I have tested my changes manually and by adding relevant tests
- [X] I have performed all required documentation updates

**Review Checklist**

- [X] I have self-reviewed my changes
- [X] My Pull Request is ready for review

---
