### PR TITLE
Update docs to reference beta 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ These compose cleanly, so complex patterns don't require complex code. And becau
 ## Installation
 
 > [!Note]
-> FastMCP 3.0 is currently in beta. Install with: `pip install fastmcp==3.0.0b1`
+> FastMCP 3.0 is currently in beta. Install with: `pip install fastmcp==3.0.0b2`
 >
 > For production systems requiring stability, pin to v2: `pip install 'fastmcp<3'`
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -665,7 +665,7 @@
             "icon": "code"
           }
         ],
-        "version": "v3.0.0 (beta 1)"
+        "version": "v3.0.0 (beta 2)"
       },
       {
         "dropdowns": [

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -8,17 +8,17 @@ icon: arrow-down-to-line
 We recommend using [uv](https://docs.astral.sh/uv/getting-started/installation/) to install and manage FastMCP.
 
 <Note>
-FastMCP 3.0 is currently in beta. Package managers won't install beta versions by default—you must explicitly request one (e.g., `>=3.0.0b1`).
+FastMCP 3.0 is currently in beta. Package managers won't install beta versions by default—you must explicitly request one (e.g., `>=3.0.0b2`).
 </Note>
 
 ```bash
-pip install "fastmcp>=3.0.0b1"
+pip install "fastmcp>=3.0.0b2"
 ```
 
 Or with uv:
 
 ```bash
-uv add "fastmcp>=3.0.0b1"
+uv add "fastmcp>=3.0.0b2"
 ```
 
 ### Optional Dependencies
@@ -26,7 +26,7 @@ uv add "fastmcp>=3.0.0b1"
 FastMCP provides optional extras for specific features. For example, to install the background tasks extra:
 
 ```bash
-pip install "fastmcp[tasks]==3.0.0b1"
+pip install "fastmcp[tasks]==3.0.0b2"
 ```
 
 See [Background Tasks](/servers/tasks) for details on the task system.

--- a/docs/servers/tasks.mdx
+++ b/docs/servers/tasks.mdx
@@ -43,7 +43,7 @@ MCP background tasks are different: they're **protocol-native**. This means MCP 
 <VersionBadge version="3.0.0" /> Background tasks require the `tasks` extra:
 
 ```bash
-pip install "fastmcp[tasks]>=3.0.0b1"
+pip install "fastmcp[tasks]>=3.0.0b2"
 ```
 
 Add `task=True` to any tool, resource, resource template, or prompt decorator. This marks the component as capable of background execution.


### PR DESCRIPTION
All user-facing install commands and version badges still pointed at `3.0.0b1`. This updates them to `3.0.0b2` across the README, installation guide, tasks docs, and the Mintlify nav version badge.

Historical changelog and release-notes entries for b1 are left as-is.