### PR TITLE
Add FASTMCP_TRANSPORT setting

### DIFF
--- a/src/fastmcp/server/mixins/transport.py
+++ b/src/fastmcp/server/mixins/transport.py
@@ -53,7 +53,7 @@ class TransportMixin:
         if show_banner is None:
             show_banner = fastmcp.settings.show_server_banner
         if transport is None:
-            transport = "stdio"
+            transport = fastmcp.settings.transport
         if transport not in {"stdio", "http", "sse", "streamable-http"}:
             raise ValueError(f"Unknown transport: {transport}")
 

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -227,6 +227,9 @@ class Settings(BaseSettings):
         ),
     ] = None
 
+    # Transport settings
+    transport: Literal["stdio", "http", "sse", "streamable-http"] = "stdio"
+
     # HTTP settings
     host: str = "127.0.0.1"
     port: int = 8000

--- a/tests/utilities/test_tests.py
+++ b/tests/utilities/test_tests.py
@@ -1,4 +1,7 @@
+from unittest.mock import AsyncMock, patch
+
 import fastmcp
+from fastmcp import FastMCP
 from fastmcp.utilities.tests import temporary_settings
 
 
@@ -8,3 +11,31 @@ class TestTemporarySettings:
         with temporary_settings(log_level="ERROR"):
             assert fastmcp.settings.log_level == "ERROR"
         assert fastmcp.settings.log_level == "DEBUG"
+
+
+class TestTransportSetting:
+    def test_transport_default_is_stdio(self):
+        assert fastmcp.settings.transport == "stdio"
+
+    def test_transport_setting_can_be_changed(self):
+        with temporary_settings(transport="http"):
+            assert fastmcp.settings.transport == "http"
+        assert fastmcp.settings.transport == "stdio"
+
+    async def test_run_async_uses_transport_setting(self):
+        mcp = FastMCP("test")
+        with temporary_settings(transport="http"):
+            with patch.object(
+                mcp, "run_http_async", new_callable=AsyncMock
+            ) as mock_http:
+                await mcp.run_async()
+                mock_http.assert_called_once()
+
+    async def test_run_async_explicit_transport_overrides_setting(self):
+        mcp = FastMCP("test")
+        with temporary_settings(transport="http"):
+            with patch.object(
+                mcp, "run_stdio_async", new_callable=AsyncMock
+            ) as mock_stdio:
+                await mcp.run_async(transport="stdio")
+                mock_stdio.assert_called_once()


### PR DESCRIPTION
`run_async()` hardcoded `"stdio"` as the fallback when no transport was specified, which meant users running third-party servers (like AWS MCP servers in ECS containers) had no way to change the default transport without modifying source code. The CLI and `fastmcp.json` provided workarounds, but a bare `mcp.run()` call was locked to stdio.

This adds a `transport` field to `Settings` so that `FASTMCP_TRANSPORT=http` (or any valid transport) controls the default. `run_async` reads from the setting instead of hardcoding `"stdio"`, while explicit `transport=` arguments and CLI `--transport` flags still override it. Fits naturally alongside the existing `FASTMCP_HOST` and `FASTMCP_PORT` settings.

```python
# Third-party server code you can't modify:
mcp.run()  # reads FASTMCP_TRANSPORT from env

# Or in your own code:
import fastmcp
fastmcp.settings.transport = "http"
```

Closes #1795
Supersedes #1796 