### PR TITLE
Validate workspace path is a directory in cursor install

### DIFF
--- a/src/fastmcp/cli/install/cursor.py
+++ b/src/fastmcp/cli/install/cursor.py
@@ -91,6 +91,9 @@ def install_cursor_workspace(
     if not workspace_path.exists():
         print(f"[red]Workspace directory does not exist: {workspace_path}[/red]")
         return False
+    if not workspace_path.is_dir():
+        print(f"[red]Workspace path is not a directory: {workspace_path}[/red]")
+        return False
 
     # Create .cursor directory in workspace
     cursor_dir = workspace_path / ".cursor"

--- a/tests/cli/test_cursor.py
+++ b/tests/cli/test_cursor.py
@@ -9,6 +9,7 @@ from fastmcp.cli.install.cursor import (
     cursor_command,
     generate_cursor_deeplink,
     install_cursor,
+    install_cursor_workspace,
     open_deeplink,
 )
 from fastmcp.mcp_config import StdioMCPServer
@@ -355,6 +356,20 @@ class TestInstallCursor:
         assert result is False
         # Verify failure message was printed
         mock_print.assert_called()
+
+    def test_install_cursor_workspace_path_is_file(self, tmp_path):
+        """Test that passing a file as workspace_path returns False."""
+        file_path = tmp_path / "somefile.txt"
+        file_path.write_text("hello")
+
+        result = install_cursor_workspace(
+            file=Path("/path/to/server.py"),
+            server_object=None,
+            name="test-server",
+            workspace_path=file_path,
+        )
+
+        assert result is False
 
     def test_install_cursor_deduplicate_packages(self):
         """Test that duplicate packages are deduplicated."""


### PR DESCRIPTION
`fastmcp install cursor --workspace` checked that the path exists but not that it's a directory. Passing a file path caused an unclear OS error when trying to create `.cursor/mcp.json` inside it. Now returns a clear error message.

Closes #3426