### PR TITLE
Fix "FastMCP Constructor Parameters" in documentation server.mdx (Remove old parameters & Add new parameter)

### DIFF
--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -76,16 +76,8 @@ The `FastMCP` constructor accepts several configuration options. The most common
   Hide components with any matching tag
 </ParamField>
 
-<ParamField body="on_duplicate_tools" type='Literal["error", "warn", "replace"]' default="error">
-  How to handle duplicate tool registrations
-</ParamField>
-
-<ParamField body="on_duplicate_resources" type='Literal["error", "warn", "replace"]' default="warn">
-  How to handle duplicate resource registrations
-</ParamField>
-
-<ParamField body="on_duplicate_prompts" type='Literal["error", "warn", "replace"]' default="replace">
-  How to handle duplicate prompt registrations
+<ParamField body="on_duplicate" type='Literal["warn", "error", "replace", "ignore"]' default="warn">
+  How to handle duplicate component registrations
 </ParamField>
 
 


### PR DESCRIPTION
Fix description of "FastMCP Constructor Parameters":
Remove parameters `on_duplicate_tools`, `on_duplicate_resources` and `on_duplicate_prompts`, which are no longer accepted by FastMCP(). Add the new parameter `on_duplicate` and its description.

## Description
<!-- 
Please provide a clear and concise description of the changes made in this pull request.

Using AI to generate code? Please include a note in the description with which AI tool you used.
-->

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [x] My change closes #3318 
- [x] I have followed the repository's development workflow
- [x] ~~I have tested my changes manually and by adding relevant tests~~
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
