### PR TITLE
Enforce token scopes in WorkOS verifier to prevent scope bypass

### DIFF
--- a/src/fastmcp/server/auth/providers/workos.py
+++ b/src/fastmcp/server/auth/providers/workos.py
@@ -83,12 +83,26 @@ class WorkOSTokenVerifier(TokenVerifier):
                     return None
 
                 user_data = response.json()
+                token_scopes = (
+                    parse_scopes(user_data.get("scope") or user_data.get("scopes"))
+                    or []
+                )
+
+                if self.required_scopes and not all(
+                    scope in token_scopes for scope in self.required_scopes
+                ):
+                    logger.debug(
+                        "WorkOS token missing required scopes. required=%s actual=%s",
+                        self.required_scopes,
+                        token_scopes,
+                    )
+                    return None
 
                 # Create AccessToken with WorkOS user info
                 return AccessToken(
                     token=token,
                     client_id=str(user_data.get("sub", "unknown")),
-                    scopes=self.required_scopes or [],
+                    scopes=token_scopes,
                     expires_at=None,  # Will be set from token introspection if needed
                     claims={
                         "sub": user_data.get("sub"),

--- a/tests/server/auth/providers/test_workos.py
+++ b/tests/server/auth/providers/test_workos.py
@@ -5,10 +5,15 @@ from urllib.parse import urlparse
 import httpx
 import pytest
 from key_value.aio.stores.memory import MemoryStore
+from pytest_httpx import HTTPXMock
 
 from fastmcp import Client, FastMCP
 from fastmcp.client.transports import StreamableHttpTransport
-from fastmcp.server.auth.providers.workos import AuthKitProvider, WorkOSProvider
+from fastmcp.server.auth.providers.workos import (
+    AuthKitProvider,
+    WorkOSProvider,
+    WorkOSTokenVerifier,
+)
 from fastmcp.utilities.tests import HeadlessOAuth, run_server_async
 
 
@@ -165,3 +170,50 @@ class TestAuthKitProvider:
     #     assert tools is not None
     #     assert len(tools) > 0
     #     assert "add" in tools
+
+
+class TestWorkOSTokenVerifierScopes:
+    async def test_verify_token_rejects_missing_required_scopes(
+        self, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            url="https://test.authkit.app/oauth2/userinfo",
+            status_code=200,
+            json={
+                "sub": "user_123",
+                "email": "user@example.com",
+                "scope": "openid profile",
+            },
+        )
+
+        verifier = WorkOSTokenVerifier(
+            authkit_domain="https://test.authkit.app",
+            required_scopes=["read:secrets"],
+        )
+
+        result = await verifier.verify_token("token")
+
+        assert result is None
+
+    async def test_verify_token_returns_actual_token_scopes(
+        self, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            url="https://test.authkit.app/oauth2/userinfo",
+            status_code=200,
+            json={
+                "sub": "user_123",
+                "email": "user@example.com",
+                "scope": "openid profile read:secrets",
+            },
+        )
+
+        verifier = WorkOSTokenVerifier(
+            authkit_domain="https://test.authkit.app",
+            required_scopes=["read:secrets"],
+        )
+
+        result = await verifier.verify_token("token")
+
+        assert result is not None
+        assert result.scopes == ["openid", "profile", "read:secrets"]


### PR DESCRIPTION
### Motivation

- The WorkOS token verifier previously stamped `AccessToken.scopes` from the configured `required_scopes` without inspecting the token/userinfo response, enabling under-scoped tokens to bypass FastMCP scope checks.

### Description

- Parse `scope`/`scopes` from the WorkOS `/oauth2/userinfo` response with `parse_scopes` and use those values as the token's real scopes.
- Reject verification when any configured `required_scopes` are missing from the token's scopes and return `None` in that case.
- Populate `AccessToken.scopes` with the parsed token scopes (instead of `required_scopes`).
- Add unit tests to assert rejection for missing required scopes and that returned `AccessToken.scopes` reflects actual token scopes, and run code formatting fixes.

### Testing

- Ran `uv sync` which completed successfully.
- Ran the full test suite via `uv run pytest -n auto`, which exercised the repo but encountered many unrelated timeouts/errors (summary: 4676 passed, 14 failed, 2 errors, 2 skipped, 14 xfailed, 22 warnings); failures appear unrelated to this change.
- Ran focused tests `uv run pytest tests/server/auth/providers/test_workos.py` and they passed (`7 passed`).
- Ran `ruff` to auto-fix import formatting and ran formatter; formatting issues were resolved.
- `uv run prek run --all-files` could not complete due to pre-commit hook initialization failing from network restrictions (failed to clone hook repo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab1c478a10832d8d6548a63c0ae876)