### PR TITLE
pin pydantic-monty to 0.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ anthropic = ["anthropic>=0.40.0"]
 apps = ["prefab-ui>=0.11.2"]
 # PyJWT floor: transitive via msal; CVE-2026-32597 affects <= 2.11.0
 azure = ["azure-identity>=1.16.0", "PyJWT>=2.12.0"]
-code-mode = ["pydantic-monty>=0.0.8"]
+code-mode = ["pydantic-monty==0.0.8"]
 gemini = ["google-genai>=1.18.0"]
 openai = ["openai>=1.102.0"]
 tasks = ["pydocket>=0.18.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -865,7 +865,7 @@ requires-dist = [
     { name = "prefab-ui", marker = "extra == 'apps'", specifier = ">=0.11.2" },
     { name = "py-key-value-aio", extras = ["filetree", "keyring", "memory"], specifier = ">=0.4.4,<0.5.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.7" },
-    { name = "pydantic-monty", marker = "extra == 'code-mode'", specifier = ">=0.0.8" },
+    { name = "pydantic-monty", marker = "extra == 'code-mode'", specifier = "==0.0.8" },
     { name = "pydocket", marker = "extra == 'tasks'", specifier = ">=0.18.0" },
     { name = "pyjwt", marker = "extra == 'azure'", specifier = ">=2.12.0" },
     { name = "pyperclip", specifier = ">=1.9.0" },


### PR DESCRIPTION
`pydantic-monty` is experimental with breaking changes between releases, so `>=0.0.8` is too permissive. This pins it to exactly `0.0.8` until the library stabilizes.