### PR TITLE
Add -m/--module flag to `fastmcp run` and `dev inspector`

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -481,8 +481,6 @@ async def run(
             ignored_options.append("--port")
         if path:
             ignored_options.append("--path")
-        if reload:
-            ignored_options.append("--reload")
         if ignored_options:
             logger.warning(
                 f"Options {', '.join(ignored_options)} are ignored in module mode "
@@ -505,6 +503,25 @@ async def run(
             test_cmd = ["test"]
             if env.build_command(test_cmd) != test_cmd:
                 env_builder = env.build_command
+
+        if reload:
+            # Build a fastmcp run command for the reload watcher to restart
+            reload_cmd = ["fastmcp", "run", server_spec, "--module", "--no-reload"]
+            if log_level:
+                reload_cmd.extend(["--log-level", log_level])
+            if no_banner:
+                reload_cmd.append("--no-banner")
+            if env_builder is not None:
+                reload_cmd.append("--skip-env")
+            if server_args:
+                reload_cmd.append("--")
+                reload_cmd.extend(server_args)
+            if env_builder is not None:
+                reload_cmd = env_builder(reload_cmd)
+            await run_module.run_with_reload(
+                reload_cmd, reload_dirs=reload_dir, is_stdio=True
+            )
+            return
 
         run_module.run_module_command(
             server_spec,

--- a/src/fastmcp/cli/run.py
+++ b/src/fastmcp/cli/run.py
@@ -8,6 +8,7 @@ import re
 import signal
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
@@ -259,7 +260,7 @@ async def run_command(
 def run_module_command(
     module_name: str,
     *,
-    env_command_builder: Any | None = None,
+    env_command_builder: Callable[[list[str]], list[str]] | None = None,
     extra_args: list[str] | None = None,
 ) -> None:
     """Run a Python module directly using ``python -m <module>``.


### PR DESCRIPTION
## Description

Currently `fastmcp run` always attempts to import a server object from a Python file — but some MCP servers are designed to be invoked as modules (`python -m <module>`), where the server starts as a side effect of running `__main__.py`. This PR adds a `-m / --module` flag so users can run `fastmcp run -m my_server` and have FastMCP delegate to `python -m my_server` directly, bypassing all server-object discovery logic.

```bash
# Run a module-based MCP server
fastmcp run -m my_server

# With extra arguments forwarded to the module
fastmcp run -m my_server -- --verbose --port 8080

# With uv environment options
fastmcp run -m my_server --with httpx --with-editable .

# Inspect a module-based server
fastmcp dev inspector -m my_server
```

When `--module` is active, options that only apply to FastMCP's built-in server hosting (`--transport`, `--host`, `--port`, `--path`, `--reload`) are ignored with a warning, since the module manages its own startup.

🤖 Generated with GitHub Copilot (Claude)

**Contributors Checklist**

- [x] My change closes #53
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review"