### PR TITLE
feat: add CommandConfigProvider for YAML/JSON command-backed tools

### DIFF
--- a/src/fastmcp/server/providers/__init__.py
+++ b/src/fastmcp/server/providers/__init__.py
@@ -46,15 +46,22 @@ if TYPE_CHECKING:
 __all__ = [
     "AggregateProvider",
     "ClaudeSkillsProvider",
+    "CommandBackedTool",
+    "CommandConfigProvider",
+    "CommandToolSpec",
+    "CommandToolsSpec",
     "FastMCPProvider",
     "FileSystemProvider",
     "LocalProvider",
     "OpenAPIProvider",
+    "ParameterSpec",
     "Provider",
     "ProxyProvider",
     "SkillProvider",
     "SkillsDirectoryProvider",
     "SkillsProvider",  # Backwards compatibility alias for SkillsDirectoryProvider
+    "load_command_tools_spec",
+    "parameter_spec_to_json_schema",
 ]
 
 
@@ -68,4 +75,16 @@ def __getattr__(name: str):
         from fastmcp.server.providers.openapi import OpenAPIProvider
 
         return OpenAPIProvider
+    if name in (
+        "CommandBackedTool",
+        "CommandConfigProvider",
+        "CommandToolSpec",
+        "CommandToolsSpec",
+        "ParameterSpec",
+        "load_command_tools_spec",
+        "parameter_spec_to_json_schema",
+    ):
+        from fastmcp.server.providers import command_config
+
+        return getattr(command_config, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/fastmcp/server/providers/command_config/__init__.py
+++ b/src/fastmcp/server/providers/command_config/__init__.py
@@ -1,0 +1,23 @@
+"""Config-driven command-backed tools (YAML/JSON) as a first-class Provider."""
+
+from fastmcp.server.providers.command_config.loader import load_command_tools_spec
+from fastmcp.server.providers.command_config.models import (
+    CommandToolSpec,
+    CommandToolsSpec,
+    ParameterSpec,
+)
+from fastmcp.server.providers.command_config.provider import CommandConfigProvider
+from fastmcp.server.providers.command_config.tool import (
+    CommandBackedTool,
+    parameter_spec_to_json_schema,
+)
+
+__all__ = [
+    "CommandBackedTool",
+    "CommandConfigProvider",
+    "CommandToolSpec",
+    "CommandToolsSpec",
+    "ParameterSpec",
+    "load_command_tools_spec",
+    "parameter_spec_to_json_schema",
+]

--- a/src/fastmcp/server/providers/command_config/loader.py
+++ b/src/fastmcp/server/providers/command_config/loader.py
@@ -1,0 +1,36 @@
+"""Load CommandToolsSpec from disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp.server.providers.command_config.models import (
+    CommandToolsSpec,
+    apply_working_dir_base,
+    parse_command_tools_document,
+)
+
+
+def load_command_tools_spec(
+    path: Path | str,
+    *,
+    resolve_relative_working_dirs: bool = True,
+) -> CommandToolsSpec:
+    """Load and validate a command-tools config from YAML or JSON.
+
+    Args:
+        path: Path to ``.yaml``, ``.yml``, or ``.json`` file.
+        resolve_relative_working_dirs: If True, relative ``working_dir`` values are
+            resolved against the config file's parent directory (not the process cwd).
+
+    Raises:
+        ValueError: Unknown file extension or parse errors surfaced as validation errors.
+        pydantic.ValidationError: Invalid document structure.
+    """
+    p = Path(path)
+    raw = p.read_text(encoding="utf-8")
+    data = parse_command_tools_document(raw, suffix=p.suffix)
+    spec = CommandToolsSpec.model_validate(data)
+    if resolve_relative_working_dirs:
+        spec = apply_working_dir_base(spec, p)
+    return spec

--- a/src/fastmcp/server/providers/command_config/models.py
+++ b/src/fastmcp/server/providers/command_config/models.py
@@ -1,0 +1,118 @@
+"""Pydantic models for command-backed MCP tools loaded from YAML/JSON."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+
+class ParameterSpec(BaseModel):
+    """Single tool parameter schema (maps to JSON Schema for MCP)."""
+
+    type: Literal["string", "number", "integer", "boolean"] = Field(
+        description="JSON Schema type for the parameter"
+    )
+    description: str | None = Field(default=None, description="Parameter description")
+    required: bool = Field(default=False, description="Whether the parameter is required")
+    default: Any = Field(default=None, description="Default when not provided by the client")
+
+
+class CommandToolSpec(BaseModel):
+    """One command-backed tool definition."""
+
+    name: str = Field(description="Tool name exposed to MCP clients")
+    description: str = Field(description="Tool description")
+    command: str = Field(
+        description="Executable name or path (first argv element; never passed to a shell)"
+    )
+    args_template: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Argument list. A token that is exactly '{param_name}' is replaced with the "
+            "string form of that parameter; all other tokens are passed through unchanged."
+        ),
+    )
+    working_dir: str | None = Field(
+        default=None,
+        description="Process working directory, or None for server cwd",
+    )
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra environment variables (merged over os.environ)",
+    )
+    timeout_seconds: int | None = Field(
+        default=None,
+        description="Subprocess timeout in seconds; None means no timeout",
+    )
+    parameters: dict[str, ParameterSpec] = Field(
+        default_factory=dict,
+        description="Parameter definitions for validation and JSON Schema",
+    )
+
+
+class CommandToolsSpec(BaseModel):
+    """Root document: optional server display name and list of tools."""
+
+    server_name: str | None = Field(default=None, description="Suggested MCP server name")
+    tools: list[CommandToolSpec] = Field(
+        default_factory=list,
+        description="Command-backed tools to expose",
+    )
+
+    @model_validator(mode="after")
+    def _tool_names_unique(self) -> Self:
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for t in self.tools:
+            if t.name in seen:
+                duplicates.add(t.name)
+            seen.add(t.name)
+        if duplicates:
+            raise ValueError(
+                f"Duplicate tool name(s) in command tools config: {sorted(duplicates)}"
+            )
+        return self
+
+
+def parse_command_tools_document(raw: str, *, suffix: str) -> dict[str, Any]:
+    """Parse YAML or JSON text into a dict for model_validate."""
+    suf = suffix.lower()
+    if suf in (".yaml", ".yml"):
+        data = yaml.safe_load(raw)
+    elif suf == ".json":
+        data = json.loads(raw)
+    else:
+        raise ValueError(
+            f"Unsupported config format {suffix!r}. Use .yaml, .yml, or .json"
+        )
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            "Command tools config root must be a JSON object or YAML mapping, not a list or scalar"
+        )
+    return data
+
+
+def apply_working_dir_base(spec: CommandToolsSpec, config_path: Path) -> CommandToolsSpec:
+    """Resolve relative working_dir values against the config file's parent directory."""
+    base = config_path.resolve().parent
+    new_tools: list[CommandToolSpec] = []
+    for t in spec.tools:
+        wd = t.working_dir
+        if wd is None:
+            new_tools.append(t)
+            continue
+        p = Path(wd)
+        if p.is_absolute():
+            new_tools.append(t)
+        else:
+            new_tools.append(
+                t.model_copy(update={"working_dir": str((base / p).resolve())})
+            )
+    return spec.model_copy(update={"tools": new_tools})

