### PR TITLE
Add v3.0.2 release notes

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,23 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v3.0.2" description="2026-02-22">
+
+**[v3.0.2: Threecovery Mode II](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.0.2)**
+
+Two community-contributed fixes: auth headers from MCP transport no longer leak through to downstream OpenAPI APIs, and background task workers now correctly receive the originating request ID. Plus a new docs example for context-aware tool factories.
+
+### Fixes 🐞
+* fix: prevent MCP transport auth header from leaking to downstream OpenAPI APIs by [@stakeswky](https://github.com/stakeswky) in [#3262](https://github.com/PrefectHQ/fastmcp/pull/3262)
+* fix: propagate origin_request_id to background task workers by [@gfortaine](https://github.com/gfortaine) in [#3175](https://github.com/PrefectHQ/fastmcp/pull/3175)
+### Docs 📚
+* Add v3.0.1 release notes by [@jlowin](https://github.com/jlowin) in [#3259](https://github.com/PrefectHQ/fastmcp/pull/3259)
+* docs: add context-aware tool factory example by [@machov](https://github.com/machov) in [#3264](https://github.com/PrefectHQ/fastmcp/pull/3264)
+
+**Full Changelog**: [v3.0.1...v3.0.2](https://github.com/PrefectHQ/fastmcp/compare/v3.0.1...v3.0.2)
+
+</Update>
+
 <Update label="v3.0.1" description="2026-02-20">
 
 **[v3.0.1: Three-covery Mode](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.0.1)**
@@ -13,7 +30,6 @@ First patch after 3.0 — mostly smoothing out rough edges discovered in the wil
 
 ### Enhancements 🔧
 * Add verify_id_token option to OIDCProxy by [@jlowin](https://github.com/jlowin) in [#3248](https://github.com/PrefectHQ/fastmcp/pull/3248)
-
 ### Fixes 🐞
 * Fix v3.0.0 changelog compare link by [@jlowin](https://github.com/jlowin) in [#3223](https://github.com/PrefectHQ/fastmcp/pull/3223)
 * Fix MDX parse error in upgrade guide prompts by [@jlowin](https://github.com/jlowin) in [#3227](https://github.com/PrefectHQ/fastmcp/pull/3227)
@@ -26,6 +42,7 @@ First patch after 3.0 — mostly smoothing out rough edges discovered in the wil
 * Use max_completion_tokens instead of deprecated max_tokens in OpenAI handler by [@jlowin](https://github.com/jlowin) in [#3254](https://github.com/PrefectHQ/fastmcp/pull/3254)
 * Fix ty compatibility with upgraded deps by [@jlowin](https://github.com/jlowin) in [#3257](https://github.com/PrefectHQ/fastmcp/pull/3257)
 * Fix decorator overload return types for function mode by [@jlowin](https://github.com/jlowin) in [#3258](https://github.com/PrefectHQ/fastmcp/pull/3258)
+
 
 ### Docs 📚
 * Sync README with welcome.mdx, fix install count by [@jlowin](https://github.com/jlowin) in [#3224](https://github.com/PrefectHQ/fastmcp/pull/3224)

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,16 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 3.0.2" description="February 22, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v3.0.2: Threecovery Mode II"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v3.0.2"
+cta="Read the release notes"
+>
+Two community-contributed fixes: auth headers from MCP transport no longer leak through to downstream OpenAPI APIs, and background task workers now correctly receive the originating request ID. Plus a new docs example for context-aware tool factories.
+</Card>
+</Update>
+
 <Update label="FastMCP 3.0.1" description="February 20, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v3.0.1: Three-covery Mode"


### PR DESCRIPTION
Adds the v3.0.2 "Threecovery Mode II" entry to both `updates.mdx` and `changelog.mdx`.