### PR TITLE
Fix flaky OpenAPI performance test threshold

### DIFF
--- a/tests/server/providers/openapi/test_comprehensive.py
+++ b/tests/server/providers/openapi/test_comprehensive.py
@@ -731,9 +731,11 @@ class TestOpenAPIComprehensive:
 
         end_time = time.time()
 
-        # Should be very fast (no code generation)
+        # Should be fast (no code generation). Use generous threshold for slow
+        # CI runners (Windows); the intent is to catch obvious regressions
+        # (e.g., accidentally re-introducing code generation), not to benchmark.
         initialization_time = end_time - start_time
-        assert initialization_time < 0.1  # Should be under 100ms
+        assert initialization_time < 1.0
 
         # Verify provider was created correctly
         assert provider is not None


### PR DESCRIPTION
Cherry-picked from #3348 (thanks @geopopos). The initialization performance test used a 100ms threshold that was too tight for slow CI runners (especially Windows), causing intermittent failures. Bumped to 1.0s — still catches the actual regression it's designed for (accidentally reintroducing code generation) without flaking on load.