### PR TITLE
feat: authorization server url in Client

### DIFF
--- a/docs/clients/auth/oauth.mdx
+++ b/docs/clients/auth/oauth.mdx
@@ -61,6 +61,7 @@ You don't need to pass `mcp_url` when using `OAuth` with `Client(auth=...)` — 
 - **`token_storage`** (`AsyncKeyValue`, optional): Storage backend for persisting OAuth tokens. Defaults to in-memory storage (tokens lost on restart). See [Token Storage](#token-storage) for encrypted storage options
 - **`additional_client_metadata`** (`dict[str, Any]`, optional): Extra metadata for client registration
 - **`callback_port`** (`int`, optional): Fixed port for OAuth callback server. If not specified, uses a random available port
+- **`authorization_server_url`** (`str`, optional): URL of the OAuth authorization server. When provided, skips the initial 401 round-trip and protected resource metadata discovery, going straight to fetching authorization server metadata from this URL. See [Pre-Configured Authorization Server](#pre-configured-authorization-server)
 - **`httpx_client_factory`** (`McpHttpClientFactory`, optional): Factory for creating httpx clients
 
 
@@ -184,3 +185,37 @@ oauth = OAuth(client_id="my-public-client-id")
 <Note>
 When using pre-registered credentials, the client will not attempt Dynamic Client Registration. If the server rejects the credentials, the error is surfaced immediately rather than falling back to DCR.
 </Note>
+
+## Pre-Configured Authorization Server
+
+<VersionBadge version="3.0.0" />
+
+By default, the OAuth client discovers the authorization server by first sending an unauthenticated request, receiving a `401`, and then following the discovery chain (Protected Resource Metadata → Authorization Server Metadata). When you already know the authorization server URL — e.g. from a config file or environment variable — you can skip this round-trip entirely by providing `authorization_server_url`.
+
+```python
+from fastmcp import Client
+from fastmcp.client.auth import OAuth
+
+async with Client(
+    "https://mcp-server.example.com/mcp",
+    auth=OAuth(
+        client_id="my-client",
+        client_secret="my-secret",
+        authorization_server_url="https://auth.example.com",
+    ),
+) as client:
+    # No 401 round-trip — goes straight to OASM fetch → token exchange
+    await client.ping()
+```
+
+When `authorization_server_url` is provided, the client:
+
+1. Fetches Authorization Server Metadata from the given URL directly
+2. Registers or authenticates using the discovered metadata
+3. Sends the first real request already authenticated
+
+When omitted, the behavior is exactly as before (401-triggered discovery).
+
+<Tip>
+This is useful in controlled/enterprise environments where the auth server is always known, saving one full round-trip of latency on the first connection. It also complements [Token Storage](#token-storage) — token storage avoids repeated 401s on subsequent connections, while `authorization_server_url` avoids the 401 on the very first connection.
+</Tip>

--- a/tests/client/auth/test_oauth_authorization_server_url.py
+++ b/tests/client/auth/test_oauth_authorization_server_url.py
@@ -1,0 +1,172 @@
+"""Tests for OAuth authorization_server_url (skip 401 discovery)."""
+
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+from fastmcp.client import Client
+from fastmcp.client.auth import OAuth
+from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.server.auth.auth import ClientRegistrationOptions
+from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
+from fastmcp.server.server import FastMCP
+from fastmcp.utilities.http import find_available_port
+from fastmcp.utilities.tests import HeadlessOAuth, run_server_async
+
+
+class TestAuthorizationServerUrlInit:
+    """authorization_server_url should be stored and accessible."""
+
+    def test_stores_authorization_server_url(self):
+        oauth = OAuth(
+            mcp_url="https://example.com/mcp",
+            authorization_server_url="https://auth.example.com",
+        )
+        assert oauth._authorization_server_url == "https://auth.example.com"
+
+    def test_default_authorization_server_url_is_none(self):
+        oauth = OAuth(mcp_url="https://example.com/mcp")
+        assert oauth._authorization_server_url is None
+
+    def test_combines_with_static_client(self):
+        oauth = OAuth(
+            mcp_url="https://example.com/mcp",
+            client_id="my-client",
+            client_secret="my-secret",
+            authorization_server_url="https://auth.example.com",
+        )
+        assert oauth._authorization_server_url == "https://auth.example.com"
+        assert oauth._static_client_info is not None
+        assert oauth._static_client_info.client_id == "my-client"
+
+
+class TestProactiveAuthE2E:
+    """End-to-end tests: authorization_server_url skips the 401 round-trip."""
+
+    async def test_proactive_auth_with_dcr(self):
+        """When authorization_server_url is set, client skips 401 and uses DCR."""
+        port = find_available_port()
+        callback_port = find_available_port()
+        issuer_url = f"http://127.0.0.1:{port}"
+
+        provider = InMemoryOAuthProvider(
+            base_url=issuer_url,
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True,
+                valid_scopes=["read", "write"],
+            ),
+        )
+
+        server = FastMCP("TestServer", auth=provider)
+
+        @server.tool
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        async with run_server_async(server, port=port, transport="http") as url:
+            parsed = urlparse(url)
+            auth_server_url = f"{parsed.scheme}://{parsed.netloc}"
+
+            oauth = HeadlessOAuth(
+                mcp_url=url,
+                scopes=["read", "write"],
+                callback_port=callback_port,
+                authorization_server_url=auth_server_url,
+            )
+
+            async with Client(
+                transport=StreamableHttpTransport(url),
+                auth=oauth,
+            ) as client:
+                assert await client.ping()
+                tools = await client.list_tools()
+                assert any(t.name == "greet" for t in tools)
+
+    async def test_proactive_auth_with_static_client(self):
+        """authorization_server_url + static client_id skips 401 and DCR."""
+        port = find_available_port()
+        callback_port = find_available_port()
+        issuer_url = f"http://127.0.0.1:{port}"
+
+        provider = InMemoryOAuthProvider(
+            base_url=issuer_url,
+            client_registration_options=ClientRegistrationOptions(
+                enabled=False,
+                valid_scopes=["read"],
+            ),
+        )
+
+        server = FastMCP("TestServer", auth=provider)
+
+        @server.tool
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        pre_registered = OAuthClientInformationFull(
+            client_id="known-client",
+            client_secret="known-secret",
+            redirect_uris=[AnyUrl(f"http://localhost:{callback_port}/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="client_secret_post",
+            scope="read",
+        )
+        await provider.register_client(pre_registered)
+
+        async with run_server_async(server, port=port, transport="http") as url:
+            parsed = urlparse(url)
+            auth_server_url = f"{parsed.scheme}://{parsed.netloc}"
+
+            oauth = HeadlessOAuth(
+                mcp_url=url,
+                client_id="known-client",
+                client_secret="known-secret",
+                scopes=["read"],
+                callback_port=callback_port,
+                authorization_server_url=auth_server_url,
+            )
+
+            async with Client(
+                transport=StreamableHttpTransport(url),
+                auth=oauth,
+            ) as client:
+                result = await client.call_tool("add", {"a": 5, "b": 7})
+                assert result.data == 12
+
+    async def test_without_authorization_server_url_still_works(self):
+        """Normal 401-triggered flow remains unchanged when parameter is omitted."""
+        port = find_available_port()
+        callback_port = find_available_port()
+        issuer_url = f"http://127.0.0.1:{port}"
+
+        provider = InMemoryOAuthProvider(
+            base_url=issuer_url,
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True,
+                valid_scopes=["read"],
+            ),
+        )
+
+        server = FastMCP("TestServer", auth=provider)
+
+        @server.tool
+        def echo(msg: str) -> str:
+            return msg
+
+        async with run_server_async(server, port=port, transport="http") as url:
+            oauth = HeadlessOAuth(
+                mcp_url=url,
+                scopes=["read"],
+                callback_port=callback_port,
+                # authorization_server_url intentionally omitted
+            )
+
+            async with Client(
+                transport=StreamableHttpTransport(url),
+                auth=oauth,
+            ) as client:
+                assert await client.ping()


### PR DESCRIPTION
## Description

### Support pre-configured `authorization_server_url` in `OAuth`

Today, the `OAuth` client always sends an unauthenticated request first, receives a `401`, and only then triggers the full discovery chain (PRM → OASM → registration → token exchange) — even when the authorization server is already known.

> [!NOTE]
> In most scenarios where the client provides a `client_id` and/or `client_secret`, the authorization server is already known. These credentials are typically issued by — and bound to — a specific identity provider.

In enterprise and other controlled environments — and especially in cases where a `client_id` and/or `client_secret` is already configured — the authorization server URL is known upfront (via configuration files, environment variables, or deployment manifests). Since these credentials are issued by a specific identity provider, they implicitly determine the authorization server. In such scenarios, the initial `401` round-trip introduces unnecessary latency and overhead, without adding any functional value.

### Solution

This adds an optional `authorization_server_url` parameter to `OAuth` that lets clients go straight to OASM discovery and token acquisition before the first real request, eliminating the unnecessary 401.

```python
from fastmcp import Client
from fastmcp.client.auth import OAuth

auth = OAuth(
    client_id="my-client",
    client_secret="my-secret",
    authorization_server_url="https://auth.example.com",  # skip 401 + PRM
)

async with Client("https://mcp-server.example.com/mcp", auth=auth) as client:
    # First request is already authenticated — no 401 round-trip
    await client.ping()
```

### How it works

The MCP SDK's `OAuthClientProvider.async_auth_flow` only triggers OASM discovery and token acquisition reactively — inside the `if response.status_code == 401:` branch of the httpx auth generator. There's no hook to pre-populate the context before that branch runs.

Rather than monkeypatching the parent class, this PR adds a `_proactive_auth()` method on FastMCP's `OAuth` subclass. It runs *before* delegating to the parent's `async_auth_flow` generator:

1. Sets `context.auth_server_url` directly from the provided URL
2. Fetches OASM via the standard `build_oauth_authorization_server_metadata_discovery_urls` + `handle_auth_metadata_response` helpers from the MCP SDK — the same code paths used during normal 401-triggered discovery
3. Registers the client (DCR, CIMD, or static credentials — all three paths are supported)
4. Completes the authorization code grant (browser + callback + PKCE)
5. Exchanges for tokens via `_exchange_token_authorization_code` / `_handle_token_response`

When `async_auth_flow` then delegates to the parent, it finds valid tokens already in `context.current_tokens`, adds the `Authorization: Bearer` header, and yields the request — the server responds with 200 on the first try.

**Without** `authorization_server_url` (current behavior, unchanged):
```
POST /mcp → 401 → GET PRM → GET OASM → POST /register → GET /authorize → POST /token → POST /mcp (200)
```

**With** `authorization_server_url`:
```
GET OASM → POST /register → GET /authorize → POST /token → POST /mcp (200)
```

### Protocol compliance

This is fully compliant with the MCP spec's OAuth 2.1 authorization flow. The feature only changes *when* discovery happens (proactively vs. reactively) — it still fetches OASM from `/.well-known/oauth-authorization-server` per RFC 8414, still performs DCR per RFC 7591 when needed, and still uses Authorization Code + PKCE per OAuth 2.1. The parameter is purely opt-in; omitting it preserves the exact same 401-triggered behavior.


---


**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes #(issue number)
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
