### PR TITLE
Fix v2 upgrade guide: remove incorrect v1 import advice

### DIFF
--- a/docs/getting-started/upgrading/from-fastmcp-2.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-2.mdx
@@ -10,7 +10,7 @@ This guide covers breaking changes and migration steps when upgrading FastMCP.
 
 ## v3.0.0
 
-For most servers, upgrading to v3 is straightforward. The breaking changes below affect constructor kwargs, a few renamed methods, and some less commonly used features.
+For most servers, upgrading to v3 is straightforward. The breaking changes below affect deprecated constructor kwargs, sync-to-async shifts, a few renamed methods, and some less commonly used features.
 
 ### Install
 


### PR DESCRIPTION
The "Upgrading from FastMCP 2" guide opened by telling v2 users to swap `from mcp.server.fastmcp import FastMCP` for `from fastmcp import FastMCP` — an import change that only applies to v1/MCP SDK users (already covered in the other guide). FastMCP 2 users have always used `from fastmcp import FastMCP`.

Removed the bogus import migration step from both the prose and the embedded LLM prompt, and reframed the opening to accurately describe what v2→v3 actually touches: deprecated constructor kwargs, sync-to-async shifts, and renamed methods.