### PR TITLE
fix: use raw strings for regex in pytest.raises match

### DIFF
--- a/tests/tools/tool_transform/test_tool_transform.py
+++ b/tests/tools/tool_transform/test_tool_transform.py
@@ -428,13 +428,13 @@ async def test_fn_with_kwargs_dropped_args_not_in_kwargs(add_tool):
 
 async def test_forward_outside_context_raises_error():
     """Test that forward() raises error when called outside transform context."""
-    with pytest.raises(RuntimeError, match="forward\(\) can only be called"):
+    with pytest.raises(RuntimeError, match=r"forward\(\) can only be called"):
         await forward(x=1)
 
 
 async def test_forward_raw_outside_context_raises_error():
     """Test that forward_raw() raises error when called outside transform context."""
-    with pytest.raises(RuntimeError, match="forward_raw\(\) can only be called"):
+    with pytest.raises(RuntimeError, match=r"forward_raw\(\) can only be called"):
         await forward_raw(x=1)
 
 


### PR DESCRIPTION
Fixes deprecation warnings from invalid escape sequences in test regex patterns.