### PR TITLE
Fix invalid uv add command in upgrade guide

### DIFF
--- a/docs/getting-started/upgrading/from-fastmcp-2.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-2.mdx
@@ -19,7 +19,7 @@ Since you already have `fastmcp` installed, you need to explicitly request the n
 ```bash
 pip install --upgrade fastmcp
 # or
-uv add fastmcp@latest
+uv add --upgrade fastmcp
 ```
 
 If you pin versions in a requirements file or `pyproject.toml`, update your pin to `fastmcp>=3.0.0,<4`.


### PR DESCRIPTION
`uv add fastmcp@latest` isn't a valid PEP 508 specifier — uv interprets `@latest` as a direct reference and fails. Changed to `uv add --upgrade fastmcp`.