### PR TITLE
Return after `McpError` in initialization middleware to prevent fallthrough

### DIFF
--- a/src/fastmcp/server/low_level.py
+++ b/src/fastmcp/server/low_level.py
@@ -144,6 +144,7 @@ class MiddlewareServerSession(ServerSession):
                             "Cannot send error response as response was already sent.",
                             exc_info=e,
                         )
+                    return None
 
         # Fall through to default handling (task methods now handled via registered handlers)
         return await super()._received_request(responder)


### PR DESCRIPTION
### Motivation
- Fix a security/regression where `McpError` raised from initialization middleware was sent to the client but execution fell through into the default `ServerSession` handler, allowing the same initialize request to be processed despite middleware rejection.

### Description
- Stop processing after handling a middleware `McpError` in `MiddlewareServerSession._received_request` by returning `None` once the error response is sent (prevents fallthrough into `super()._received_request`).

### Testing
- Ran `uv sync` and the full test suite with `uv run pytest -n auto` (the repo’s test suite completed but includes unrelated failures/timeouts in this environment); the specific middleware initialization tests ran cleanly with `uv run pytest tests/server/middleware/test_initialization_middleware.py -q` which reported `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab007a230c832d873c2967e83b23e5)