### PR TITLE
Harden fastmcp metadata parsing in proxy paths

### DIFF
--- a/src/fastmcp/utilities/components.py
+++ b/src/fastmcp/utilities/components.py
@@ -31,7 +31,13 @@ def get_fastmcp_metadata(meta: dict[str, Any] | None) -> FastMCPMeta:
     """
     if not meta:
         return {}
-    return cast(FastMCPMeta, meta.get("fastmcp") or meta.get("_fastmcp") or {})
+
+    for key in ("fastmcp", "_fastmcp"):
+        metadata = meta.get(key)
+        if isinstance(metadata, dict):
+            return cast(FastMCPMeta, metadata)
+
+    return {}
 
 
 def _convert_set_default_none(maybe_set: set[T] | Sequence[T] | None) -> set[T]:

--- a/tests/utilities/test_components.py
+++ b/tests/utilities/test_components.py
@@ -13,6 +13,7 @@ from fastmcp.utilities.components import (
     FastMCPComponent,
     FastMCPMeta,
     _convert_set_default_none,
+    get_fastmcp_metadata,
 )
 
 
@@ -249,6 +250,25 @@ class TestKeyPrefix:
 
             assert len(w) == 0
             assert WithPrefix.make_key("test") == "custom:test"
+
+
+class TestGetFastMCPMetadata:
+    """Tests for get_fastmcp_metadata helper."""
+
+    def test_returns_fastmcp_namespace_when_dict(self):
+        meta = {"fastmcp": {"tags": ["a"]}, "_fastmcp": {"tags": ["b"]}}
+
+        assert get_fastmcp_metadata(meta) == {"tags": ["a"]}
+
+    def test_falls_back_to_legacy_namespace_when_dict(self):
+        meta = {"fastmcp": "invalid", "_fastmcp": {"tags": ["legacy"]}}
+
+        assert get_fastmcp_metadata(meta) == {"tags": ["legacy"]}
+
+    def test_ignores_non_dict_metadata(self):
+        assert get_fastmcp_metadata({"fastmcp": "invalid"}) == {}
+        assert get_fastmcp_metadata({"fastmcp": ["invalid"]}) == {}
+        assert get_fastmcp_metadata({"_fastmcp": "invalid"}) == {}
 
 
 class TestComponentEnableDisable:


### PR DESCRIPTION
### Motivation

- Proxy component ingestion assumed `meta["fastmcp"]` (or legacy `_fastmcp`) is always a mapping, so a remote server returning a non-dict value could cause `.get("tags")` to raise and crash proxy listing/ingestion paths.
- The change defends against malformed upstream metadata by treating non-dict `fastmcp`/`_fastmcp` values as absent, restoring the previous tolerant behavior and preventing a remote DoS vector.

### Description

- Make `get_fastmcp_metadata(meta)` defensive: it now returns the first namespace value that is a `dict` and otherwise returns `{}` so non-dict upstream values are ignored.
- Add unit tests for the helper to verify valid `fastmcp` dict is returned, legacy `_fastmcp` is used when appropriate, and non-dict values are ignored.
- Files changed: `src/fastmcp/utilities/components.py` (metadata parsing logic) and `tests/utilities/test_components.py` (new tests).

Example usage after the change:

```python
meta = {"fastmcp": "not-a-dict", "_fastmcp": {"tags": ["legacy"]}}
metadata = get_fastmcp_metadata(meta)
tags = metadata.get("tags", [])  # safe, legacy tags preserved
```

### Testing

- Ran `uv sync` successfully to prepare the environment.
- Ran the full test suite with `uv run pytest -n auto`, which surfaced unrelated existing failures/timeouts in this environment (several unrelated tests failed); these failures are not caused by this patch.
- Ran focused tests covering the change with `uv run pytest tests/utilities/test_components.py tests/server/providers/proxy/test_proxy_server.py -n auto`, which completed successfully (the component/proxy tests passed).
- Attempted `uv run prek run --all-files` but hook initialization failed due to external network access when fetching hooks (pre-commit mirror bootstrap error), so lint hooks were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aaf44c542c832da7e42da287ca0389)