### PR TITLE
Update startup banner deploy URL to Prefect Horizon

### DIFF
--- a/src/fastmcp/utilities/cli.py
+++ b/src/fastmcp/utilities/cli.py
@@ -221,7 +221,7 @@ def log_server_banner(server: FastMCP[Any]) -> None:
     if server.version:
         server_info += f", {server.version}"
     info_table.add_row("🖥", "Server:", Text(server_info, style="dim"))
-    info_table.add_row("🚀", "Deploy free:", "https://fastmcp.cloud")
+    info_table.add_row("🚀", "Deploy free:", "https://horizon.prefect.io")
 
     # Create panel with logo, title, and information using Group
     docs_url = Text("https://gofastmcp.com", style="dim")


### PR DESCRIPTION
The startup banner still points to `https://fastmcp.cloud`, which was missed during the bulk rename in #2978. This updates it to `https://horizon.prefect.io` to match the rest of the codebase.

```python
info_table.add_row("🚀", "Deploy free:", "https://horizon.prefect.io")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)