### PR TITLE
Set readOnlyHint=True on ResourcesAsTools generated tools

### DIFF
--- a/docs/servers/transforms/resources-as-tools.mdx
+++ b/docs/servers/transforms/resources-as-tools.mdx
@@ -45,6 +45,8 @@ mcp.add_transform(ResourcesAsTools(mcp))
 
 Clients now see three tools: whatever tools you defined directly, plus `list_resources` and `read_resource`.
 
+Both generated tools are annotated with `readOnlyHint=True`, since they only read data. Clients that respect tool annotations (like Cursor) can use this to auto-confirm these tool calls without prompting the user.
+
 ## Static Resources vs Templates
 
 Resources come in two forms, and the `list_resources` tool distinguishes between them in its JSON output.

--- a/src/fastmcp/server/transforms/resources_as_tools.py
+++ b/src/fastmcp/server/transforms/resources_as_tools.py
@@ -21,9 +21,13 @@ import json
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated, Any
 
+from mcp.types import ToolAnnotations
+
 from fastmcp.server.transforms import GetToolNext, Transform
 from fastmcp.tools.tool import Tool
 from fastmcp.utilities.versions import VersionSpec
+
+_DEFAULT_ANNOTATIONS = ToolAnnotations(readOnlyHint=True)
 
 if TYPE_CHECKING:
     from fastmcp.server.providers.base import Provider
@@ -119,7 +123,7 @@ class ResourcesAsTools(Transform):
 
             return json.dumps(result, indent=2)
 
-        return Tool.from_function(fn=list_resources)
+        return Tool.from_function(fn=list_resources, annotations=_DEFAULT_ANNOTATIONS)
 
     def _make_read_resource_tool(self) -> Tool:
         """Create the read_resource tool."""
@@ -158,7 +162,7 @@ class ResourcesAsTools(Transform):
 
             raise ValueError(f"Resource not found: {uri}")
 
-        return Tool.from_function(fn=read_resource)
+        return Tool.from_function(fn=read_resource, annotations=_DEFAULT_ANNOTATIONS)
 
 
 def _format_result(result: Any) -> str:

--- a/tests/server/transforms/test_resources_as_tools.py
+++ b/tests/server/transforms/test_resources_as_tools.py
@@ -225,3 +225,29 @@ class TestResourcesAsToolsRepr:
         mcp = FastMCP("Test")
         transform = ResourcesAsTools(mcp)
         assert "ResourcesAsTools" in repr(transform)
+
+
+class TestResourcesAsToolsAnnotations:
+    """Test ToolAnnotations on generated resource tools."""
+
+    async def test_list_resources_is_read_only(self):
+        """list_resources is annotated as read-only by default."""
+        mcp = FastMCP("Test")
+        mcp.add_transform(ResourcesAsTools(mcp))
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            tool = next(t for t in tools if t.name == "list_resources")
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is True
+
+    async def test_read_resource_is_read_only(self):
+        """read_resource is annotated as read-only by default."""
+        mcp = FastMCP("Test")
+        mcp.add_transform(ResourcesAsTools(mcp))
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            tool = next(t for t in tools if t.name == "read_resource")
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is True


### PR DESCRIPTION
The `list_resources` and `read_resource` tools generated by `ResourcesAsTools` are inherently read-only, but they weren't declaring that via `ToolAnnotations`. Clients like Cursor that respect `readOnlyHint` had no way to know these tools are safe to auto-confirm, so they prompted the user every time.

Now both generated tools carry `readOnlyHint=True` by default. No API change needed — the tools are just correctly describing what they already do.

```python
mcp = FastMCP("Server")
mcp.add_transform(ResourcesAsTools(mcp))
# list_resources and read_resource now have readOnlyHint=True
```

Closes #3459