### PR TITLE
Fix get_* returning None when latest version is disabled

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -612,9 +612,22 @@ class FastMCP(
         all_tools = [t for t in await super().list_tools() if t.name == name]
         all_tools = list(await apply_session_transforms(all_tools))
         enabled = [t for t in all_tools if is_enabled(t)]
-        if not enabled:
+
+        skip_auth, token = _get_auth_context()
+        authorized: list[Tool] = []
+        for t in enabled:
+            if not skip_auth and t.auth is not None:
+                ctx = AuthContext(token=token, component=t)
+                try:
+                    if not await run_auth_checks(t.auth, ctx):
+                        continue
+                except AuthorizationError:
+                    continue
+            authorized.append(t)
+
+        if not authorized:
             return None
-        return cast(Tool, max(enabled, key=version_sort_key))
+        return cast(Tool, max(authorized, key=version_sort_key))
 
     async def list_resources(
         self, *, run_middleware: bool = True
@@ -721,9 +734,22 @@ class FastMCP(
         all_resources = [r for r in await super().list_resources() if str(r.uri) == uri]
         all_resources = list(await apply_session_transforms(all_resources))
         enabled = [r for r in all_resources if is_enabled(r)]
-        if not enabled:
+
+        skip_auth, token = _get_auth_context()
+        authorized: list[Resource] = []
+        for r in enabled:
+            if not skip_auth and r.auth is not None:
+                ctx = AuthContext(token=token, component=r)
+                try:
+                    if not await run_auth_checks(r.auth, ctx):
+                        continue
+                except AuthorizationError:
+                    continue
+            authorized.append(r)
+
+        if not authorized:
             return None
-        return cast(Resource, max(enabled, key=version_sort_key))
+        return cast(Resource, max(authorized, key=version_sort_key))
 
     async def list_resource_templates(
         self, *, run_middleware: bool = True
@@ -836,9 +862,22 @@ class FastMCP(
         ]
         all_templates = list(await apply_session_transforms(all_templates))
         enabled = [t for t in all_templates if is_enabled(t)]
-        if not enabled:
+
+        skip_auth, token = _get_auth_context()
+        authorized: list[ResourceTemplate] = []
+        for t in enabled:
+            if not skip_auth and t.auth is not None:
+                ctx = AuthContext(token=token, component=t)
+                try:
+                    if not await run_auth_checks(t.auth, ctx):
+                        continue
+                except AuthorizationError:
+                    continue
+            authorized.append(t)
+
+        if not authorized:
             return None
-        return cast(ResourceTemplate, max(enabled, key=version_sort_key))
+        return cast(ResourceTemplate, max(authorized, key=version_sort_key))
 
     async def list_prompts(self, *, run_middleware: bool = True) -> Sequence[Prompt]:
         """List all enabled prompts from providers.
@@ -943,9 +982,22 @@ class FastMCP(
         all_prompts = [p for p in await super().list_prompts() if p.name == name]
         all_prompts = list(await apply_session_transforms(all_prompts))
         enabled = [p for p in all_prompts if is_enabled(p)]
-        if not enabled:
+
+        skip_auth, token = _get_auth_context()
+        authorized: list[Prompt] = []
+        for p in enabled:
+            if not skip_auth and p.auth is not None:
+                ctx = AuthContext(token=token, component=p)
+                try:
+                    if not await run_auth_checks(p.auth, ctx):
+                        continue
+                except AuthorizationError:
+                    continue
+            authorized.append(p)
+
+        if not authorized:
             return None
-        return cast(Prompt, max(enabled, key=version_sort_key))
+        return cast(Prompt, max(authorized, key=version_sort_key))
 
     @overload
     async def call_tool(

--- a/tests/server/versioning/test_visibility_version_fallback.py
+++ b/tests/server/versioning/test_visibility_version_fallback.py
@@ -8,10 +8,31 @@ fall back to the next-highest enabled version instead of returning None.
 
 from __future__ import annotations
 
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from mcp.types import TextContent
 
 from fastmcp import FastMCP
+from fastmcp.server.auth import AccessToken, require_scopes
 from fastmcp.utilities.versions import VersionSpec
+
+
+def _make_token(scopes: list[str] | None = None) -> AccessToken:
+    """Create a test access token."""
+    return AccessToken(
+        token="test-token",
+        client_id="test-client",
+        scopes=scopes or [],
+        expires_at=None,
+        claims={},
+    )
+
+
+def _set_token(token: AccessToken | None):
+    """Set the access token in the auth context var."""
+    if token is None:
+        return auth_context_var.set(None)
+    return auth_context_var.set(AuthenticatedUser(token))
 
 
 class TestToolVersionFallback:
@@ -228,3 +249,128 @@ class TestPromptVersionFallback:
 
         prompt = await mcp.get_prompt("greet", VersionSpec(eq="2.0"))
         assert prompt is None
+
+
+class TestFallbackRespectsAuth:
+    """Fallback to older versions must enforce auth checks.
+
+    When the highest version is disabled and the code falls back to older
+    versions, those candidates must go through auth filtering. Otherwise
+    a protected v1 could be exposed to unauthenticated users when a
+    public v2 is disabled.
+    """
+
+    async def test_tool_fallback_respects_auth(self):
+        """Disabling v2 should not expose auth-protected v1 to unauthorized users."""
+        mcp = FastMCP()
+
+        @mcp.tool(version="1.0", auth=require_scopes("admin"))
+        def calc() -> int:
+            return 1
+
+        @mcp.tool(version="2.0")
+        def calc() -> int:
+            return 2
+
+        mcp.disable(version=VersionSpec(eq="2.0"))
+
+        # Without an admin token, v1 should NOT be returned
+        tool = await mcp.get_tool("calc")
+        assert tool is None
+
+    async def test_tool_fallback_allows_authorized_user(self):
+        """Fallback should return auth-protected v1 to authorized users."""
+        mcp = FastMCP()
+
+        @mcp.tool(version="1.0", auth=require_scopes("admin"))
+        def calc() -> int:
+            return 1
+
+        @mcp.tool(version="2.0")
+        def calc() -> int:
+            return 2
+
+        mcp.disable(version=VersionSpec(eq="2.0"))
+
+        token = _make_token(scopes=["admin"])
+        tok = _set_token(token)
+        try:
+            tool = await mcp.get_tool("calc")
+            assert tool is not None
+            assert tool.version == "1.0"
+        finally:
+            auth_context_var.reset(tok)
+
+    async def test_resource_fallback_respects_auth(self):
+        """Disabling v2 should not expose auth-protected v1 resource."""
+        mcp = FastMCP()
+
+        @mcp.resource("data://info", version="1.0", auth=require_scopes("admin"))
+        def info() -> str:
+            return "v1"
+
+        @mcp.resource("data://info", version="2.0")
+        def info() -> str:
+            return "v2"
+
+        mcp.disable(version=VersionSpec(eq="2.0"))
+
+        resource = await mcp.get_resource("data://info")
+        assert resource is None
+
+    async def test_resource_template_fallback_respects_auth(self):
+        """Disabling v2 should not expose auth-protected v1 template."""
+        mcp = FastMCP()
+
+        @mcp.resource("data://items/{id}", version="1.0", auth=require_scopes("admin"))
+        def item(id: str) -> str:
+            return f"v1-{id}"
+
+        @mcp.resource("data://items/{id}", version="2.0")
+        def item(id: str) -> str:
+            return f"v2-{id}"
+
+        mcp.disable(version=VersionSpec(eq="2.0"))
+
+        template = await mcp.get_resource_template("data://items/{id}")
+        assert template is None
+
+    async def test_prompt_fallback_respects_auth(self):
+        """Disabling v2 should not expose auth-protected v1 prompt."""
+        mcp = FastMCP()
+
+        @mcp.prompt(version="1.0", auth=require_scopes("admin"))
+        def greet() -> str:
+            return "hello v1"
+
+        @mcp.prompt(version="2.0")
+        def greet() -> str:
+            return "hello v2"
+
+        mcp.disable(version=VersionSpec(eq="2.0"))
+
+        prompt = await mcp.get_prompt("greet")
+        assert prompt is None
+
+    async def test_fallback_skips_unauthorized_picks_next(self):
+        """When multiple fallback candidates exist, skip unauthorized ones."""
+        mcp = FastMCP()
+
+        @mcp.tool(version="1.0")
+        def calc() -> int:
+            return 1
+
+        @mcp.tool(version="2.0", auth=require_scopes("admin"))
+        def calc() -> int:
+            return 2
+
+        @mcp.tool(version="3.0")
+        def calc() -> int:
+            return 3
+
+        mcp.disable(version=VersionSpec(eq="3.0"))
+
+        # v2 requires admin, so unauthorized user should get v1
+        tool = await mcp.get_tool("calc")
+        assert tool is not None
+        assert tool.version == "1.0"


### PR DESCRIPTION
When the highest version of a component was disabled via the visibility transform, \`get_tool\`/\`get_resource\`/\`get_resource_template\`/\`get_prompt\` returned \`None\` instead of falling back to the next-highest enabled version. The \`list_*\` path was unaffected because \`dedupe_with_versions\` already runs after visibility filtering there.

The fix adds a fallback in each \`get_*\` method: when no explicit version is requested and the highest version is disabled, it queries all versions, filters by visibility, and selects the highest enabled one. When an explicit version is requested and disabled, \`None\` is correctly returned.

Closes #3421