### PR TITLE
Fix tool argument rename collisions with passthrough params

### DIFF
--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -554,12 +554,16 @@ class TransformedTool(Tool):
         # Additional validation: check for naming conflicts after transformation
         if transform_args:
             new_names = []
-            for old_name, transform in transform_args.items():
-                if not transform.hide:
-                    if transform.name is not NotSet:
-                        new_names.append(transform.name)
-                    else:
-                        new_names.append(old_name)
+            for old_name in parent_params:
+                transform = transform_args.get(old_name, ArgTransform())
+
+                if transform.hide:
+                    continue
+
+                if transform.name is not NotSet:
+                    new_names.append(transform.name)
+                else:
+                    new_names.append(old_name)
 
             # Check for duplicate names after transformation
             name_counts = {}

--- a/tests/tools/tool_transform/test_tool_transform.py
+++ b/tests/tools/tool_transform/test_tool_transform.py
@@ -482,6 +482,20 @@ def test_transform_args_creates_duplicate_names(add_tool):
         )
 
 
+def test_transform_args_collision_with_passthrough_name(add_tool):
+    """Test that renaming to a passthrough parameter name raises ValueError."""
+    with pytest.raises(
+        ValueError,
+        match="Multiple arguments would be mapped to the same names: old_y",
+    ):
+        Tool.from_tool(
+            add_tool,
+            transform_args={
+                "old_x": ArgTransform(name="old_y"),
+            },
+        )
+
+
 def test_function_without_kwargs_missing_params(add_tool):
     """Test that function missing required transformed parameters raises ValueError."""
 


### PR DESCRIPTION
### Motivation
- A rename in `TransformedTool.from_tool` only validated names present in `transform_args`, allowing a transformed argument to be renamed to a name that a passthrough (unchanged) parameter already uses, which silently overwrote/misrouted parameters when building the transformed schema and mapping.

### Description
- Change duplicate-name validation to iterate the full parent parameter set (`parent_params`) and apply explicit `transform_args` when present while treating missing entries as passthroughs by using `ArgTransform()` as the default.
- Skip hidden parameters during validation and treat explicit `ArgTransform.name` (or the original `old_name` when `NotSet`) as the effective name to check for duplicates.
- Add a focused regression test `test_transform_args_collision_with_passthrough_name` in `tests/tools/tool_transform/test_tool_transform.py` that asserts renaming `old_x` to `old_y` (when `old_y` is passthrough) raises `ValueError`.

### Testing
- Ran `uv sync` successfully to ensure dependencies were available in this environment.
- Ran the full test suite with `uv run pytest -n auto`, which exposed unrelated test failures in other areas (11 failed, 1 error); these failures are outside the scope of this focused fix.
- Ran the focused tests with `uv run pytest tests/tools/tool_transform/test_tool_transform.py -k "duplicate_names or collision_with_passthrough_name"` and the two selected tests passed.
- Ran `uv run prek run --all-files` which failed to initialize hooks due to network access to an external repo (repo fetch returned a 403), so lint/prek checks could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab355895ac832d8b72b3c8bee9b49f)