### PR TITLE
Handle AuthorizationError as exclusion in AuthMiddleware list hooks

### DIFF
--- a/src/fastmcp/server/middleware/authorization.py
+++ b/src/fastmcp/server/middleware/authorization.py
@@ -102,8 +102,11 @@ class AuthMiddleware(Middleware):
         authorized_tools: list[Tool] = []
         for tool in tools:
             ctx = AuthContext(token=token, component=tool)
-            if await run_auth_checks(self.auth, ctx):
-                authorized_tools.append(tool)
+            try:
+                if await run_auth_checks(self.auth, ctx):
+                    authorized_tools.append(tool)
+            except AuthorizationError:
+                continue
 
         return authorized_tools
 
@@ -169,8 +172,11 @@ class AuthMiddleware(Middleware):
         authorized_resources: list[Resource] = []
         for resource in resources:
             ctx = AuthContext(token=token, component=resource)
-            if await run_auth_checks(self.auth, ctx):
-                authorized_resources.append(resource)
+            try:
+                if await run_auth_checks(self.auth, ctx):
+                    authorized_resources.append(resource)
+            except AuthorizationError:
+                continue
 
         return authorized_resources
 
@@ -238,8 +244,11 @@ class AuthMiddleware(Middleware):
         authorized_templates: list[ResourceTemplate] = []
         for template in templates:
             ctx = AuthContext(token=token, component=template)
-            if await run_auth_checks(self.auth, ctx):
-                authorized_templates.append(template)
+            try:
+                if await run_auth_checks(self.auth, ctx):
+                    authorized_templates.append(template)
+            except AuthorizationError:
+                continue
 
         return authorized_templates
 
@@ -262,8 +271,11 @@ class AuthMiddleware(Middleware):
         authorized_prompts: list[Prompt] = []
         for prompt in prompts:
             ctx = AuthContext(token=token, component=prompt)
-            if await run_auth_checks(self.auth, ctx):
-                authorized_prompts.append(prompt)
+            try:
+                if await run_auth_checks(self.auth, ctx):
+                    authorized_prompts.append(prompt)
+            except AuthorizationError:
+                continue
 
         return authorized_prompts
 


### PR DESCRIPTION
## Description
<!-- 
Please provide a clear and concise description of the changes made in this pull request.

Using AI to generate code? Please include a note in the description with which AI tool you used.
-->
This PR updates `AuthMiddleware` list hooks to treat `AuthorizationError` as exclusion instead of letting it fail the entire list request. The change is limited to the four list hooks in `src/fastmcp/server/middleware/authorization.py`. I also added regression tests for tools, resources, resource templates, and prompts to verify that denied items are skipped while allowed items continue to be returned.

  I used gpt-5.3-codex to help draft and refine this change.

**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.

If you do not follow these steps, your Pull Request will be closed without review.
-->

- [X] My change closes #3333
- [X] I have followed the repository's development workflow
- [X] I have tested my changes manually and by adding relevant tests
- [ ] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->

- [X] I have self-reviewed my changes
- [X] My Pull Request is ready for review

---
