### PR TITLE
Add tags from skill frontmatter to SkillResource

### DIFF
--- a/src/fastmcp/server/providers/skills/skill_provider.py
+++ b/src/fastmcp/server/providers/skills/skill_provider.py
@@ -283,6 +283,9 @@ class SkillProvider(Provider):
         skill = self.skill_info
         resources: list[Resource] = []
 
+        # Extract tags from frontmatter (convert list to set)
+        tags = set(skill.frontmatter.get("tags", []))
+
         # Main skill file
         resources.append(
             SkillResource(
@@ -292,6 +295,7 @@ class SkillProvider(Provider):
                 mime_type="text/markdown",
                 skill_info=skill,
                 is_manifest=False,
+                tags=tags,
             )
         )
 
@@ -304,6 +308,7 @@ class SkillProvider(Provider):
                 mime_type="application/json",
                 skill_info=skill,
                 is_manifest=True,
+                tags=tags,
             )
         )
 
@@ -347,6 +352,9 @@ class SkillProvider(Provider):
         if skill_name != skill.name:
             return None
 
+        # Extract tags from frontmatter (convert list to set)
+        tags = set(skill.frontmatter.get("tags", []))
+
         if file_path == "_manifest":
             return SkillResource(
                 uri=AnyUrl(uri),
@@ -355,6 +363,7 @@ class SkillProvider(Provider):
                 mime_type="application/json",
                 skill_info=skill,
                 is_manifest=True,
+                tags=tags,
             )
         elif file_path == self._main_file_name:
             return SkillResource(
@@ -364,6 +373,7 @@ class SkillProvider(Provider):
                 mime_type="text/markdown",
                 skill_info=skill,
                 is_manifest=False,
+                tags=tags,
             )
         elif self._supporting_files == "resources":
             # Check if it's a known supporting file


### PR DESCRIPTION
This PR fixes #3402 by adding tags from skill frontmatter to SkillResource.

## Problem
SkillsProvider parses tags from the SKILL.md frontmatter but never adds them to the SkillResource. The Resource class has a tags field, but it was never populated.

## Solution
Extract tags from skill.frontmatter and pass them when creating SkillResource instances in both _list_resources() and _get_resource() methods.

## Changes
- In _list_resources(): Extract tags from frontmatter and pass to SkillResource for both main file and manifest
- In _get_resource(): Extract tags from frontmatter and pass to SkillResource for both main file and manifest

## Testing
- Verified that frontmatter parsing correctly extracts tags as a list
- Verified that tags convert correctly to a set (as required by the Resource class)
- Verified that empty tags handling works correctly