### PR TITLE
fix: add missing asyncio import in FunctionTool.run()

### DIFF
--- a/src/fastmcp/tools/function_tool.py
+++ b/src/fastmcp/tools/function_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import warnings
 from collections.abc import Callable


### PR DESCRIPTION
## Summary

- Adds the missing `import asyncio` to `fastmcp/tools/function_tool.py`
- Without this import, any sync function registered via `Tool.from_function()` crashes with `NameError: name 'asyncio' is not defined` at runtime because `FunctionTool.run()` calls `asyncio.to_thread()` on line 286

## Reproduction

```python
import asyncio
from fastmcp.tools.tool import Tool

def greet(name: str) -> str:
    return f"Hello, {name}"

async def main():
    tool = Tool.from_function(greet, name="greet", description="test")
    await tool.run({"name": "world"})
    # NameError: name 'asyncio' is not defined

asyncio.run(main())
```

Fixes #3270

Made with [Cursor](https://cursor.com)