### PR TITLE
Fix middleware state not propagating to mounted sub-server tools

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -261,6 +261,8 @@ class FastMCP(
             pydantic_model=StateValue,
             default_collection="fastmcp_state",
         )
+        # Parent state store for mounted servers (set by mount())
+        self._parent_state_store: PydanticAdapter[StateValue] | None = None
 
         # Create LocalProvider for local components
         self._local_provider: LocalProvider = LocalProvider(
@@ -1815,6 +1817,10 @@ class FastMCP(
                 for old_name, new_name in tool_names.items()
             }
             provider = provider.wrap_transform(ToolTransform(transforms))
+
+        # Share parent state store so middleware state propagates to mounted tools
+        if server._parent_state_store is None:
+            server._parent_state_store = self._state_store
 
         # Use add_provider with namespace (applies namespace in AggregateProvider)
         self.add_provider(provider, namespace=namespace or "")


### PR DESCRIPTION
## Description

Attempt to fix middleware state not propagating to mounted sub-server tools, as reported in #3230.

When middleware on a parent `FastMCP` instance sets state via `context.fastmcp_context.set_state()`, tools on mounted sub-servers cannot read that state — `ctx.get_state()` returns `None`. This appears to be caused by each `FastMCP` instance having its own independent `_state_store`. This PR chains state stores via a `_parent_state_store` reference set during `mount()`, and falls back to the parent store in `get_state()` when a key isn't found locally.

**Contributors Checklist**

- [x] My change closes #3230
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [ ] I have performed all required documentation updates

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review