--- a/src/fastmcp/server/providers/command_config/provider.py
+++ b/src/fastmcp/server/providers/command_config/provider.py
@@ -1,0 +1,27 @@
+"""CommandConfigProvider — exposes command-backed tools from a CommandToolsSpec."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from fastmcp.server.providers.base import Provider
+from fastmcp.server.providers.command_config.models import CommandToolsSpec
+from fastmcp.server.providers.command_config.tool import (
+    CommandBackedTool,
+    parameter_spec_to_json_schema,
+)
+from fastmcp.tools.tool import Tool
+
+
+class CommandConfigProvider(Provider):
+    """Provider that registers one MCP tool per entry in :class:`CommandToolsSpec`."""
+
+    def __init__(self, spec: CommandToolsSpec) -> None:
+        super().__init__()
+        self._spec = spec
+
+    async def _list_tools(self) -> Sequence[Tool]:
+        return [
+            CommandBackedTool(ts, parameter_spec_to_json_schema(ts.parameters))
+            for ts in self._spec.tools
+        ]

--- a/src/fastmcp/server/providers/command_config/tool.py
+++ b/src/fastmcp/server/providers/command_config/tool.py
@@ -1,0 +1,213 @@
+"""CommandBackedTool: MCP Tool that runs a subprocess (no shell)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+from mcp.types import TextContent
+
+from fastmcp.server.providers.command_config.models import (
+    CommandToolSpec,
+    ParameterSpec,
+)
+from fastmcp.server.tasks.config import TaskConfig
+from fastmcp.tools.tool import Tool, ToolResult
+
+
+def parameter_spec_to_json_schema(parameters: dict[str, ParameterSpec]) -> dict[str, Any]:
+    """Build JSON Schema object for MCP tool parameters."""
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for param_name, spec in parameters.items():
+        properties[param_name] = {
+            "type": spec.type,
+            "description": spec.description or "",
+        }
+        if spec.required:
+            required.append(param_name)
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    }
+
+
+def _resolve_arguments(
+    spec: CommandToolSpec, arguments: dict[str, Any]
+) -> tuple[dict[str, Any], str | None]:
+    """Apply defaults, validate required fields, coerce types."""
+    resolved: dict[str, Any] = dict(arguments)
+    for param_name, param_spec in spec.parameters.items():
+        if param_name not in resolved:
+            if param_spec.default is not None:
+                resolved[param_name] = param_spec.default
+            elif param_spec.required:
+                return {}, f"Missing required parameter: {param_name}"
+            else:
+                continue
+        raw = resolved[param_name]
+        if param_spec.type == "string":
+            resolved[param_name] = str(raw) if raw is not None else ""
+        elif param_spec.type == "number":
+            try:
+                resolved[param_name] = float(raw)
+            except (TypeError, ValueError):
+                return (
+                    {},
+                    f"Parameter {param_name} must be a number, got {type(raw).__name__}",
+                )
+        elif param_spec.type == "integer":
+            try:
+                resolved[param_name] = int(raw)
+            except (TypeError, ValueError):
+                return (
+                    {},
+                    f"Parameter {param_name} must be an integer, got {type(raw).__name__}",
+                )
+        elif param_spec.type == "boolean":
+            if isinstance(raw, bool):
+                resolved[param_name] = raw
+            elif isinstance(raw, str):
+                resolved[param_name] = raw.lower() in ("true", "1", "yes")
+            else:
+                resolved[param_name] = bool(raw)
+    return resolved, None
+
+
+def _replace_placeholders(
+    args_template: list[str], resolved: dict[str, Any]
+) -> tuple[list[str], str | None]:
+    """Substitute ``{param}`` tokens (whole argv element only)."""
+    out: list[str] = []
+    for part in args_template:
+        if len(part) >= 2 and part.startswith("{") and part.endswith("}"):
+            key = part[1:-1]
+            if key not in resolved:
+                return [], f"Placeholder {{{key}}} has no value in arguments"
+            out.append(str(resolved[key]))
+        else:
+            out.append(part)
+    return out, None
+
+
+def _failure_result(
+    err: str,
+    *,
+    command: list[str],
+    cwd: str | None,
+) -> ToolResult:
+    return ToolResult(
+        content=TextContent(type="text", text=f"Error: {err}"),
+        structured_content={
+            "ok": False,
+            "error": err,
+            "exit_code": -1,
+            "stdout": "",
+            "stderr": "",
+            "command": command,
+            "working_dir": cwd,
+        },
+    )
+
+
+class CommandBackedTool(Tool):
+    """Runs ``command`` + resolved ``args_template`` via :func:`asyncio.create_subprocess_exec`.
+
+    Security: ``shell`` is never used; arguments are passed as a list (no shell injection
+    from metacharacters in parameter values). Users must still trust configured executables
+    and working directories.
+    """
+
+    task_config: TaskConfig = TaskConfig(mode="forbidden")
+
+    def __init__(self, tool_spec: CommandToolSpec, parameters_schema: dict[str, Any]):
+        # Intentionally omit Tool.timeout: timeout is enforced only around communicate()
+        # to avoid stacking with server-level tool timeouts.
+        super().__init__(
+            name=tool_spec.name,
+            description=tool_spec.description,
+            parameters=parameters_schema,
+        )
+        self._tool_spec = tool_spec
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        spec = self._tool_spec
+        resolved, err = _resolve_arguments(spec, arguments)
+        if err:
+            return _failure_result(err, command=[], cwd=spec.working_dir)
+
+        resolved_args, err = _replace_placeholders(spec.args_template, resolved)
+        if err:
+            return _failure_result(err, command=[], cwd=spec.working_dir)
+
+        cmd_list = [spec.command, *resolved_args]
+        cwd: str | None = spec.working_dir
+        if cwd is not None:
+            cwd_path = Path(cwd)
+            if not cwd_path.is_dir():
+                return _failure_result(
+                    f"working_dir does not exist or is not a directory: {cwd}",
+                    command=cmd_list,
+                    cwd=cwd,
+                )
+
+        env = os.environ.copy()
+        env.update(spec.env)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd_list,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+            timeout = spec.timeout_seconds
+            if timeout is not None and timeout > 0:
+                try:
+                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                        proc.communicate(), timeout=float(timeout)
+                    )
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+                    msg = f"Command timed out after {timeout} seconds"
+                    return _failure_result(msg, command=cmd_list, cwd=cwd)
+            else:
+                stdout_bytes, stderr_bytes = await proc.communicate()
+
+            stdout_str = stdout_bytes.decode("utf-8", errors="replace")
+            stderr_str = stderr_bytes.decode("utf-8", errors="replace")
+            exit_code = proc.returncode if proc.returncode is not None else -1
+            ok = exit_code == 0
+
+            if ok:
+                text = "Command executed successfully.\nexit_code: 0\nstdout:\n" + stdout_str
+                if stderr_str:
+                    text += "\nstderr:\n" + stderr_str
+            else:
+                text = (
+                    f"Command failed.\nexit_code: {exit_code}\nstderr:\n"
+                    f"{stderr_str}\nstdout:\n{stdout_str}"
+                )
+
+            return ToolResult(
+                content=TextContent(type="text", text=text),
+                structured_content={
+                    "ok": ok,
+                    "exit_code": exit_code,
+                    "stdout": stdout_str,
+                    "stderr": stderr_str,
+                    "command": cmd_list,
+                    "working_dir": cwd,
+                },
+            )
+        except FileNotFoundError as e:
+            err_msg = f"Command or executable not found: {e}"
+            return _failure_result(err_msg, command=cmd_list, cwd=cwd)
+        except Exception as e:
+            err_msg = f"{type(e).__name__}: {e}"
+            return _failure_result(err_msg, command=cmd_list, cwd=cwd)

