### PR TITLE
Fix docs banner pushing nav down

### DIFF
--- a/docs/css/banner.css
+++ b/docs/css/banner.css
@@ -6,7 +6,6 @@
   font-weight: 600 !important;
   padding-top: 12px !important;
   padding-bottom: 12px !important;
-  position: relative !important;
   overflow: hidden !important;
 }
 


### PR DESCRIPTION
Our custom `banner.css` had `position: relative !important` which was overriding Mintlify's `lg:fixed` Tailwind class on the banner element. Mintlify's current layout expects the banner to be fixed-positioned on large screens, with a spacer div in the flow to compensate. The `!important` override kept the banner in-flow, so the page accounted for the banner height twice — creating a visible gap between the banner and the navigation bar.

Removing the position override lets Mintlify's responsive positioning work as intended.