### PR TITLE
Add executable hash verification to prevent MCP poisoning

### DIFF
--- a/examples/hash_verification_example.py
+++ b/examples/hash_verification_example.py
@@ -1,0 +1,70 @@
+"""Example: Preventing MCP Poisoning with Executable Hash Verification
+
+This example demonstrates how to use hash verification to prevent MCP poisoning
+attacks where a malicious actor replaces a legitimate MCP server executable with
+a compromised version.
+"""
+
+import hashlib
+import sys
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.transports.stdio import PythonStdioTransport
+
+
+def compute_executable_hash(
+    executable_path: str | Path, algorithm: str = "sha256"
+) -> str:
+    """Compute hash of an executable.
+
+    Run this once to get the hash of your trusted executable, then
+    use that hash in your client configuration.
+    """
+    hasher = hashlib.new(algorithm)
+    with open(executable_path, "rb") as f:
+        while chunk := f.read(8192):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+async def secure_connection_example():
+    """Connect to an MCP server with executable verification."""
+
+    # Step 1: Compute the hash of your trusted Python interpreter
+    python_path = sys.executable
+    trusted_hash = compute_executable_hash(python_path)
+
+    print(f"Python interpreter: {python_path}")
+    print(f"Trusted hash: {trusted_hash}\n")
+
+    # Step 2: Create a transport with hash verification enabled
+    transport = PythonStdioTransport(
+        script_path="my_mcp_server.py",
+        expected_hash=trusted_hash,
+        hash_algorithm="sha256",
+    )
+
+    # Step 3: Connect - will fail if executable has been modified
+    client = Client(transport=transport)
+    try:
+        async with client:
+            print("✓ Connection established - executable verified")
+            tools = await client.list_tools()
+            print(f"Available tools: {[t.name for t in tools]}")
+    except ValueError as e:
+        print(f"✗ Security check failed: {e}")
+
+
+if __name__ == "__main__":
+    print("MCP Poisoning Prevention Example")
+    print()
+    print("To use hash verification:")
+    print("1. Compute hash of your trusted executable once")
+    print("2. Store the hash securely (config file, environment variable)")
+    print("3. Pass expected_hash when creating the transport")
+    print()
+
+    python_hash = compute_executable_hash(sys.executable)
+    print("Your Python interpreter hash (SHA-256):")
+    print(f"  {python_hash}")

