### PR TITLE
Overhaul v3.0 upgrade guide

### DIFF
--- a/docs/development/upgrade-guide.mdx
+++ b/docs/development/upgrade-guide.mdx
@@ -294,9 +294,11 @@ from fastmcp.server.providers.openapi import OpenAPIProvider
 
 ```python
 # Deprecated
+from fastmcp.server.openapi import FastMCPOpenAPI
 server = FastMCPOpenAPI(spec, client)
 
 # New
+from fastmcp import FastMCP
 from fastmcp.server.providers.openapi import OpenAPIProvider
 server = FastMCP("my_api", providers=[OpenAPIProvider(spec, client)])
 ```


### PR DESCRIPTION
The upgrade guide was missing some significant v3 breaking changes and read like a sparse changelog rather than something that helps people actually migrate. This rewrites it to be educational and complete.

**What changed:**

- Added the removed constructor kwargs section (host, port, log_level, etc.) — this was the biggest gap since `FastMCP("server", host="0.0.0.0", port=8080)` was probably the most common v2 HTTP pattern
- Added missing deprecations: `import_server()`, module path changes for proxy/openapi, `FastMCPOpenAPI` class
- Removed items incorrectly listed as deprecations that are actually hard `TypeError`s (`include_tags`, `exclude_tags`, `tool_serializer`)
- Fixed `components=["tool"]` → `components={"tool"}` to match actual type annotation
- Clarified that `include_fastmcp_meta` removal means metadata can no longer be suppressed
- Each breaking change now explains *why* the API changed, not just what to search-and-replace
- Flattened heading structure so the TOC shows sections (Breaking Changes / Behavior Changes / Deprecated Features) rather than every individual item

**LLM migration prompt:**

Added a `<Prompt>` component (Mintlify's copyable prompt widget) at the top of the v3 section. Users can copy it into any LLM alongside their server code for automated migration guidance. The prompt is self-contained with numbered categories, inline fix instructions, and a link to the full guide for edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revamped v3.0.0 upgrade guide with a prominent BREAKING CHANGES section and an automated-migration prompt to assist bulk updates.
  * Expanded and reorganized breaking changes into detailed, enumerated migration steps with before/after examples for constructors, transports, providers, decorators, prompts, metadata, storage, and provider flows.
  * Added a comprehensive DEPRECATIONS section and updated examples throughout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->