### PR TITLE
fix: dereference_refs() v2 backport (fixes #3153)

### DIFF
--- a/src/fastmcp/utilities/json_schema.py
+++ b/src/fastmcp/utilities/json_schema.py
@@ -6,6 +6,53 @@ from typing import Any
 from jsonref import JsonRefError, replace_refs
 
 
+def _defs_have_cycles(defs: dict[str, Any]) -> bool:
+    """Check whether any definitions in ``$defs`` form a reference cycle.
+
+    A cycle means a definition directly or transitively references itself
+    (e.g. Node → children → Node, or A → B → A).  ``jsonref.replace_refs``
+    silently produces Python-level object cycles for these, which Pydantic's
+    serializer rejects.
+    """
+    if not defs:
+        return False
+
+    # Build adjacency: def_name -> set of def_names it references.
+    edges: dict[str, set[str]] = defaultdict(set)
+
+    def _collect_refs(obj: Any, source: str) -> None:
+        if isinstance(obj, dict):
+            ref = obj.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/$defs/"):
+                edges[source].add(ref.split("/")[-1])
+            for v in obj.values():
+                _collect_refs(v, source)
+        elif isinstance(obj, list):
+            for item in obj:
+                _collect_refs(item, source)
+
+    for name, definition in defs.items():
+        _collect_refs(definition, name)
+
+    # DFS cycle detection.
+    UNVISITED, IN_STACK, DONE = 0, 1, 2
+    state: dict[str, int] = defaultdict(int)
+
+    def _has_cycle(node: str) -> bool:
+        state[node] = IN_STACK
+        for neighbor in edges.get(node, ()):
+            if neighbor not in defs:
+                continue
+            if state[neighbor] == IN_STACK:
+                return True
+            if state[neighbor] == UNVISITED and _has_cycle(neighbor):
+                return True
+        state[node] = DONE
+        return False
+
+    return any(state[name] == UNVISITED and _has_cycle(name) for name in defs)
+
+
 def dereference_refs(schema: dict[str, Any]) -> dict[str, Any]:
     """Resolve all $ref references in a JSON schema by inlining definitions.
 
@@ -35,6 +82,13 @@ def dereference_refs(schema: dict[str, Any]) -> dict[str, Any]:
         >>> resolved = dereference_refs(schema)
         >>> # Result: {"properties": {"cat": {"enum": ["a", "b"], "type": "string", "default": "a"}}}
     """
+    # Circular $defs can't be fully inlined — jsonref.replace_refs produces
+    # Python dicts with object-identity cycles that Pydantic's model_dump
+    # rejects with "Circular reference detected (id repeated)".
+    # Detect cycles up front and fall back to root-only resolution.
+    if _defs_have_cycles(schema.get("$defs", {})):
+        return resolve_root_ref(schema)
+
     try:
         # Use jsonref to resolve all $ref references
         # proxies=False returns plain dicts (not proxy objects)


### PR DESCRIPTION
## Summary

This PR fixes issue #3153 where the backport of `dereference_refs()` to v2 was incomplete. The function was added but was missing critical cycle detection logic, causing circular references to fail with "ValueError: Circular reference detected" instead of gracefully falling back to root-only resolution.

## Changes

- Added `_defs_have_cycles()` function to detect circular references in $defs before attempting dereferencing
- Added cycle detection at the start of `dereference_refs()` to fall back to `resolve_root_ref()` for circular schemas
- This prevents `jsonref.replace_refs()` from creating Python object cycles that fail JSON serialization

## Testing

- All existing tests in `tests/utilities/test_json_schema.py::TestDereferenceRefs` pass
- Verified circular reference schemas now serialize correctly to JSON
- Code style checks pass (black, ruff)

## Related

- Fixes #3153
- Backports cycle detection logic from main branch