--- a/examples/secure_mcp_client.py
+++ b/examples/secure_mcp_client.py
@@ -1,0 +1,105 @@
+"""Secure MCP Client with Hash Verification
+
+This example shows how to build a production-ready MCP client that verifies
+executable integrity before connecting to servers.
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.transports.stdio import StdioTransport
+
+
+class SecureMCPConfig:
+    """Configuration manager for secure MCP connections."""
+
+    def __init__(self, config_file: Path):
+        self.config_file = config_file
+        self.config: dict = self._load_config()
+
+    def _load_config(self) -> dict:
+        if not self.config_file.exists():
+            return {"servers": {}}
+        return json.loads(self.config_file.read_text())
+
+    def save_config(self) -> None:
+        self.config_file.parent.mkdir(parents=True, exist_ok=True)
+        self.config_file.write_text(json.dumps(self.config, indent=2))
+
+    def add_server(
+        self,
+        name: str,
+        command: str,
+        args: list[str],
+        expected_hash: str,
+        hash_algorithm: str = "sha256",
+    ) -> None:
+        self.config["servers"][name] = {
+            "command": command,
+            "args": args,
+            "expected_hash": expected_hash,
+            "hash_algorithm": hash_algorithm,
+        }
+        self.save_config()
+
+    def get_server(self, name: str) -> dict | None:
+        return self.config["servers"].get(name)
+
+
+def compute_executable_hash(
+    executable_path: str | Path, algorithm: str = "sha256"
+) -> str:
+    hasher = hashlib.new(algorithm)
+    with open(executable_path, "rb") as f:
+        while chunk := f.read(8192):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+async def connect_to_server(config: SecureMCPConfig, server_name: str) -> None:
+    """Connect to a configured server with hash verification."""
+
+    server_config = config.get_server(server_name)
+    if not server_config:
+        raise ValueError(f"Server '{server_name}' not found in configuration")
+
+    transport = StdioTransport(
+        command=server_config["command"],
+        args=server_config["args"],
+        expected_hash=server_config["expected_hash"],
+        hash_algorithm=server_config["hash_algorithm"],
+    )
+
+    client = Client(transport=transport)
+    try:
+        async with client:
+            print("✓ Connection established - executable verified")
+            tools = await client.list_tools()
+            for tool in tools:
+                print(f"  - {tool.name}: {tool.description}")
+    except ValueError as e:
+        print(f"✗ Security check failed: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    python_hash = compute_executable_hash(sys.executable)
+    print("Python interpreter hash (SHA-256):")
+    print(f"  Path: {sys.executable}")
+    print(f"  Hash: {python_hash}")
+    print()
+    print("Usage:")
+    print("""
+    transport = PythonStdioTransport(
+        script_path="my_server.py",
+        expected_hash="<hash>",
+        hash_algorithm="sha256",
+    )
+    client = Client(transport=transport)
+
+    async with client:
+        tools = await client.list_tools()
+    """)

--- a/src/fastmcp/client/transports/stdio.py
+++ b/src/fastmcp/client/transports/stdio.py
@@ -1,11 +1,12 @@
 import asyncio
 import contextlib
+import hashlib
 import os
 import shutil
 import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import TextIO, cast
+from typing import Literal, TextIO, cast
 
 import anyio
 from mcp import ClientSession, StdioServerParameters
@@ -17,6 +18,8 @@ from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.mcp_server_config.v1.environments.uv import UVEnvironment
 
 logger = get_logger(__name__)
+
+HashAlgorithm = Literal["sha256", "sha512", "sha1", "md5"]
 
 
 class StdioTransport(ClientTransport):
@@ -35,6 +38,8 @@ class StdioTransport(ClientTransport):
         cwd: str | None = None,
         keep_alive: bool | None = None,
         log_file: Path | TextIO | None = None,
+        expected_hash: str | None = None,
+        hash_algorithm: HashAlgorithm = "sha256",
     ):
         """
         Initialize a Stdio transport.
@@ -53,6 +58,11 @@ class StdioTransport(ClientTransport):
                    if not provided. When a Path is provided, the file will be created
                    if it doesn't exist, or appended to if it does. When set, server
                    errors will be written to this file instead of appearing in the console.
+            expected_hash: Optional hash to verify the executable against before spawning.
+                          Prevents MCP poisoning attacks by ensuring the binary hasn't been
+                          tampered with. Format: hexadecimal string (e.g., "abc123...").
+            hash_algorithm: Hash algorithm to use for verification (default: "sha256").
+                           Supported: "sha256", "sha512", "sha1", "md5".
         """
         self.command = command
         self.args = args
@@ -62,6 +72,8 @@ class StdioTransport(ClientTransport):
             keep_alive = True
         self.keep_alive = keep_alive
         self.log_file = log_file
+        self.expected_hash = expected_hash
+        self.hash_algorithm = hash_algorithm
 
         self._session: ClientSession | None = None
         self._connect_task: asyncio.Task | None = None
@@ -97,6 +109,8 @@ class StdioTransport(ClientTransport):
                 env=self.env,
                 cwd=self.cwd,
                 log_file=self.log_file,
+                expected_hash=self.expected_hash,
+                hash_algorithm=self.hash_algorithm,
                 # TODO(ty): remove when ty supports Unpack[TypedDict] inference
                 session_kwargs=session_kwargs,  # type: ignore[arg-type]
                 ready_event=self._ready_event,
@@ -152,6 +166,8 @@ async def _stdio_transport_connect_task(
     env: dict[str, str] | None,
     cwd: str | None,
     log_file: Path | TextIO | None,
+    expected_hash: str | None,
+    hash_algorithm: HashAlgorithm,
     session_kwargs: SessionKwargs,
     ready_event: anyio.Event,
     stop_event: anyio.Event,
@@ -161,6 +177,10 @@ async def _stdio_transport_connect_task(
     to ensure that the connection task does not hold a reference to the Transport object."""
 
     try:
