### PR TITLE
Add security label to triage workflow and release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,12 +8,25 @@ changelog:
       labels:
         - feature
 
-    - title: Enhancements 🔧
+    - title: Breaking Changes ⚠️
+      labels:
+        - breaking change
+      exclude:
+        labels:
+          - contrib
+          - security
+
+    - title: Enhancements ✨
       labels:
         - enhancement
       exclude:
         labels:
           - breaking change
+          - security
+
+    - title: Security 🔒
+      labels:
+        - security
 
     - title: Fixes 🐞
       labels:
@@ -21,13 +34,7 @@ changelog:
       exclude:
         labels:
           - contrib
-
-    - title: Breaking Changes 🛫
-      labels:
-        - breaking change
-      exclude:
-        labels:
-          - contrib
+          - security
 
     - title: Docs 📚
       labels:
@@ -41,6 +48,9 @@ changelog:
     - title: Dependencies 📦
       labels:
         - dependencies
+      exclude:
+        labels:
+          - security
 
     - title: Other Changes 🦾
       labels:

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -108,6 +108,7 @@ jobs:
           - http: HTTP transport or networking is the main issue
           - contrib: Specifically about community contributions in src/contrib/
           - tests: Issues primarily about testing infrastructure, CI/CD workflows, or test coverage
+          - security: Apply ONLY when the issue/PR addresses an exploitable vulnerability or hardens against one. Examples: SSRF, LFI, path traversal, injection, auth bypass allowing unauthorized access, scope escalation, open redirects. Do NOT apply for ordinary auth bugs (wrong scopes returned, token refresh logic, OAuth flow correctness) unless an attacker could exploit the bug to bypass access controls or escalate privileges. The key question: "Could a malicious actor exploit this?" If the answer is just "it breaks for legitimate users," that's a bug, not a security issue.
 
           IMPORTANT LABELING RULES:
           - Be selective - only apply labels that are clearly relevant


### PR DESCRIPTION
After a wave of security-related PRs (SSRF, path traversal, auth bypass, scope escalation), we had no way to distinguish them from ordinary bug fixes in triage or release notes.

This adds a `security` label to the Marvin triage workflow with guidance that draws a clear line between exploitable vulnerabilities and regular auth/correctness bugs — the key question being "could a malicious actor exploit this?" rather than "does this break for legitimate users."

The release notes template gets a new Security 🔒 section (after Enhancements, before Fixes), with exclusion rules so security PRs don't also appear under Fixes, Enhancements, or Dependencies. Also moves Breaking Changes up to second position (after Features) and freshens up a couple emoji choices.