### PR TITLE
Handle Windows npx detection when npx.cmd is missing

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -54,7 +54,7 @@ def _get_npx_command():
             try:
                 subprocess.run([cmd, "--version"], check=True, capture_output=True)
                 return cmd
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, FileNotFoundError):
                 continue
         return None
     return "npx"  # On Unix-like systems, just use npx

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -441,6 +441,23 @@ class TestWindowsSpecific:
             assert mock_run.call_count == 2
 
     @patch("subprocess.run")
+    def test_get_npx_command_windows_cmd_missing(self, mock_run):
+        """Test npx command detection continues when npx.cmd is missing."""
+        from fastmcp.cli.cli import _get_npx_command
+
+        with patch("sys.platform", "win32"):
+            # Missing npx.cmd should not abort detection
+            mock_run.side_effect = [
+                FileNotFoundError("npx.cmd not found"),
+                Mock(returncode=0),
+            ]
+
+            result = _get_npx_command()
+
+            assert result == "npx.exe"
+            assert mock_run.call_count == 2
+
+    @patch("subprocess.run")
     def test_get_npx_command_windows_fallback(self, mock_run):
         """Test npx command detection on Windows with plain npx."""
         from fastmcp.cli.cli import _get_npx_command


### PR DESCRIPTION
### Motivation
- On Windows, `_get_npx_command()` probed `npx.cmd`, `npx.exe`, and `npx` using `subprocess.run(..., shell=False)`, but only caught `subprocess.CalledProcessError`, so a missing executable raised `FileNotFoundError` and aborted the probe early instead of falling back to the next candidate.

### Description
- Continue probing when the candidate binary is absent by catching `FileNotFoundError` in the same except block as `CalledProcessError`, and add a focused unit test `test_get_npx_command_windows_cmd_missing` that simulates `FileNotFoundError` for `npx.cmd` and verifies fallback to `npx.exe`.

Before/after (conceptual):
`except subprocess.CalledProcessError:` -> `except (subprocess.CalledProcessError, FileNotFoundError):`

### Testing
- Ran `uv sync` (succeeded), ran the full test suite `uv run pytest -n auto` (environment showed unrelated timeouts/integration failures outside this CLI change), and ran the focused CLI tests with `uv run pytest tests/cli/test_cli.py -k npx_command` which passed (6 passed); `uv run prek run --all-files` failed to init hooks due to external network access to a git dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab0f75a164832db09251bc8928e502)