### PR TITLE
Document cache key identity behavior

### DIFF
--- a/docs/servers/middleware.mdx
+++ b/docs/servers/middleware.mdx
@@ -431,6 +431,10 @@ mcp.add_middleware(ResponseCachingMiddleware(
 
 See [Storage Backends](/servers/storage-backends) for complete options.
 
+<Note>
+Cache keys are based on the operation name and arguments only — they do not include user or session identity. If your tools return user-specific data derived from auth context (e.g., headers or session state) rather than from the request arguments, you should either disable caching for those tools or ensure user identity is part of the tool arguments.
+</Note>
+
 ### Rate Limiting
 
 ```python


### PR DESCRIPTION
The caching middleware keys on operation name + arguments, which is standard cache behavior — but it's worth calling out explicitly that cache keys don't include user/session identity. This matters when tools return user-specific data derived from auth context rather than request arguments.

Adds a note to the caching section of the middleware docs.