### PR TITLE
Add early-development warning to Prefab docs

### DIFF
--- a/docs/apps/overview.mdx
+++ b/docs/apps/overview.mdx
@@ -18,6 +18,10 @@ FastMCP implements the [MCP Apps extension](https://modelcontextprotocol.io/docs
 
 <VersionBadge version="3.1.0" />
 
+<Tip>
+[Prefab](https://prefab.prefect.io) is in extremely early, active development — its API changes frequently and breaking changes can occur with any release. The FastMCP integration is equally new and under rapid development. These docs are included for users who want to work on the cutting edge; production use is not recommended. Always [pin `prefab-ui` to a specific version](/apps/prefab#getting-started) in your dependencies.
+</Tip>
+
 [Prefab UI](https://prefab.prefect.io) is a declarative UI framework for Python. You describe layouts, charts, tables, forms, and interactive behaviors using a Python DSL — and the framework compiles them to a JSON protocol that a shared renderer interprets. It started as a component library inside FastMCP and grew into its own framework with [comprehensive documentation](https://prefab.prefect.io).
 
 ```python

--- a/docs/apps/patterns.mdx
+++ b/docs/apps/patterns.mdx
@@ -10,6 +10,10 @@ import { VersionBadge } from '/snippets/version-badge.mdx'
 
 <VersionBadge version="3.1.0" />
 
+<Tip>
+[Prefab](https://prefab.prefect.io) is in extremely early, active development — its API changes frequently and breaking changes can occur with any release. The FastMCP integration is equally new and under rapid development. These docs are included for users who want to work on the cutting edge; production use is not recommended. Always pin `prefab-ui` to a specific version in your dependencies.
+</Tip>
+
 The most common use of Prefab is giving your tools a visual representation — a chart instead of raw numbers, a sortable table instead of a text dump, a status dashboard instead of a list of booleans. Each pattern below is a complete, copy-pasteable tool.
 
 ## Charts

--- a/docs/apps/prefab.mdx
+++ b/docs/apps/prefab.mdx
@@ -10,6 +10,10 @@ import { VersionBadge } from '/snippets/version-badge.mdx'
 
 <VersionBadge version="3.1.0" />
 
+<Tip>
+[Prefab](https://prefab.prefect.io) is in extremely early, active development — its API changes frequently and breaking changes can occur with any release. The FastMCP integration is equally new and under rapid development. These docs are included for users who want to work on the cutting edge; production use is not recommended. Always pin `prefab-ui` to a specific version in your dependencies (see below).
+</Tip>
+
 [Prefab UI](https://prefab.prefect.io) is a declarative UI framework for Python. You describe what your interface should look like — a chart, a table, a form — and return it from your tool. FastMCP takes care of everything else: registering the renderer, wiring the protocol metadata, and delivering the component tree to the host.
 
 Prefab started as a component library inside FastMCP and grew into a full framework for building interactive applications — with its own state management, reactive expression system, and action model. The [Prefab documentation](https://prefab.prefect.io) covers all of this in depth. This page focuses on the FastMCP integration: what you return from a tool, and what FastMCP does with it.


### PR DESCRIPTION
Adds a prominent Tip callout to the three Prefab docs pages (overview, prefab, patterns) warning that Prefab is in extremely early development, the FastMCP integration is equally nascent, and production use is not recommended. Part of the 3.1 docs cleanup before fast-forwarding `published-docs`.