### PR TITLE
Prevent skills manifests from hashing files outside the skill directory

### DIFF
--- a/src/fastmcp/server/providers/skills/_common.py
+++ b/src/fastmcp/server/providers/skills/_common.py
@@ -86,16 +86,22 @@ def compute_file_hash(path: Path) -> str:
 def scan_skill_files(skill_dir: Path) -> list[SkillFileInfo]:
     """Scan a skill directory for all files."""
     files = []
+    resolved_skill_dir = skill_dir.resolve()
+
     # Sort for deterministic ordering across platforms
     for file_path in sorted(skill_dir.rglob("*")):
         if file_path.is_file():
+            resolved_file_path = file_path.resolve()
+            if not resolved_file_path.is_relative_to(resolved_skill_dir):
+                continue
+
             rel_path = file_path.relative_to(skill_dir)
             files.append(
                 SkillFileInfo(
                     # Use POSIX paths for cross-platform URI consistency
                     path=rel_path.as_posix(),
-                    size=file_path.stat().st_size,
-                    hash=compute_file_hash(file_path),
+                    size=resolved_file_path.stat().st_size,
+                    hash=compute_file_hash(resolved_file_path),
                 )
             )
     return files

--- a/tests/server/providers/test_skills_provider.py
+++ b/tests/server/providers/test_skills_provider.py
@@ -169,6 +169,28 @@ This is my skill content.
             assert "reference.md" in paths
             assert "scripts/helper.py" in paths
 
+    async def test_manifest_ignores_symlink_target_outside_skill(self, tmp_path: Path):
+        skill_dir = tmp_path / "symlinked-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Skill\n")
+
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("secret")
+        (skill_dir / "leak.txt").symlink_to(outside_file)
+
+        mcp = FastMCP("Test")
+        mcp.add_provider(SkillProvider(skill_path=skill_dir))
+
+        async with Client(mcp) as client:
+            result = await client.read_resource(
+                AnyUrl("skill://symlinked-skill/_manifest")
+            )
+            manifest = json.loads(result[0].text)
+
+        paths = {f["path"] for f in manifest["files"]}
+        assert "SKILL.md" in paths
+        assert "leak.txt" not in paths
+
     async def test_read_supporting_file_via_template(self, single_skill_dir: Path):
         mcp = FastMCP("Test")
         mcp.add_provider(SkillProvider(skill_path=single_skill_dir))


### PR DESCRIPTION
### Motivation

- The skill scanner previously followed filesystem entries (including symlinks) and computed sizes/hashes unconditionally, which allowed a symlink inside a skill folder to disclose hash/size metadata for files outside the skill root via the generated manifest.
- This is an information disclosure risk because later read-time path checks block access but the manifest already leaked an existence/content oracle (hashes), so discovery must enforce the skill directory boundary.

### Description

- Tighten `scan_skill_files` to resolve the skill root and each discovered file, and skip any discovered entry whose resolved target is not inside the resolved skill directory before computing `stat()` or hashing; sizes/hashes are now computed from the resolved in-skill path only. (See `src/fastmcp/server/providers/skills/_common.py`.)
- Preserve deterministic discovery ordering and POSIX-style relative paths when including legitimate in-skill files.
- Add a regression test that creates a symlink inside a skill pointing to a file outside the skill directory and asserts the manifest excludes that symlinked external target. (See `tests/server/providers/test_skills_provider.py`.)

### Testing

- Ran `uv sync` and dependency resolution succeeded.
- Ran `uv run ruff check` and `uv run ruff format` for the modified files and fixed formatting; `ruff check` passed on the changed files.
- Ran `uv run pytest tests/server/providers/test_skills_provider.py -n auto` and the skill-provider tests (including the new regression test) passed (`43 passed`).
- Ran the full test suite with `uv run pytest -n auto`; unrelated existing tests in the environment showed several timeouts/failures (external to this change) while the modified skill-provider tests passed locally.  
- `uv run prek run --all-files` failed to initialize hooks due to network restrictions fetching a pre-commit hook, not due to code issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aaf416bdc8832d97222bcb9555b859)