### PR TITLE
fix: snapshot access token for background tasks (#3095)

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -318,6 +318,10 @@ class Context:
         Returns an empty dict if no lifespan was configured or if the MCP
         session is not yet established.
 
+        In background tasks (Docket workers), where request_context is not
+        available, falls back to reading from the FastMCP server's lifespan
+        result directly.
+
         Example:
         ```python
         @server.tool
@@ -330,6 +334,11 @@ class Context:
         """
         rc = self.request_context
         if rc is None:
+            # In background tasks, request_context is not available.
+            # Fall back to the server's lifespan result directly (#3095).
+            result = self.fastmcp._lifespan_result
+            if result is not None:
+                return result
             return {}
         return rc.lifespan_context
 


### PR DESCRIPTION
## Summary

Makes `get_access_token()` return the caller's token inside Docket background tasks. The token is snapshotted to Redis at submission time and restored into a ContextVar when the worker picks up the task.

Also fixes `lifespan_context` returning `{}` in background tasks by falling back to the server's lifespan result when `request_context` is unavailable.

Closes #3095. Supersedes #3121.

## Changes

**`handlers.py`** — snapshot token at submit time
- Call `get_access_token()` in `submit_to_docket()` and store the result in Redis alongside other task metadata

**`dependencies.py`** — restore token in worker
- New `_task_access_token` ContextVar for the restored token
- New `_restore_task_access_token()` reads from Redis and sets the ContextVar
- `get_access_token()` falls back to `_task_access_token` when HTTP request and SDK context var are both unavailable
- `_CurrentContext.__aenter__()` restores the token when entering background task context
- `_CurrentAccessToken.__aenter__()` restores the token as fallback when `_CurrentContext` hasn't run (no `ctx: Context` in signature)
- Expiration check: expired tokens return `None`

**`context.py`** — lifespan fallback
- `lifespan_context` falls back to `server._lifespan_result` when `request_context` is `None`

**Tests** — integration, zero mocks
- `test_token_round_trips_through_background_task`: E2E with `Client(mcp)` + `memory://` Docket — token injected via SDK auth context, verified inside worker
- `test_no_token_when_unauthenticated`: no auth → `None` in worker
- `test_expired_token_returns_none`, `test_valid_token_with_future_expiry`, `test_token_without_expiry_always_valid`: expiration edge cases
- `test_lifespan_context_falls_back_to_server_result`, `test_lifespan_context_returns_empty_dict_when_no_lifespan`: lifespan fallback

## Review feedback addressed

**@chrisguidry's comments on #3121:**
- De-mocked the test suite — replaced `MagicMock`/`patch` tests with real `Client(mcp)` + fakeredis integration tests (same pattern as #2906 and `test_task_elicitation_relay.py`)
- Removed `try`/`finally` blocks in tests — ContextVar cleanup via `cv_token` pattern
- Dropped the `test_lifespan_context_still_uses_request_context_when_available` test that relied on `patch.object`

**CodeRabbit feedback:**
- Replaced silent `except Exception: pass` with `logger.warning(..., exc_info=True)` (fixes S110/BLE001)
- Dropped `DocketDependency.docket.get()` fallback — uses only `_current_docket` ContextVar (no unstable internal API)
- Hoisted `from datetime import datetime, timezone` to module-level imports
- Typed `_access_token_cv_token` as `Token[AccessToken | None] | None` instead of `Any`

## Credit

Based on the initial work by @cristiangreco94 in #3121. The core design (snapshot at submit → restore in worker → ContextVar fallback) is his — this PR rebases onto current `main`, resolves conflicts from #2906/#3136, rewrites tests as integration, and addresses review feedback.