### PR TITLE
Forward scopes_supported through RemoteAuthProvider subclasses

### DIFF
--- a/src/fastmcp/server/auth/providers/descope.py
+++ b/src/fastmcp/server/auth/providers/descope.py
@@ -68,6 +68,9 @@ class DescopeProvider(RemoteAuthProvider):
         project_id: str | None = None,
         descope_base_url: AnyHttpUrl | str | None = None,
         required_scopes: list[str] | None = None,
+        scopes_supported: list[str] | None = None,
+        resource_name: str | None = None,
+        resource_documentation: AnyHttpUrl | None = None,
         token_verifier: TokenVerifier | None = None,
     ):
         """Initialize Descope metadata provider.
@@ -80,6 +83,11 @@ class DescopeProvider(RemoteAuthProvider):
             descope_base_url: Your Descope base URL (e.g., "https://api.descope.com"). Used with project_id for backwards compatibility.
             required_scopes: Optional list of scopes that must be present in validated tokens.
                 These scopes will be included in the protected resource metadata.
+            scopes_supported: Optional list of scopes to advertise in OAuth metadata.
+                If None, uses required_scopes. Use this when the scopes clients should
+                request differ from the scopes enforced on tokens.
+            resource_name: Optional name for the protected resource metadata.
+            resource_documentation: Optional documentation URL for the protected resource.
             token_verifier: Optional token verifier. If None, creates JWT verifier for Descope
         """
         self.base_url = AnyHttpUrl(str(base_url).rstrip("/"))
@@ -149,6 +157,9 @@ class DescopeProvider(RemoteAuthProvider):
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(issuer_url)],
             base_url=self.base_url,
+            scopes_supported=scopes_supported,
+            resource_name=resource_name,
+            resource_documentation=resource_documentation,
         )
 
     def get_routes(

--- a/src/fastmcp/server/auth/providers/propelauth.py
+++ b/src/fastmcp/server/auth/providers/propelauth.py
@@ -80,6 +80,9 @@ class PropelAuthProvider(RemoteAuthProvider):
         introspection_client_secret: str | SecretStr,
         base_url: AnyHttpUrl | str,
         required_scopes: list[str] | None = None,
+        scopes_supported: list[str] | None = None,
+        resource_name: str | None = None,
+        resource_documentation: AnyHttpUrl | None = None,
         resource: AnyHttpUrl | str | None = None,
         token_introspection_overrides: (
             PropelAuthTokenIntrospectionOverrides | None
@@ -93,6 +96,11 @@ class PropelAuthProvider(RemoteAuthProvider):
             introspection_client_secret: Introspection Client Secret from the PropelAuth Dashboard
             base_url: Public URL of this FastMCP server
             required_scopes: Optional list of scopes that must be present in tokens
+            scopes_supported: Optional list of scopes to advertise in OAuth metadata.
+                If None, uses required_scopes. Use this when the scopes clients should
+                request differ from the scopes enforced on tokens.
+            resource_name: Optional name for the protected resource metadata.
+            resource_documentation: Optional documentation URL for the protected resource.
             resource: Optional resource URI (RFC 8707) identifying this MCP server.
                 Use this when multiple MCP servers share the same PropelAuth
                 authorization server (e.g. ``resource="https://api.example.com/mcp"``),
@@ -125,6 +133,9 @@ class PropelAuthProvider(RemoteAuthProvider):
             token_verifier=token_verifier,
             authorization_servers=[authorization_server_url],
             base_url=base_url,
+            scopes_supported=scopes_supported,
+            resource_name=resource_name,
+            resource_documentation=resource_documentation,
         )
 
     def get_routes(

--- a/src/fastmcp/server/auth/providers/scalekit.py
+++ b/src/fastmcp/server/auth/providers/scalekit.py
@@ -69,6 +69,9 @@ class ScalekitProvider(RemoteAuthProvider):
         mcp_url: AnyHttpUrl | str | None = None,
         client_id: str | None = None,
         required_scopes: list[str] | None = None,
+        scopes_supported: list[str] | None = None,
+        resource_name: str | None = None,
+        resource_documentation: AnyHttpUrl | None = None,
         token_verifier: TokenVerifier | None = None,
     ):
         """Initialize Scalekit resource server provider.
@@ -80,6 +83,11 @@ class ScalekitProvider(RemoteAuthProvider):
             mcp_url: Deprecated alias for base_url. Will be removed in a future release.
             client_id: Deprecated parameter, no longer required. Will be removed in a future release.
             required_scopes: Optional list of scopes that must be present in tokens
+            scopes_supported: Optional list of scopes to advertise in OAuth metadata.
+                If None, uses required_scopes. Use this when the scopes clients should
+                request differ from the scopes enforced on tokens.
+            resource_name: Optional name for the protected resource metadata.
+            resource_documentation: Optional documentation URL for the protected resource.
             token_verifier: Optional token verifier. If None, creates JWT verifier for Scalekit
         """
         # Resolve base_url from mcp_url if needed (backwards compatibility)
@@ -140,6 +148,9 @@ class ScalekitProvider(RemoteAuthProvider):
                 AnyHttpUrl(f"{self.environment_url}/resources/{self.resource_id}")
             ],
             base_url=base_url_value,
