### PR TITLE
Update Marvin workflow models to claude-sonnet-4-6

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -88,7 +88,7 @@ jobs:
             --allowedTools Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh api:*),Bash(gh issue comment:*),Task
           settings: |
             {
-              "model": "claude-sonnet-4-5-20250929",
+              "model": "claude-sonnet-4-6",
               "env": {
                 "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}"
               }

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -141,7 +141,7 @@ jobs:
             --allowedTools Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__get_pull_request_files
           settings: |
             {
-              "model": "claude-sonnet-4-5-20250929",
+              "model": "claude-sonnet-4-6",
               "env": {
                 "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}"
               }


### PR DESCRIPTION
The label-triage and dedupe-issues workflows were pinned to `claude-sonnet-4-5-20250929`. Updates them to `claude-sonnet-4-6`.