### PR TITLE
Remove system role references from docs

### DIFF
--- a/docs/clients/prompts.mdx
+++ b/docs/clients/prompts.mdx
@@ -90,9 +90,9 @@ async with client:
         "expertise": "python programming"
     })
 
-    # Typically returns messages with role="system"
-    system_message = result.messages[0]
-    print(f"System prompt: {system_message.content}")
+    # Access the returned messages
+    message = result.messages[0]
+    print(f"Prompt: {message.content}")
 ```
 
 Conversation templates generate multi-turn flows:

--- a/docs/servers/transforms/prompts-as-tools.mdx
+++ b/docs/servers/transforms/prompts-as-tools.mdx
@@ -116,7 +116,7 @@ result = await client.call_tool(
 ## Message Format
 
 Rendered prompts return a messages array following the standard MCP format. Each message includes:
-- `role`: The message role (typically "user", "assistant", or "system")
+- `role`: The message role ("user" or "assistant")
 - `content`: The message text content
 
 Multi-message prompts are supported - the array will contain all messages in order.

--- a/docs/v2/clients/prompts.mdx
+++ b/docs/v2/clients/prompts.mdx
@@ -190,9 +190,9 @@ async with client:
         "expertise": "python programming"
     })
     
-    # Typically returns messages with role="system"
-    system_message = result.messages[0]
-    print(f"System prompt: {system_message.content}")
+    # Access the returned messages
+    message = result.messages[0]
+    print(f"Prompt: {message.content}")
 ```
 
 ### Conversation Templates


### PR DESCRIPTION
The MCP spec only supports "user" and "assistant" roles for prompt messages. Removes incorrect references to a "system" role from the docs.

Closes #3160

Generated with [Claude Code](https://claude.ai/code)