+        # Verify executable hash before spawning if requested
+        if expected_hash:
+            _verify_executable_hash(command, expected_hash, hash_algorithm, env, cwd)
+
         async with contextlib.AsyncExitStack() as stack:
             try:
                 server_params = StdioServerParameters(
@@ -202,6 +222,90 @@ async def _stdio_transport_connect_task(
         raise
 
 
+def _verify_executable_hash(
+    command: str,
+    expected_hash: str,
+    hash_algorithm: HashAlgorithm,
+    env: dict[str, str] | None,
+    cwd: str | None,
+) -> None:
+    """Verify the executable hash matches the expected value.
+
+    Args:
+        command: Command to verify (will be resolved to full path)
+        expected_hash: Expected hash value (hexadecimal string)
+        hash_algorithm: Hash algorithm to use
+        env: Environment variables (for PATH resolution)
+        cwd: Working directory (for relative path resolution)
+
+    Raises:
+        FileNotFoundError: If executable cannot be found
+        ValueError: If hash doesn't match or algorithm is unsupported
+    """
+    # Resolve command to full path
+    executable_path = _resolve_executable_path(command, env, cwd)
+
+    # Compute hash
+    hasher = hashlib.new(hash_algorithm)
+    with open(executable_path, "rb") as f:
+        while chunk := f.read(8192):
+            hasher.update(chunk)
+    actual_hash = hasher.hexdigest()
+
+    # Compare
+    if actual_hash != expected_hash.lower():
+        raise ValueError(
+            f"Executable hash mismatch for {executable_path}: "
+            f"expected {expected_hash}, got {actual_hash}. "
+            f"This may indicate the executable has been tampered with."
+        )
+
+    logger.info(f"Executable hash verified: {executable_path} ({hash_algorithm})")
+
+
+def _resolve_executable_path(
+    command: str, env: dict[str, str] | None, cwd: str | None
+) -> Path:
+    """Resolve command to absolute executable path.
+
+    Args:
+        command: Command name or path
+        env: Environment variables (for PATH resolution)
+        cwd: Working directory (for relative path resolution)
+
+    Returns:
+        Absolute path to executable
+
+    Raises:
+        FileNotFoundError: If executable cannot be found
+    """
+    # If it's already an absolute path
+    if Path(command).is_absolute():
+        path = Path(command)
+        if not path.is_file():
+            raise FileNotFoundError(f"Executable not found: {command}")
+        return path
+
+    # If it's a relative path
+    if "/" in command or "\\" in command:
+        base = Path(cwd) if cwd else Path.cwd()
+        path = (base / command).resolve()
+        if not path.is_file():
+            raise FileNotFoundError(f"Executable not found: {command}")
+        return path
+
+    # Search in PATH
+    search_env = env if env else os.environ
+    path_str = shutil.which(command, path=search_env.get("PATH"))
+    if not path_str:
+        raise FileNotFoundError(
+            f"Executable '{command}' not found in PATH. "
+            f"Cannot verify hash without absolute path."
+        )
+
+    return Path(path_str).resolve()
+
+
 class PythonStdioTransport(StdioTransport):
     """Transport for running Python scripts."""
 
@@ -214,6 +318,8 @@ class PythonStdioTransport(StdioTransport):
         python_cmd: str = sys.executable,
         keep_alive: bool | None = None,
         log_file: Path | TextIO | None = None,
+        expected_hash: str | None = None,
+        hash_algorithm: HashAlgorithm = "sha256",
     ):
         """
         Initialize a Python transport.
@@ -233,6 +339,8 @@ class PythonStdioTransport(StdioTransport):
                    if not provided. When a Path is provided, the file will be created
                    if it doesn't exist, or appended to if it does. When set, server
                    errors will be written to this file instead of appearing in the console.
+            expected_hash: Optional hash to verify the Python interpreter against before spawning.
+            hash_algorithm: Hash algorithm to use for verification (default: "sha256").
         """
         script_path = Path(script_path).resolve()
         if not script_path.is_file():
@@ -251,6 +359,8 @@ class PythonStdioTransport(StdioTransport):
             cwd=cwd,
             keep_alive=keep_alive,
             log_file=log_file,
+            expected_hash=expected_hash,
+            hash_algorithm=hash_algorithm,
         )
         self.script_path = script_path
 