+            scopes_supported=scopes_supported,
+            resource_name=resource_name,
+            resource_documentation=resource_documentation,
         )
 
     def get_routes(

--- a/src/fastmcp/server/auth/providers/supabase.py
+++ b/src/fastmcp/server/auth/providers/supabase.py
@@ -76,6 +76,9 @@ class SupabaseProvider(RemoteAuthProvider):
         auth_route: str = "/auth/v1",
         algorithm: Literal["HS256", "RS256", "ES256"] = "ES256",
         required_scopes: list[str] | None = None,
+        scopes_supported: list[str] | None = None,
+        resource_name: str | None = None,
+        resource_documentation: AnyHttpUrl | None = None,
         token_verifier: TokenVerifier | None = None,
     ):
         """Initialize Supabase metadata provider.
@@ -90,6 +93,11 @@ class SupabaseProvider(RemoteAuthProvider):
             required_scopes: Optional list of scopes to require for all requests.
                 Note: Supabase currently uses RLS policies for authorization. OAuth-level
                 scopes are an upcoming feature.
+            scopes_supported: Optional list of scopes to advertise in OAuth metadata.
+                If None, uses required_scopes. Use this when the scopes clients should
+                request differ from the scopes enforced on tokens.
+            resource_name: Optional name for the protected resource metadata.
+            resource_documentation: Optional documentation URL for the protected resource.
             token_verifier: Optional token verifier. If None, creates JWT verifier for Supabase
         """
         self.project_url = str(project_url).rstrip("/")
@@ -121,6 +129,9 @@ class SupabaseProvider(RemoteAuthProvider):
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(f"{self.project_url}/{self.auth_route}")],
             base_url=self.base_url,
+            scopes_supported=scopes_supported,
+            resource_name=resource_name,
+            resource_documentation=resource_documentation,
         )
 
     def get_routes(

--- a/src/fastmcp/server/auth/providers/workos.py
+++ b/src/fastmcp/server/auth/providers/workos.py
@@ -272,6 +272,9 @@ class AuthKitProvider(RemoteAuthProvider):
         base_url: AnyHttpUrl | str,
         client_id: str | None = None,
         required_scopes: list[str] | None = None,
+        scopes_supported: list[str] | None = None,
+        resource_name: str | None = None,
+        resource_documentation: AnyHttpUrl | None = None,
         token_verifier: TokenVerifier | None = None,
     ):
         """Initialize AuthKit metadata provider.
@@ -283,6 +286,11 @@ class AuthKitProvider(RemoteAuthProvider):
                 validate the JWT audience claim. Found in your WorkOS Dashboard under
                 API Keys. This is the project-level client ID, not individual MCP client IDs.
             required_scopes: Optional list of scopes to require for all requests
+            scopes_supported: Optional list of scopes to advertise in OAuth metadata.
+                If None, uses required_scopes. Use this when the scopes clients should
+                request differ from the scopes enforced on tokens.
+            resource_name: Optional name for the protected resource metadata.
+            resource_documentation: Optional documentation URL for the protected resource.
             token_verifier: Optional token verifier. If None, creates JWT verifier for AuthKit
         """
         self.authkit_domain = str(authkit_domain).rstrip("/")
@@ -314,6 +322,9 @@ class AuthKitProvider(RemoteAuthProvider):
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(self.authkit_domain)],
             base_url=self.base_url,
+            scopes_supported=scopes_supported,
+            resource_name=resource_name,
+            resource_documentation=resource_documentation,
         )
 
     def get_routes(


### PR DESCRIPTION
`RemoteAuthProvider` accepts `scopes_supported`, `resource_name`, and `resource_documentation` parameters for controlling OAuth protected resource metadata, but none of its convenience subclasses forwarded them. This meant users of `SupabaseProvider`, `DescopeProvider`, `PropelAuthProvider`, `ScalekitProvider`, or `AuthKitProvider` had no way to advertise metadata scopes independently of token validation scopes — leading to empty `scopes_supported` in the well-known endpoint and breaking clients like VS Code that key sessions on scopes.

```python
# This now works on all RemoteAuthProvider subclasses
auth = SupabaseProvider(
    project_url="https://abc123.supabase.co",
    base_url="https://my-server.com",
    scopes_supported=["openid", "profile", "email"],
)
```

Closes #3345