### PR TITLE
fix: replace hardcoded TTL with DEFAULT_TTL_MS constant in task notifications

### DIFF
--- a/src/fastmcp/server/tasks/subscriptions.py
+++ b/src/fastmcp/server/tasks/subscriptions.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from docket.execution import ExecutionState
 from mcp.types import TaskStatusNotification, TaskStatusNotificationParams
 
+from fastmcp.server.tasks.config import DEFAULT_TTL_MS
 from fastmcp.server.tasks.keys import parse_task_key
 from fastmcp.server.tasks.requests import DOCKET_TO_MCP_STATE
 from fastmcp.utilities.logging import get_logger
@@ -133,7 +134,7 @@ async def _send_status_notification(
         "status": mcp_status,
         "createdAt": created_at,
         "lastUpdatedAt": datetime.now(timezone.utc).isoformat(),
-        "ttl": 60000,
+        "ttl": DEFAULT_TTL_MS,
         "pollInterval": poll_interval_ms,
     }
 
@@ -198,7 +199,7 @@ async def _send_progress_notification(
         "status": mcp_status,
         "createdAt": created_at,
         "lastUpdatedAt": datetime.now(timezone.utc).isoformat(),
-        "ttl": 60000,
+        "ttl": DEFAULT_TTL_MS,
         "pollInterval": poll_interval_ms,
         "statusMessage": execution.progress.message,
     }


### PR DESCRIPTION
Fixes #3279

## Summary

Replace hardcoded `60000` with the `DEFAULT_TTL_MS` constant from `config.py` in `_send_status_notification()` and `_send_progress_notification()` in `subscriptions.py`.

This makes `subscriptions.py` consistent with `requests.py`, which already imports and uses `DEFAULT_TTL_MS`.

## Changes

- Import `DEFAULT_TTL_MS` from `fastmcp.server.tasks.config` in `subscriptions.py`
- Replace `"ttl": 60000` with `"ttl": DEFAULT_TTL_MS` on lines 137 and 202

## Tests

Ran task-related tests: `uv run pytest tests/ -x -q -k "task"` — 353 passed.
Ran ruff linter: all checks passed.