### PR TITLE
Graceful degradation for multi-server proxy setup

### DIFF
--- a/src/fastmcp/client/transports/config.py
+++ b/src/fastmcp/client/transports/config.py
@@ -112,7 +112,9 @@ class MCPConfigTransport(ClientTransport):
                     transport, _client, proxy = await self._create_proxy(
                         name, server_config, timeout, stack
                     )
-                except Exception:
+                except Exception:  # Broad catch is intentional: failure modes
+                    # are diverse (OSError, TimeoutError, RuntimeError, etc.)
+                    # and the whole point is to skip any server that can't connect.
                     logger.warning(
                         "Failed to connect to MCP server %r, skipping",
                         name,

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1007,7 +1007,15 @@ async def test_single_server_config_transport():
     assert len(transport._transports) == 1
 
 
-async def test_multi_server_partial_failure(tmp_path: Path):
+@pytest.mark.parametrize(
+    "server_order",
+    [
+        {"good_server": True, "bad_server": False},
+        {"bad_server": False, "good_server": True},
+    ],
+    ids=["good_first", "bad_first"],
+)
+async def test_multi_server_partial_failure(tmp_path: Path, server_order: dict):
     """When one server fails to connect, the others should still work."""
     server_script = inspect.cleandoc("""
         from fastmcp import FastMCP
@@ -1025,20 +1033,20 @@ async def test_multi_server_partial_failure(tmp_path: Path):
     script_path = tmp_path / "test.py"
     script_path.write_text(server_script)
 
-    config = {
-        "mcpServers": {
-            "good_server": {
+    servers = {}
+    for name, is_good in server_order.items():
+        if is_good:
+            servers[name] = {
                 "command": "python",
                 "args": [str(script_path)],
-            },
-            "bad_server": {
+            }
+        else:
+            servers[name] = {
                 "command": "this-command-does-not-exist-anywhere",
                 "args": [],
-            },
-        }
-    }
+            }
 
-    client = Client(config)
+    client = Client({"mcpServers": servers})
     async with client:
         tools = await client.list_tools()
         tool_names = [t.name for t in tools]


### PR DESCRIPTION
`MCPConfigTransport` currently fails the entire proxy setup if any single upstream server can't connect — even when other servers in the config are perfectly healthy. This contradicts the graceful-failure philosophy that `AggregateProvider` already implements at runtime, where individual provider failures are logged and skipped.

The setup phase now matches that philosophy: each `_create_proxy()` call is individually wrapped, failures are logged at WARNING level with full tracebacks, and the composite is built from whichever servers succeed. If *all* servers fail, a `ConnectionError` is raised rather than silently returning an empty composite.

```python
config = {
    "mcpServers": {
        "healthy": {"command": "python", "args": ["server.py"]},
        "unreachable": {"command": "nonexistent-binary"},
    }
}

# Before: ConnectionError (total failure)
# After: works — tools from "healthy" are available,
#         WARNING log for "unreachable"
client = Client(config)
async with client:
    tools = await client.list_tools()
```

Closes #3533