### PR TITLE
fix: support ImageContent, AudioContent, and ResourceLink in Message

### DIFF
--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -17,9 +17,12 @@ if TYPE_CHECKING:
 import mcp.types
 from mcp import GetPromptResult
 from mcp.types import (
+    AudioContent,
     EmbeddedResource,
     Icon,
+    ImageContent,
     PromptMessage,
+    ResourceLink,
     TextContent,
 )
 from mcp.types import Prompt as SDKPrompt
@@ -61,7 +64,7 @@ class Message(pydantic.BaseModel):
     """
 
     role: Literal["user", "assistant"]
-    content: TextContent | EmbeddedResource
+    content: TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource
 
     def __init__(
         self,
@@ -72,13 +75,20 @@ class Message(pydantic.BaseModel):
 
         Args:
             content: The message content. str passes through directly.
-                     TextContent and EmbeddedResource pass through.
-                     Other types (dict, list, BaseModel) are JSON-serialized.
+                     MCP content types (TextContent, ImageContent,
+                     AudioContent, ResourceLink, EmbeddedResource) pass
+                     through. Other types (dict, list, BaseModel) are
+                     JSON-serialized.
             role: The message role, either "user" or "assistant".
         """
-        # Handle already-wrapped content types
-        if isinstance(content, (TextContent, EmbeddedResource)):
-            normalized_content: TextContent | EmbeddedResource = content
+        # Handle already-wrapped MCP content types
+        if isinstance(
+            content,
+            (TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource),
+        ):
+            normalized_content: (
+                TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource
+            ) = content
         elif isinstance(content, str):
             normalized_content = TextContent(type="text", text=content)
         else:

--- a/tests/prompts/test_prompt.py
+++ b/tests/prompts/test_prompt.py
@@ -493,6 +493,38 @@ class TestMessage:
         assert isinstance(mcp_msg.content, TextContent)
         assert mcp_msg.content.text == "Hello"
 
+    def test_message_passes_through_image_content(self):
+        """Test Message passes through ImageContent without JSON-serializing it."""
+        from mcp.types import ImageContent
+
+        image = ImageContent(type="image", data="iVBOR...", mimeType="image/png")
+        msg = Message(image)
+        assert isinstance(msg.content, ImageContent)
+        assert msg.content.data == "iVBOR..."
+        assert msg.content.mimeType == "image/png"
+
+        # Round-trip through MCP PromptMessage
+        mcp_msg = msg.to_mcp_prompt_message()
+        assert isinstance(mcp_msg.content, ImageContent)
+
+    def test_message_passes_through_audio_content(self):
+        """Test Message passes through AudioContent without JSON-serializing it."""
+        from mcp.types import AudioContent
+
+        audio = AudioContent(type="audio", data="AAAA...", mimeType="audio/wav")
+        msg = Message(audio)
+        assert isinstance(msg.content, AudioContent)
+        assert msg.content.data == "AAAA..."
+
+    def test_message_passes_through_resource_link(self):
+        """Test Message passes through ResourceLink without JSON-serializing it."""
+        from mcp.types import ResourceLink
+
+        link = ResourceLink(type="resource_link", uri="file:///test.txt")
+        msg = Message(link)
+        assert isinstance(msg.content, ResourceLink)
+        assert str(msg.content.uri) == "file:///test.txt"
+
 
 class TestPromptResult:
     def test_promptresult_from_string(self):


### PR DESCRIPTION
## Summary

Fixes #3395 — `Message` class silently JSON-serializes `ImageContent` and `AudioContent` instead of preserving them.

## Problem

`Message.content` only accepts `TextContent | EmbeddedResource`. When a `PromptMessage` containing `ImageContent` (or `AudioContent`) is converted to a `Message` — as happens in `ProxyPrompt.render()` — the content falls through to JSON serialization, producing a `TextContent` with the image/audio object as a JSON string.

This breaks the MCP contract and causes the `prompts-get-with-image` conformance test to fail.

## Fix

- Expand `Message.content` type annotation to include all MCP content block types: `TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource`
- Pass these types through in `__init__` instead of JSON-serializing them
- Add tests for `ImageContent`, `AudioContent`, and `ResourceLink` passthrough

The change is backward-compatible — existing `TextContent`, `EmbeddedResource`, `str`, and auto-serialized types work exactly as before.