### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ dmypy.json
 
 # Claude worktree management
 .claude-wt/worktrees
+.claude/worktrees/
 
 # Agents
 /PLAN.md


### PR DESCRIPTION
The `.claude/worktrees/` directory (used by Claude Code for isolated subagent work) was showing up as untracked. Added it to `.gitignore` alongside the existing `.claude-wt/worktrees` entry.