### PR TITLE
fix: stop suppressing server stderr in fastmcp call

### DIFF
--- a/src/fastmcp/cli/client.py
+++ b/src/fastmcp/cli/client.py
@@ -2,7 +2,6 @@
 
 import difflib
 import json
-import os
 import shlex
 import sys
 from pathlib import Path
@@ -100,7 +99,6 @@ def resolve_server_spec(
             return StdioTransport(
                 command="fastmcp",
                 args=["run", str(resolved_path), "--no-banner"],
-                log_file=Path(os.devnull),
             )
         # .js — pass through for Client's infer_transport
         return spec
@@ -125,7 +123,7 @@ def _build_stdio_from_command(command_str: str) -> StdioTransport:
         console.print("[bold red]Error:[/bold red] Empty --command")
         sys.exit(1)
 
-    return StdioTransport(command=parts[0], args=parts[1:], log_file=Path(os.devnull))
+    return StdioTransport(command=parts[0], args=parts[1:])
 
 
 def _resolve_json_spec(path: Path) -> str | dict[str, Any]:


### PR DESCRIPTION
`fastmcp call` was sending server subprocess stderr to `/dev/null`, which meant any `print(..., file=sys.stderr)` or logging output from tool functions was silently discarded. This made print-debugging impossible when using stdio transport.

The fix removes the explicit `/dev/null` redirect, letting stderr flow through to the terminal as expected. `print()` to stdout is still consumed by the JSON-RPC protocol on stdio (that's inherent to the transport), but stderr debugging now works.

Closes #3278