### PR TITLE
Auto-close upgrade check issue when build passes

### DIFF
--- a/.github/workflows/run-upgrade-checks.yml
+++ b/.github/workflows/run-upgrade-checks.yml
@@ -135,7 +135,7 @@ jobs:
   close-on-success:
     name: Close issue on success
     needs: [static_analysis, run_tests, run_integration_tests]
-    if: success() && github.event.pull_request == null
+    if: success() && github.event.pull_request == null && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The upgrade checks workflow creates an issue (and adds comments on each subsequent failure) when the build breaks, but nothing closes the issue when the build goes green again. This meant #3484 stayed open long after the underlying `pydantic-monty` compatibility fix landed, accumulating stale failure comments from queued runs of already-fixed commits.

This adds a `close-on-success` job that mirrors the existing `notify` job — when all three check groups pass, it finds the open `"build failed"` issue and closes it with a comment pointing to the commit that resolved things. Also fixes the label from `"build-failure"` to `"build failed"` to match what the action actually uses by default.

Closes #3484