--- a/tests/client/transports/test_hash_verification.py
+++ b/tests/client/transports/test_hash_verification.py
@@ -1,0 +1,68 @@
+"""Tests for executable hash verification in stdio transports."""
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from fastmcp.client.transports.stdio import (
+    HashAlgorithm,
+    PythonStdioTransport,
+    _verify_executable_hash,
+)
+
+
+def compute_file_hash(path: Path, algorithm: str = "sha256") -> str:
+    """Compute hash of a file."""
+    hasher = hashlib.new(algorithm)
+    with open(path, "rb") as f:
+        while chunk := f.read(8192):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def test_verify_hash_success():
+    """Test that verification passes when hash matches."""
+    python_path = Path(sys.executable).resolve()
+    expected_hash = compute_file_hash(python_path)
+    # Should not raise
+    _verify_executable_hash(sys.executable, expected_hash, "sha256", None, None)
+
+
+def test_verify_hash_failure():
+    """Test that verification fails when hash doesn't match."""
+    with pytest.raises(ValueError, match="Executable hash mismatch"):
+        _verify_executable_hash(sys.executable, "0" * 64, "sha256", None, None)
+
+
+def test_verify_hash_different_algorithms():
+    """Test hash verification with different algorithms."""
+    python_path = Path(sys.executable).resolve()
+    algorithms: list[HashAlgorithm] = ["sha256", "sha512", "md5"]
+    for algorithm in algorithms:
+        expected_hash = compute_file_hash(python_path, algorithm)
+        _verify_executable_hash(sys.executable, expected_hash, algorithm, None, None)
+
+
+def test_verify_hash_file_not_found():
+    """Test that verification fails for missing executables."""
+    with pytest.raises(FileNotFoundError):
+        _verify_executable_hash("/nonexistent/binary", "abc", "sha256", None, None)
+
+
+@pytest.mark.asyncio
+async def test_transport_hash_mismatch_prevents_connect(tmp_path: Path):
+    """Test that transport refuses to connect when hash doesn't match."""
+    script = tmp_path / "server.py"
+    script.write_text("print('hello')")
+
+    transport = PythonStdioTransport(
+        script_path=script,
+        python_cmd=sys.executable,
+        expected_hash="0" * 64,
+        hash_algorithm="sha256",
+    )
+
+    with pytest.raises(ValueError, match="Executable hash mismatch"):
+        await transport.connect()


### PR DESCRIPTION
Stdio transports now support optional hash verification of executables before spawning. Prevents attacks where malicious actors replace legitimate MCP server binaries.

New parameters on StdioTransport:
- expected_hash: Optional hash to verify against
- hash_algorithm: Algorithm to use (sha256, sha512, sha1, md5)

Verification runs before subprocess creation and raises ValueError on mismatch.

Example:
    client = Client(
        "python",
        args=["server.py"],
        expected_hash="abc123...",
        hash_algorithm="sha256",
    )

Note: this commit was made using the assistance of claude sonnet 4.6

## Description

<!-- What does this PR do? Link to the issue it addresses. -->

Closes #
#3526 
## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
