### PR TITLE
Update docs banner and fix mobile layout

### DIFF
--- a/docs/css/banner.css
+++ b/docs/css/banner.css
@@ -64,3 +64,11 @@
   color: #f1f5f9 !important;
 }
 
+@media (max-width: 767px) {
+  #banner {
+    font-size: 0.8rem !important;
+    padding-top: 8px !important;
+    padding-bottom: 8px !important;
+  }
+}
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,7 +12,7 @@
     "decoration": "gradient"
   },
   "banner": {
-    "content": "Join us at the inaugural PyAI Conf in San Francisco on March 10th! [Learn More](https://pyai.events?utm_source=gofastmcp)"
+    "content": "Deploy FastMCP servers for free on [Prefect Horizon](https://www.prefect.io/horizon)"
   },
   "colors": {
     "dark": "#f72585",


### PR DESCRIPTION
The docs banner was wrapping to 2 lines on mobile viewports, pushing the breadcrumb bar down into the content area. Two changes:

- Replace the PyAI Conf banner with Prefect Horizon
- Add a mobile media query (`max-width: 767px`) to `banner.css` that shrinks font size and padding, keeping the banner on one line at narrow widths