### PR TITLE
Fix MDX parse error in upgrade guide prompts

### DIFF
--- a/docs/getting-started/upgrading/from-fastmcp-2.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-2.mdx
@@ -60,7 +60,7 @@ BREAKING CHANGES (will crash at import or runtime):
 4. PROMPTS: mcp.types.PromptMessage replaced by fastmcp.prompts.Message.
    Before: PromptMessage(role="user", content=TextContent(type="text", text="Hello"))
    After:  Message("Hello")  # role defaults to "user", accepts plain strings
-   Also: if prompts return raw dicts like {"role": "user", "content": "..."}, these must become Message objects.
+   Also: if prompts return raw dicts like `{"role": "user", "content": "..."}`, these must become Message objects.
    v2 silently coerced dicts; v3 requires typed Message objects or plain strings.
 
 5. AUTH PROVIDERS: No longer auto-load from env vars. Pass client_id, client_secret explicitly via os.environ.

--- a/docs/getting-started/upgrading/from-mcp-sdk.mdx
+++ b/docs/getting-started/upgrading/from-mcp-sdk.mdx
@@ -48,7 +48,7 @@ STEP 3 — PROMPTS (only if using PromptMessage directly or returning dicts):
 mcp.types.PromptMessage is replaced by fastmcp.prompts.Message.
 Before: `PromptMessage(role="user", content=TextContent(type="text", text="Hello"))`
 After:  `Message("Hello")`  — role defaults to "user", accepts plain strings.
-Also: if prompts return raw dicts like {"role": "user", "content": "..."}, these must become Message objects or plain strings.
+Also: if prompts return raw dicts like `{"role": "user", "content": "..."}`, these must become Message objects or plain strings.
 The MCP SDK's FastMCP 1.0 silently coerced dicts; standalone FastMCP requires typed returns.
 
 STEP 4 — OTHER MCP IMPORTS (only if importing from mcp.* directly):


### PR DESCRIPTION
The `broken-links` doc check was failing with an Acorn parse error because curly braces inside the `<Prompt>` components were being interpreted as JSX expressions rather than literal text.

Wrapping the dict examples in backticks fixes the parse error and is the right call anyway — they're code examples and should render as inline code.