### PR TITLE
Fix $ref output schema object detection regression

### DIFF
--- a/src/fastmcp/tools/function_parsing.py
+++ b/src/fastmcp/tools/function_parsing.py
@@ -83,18 +83,24 @@ def _is_object_schema(
 
     # Resolve local $ref definitions and recurse into the target schema.
     ref = schema.get("$ref")
-    if not isinstance(ref, str) or not ref.startswith("#/$defs/"):
+    if not isinstance(ref, str) or not ref.startswith("#/"):
         return False
 
     if ref in seen_refs:
         return False
 
-    definition_name = ref.removeprefix("#/$defs/")
-    definitions = root_schema.get("$defs")
-    if not isinstance(definitions, dict):
-        return False
+    # Walk the JSON Pointer path from the root schema, unescaping each
+    # token per RFC 6901 (~1 → /, ~0 → ~).
+    pointer = ref.removeprefix("#/")
+    segments = pointer.split("/")
+    target: Any = root_schema
+    for segment in segments:
+        unescaped = segment.replace("~1", "/").replace("~0", "~")
+        if not isinstance(target, dict) or unescaped not in target:
+            return False
+        target = target[unescaped]
 
-    target_schema = definitions.get(definition_name)
+    target_schema = target
     if not isinstance(target_schema, dict):
         return False
 

--- a/tests/server/providers/local_provider_tools/test_output_schema.py
+++ b/tests/server/providers/local_provider_tools/test_output_schema.py
@@ -11,6 +11,7 @@ from pydantic import AnyUrl, BaseModel, TypeAdapter
 from typing_extensions import TypeAliasType, TypedDict
 
 from fastmcp import FastMCP
+from fastmcp.tools.function_parsing import _is_object_schema
 from fastmcp.tools.tool import ToolResult
 from fastmcp.utilities.json_schema import compress_schema
 
@@ -308,3 +309,73 @@ class TestToolOutputSchema:
 
         result = await mcp.call_tool("alias_tool", {})
         assert result.structured_content == {"result": "foo"}
+
+
+class TestIsObjectSchemaRefResolution:
+    """Tests for $ref resolution in _is_object_schema, including JSON Pointer
+    escaping and nested $defs paths."""
+
+    def test_simple_ref_to_object(self):
+        schema = {
+            "$ref": "#/$defs/MyModel",
+            "$defs": {
+                "MyModel": {"type": "object", "properties": {"x": {"type": "int"}}}
+            },
+        }
+        assert _is_object_schema(schema) is True
+
+    def test_simple_ref_to_non_object(self):
+        schema = {
+            "$ref": "#/$defs/MyEnum",
+            "$defs": {"MyEnum": {"enum": ["a", "b"]}},
+        }
+        assert _is_object_schema(schema) is False
+
+    def test_nested_defs_path(self):
+        """Refs like #/$defs/Outer/$defs/Inner should walk into nested dicts."""
+        schema = {
+            "$ref": "#/$defs/Outer/$defs/Inner",
+            "$defs": {
+                "Outer": {
+                    "$defs": {
+                        "Inner": {
+                            "type": "object",
+                            "properties": {"y": {"type": "string"}},
+                        },
+                    },
+                },
+            },
+        }
+        assert _is_object_schema(schema) is True
+
+    def test_nested_defs_non_object(self):
+        schema = {
+            "$ref": "#/$defs/Outer/$defs/Inner",
+            "$defs": {
+                "Outer": {
+                    "$defs": {
+                        "Inner": {"type": "string"},
+                    },
+                },
+            },
+        }
+        assert _is_object_schema(schema) is False
+
+    def test_json_pointer_tilde_escape(self):
+        """~0 should unescape to ~ and ~1 should unescape to /."""
+        schema = {
+            "$ref": "#/$defs/has~1slash~0tilde",
+            "$defs": {"has/slash~tilde": {"type": "object", "properties": {}}},
+        }
+        assert _is_object_schema(schema) is True
+
+    def test_missing_nested_segment_returns_false(self):
+        schema = {
+            "$ref": "#/$defs/Outer/$defs/Missing",
+            "$defs": {
+                "Outer": {
+                    "$defs": {},
+                },
+            },
+        }
+        assert _is_object_schema(schema) is False


### PR DESCRIPTION
### Motivation

- A recent simplification treated any schema containing both `$ref` and `$defs` as an object, which causes non-object referenced schemas (for example Pydantic alias/enums) to be misclassified and skip wrapping.  This can lead to `ToolResult` runtime `ValueError` because `structured_content` must be a `dict`.
- The goal is to preserve wrapping for non-object referenced schemas by resolving local `#/$defs/...` targets before deciding whether a schema is object-shaped.

### Description

- Update `_is_object_schema` in `src/fastmcp/tools/function_parsing.py` to accept optional `_root_schema` and `_seen_refs` parameters and resolve local `#/$defs/...` references recursively instead of assuming `$ref + $defs` means an object. 
- Add cycle protection when resolving references so recursive definitions do not loop infinitely.
- Add a focused regression test `test_output_schema_wraps_non_object_ref_schema` in `tests/server/providers/local_provider_tools/test_output_schema.py` which uses a `TypeAliasType`/`Literal` alias to ensure non-object `$ref` schemas are wrapped (`x-fastmcp-wrap-result`) and runtime `structured_content` is a dict.
- Small test import updates to support the new test (`Literal`, `TypeAliasType`).

### Testing

- Ran `uv sync` successfully to install dependencies.
- Ran the full test suite with `uv run pytest -n auto`, which completed but reported unrelated failures in the container run (`12` failed, `1` error) that appear environment/timeout related and not caused by this change.
- Ran the focused tests for this change with `uv run pytest tests/server/providers/local_provider_tools/test_output_schema.py`, and all `20` tests passed.  `prek` static hook run `uv run prek run --all-files` failed to initialize due to a network/git clone error (403) and could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab04246f5c832d98414455f6e4a5ef)