### PR TITLE
Fix v3.0.0 changelog compare link

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -228,7 +228,7 @@ pip install fastmcp -U
 * [@martimfasantos](https://github.com/martimfasantos) made their first contribution in [#3086](https://github.com/PrefectHQ/fastmcp/pull/3086)
 * [@jfBiswajit](https://github.com/jfBiswajit) made their first contribution in [#3193](https://github.com/PrefectHQ/fastmcp/pull/3193)
 
-**Full Changelog**: https://github.com/PrefectHQ/fastmcp/compare/v2.14.1...v3.0.0
+**Full Changelog**: https://github.com/PrefectHQ/fastmcp/compare/v2.14.5...v3.0.0
 
 </Update>
 


### PR DESCRIPTION
The v3.0.0 changelog entry's "Full Changelog" compare link pointed at v2.14.1 instead of v2.14.5 (the actual last v2 release). One-character fix.