### PR TITLE
fix: use dynamic version in CLI help text

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -39,7 +39,7 @@ console = Console()
 
 app = cyclopts.App(
     name="fastmcp",
-    help="FastMCP 2.0 - The fast, Pythonic way to build MCP servers and clients.",
+    help=f"FastMCP {fastmcp.__version__} - The fast, Pythonic way to build MCP servers and clients.",
     version=fastmcp.__version__,
     # Disable automatic negative parameters by default
     default_parameter=Parameter(negative=()),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -14,7 +14,7 @@ class TestMainCLI:
         """Test that the main app is properly configured."""
         # app.name is a tuple in cyclopts
         assert "fastmcp" in app.name
-        assert "FastMCP 2.0" in app.help
+        assert "FastMCP" in app.help
         # Just check that version exists, not the specific value
         assert hasattr(app, "version")
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `"FastMCP 2.0"` in CLI help text with `f"FastMCP {fastmcp.__version__}"`
- Updates test to check for `"FastMCP"` instead of `"FastMCP 2.0"`

## Problem
Running `fastmcp --help` displays "FastMCP 2.0" even when version 3.x is installed. The `version` parameter on line 43 already uses `fastmcp.__version__` correctly, but the `help` string on line 42 was hardcoded.

## Test plan
- [ ] `fastmcp --help` shows the correct installed version
- [ ] `test_app_exists` passes with the updated assertion

Fixes #3455

https://claude.ai/code/session_011TWMvnjeLgAJg9XtxoLfZT