### PR TITLE
Escape client_id in OAuth consent advanced details

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy/ui.py
+++ b/src/fastmcp/server/auth/oauth_proxy/ui.py
@@ -84,7 +84,7 @@ def create_consent_html(
     detail_rows = [
         ("Application Name", html_module.escape(client_name or client_id)),
         ("Application Website", html_module.escape(client_website_url or "N/A")),
-        ("Application ID", client_id),
+        ("Application ID", html_module.escape(client_id)),
         ("Redirect URI", redirect_uri_escaped),
         (
             "Requested Scopes",

--- a/tests/server/auth/oauth_proxy/test_ui.py
+++ b/tests/server/auth/oauth_proxy/test_ui.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse
 
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
-from fastmcp.server.auth.oauth_proxy.ui import create_error_html
+from fastmcp.server.auth.oauth_proxy.ui import create_consent_html, create_error_html
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 
 
@@ -99,3 +99,21 @@ class TestErrorPageRendering:
         assert b"invalid_scope" in response.body
         assert b"doesn&#x27;t exist" in response.body  # HTML-escaped apostrophe
         assert b"OAuth Error" in response.body
+
+
+class TestConsentPageRendering:
+    """Test consent page rendering and escaping."""
+
+    def test_create_consent_html_escapes_client_id_in_details(self):
+        """Test that Application ID is escaped in advanced details."""
+
+        html = create_consent_html(
+            client_id='evil<img src=x onerror=alert("xss")>',
+            redirect_uri="https://example.com/callback",
+            scopes=["read"],
+            txn_id="txn",
+            csrf_token="csrf",
+        )
+
+        assert 'evil<img src=x onerror=alert("xss")>' not in html
+        assert "evil&lt;img src=x onerror=alert(&quot;xss&quot;)&gt;" in html


### PR DESCRIPTION
### Motivation

- The consent page was rendering the `client_id` raw in the advanced details section, reintroducing an XSS regression when attacker-controlled client IDs are present; this change restores consistent escaping for user-controlled fields.

### Description

- Escape `client_id` before rendering the "Application ID" detail in `create_consent_html` so all advanced detail values are HTML-escaped (file: `src/fastmcp/server/auth/oauth_proxy/ui.py`).
- Add a focused unit test `TestConsentPageRendering::test_create_consent_html_escapes_client_id_in_details` that verifies a malicious `client_id` is not rendered as raw HTML (file: `tests/server/auth/oauth_proxy/test_ui.py`).

### Testing

- Ran `uv sync` which completed successfully.
- Ran the full test suite with `uv run pytest -n auto`, which exposed unrelated flaky/timeouts in this environment but was used to validate the PR initially; the failures were not related to the UI change.
- Ran targeted tests with `uv run pytest tests/server/auth/oauth_proxy/test_ui.py tests/server/auth/test_oauth_consent_page.py` and they passed (18 passed in ~3.3s).
- Ran `uv run prek run --all-files` which failed due to an external pre-commit hook fetch failing in the environment (`CONNECT tunnel failed, response 403`).

🤖 Generated with GPT-5.2-Codex

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab0d9f68b8832d8b8f41486e55a2e1)