### PR TITLE
Fix Marvin app token to use PrefectHQ org installation

### DIFF
--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           app-id: ${{ secrets.MARVIN_APP_ID }}
           private-key: ${{ secrets.MARVIN_APP_PRIVATE_KEY }}
+          owner: PrefectHQ
 
       - name: Set triage prompt
         id: triage-prompt


### PR DESCRIPTION
After the repo transfer from jlowin/ to PrefectHQ/, the `create-github-app-token` action may resolve to the personal jlowin installation instead of the PrefectHQ org installation. This causes PR labels to show as applied by "jlowin" rather than "marvin-context-protocol".

Adding `owner: PrefectHQ` forces the token to use the org installation.