--- a/tests/server/providers/test_command_config.py
+++ b/tests/server/providers/test_command_config.py
@@ -1,0 +1,269 @@
+"""Tests for CommandConfigProvider and command_config models."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from fastmcp import Client, FastMCP
+from fastmcp.server.providers.command_config import (
+    CommandBackedTool,
+    CommandConfigProvider,
+    CommandToolSpec,
+    ParameterSpec,
+    load_command_tools_spec,
+    parameter_spec_to_json_schema,
+)
+
+
+def _write_echo_and_fail_scripts(project: Path) -> None:
+    scripts = project / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "echo_tool.py").write_text(
+        """import argparse
+import sys
+p = argparse.ArgumentParser()
+p.add_argument("--msg", required=True)
+args = p.parse_args()
+print(args.msg)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    (scripts / "fail_stub.py").write_text(
+        """import sys
+print("err", file=sys.stderr)
+sys.exit(1)
+""",
+        encoding="utf-8",
+    )
+
+
+def test_load_command_tools_spec_yaml(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server_name: "TestServer"
+tools:
+  - name: "echo_tool"
+    description: "Echo"
+    command: "python"
+    args_template: ["scripts/echo.py", "--msg", "{msg}"]
+    parameters:
+      msg:
+        type: "string"
+        description: "Message"
+        required: true
+""",
+        encoding="utf-8",
+    )
+    spec = load_command_tools_spec(config_file, resolve_relative_working_dirs=False)
+    assert spec.server_name == "TestServer"
+    assert len(spec.tools) == 1
+    assert spec.tools[0].name == "echo_tool"
+
+
+def test_load_command_tools_spec_json(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    config_file.write_text(
+        '{"server_name": "J", "tools": [{"name": "t", "description": "d", "command": "python", "args_template": [], "parameters": {}}]}',
+        encoding="utf-8",
+    )
+    spec = load_command_tools_spec(config_file, resolve_relative_working_dirs=False)
+    assert spec.server_name == "J"
+
+
+def test_load_command_tools_spec_bad_extension(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.txt"
+    config_file.write_text("tools: []", encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported config format"):
+        load_command_tools_spec(config_file)
+
+
+def test_load_command_tools_spec_duplicate_names(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+tools:
+  - name: "dup"
+    description: "a"
+    command: "python"
+  - name: "dup"
+    description: "b"
+    command: "python"
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValidationError, match="Duplicate tool name"):
+        load_command_tools_spec(config_file, resolve_relative_working_dirs=False)
+
+
+def test_resolve_relative_working_dir(tmp_path: Path) -> None:
+    sub = tmp_path / "proj"
+    sub.mkdir()
+    config_file = sub / "config.yaml"
+    config_file.write_text(
+        """
+tools:
+  - name: "t"
+    description: "d"
+    command: "python"
+    working_dir: "."
+""",
+        encoding="utf-8",
+    )
+    spec = load_command_tools_spec(config_file, resolve_relative_working_dirs=True)
+    assert spec.tools[0].working_dir == str(sub.resolve())
+
+
+@pytest.fixture
+def echo_tool_spec(tmp_path: Path) -> CommandToolSpec:
+    _write_echo_and_fail_scripts(tmp_path)
+    return CommandToolSpec(
+        name="echo_tool",
+        description="Echo",
+        command=sys.executable,
+        args_template=["scripts/echo_tool.py", "--msg", "{msg}"],
+        working_dir=str(tmp_path),
+        parameters={
+            "msg": ParameterSpec(type="string", description="Msg", required=True),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_command_backed_tool_missing_required(echo_tool_spec: CommandToolSpec) -> None:
+    schema = parameter_spec_to_json_schema(echo_tool_spec.parameters)
+    tool = CommandBackedTool(echo_tool_spec, schema)
+    result = await tool.run({})
+    assert result.structured_content is not None
+    assert result.structured_content["ok"] is False
+    assert "Missing required" in result.structured_content["error"]
+
+
+@pytest.mark.asyncio
+async def test_command_backed_tool_placeholder_missing(echo_tool_spec: CommandToolSpec) -> None:
+    schema = parameter_spec_to_json_schema(echo_tool_spec.parameters)
+    tool = CommandBackedTool(echo_tool_spec, schema)
+    result = await tool.run({"other": "x"})
+    assert result.structured_content is not None
+    assert result.structured_content["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_command_backed_tool_echo_success(echo_tool_spec: CommandToolSpec) -> None:
+    schema = parameter_spec_to_json_schema(echo_tool_spec.parameters)
+    tool = CommandBackedTool(echo_tool_spec, schema)
+    result = await tool.run({"msg": "hello"})
+    assert result.structured_content is not None
+    assert result.structured_content["ok"] is True
+    assert result.structured_content["exit_code"] == 0
+    assert "hello" in result.structured_content["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_command_backed_tool_fail_exit(tmp_path: Path) -> None:
+    _write_echo_and_fail_scripts(tmp_path)
+    spec = CommandToolSpec(
+        name="fail_stub",
+        description="Fails",
+        command=sys.executable,
+        args_template=["scripts/fail_stub.py"],
+        working_dir=str(tmp_path),
+        parameters={},
+    )
+    schema = parameter_spec_to_json_schema(spec.parameters)
+    tool = CommandBackedTool(spec, schema)
+    result = await tool.run({})
+    assert result.structured_content is not None
+    assert result.structured_content["ok"] is False
+    assert result.structured_content["exit_code"] == 1
+
+
+@pytest.mark.asyncio
+async def test_command_backed_tool_timeout() -> None:
+    spec = CommandToolSpec(
+        name="sleep_tool",
+        description="Sleep",
+        command=sys.executable,
+        args_template=["-c", "import time; time.sleep(10)"],
+        timeout_seconds=1,
+        parameters={},
+    )
+    schema = parameter_spec_to_json_schema(spec.parameters)
+    tool = CommandBackedTool(spec, schema)
+    result = await tool.run({})
+    assert result.structured_content is not None
+    assert result.structured_content["ok"] is False
+    err = result.structured_content.get("error", "").lower()
+    assert "timeout" in err or "timed out" in err
+
+
+@pytest.mark.asyncio
+async def test_command_backed_tool_working_dir_missing() -> None:
+    spec = CommandToolSpec(
+        name="bad",
+        description="Bad",
+        command=sys.executable,
+        args_template=["-c", "print(1)"],
+        working_dir="/nonexistent/dir/12345",
+        parameters={},
+    )
+    schema = parameter_spec_to_json_schema(spec.parameters)
+    tool = CommandBackedTool(spec, schema)
+    result = await tool.run({})
+    assert result.structured_content is not None
+    assert result.structured_content["ok"] is False
+    assert "working_dir" in result.structured_content.get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_command_config_provider_client(tmp_path: Path) -> None:
+    _write_echo_and_fail_scripts(tmp_path)
+    exe = json.dumps(sys.executable)
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        f"""
+server_name: "CmdCfgTest"
+tools:
+  - name: "echo_tool"
+    description: "Echo"
+    command: {exe}
+    args_template: ["scripts/echo_tool.py", "--msg", "{{msg}}"]
+    working_dir: "."
+    parameters:
+      msg:
+        type: "string"
+        required: true
+  - name: "fail_stub"
+    description: "Fail"
+    command: {exe}
+    args_template: ["scripts/fail_stub.py"]
+    working_dir: "."
+    parameters: {{}}
+""",
+        encoding="utf-8",
+    )
+    spec = load_command_tools_spec(config_file)
+    provider = CommandConfigProvider(spec)
+    mcp = FastMCP(spec.server_name or "CmdCfgTest", providers=[provider])
+
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        names = {t.name for t in tools}
+        assert "echo_tool" in names
+        assert "fail_stub" in names
+
+        result = await client.call_tool("echo_tool", {"msg": "integration_test"})
+        assert result.structured_content is not None
+        assert result.structured_content.get("ok") is True
+        assert "integration_test" in result.structured_content.get("stdout", "")
+
+        result_fail = await client.call_tool("fail_stub", {})
+        assert result_fail.structured_content is not None
+        assert result_fail.structured_content.get("ok") is False
+        assert result_fail.structured_content.get("exit_code") == 1


### PR DESCRIPTION
## Description

Closes issue #3558

Adds a first-class **command-backed tool** path: load a YAML/JSON document into `CommandToolsSpec`, expose tools via `CommandConfigProvider`, and execute each tool with `asyncio.create_subprocess_exec` (never `shell=True`). Relative `working_dir` entries resolve against the config file’s directory by default.

**Usage:**

```python
from pathlib import Path
from fastmcp import FastMCP
from fastmcp.server.providers import CommandConfigProvider, load_command_tools_spec

spec = load_command_tools_spec(Path("command-tools.yaml"))
mcp = FastMCP(spec.server_name or "MyServer", providers=[CommandConfigProvider(spec)])
```

**Design notes:** `CommandBackedTool` does not set `Tool.timeout`; timeout is applied only around `communicate()` to avoid stacking with server-level tool timeouts. Config must declare unique tool names.

## Contribution type

- [ ] Bug fix
- [ ] Documentation improvement
- [x] Enhancement

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes

**Follow-up:** Mintlify docs page under `docs/` (not included in this PR).
