### PR TITLE
fix: propagate tags from skill frontmatter to SkillResource

### DIFF
--- a/src/fastmcp/server/providers/skills/skill_provider.py
+++ b/src/fastmcp/server/providers/skills/skill_provider.py
@@ -290,6 +290,7 @@ class SkillProvider(Provider):
                 name=f"{skill.name}/{self._main_file_name}",
                 description=skill.description,
                 mime_type="text/markdown",
+                tags=set(skill.frontmatter.get("tags", [])),
                 skill_info=skill,
                 is_manifest=False,
             )
@@ -362,6 +363,7 @@ class SkillProvider(Provider):
                 name=f"{skill_name}/{self._main_file_name}",
                 description=skill.description,
                 mime_type="text/markdown",
+                tags=set(skill.frontmatter.get("tags", [])),
                 skill_info=skill,
                 is_manifest=False,
             )


### PR DESCRIPTION
## Summary

Fixes #3402.

`SkillsProvider` (and `SkillProvider`) were constructing `SkillResource` objects without populating the `tags` field, even when `tags` were declared in the skill's YAML frontmatter. This prevented tag-based filtering from working for skill resources.

### Root cause

In `skill_provider.py`, both the `list_resources()` and `get_resource()` paths constructed `SkillResource` with an empty/default `tags` set:

```python
SkillResource(
    uri=AnyUrl(f"skill://{skill.name}/{self._main_file_name}"),
    name=f"{skill.name}/{self._main_file_name}",
    description=skill.description,
    mime_type="text/markdown",
    # tags were never passed — defaults to set()
    skill_info=skill,
    is_manifest=False,
)
```

The `tags` data is available in `skill.frontmatter` (parsed from YAML frontmatter), but was never forwarded to `SkillResource`.

### Fix

Pass `tags=set(skill.frontmatter.get("tags", []))` in both construction sites (list and get paths). The manifest resources are intentionally left without tags, as they represent directory listings rather than the skill content itself.

### Testing

To reproduce before fix:
```markdown
---
description: My skill
tags: [python, testing]
---
```
```python
resources = await provider.list_resources()
# resources[0].tags == set()  # wrong — should be {"python", "testing"}
```

After fix, `resources[0].tags == {"python", "testing"}`.
