### PR TITLE
Redact sensitive headers in OpenAPI provider debug logging

### DIFF
--- a/src/fastmcp/server/providers/openapi/components.py
+++ b/src/fastmcp/server/providers/openapi/components.py
@@ -29,15 +29,23 @@ from fastmcp.utilities.openapi.director import RequestDirector
 if TYPE_CHECKING:
     from fastmcp.server import Context
 
-_SENSITIVE_HEADERS = frozenset(
-    {"authorization", "x-api-key", "cookie", "proxy-authorization"}
+_SAFE_HEADERS = frozenset(
+    {
+        "accept",
+        "accept-encoding",
+        "accept-language",
+        "cache-control",
+        "connection",
+        "content-length",
+        "content-type",
+        "host",
+        "user-agent",
+    }
 )
 
 
 def _redact_headers(headers: httpx.Headers) -> dict[str, str]:
-    return {
-        k: "***" if k.lower() in _SENSITIVE_HEADERS else v for k, v in headers.items()
-    }
+    return {k: v if k.lower() in _SAFE_HEADERS else "***" for k, v in headers.items()}
 
 
 __all__ = [

--- a/tests/server/providers/openapi/test_openapi_features.py
+++ b/tests/server/providers/openapi/test_openapi_features.py
@@ -988,9 +988,9 @@ class TestValidateOutput:
 
 
 class TestRedactHeaders:
-    """Test that sensitive headers are redacted in debug logging."""
+    """Test that non-safe headers are redacted in debug logging."""
 
-    def test_sensitive_headers_are_redacted(self):
+    def test_known_sensitive_headers_are_redacted(self):
         headers = httpx.Headers(
             {
                 "Authorization": "Bearer secret-token",
@@ -1009,7 +1009,21 @@ class TestRedactHeaders:
         assert redacted["content-type"] == "application/json"
         assert redacted["accept"] == "text/html"
 
-    def test_no_sensitive_headers(self):
+    def test_arbitrary_auth_headers_are_redacted(self):
+        """Arbitrary header names (e.g. OpenAPI apiKey-in-header) are redacted."""
+        headers = httpx.Headers(
+            {
+                "X-Custom-Token": "secret",
+                "X-My-Service-Key": "also-secret",
+                "Content-Type": "application/json",
+            }
+        )
+        redacted = _redact_headers(headers)
+        assert redacted["x-custom-token"] == "***"
+        assert redacted["x-my-service-key"] == "***"
+        assert redacted["content-type"] == "application/json"
+
+    def test_safe_only_headers(self):
         headers = httpx.Headers({"Content-Type": "application/json"})
         redacted = _redact_headers(headers)
         assert redacted == {"content-type": "application/json"}


### PR DESCRIPTION
The experimental OpenAPI provider logged full request headers at debug level, including Authorization, X-API-Key, and other sensitive values. Debug logs are often captured in production logging systems, so these should be redacted even at debug level.

Closes #3427