### PR TITLE
Increase uv transport test timeout for CI cold starts

### DIFF
--- a/tests/client/transports/test_uv_transport.py
+++ b/tests/client/transports/test_uv_transport.py
@@ -17,7 +17,7 @@ _fastmcp_src_dir = (
 )
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(60)
 @pytest.mark.client_process
 @pytest.mark.skipif(
     sys.platform == "win32",
@@ -54,7 +54,7 @@ async def test_uv_transport():
         assert sum == 3
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(60)
 @pytest.mark.client_process
 @pytest.mark.skipif(
     sys.platform == "win32",


### PR DESCRIPTION
In the lowest-direct CI job, `uv run` detects a resolution mode mismatch and rebuilds the virtual environment from scratch, downloading large packages before the subprocess can start. This cold-start exceeds the 10-second test timeout. Bumping to 60s accommodates the venv creation while still catching actual hangs.