### PR TITLE
fix: skip max_completion_tokens when maxTokens is None

### DIFF
--- a/src/fastmcp/client/sampling/handlers/openai.py
+++ b/src/fastmcp/client/sampling/handlers/openai.py
@@ -84,8 +84,9 @@ class OpenAISamplingHandler:
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": openai_messages,
-            "max_completion_tokens": params.maxTokens,
         }
+        if params.maxTokens is not None:
+            kwargs["max_completion_tokens"] = params.maxTokens
         if params.temperature is not None:
             kwargs["temperature"] = params.temperature
         if params.stopSequences:


### PR DESCRIPTION
## Description

When `maxTokens` is not specified by the caller, the OpenAI sampling handler was sending `"max_completion_tokens": null` explicitly in the API request. OpenAI treats an explicit `null` differently from an omitted key, it returns an empty response with `finish_reason: "stop"` and no content, which causes the handler to raise `ValueError("No content in response from completion")`.

**Fix:** guard `max_completion_tokens` with `if params.maxTokens is not None`, consistent with how `temperature` and `stopSequences` are already handled in the same block.

This is a follow-up to the rename fix in #3252.

**Contributors Checklist**

- [x] My change closes #3252
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review