### PR TITLE
[Documentation] Move stateless_http transport kwarg to http_app as FastMCP constructo…

### DIFF
--- a/docs/deployment/http.mdx
+++ b/docs/deployment/http.mdx
@@ -630,13 +630,13 @@ For horizontally scaled deployments, enable stateless HTTP mode. In stateless mo
 ```python
 from fastmcp import FastMCP
 
-mcp = FastMCP("My Server", stateless_http=True)
+mcp = FastMCP("My Server")
 
 @mcp.tool
 def process(data: str) -> str:
     return f"Processed: {data}"
 
-app = mcp.http_app()
+app = mcp.http_app(stateless_http=True)
 ```
 
 **Option 2: Via `run()`**


### PR DESCRIPTION
## Description

From developing I noticed a discrepancy with FastMCP setting `stateless_http` as a constructor arg; since v3 FastMCP now server raises a TypeError if `stateless_http=True` is set in the constructor with the `_check_removed_kwargs` in the server.

For example, with the current doc code you will see:

```
    raise TypeError(
        f"FastMCP() no longer accepts `{key}`. {_REMOVED_KWARGS[key]}"
    )
TypeError: FastMCP() no longer accepts `stateless_http`. Pass `stateless_http` to `run_http_async()` or `http_app()`, or set FASTMCP_STATELESS_HTTP.

```

This is a quick PR to update the documentation to move`stateless_http=True` to `http_app()` as a kwarg from the FastMCP class constructor.

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [X] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [X ] This PR addresses an existing issue (or fixes a self-evident bug)
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] I have added tests that cover my changes
- [X] I have run `uv run prek run --all-files` and all checks pass
- [X] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)
