### PR TITLE
Bind Discord token verification to configured client_id

### DIFF
--- a/src/fastmcp/server/auth/providers/discord.py
+++ b/src/fastmcp/server/auth/providers/discord.py
@@ -48,6 +48,7 @@ class DiscordTokenVerifier(TokenVerifier):
     def __init__(
         self,
         *,
+        expected_client_id: str,
         required_scopes: list[str] | None = None,
         timeout_seconds: int = 10,
         http_client: httpx.AsyncClient | None = None,
@@ -55,6 +56,7 @@ class DiscordTokenVerifier(TokenVerifier):
         """Initialize the Discord token verifier.
 
         Args:
+            expected_client_id: Expected Discord OAuth client ID for audience binding
             required_scopes: Required OAuth scopes (e.g., ['email'])
             timeout_seconds: HTTP request timeout
             http_client: Optional httpx.AsyncClient for connection pooling. When provided,
@@ -62,6 +64,7 @@ class DiscordTokenVerifier(TokenVerifier):
                 lifecycle. When None (default), a fresh client is created per call.
         """
         super().__init__(required_scopes=required_scopes)
+        self.expected_client_id = expected_client_id
         self.timeout_seconds = timeout_seconds
         self._http_client = http_client
 
@@ -121,6 +124,13 @@ class DiscordTokenVerifier(TokenVerifier):
                 user_data = token_info.get("user", {})
                 application = token_info.get("application") or {}
                 client_id = str(application.get("id", "unknown"))
+                if client_id != self.expected_client_id:
+                    logger.debug(
+                        "Discord token app ID mismatch: expected %s, got %s",
+                        self.expected_client_id,
+                        client_id,
+                    )
+                    return None
 
                 # Create AccessToken with Discord user info
                 access_token = AccessToken(
@@ -235,6 +245,7 @@ class DiscordProvider(OAuthProxy):
 
         # Create Discord token verifier
         token_verifier = DiscordTokenVerifier(
+            expected_client_id=client_id,
             required_scopes=required_scopes_final,
             timeout_seconds=timeout_seconds,
             http_client=http_client,

--- a/tests/server/auth/providers/test_discord.py
+++ b/tests/server/auth/providers/test_discord.py
@@ -1,9 +1,11 @@
 """Tests for Discord OAuth provider."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from key_value.aio.stores.memory import MemoryStore
 
-from fastmcp.server.auth.providers.discord import DiscordProvider
+from fastmcp.server.auth.providers.discord import DiscordProvider, DiscordTokenVerifier
 
 
 @pytest.fixture
@@ -81,3 +83,45 @@ class TestDiscordProvider:
 
         # Provider should initialize successfully with these scopes
         assert provider is not None
+
+    def test_token_verifier_is_bound_to_provider_client_id(
+        self, memory_storage: MemoryStore
+    ):
+        """Test DiscordProvider binds token verifier to the configured client ID."""
+        provider = DiscordProvider(
+            client_id="expected-client-id",
+            client_secret="GOCSPX-test123",
+            base_url="https://myserver.com",
+            jwt_signing_key="test-secret",
+            client_storage=memory_storage,
+        )
+
+        verifier = provider._token_validator
+        assert isinstance(verifier, DiscordTokenVerifier)
+        assert verifier.expected_client_id == "expected-client-id"
+
+
+class TestDiscordTokenVerifier:
+    """Test DiscordTokenVerifier behavior."""
+
+    async def test_rejects_token_from_different_discord_application(self):
+        """Token must be bound to configured Discord client_id."""
+        verifier = DiscordTokenVerifier(expected_client_id="expected-app-id")
+
+        mock_client = AsyncMock()
+        token_info_response = MagicMock()
+        token_info_response.status_code = 200
+        token_info_response.json.return_value = {
+            "application": {"id": "different-app-id"},
+            "user": {"id": "123"},
+            "scopes": ["identify"],
+        }
+        mock_client.get.return_value = token_info_response
+
+        with patch(
+            "fastmcp.server.auth.providers.discord.httpx.AsyncClient"
+        ) as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            result = await verifier.verify_token("token")
+
+        assert result is None

--- a/tests/server/auth/providers/test_http_client.py
+++ b/tests/server/auth/providers/test_http_client.py
@@ -245,7 +245,10 @@ class TestDiscordHttpClient:
         from fastmcp.server.auth.providers.discord import DiscordTokenVerifier
 
         client = httpx.AsyncClient()
-        verifier = DiscordTokenVerifier(http_client=client)
+        verifier = DiscordTokenVerifier(
+            expected_client_id="test-client-id",
+            http_client=client,
+        )
         assert verifier._http_client is client
 
 


### PR DESCRIPTION
### Motivation

- Discord token verification previously accepted any access token that passed `/api/oauth2/@me` and had the required scopes regardless of which Discord application minted the token, breaking audience/client binding and enabling cross-app authentication bypass. 

### Description

- Add an `expected_client_id` parameter to `DiscordTokenVerifier` and store it on the verifier. 
- During `verify_token`, compare the `application.id` returned by Discord with `expected_client_id` and reject the token if they do not match. 
- Thread the provider `client_id` into `DiscordTokenVerifier` from `DiscordProvider` so provider-based usage enforces the client/audience binding automatically. 
- Update tests to assert the verifier is bound to the provider `client_id`, add a test that rejects tokens from a different Discord application, and update an existing http-client test to satisfy the new verifier signature.

### Testing

- Ran `uv sync` successfully. 
- Ran the full test suite with `uv run pytest -n auto`; the run surfaced unrelated, pre-existing timeouts/failures in this environment (11 failed, 4679 passed, 1 error) so the repository-wide run is not green here but failures are not related to the changes. 
- Ran targeted tests `uv run pytest tests/server/auth/providers/test_discord.py tests/server/auth/providers/test_http_client.py -n auto` and both passed (`26 passed`). 
- Ran static hooks `uv run prek run --all-files` which failed to initialize external prettier hook due to network access to pre-commit mirror (environment restriction), not due to code linting errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab03c654c0832db03ecd369d228e54)