### PR TITLE
Fix stale catalog in CodeMode execute

### DIFF
--- a/src/fastmcp/experimental/transforms/code_mode.py
+++ b/src/fastmcp/experimental/transforms/code_mode.py
@@ -541,16 +541,9 @@ class CodeMode(CatalogTransform):
             ctx: Context = None,  # type: ignore[assignment]
         ) -> Any:
             """Execute tool calls using Python code."""
-            cached_tools: Sequence[Tool] | None = None
-
-            async def _get_cached_tools() -> Sequence[Tool]:
-                nonlocal cached_tools
-                if cached_tools is None:
-                    cached_tools = await transform.get_tool_catalog(ctx)
-                return cached_tools
 
             async def call_tool(tool_name: str, params: dict[str, Any]) -> Any:
-                backend_tools = await _get_cached_tools()
+                backend_tools = await transform.get_tool_catalog(ctx)
                 tool = transform._find_tool(tool_name, backend_tools)
                 if tool is None:
                     raise NotFoundError(f"Unknown tool: {tool_name}")

--- a/tests/experimental/transforms/test_code_mode.py
+++ b/tests/experimental/transforms/test_code_mode.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from mcp.types import ImageContent, TextContent
 
-from fastmcp import FastMCP
+from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.experimental.transforms.code_mode import (
     CodeMode,
@@ -505,6 +505,32 @@ async def test_code_mode_search_respects_disabled_tool_visibility() -> None:
     result = await _run_tool(mcp, "search", {"query": "secret"})
     text = _unwrap_string_result(result)
     assert "secret" not in text or "No tools" in text
+
+
+async def test_code_mode_execute_sees_mid_run_visibility_changes() -> None:
+    """Unlocking a tool mid-execution makes it callable in the same run."""
+    mcp = FastMCP("CodeMode Unlock")
+
+    @mcp.tool
+    async def unlock(ctx: Context) -> str:
+        await ctx.enable_components(names={"secret"}, components={"tool"})
+        return "unlocked"
+
+    @mcp.tool
+    async def secret() -> str:
+        return "secret-ok"
+
+    mcp.disable(names={"secret"}, components={"tool"})
+    mcp.add_transform(CodeMode(sandbox_provider=_UnsafeTestSandboxProvider()))
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "execute",
+            {
+                "code": "await call_tool('unlock', {})\nreturn await call_tool('secret', {})"
+            },
+        )
+        assert result.data == {"result": "secret-ok"}
 
 
 async def test_code_mode_execute_respects_tool_auth() -> None:


### PR DESCRIPTION
CodeMode's `execute` tool cached the backend tool catalog for the duration of a single execution block. If a `call_tool` within that block changed visibility (e.g., calling an `unlock` tool that enables a previously hidden tool), subsequent `call_tool` calls still used the stale snapshot and couldn't find the newly-visible tool.

The fix removes the caching closure — each `call_tool` now fetches a fresh catalog via `get_tool_catalog(ctx)`. Since this is an in-process `list_tools()` call (not a network round-trip), the performance cost is negligible.

```python
# This now works — secret becomes visible after unlock
await client.call_tool("execute", {
    "code": (
        "await call_tool('unlock', {})\n"
        "return await call_tool('secret', {})"  # was: Unknown tool
    )
})
```

Closes #3368