### PR TITLE
Fix stale docs: tag filtering API and missing output_schema param

### DIFF
--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -68,13 +68,6 @@ The `FastMCP` constructor accepts several configuration options. The most common
 </ParamField>
 
 
-<ParamField body="include_tags" type="set[str] | None">
-  Only expose components with at least one matching tag
-</ParamField>
-
-<ParamField body="exclude_tags" type="set[str] | None">
-  Hide components with any matching tag
-</ParamField>
 
 <ParamField body="on_duplicate_tools" type='Literal["error", "warn", "replace"]' default="error">
   How to handle duplicate tool registrations
@@ -177,25 +170,28 @@ def admin_tool() -> str:
 ```
 
 The filtering logic works as follows:
-- **Include tags**: If specified, only components with at least one matching tag are exposed
-- **Exclude tags**: Components with any matching tag are filtered out
-- **Precedence**: Exclude tags always take priority over include tags
+- **Enable with `only=True`**: Switches to allowlist mode — only components with at least one matching tag are exposed
+- **Disable**: Components with any matching tag are hidden
+- **Precedence**: Later calls override earlier ones, so call `disable` after `enable` to exclude from an allowlist
 
 <Tip>
 To ensure a component is never exposed, you can set `enabled=False` on the component itself. See the component-specific documentation for details.
 </Tip>
 
-Configure tag-based filtering when creating your server.
+Configure tag-based filtering after creating your server.
 
 ```python
 # Only expose components tagged with "public"
-mcp = FastMCP(include_tags={"public"})
+mcp = FastMCP()
+mcp.enable(tags={"public"}, only=True)
 
 # Hide components tagged as "internal" or "deprecated"
-mcp = FastMCP(exclude_tags={"internal", "deprecated"})
+mcp = FastMCP()
+mcp.disable(tags={"internal", "deprecated"})
 
 # Combine both: show admin tools but hide deprecated ones
-mcp = FastMCP(include_tags={"admin"}, exclude_tags={"deprecated"})
+mcp = FastMCP()
+mcp.enable(tags={"admin"}, only=True).disable(tags={"deprecated"})
 ```
 
 This filtering applies to all component types (tools, resources, resource templates, and prompts) and affects both listing and access.

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -126,6 +126,12 @@ def search_products_implementation(query: str, category: str | None = None) -> l
 
   Optional version identifier for this tool. See [Versioning](/servers/versioning) for details.
 </ParamField>
+
+<ParamField body="output_schema" type="dict[str, Any] | None">
+  <VersionBadge version="2.10.0" />
+
+  Optional JSON schema for the tool's output. When provided, the tool must return structured output matching this schema. If not provided, FastMCP automatically generates a schema from the function's return type annotation. See [Output Schemas](#output-schemas) for details.
+</ParamField>
 </Card>
 
 ### Using with Methods


### PR DESCRIPTION
Two doc correctness issues surfaced during an audit of user-facing docs.

The `include_tags` and `exclude_tags` constructor parameters were removed but still documented in `server.mdx` — including broken code examples that would fail at runtime. These are replaced by `server.enable(tags=..., only=True)` and `server.disable(tags=...)`, which the doc now correctly shows. The `output_schema` decorator parameter was also absent from the `@mcp.tool` ParamField reference, despite being covered in the structured output section — added for completeness.