### PR TITLE
docs: remove nonexistent MSALApp from rc1 notes

### DIFF
--- a/docs/development/v3-notes/v3-features.mdx
+++ b/docs/development/v3-notes/v3-features.mdx
@@ -45,7 +45,7 @@ async def my_tool(
 ): ...
 ```
 
-For Azure/Entra, the new `fastmcp[azure]` extra adds `EntraOBOToken` and `MSALApp` dependencies that handle the On-Behalf-Of token exchange declaratively:
+For Azure/Entra, the new `fastmcp[azure]` extra adds `EntraOBOToken`, which handles the On-Behalf-Of token exchange declaratively:
 
 ```python
 from fastmcp.server.auth.providers.azure import EntraOBOToken


### PR DESCRIPTION
The RC1 notes referenced `MSALApp` as a dependency alongside `EntraOBOToken`, but `MSALApp` was never implemented — only `EntraOBOToken` exists in `src/fastmcp/server/auth/providers/azure.py`. Removes the dangling reference.