### PR TITLE
Fix dedupe bot labeling pipeline

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -102,7 +102,7 @@ jobs:
           # Only match bot comments created in the last 10 minutes (this run)
           CUTOFF=$(date -u -d '10 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
             || date -u -v-10M '+%Y-%m-%dT%H:%M:%SZ')
-          HAS_RECENT=$(gh api "repos/${{ github.repository }}/issues/${ISSUE}/comments" \
+          HAS_RECENT=$(gh api "repos/${{ github.repository }}/issues/${ISSUE}/comments?sort=created&direction=desc&per_page=10" \
             --jq "[.[] | select(
               .user.type == \"Bot\" and
               (.body | test(\"possible duplicate issues\"; \"i\")) and


### PR DESCRIPTION
The dedupe bot's prompt told the LLM to add a `potential-duplicate` label, but that label didn't exist. The LLM saw `duplicate` was available and used that instead — making bot suggestions look like confirmed duplicate decisions. Meanwhile, the auto-close script (`scripts/auto_close_duplicates.py`) filters on `potential-duplicate`, so it never found anything. The whole pipeline was broken end-to-end.

Three fixes:

1. Created the `potential-duplicate` label (already done on the repo)
2. Removed `gh issue edit` from the LLM's allowed tools so it can't touch labels at all
3. Added a deterministic post-step that checks whether a duplicate comment was posted and adds `potential-duplicate` only then

Also tightened the prompt to be more conservative about false positives — the bot was flagging issues with vague keyword overlap as duplicates.