### PR TITLE
Guard default progress handler against total=0 notifications

### DIFF
--- a/src/fastmcp/client/progress.py
+++ b/src/fastmcp/client/progress.py
@@ -21,10 +21,13 @@ async def default_progress_handler(
         total: Optional total expected value
         message: Optional status message
     """
-    if total is not None:
+    if total not in (None, 0):
         # We have both progress and total
         percent = (progress / total) * 100
         progress_str = f"{progress}/{total} ({percent:.1f}%)"
+    elif total == 0:
+        # Avoid division by zero when a server reports an invalid total.
+        progress_str = f"{progress}/{total}"
     else:
         # We only have progress
         progress_str = f"{progress}"

--- a/tests/client/test_progress.py
+++ b/tests/client/test_progress.py
@@ -68,3 +68,9 @@ async def test_progress_handler_supplied_on_tool_call_overrides_default(
         await client.call_tool("progress_tool", {}, progress_handler=progress_handler)
 
     assert PROGRESS_MESSAGES == EXPECTED_PROGRESS_MESSAGES
+
+
+async def test_default_progress_handler_handles_zero_total() -> None:
+    from fastmcp.client.progress import default_progress_handler
+
+    await default_progress_handler(progress=1, total=0, message="starting")


### PR DESCRIPTION
### Motivation
- Prevent a client-side crash (ZeroDivisionError) in the default progress handler when an MCP server emits `total=0`, which could be abused by an untrusted or buggy server to abort tool execution.

### Description
- Update `default_progress_handler` to only compute a percentage when `total not in (None, 0)` and add an `elif total == 0` branch that logs the raw `progress/total` string without dividing, and add `test_default_progress_handler_handles_zero_total` to `tests/client/test_progress.py` to cover the case.

### Testing
- Ran `uv sync` (succeeded), ran the full suite with `uv run pytest -n auto` (the repository-wide run reported unrelated failures/timeouts), ran `uv run pytest tests/client/test_progress.py` (4 passed), and attempted `uv run prek run --all-files` which failed to initialize hooks due to external network access to `codespell` (403).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab3b5fdf54832d947f8ccf7803634c)