### PR TITLE
Bump anthropic minimum to 0.48.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.40.0"]
+anthropic = ["anthropic>=0.48.0"]
 apps = ["prefab-ui>=0.11.2"]
 # PyJWT floor: transitive via msal; CVE-2026-32597 affects <= 2.11.0
 azure = ["azure-identity>=1.16.0", "PyJWT>=2.12.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -847,7 +847,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0" },
     { name = "authlib", specifier = ">=1.6.5" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.16.0" },
     { name = "cyclopts", specifier = ">=4.0.0" },


### PR DESCRIPTION
The image/audio sampling handler PR (#3550) imports `Base64ImageSourceParam` from `anthropic.types`, which was introduced in anthropic 0.48.0. The previous floor of 0.40.0 causes an `ImportError` on the lowest-deps CI job.