### PR TITLE
Document mounted server state store isolation in upgrade guide

### DIFF
--- a/docs/getting-started/upgrading/from-fastmcp-2.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-2.mdx
@@ -229,6 +229,7 @@ await ctx.set_state("client", my_http_client, serializable=False)
 Each `FastMCP` instance has its own state store. In v2 this wasn't noticeable because mounted tools ran in the parent's context, but in v3's provider architecture each server is isolated. Non-serializable state (`serializable=False`) is request-scoped and automatically shared across mount boundaries. For serializable state, pass the same `session_state_store` to both servers:
 
 ```python
+from fastmcp import FastMCP
 from key_value.aio.stores.memory import MemoryStore
 
 store = MemoryStore()


### PR DESCRIPTION
Mounted servers in v3 each have their own state store, which means serializable state set by parent middleware isn't visible to mounted tools by default. This was an implicit behavior change from v2 where everything ran in one server context.

Adds a note to the upgrade guide (both the LLM prompt and the human-readable section) explaining the behavior and the workaround:

```python
from key_value.aio.stores.memory import MemoryStore

store = MemoryStore()
parent = FastMCP("Parent", session_state_store=store)
child = FastMCP("Child", session_state_store=store)
parent.mount(child, namespace="child")
```

Non-serializable state (`serializable=False`) is request-scoped and automatically shared across mount boundaries, so no workaround is needed there.

Closes #3230