### PR TITLE
Proxy remote server instructions via create_proxy

### DIFF
--- a/docs/servers/providers/proxy.mdx
+++ b/docs/servers/providers/proxy.mdx
@@ -129,6 +129,7 @@ Proxies automatically forward MCP protocol features:
 
 | Feature | Description |
 |---------|-------------|
+| Instructions | Server instructions from the backend |
 | Roots | Filesystem root access requests |
 | Sampling | LLM completion requests |
 | Elicitation | User input requests |
@@ -146,6 +147,24 @@ proxy = create_proxy("advanced_backend.py")
 # - Logs messages → appear in your client
 # - Reports progress → shown in your client
 ```
+
+### Server Instructions
+
+When you use `create_proxy()`, the proxy automatically fetches the backend server's instructions at startup and exposes them to clients. If you pass explicit `instructions` to `create_proxy()`, those take precedence.
+
+```python
+from fastmcp.server import create_proxy
+
+# Inherits instructions from the backend server
+proxy = create_proxy("http://example.com/mcp")
+
+# Override with your own instructions
+proxy = create_proxy("http://example.com/mcp", instructions="Custom proxy instructions")
+```
+
+<Note>
+Automatic instruction forwarding is a `create_proxy()` convenience. If you use `FastMCPProxy` or `ProxyProvider` directly, you'll need to handle instructions yourself.
+</Note>
 
 ### Disabling Features
 

--- a/src/fastmcp/server/providers/proxy.py
+++ b/src/fastmcp/server/providers/proxy.py
@@ -723,6 +723,17 @@ class ProxyProvider(Provider):
     # lifespan() uses default implementation (empty context manager)
     # because client cleanup is handled per-request
 
+    # -------------------------------------------------------------------------
+    # Instructions
+    # -------------------------------------------------------------------------
+
+    async def fetch_remote_instructions(self) -> str | None:
+        """Fetch instructions from the remote server."""
+        client = await self._get_client()
+        async with client:
+            result = await client.initialize()
+            return result.instructions
+
 
 # -----------------------------------------------------------------------------
 # Factory Functions

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -95,7 +95,7 @@ if TYPE_CHECKING:
     from fastmcp.server.providers.openapi import ComponentFn as OpenAPIComponentFn
     from fastmcp.server.providers.openapi import RouteMap
     from fastmcp.server.providers.openapi import RouteMapFn as OpenAPIRouteMapFn
-    from fastmcp.server.providers.proxy import FastMCPProxy
+    from fastmcp.server.providers.proxy import FastMCPProxy, ProxyProvider
 
 logger = get_logger(__name__)
 
@@ -2216,6 +2216,33 @@ class FastMCP(
 # -----------------------------------------------------------------------------
 
 
+def _install_instructions_lifespan(
+    server: FastMCP,
+    provider: ProxyProvider,
+) -> None:
+    """Wrap the server's lifespan to fetch remote instructions at startup.
+
+    If the remote server provides instructions and the proxy doesn't already
+    have any, the remote instructions are set on the proxy server so that
+    clients see them during initialization.
+    """
+    original_lifespan = server._lifespan
+
+    @asynccontextmanager
+    async def _proxy_lifespan(app: FastMCP) -> AsyncIterator[Any]:
+        async with original_lifespan(app) as result:
+            if app.instructions is None:
+                try:
+                    instructions = await provider.fetch_remote_instructions()
+                    if instructions is not None:
+                        app.instructions = instructions
+                except Exception:
+                    logger.debug("Failed to fetch remote server instructions for proxy")
+            yield result
+
+    server._lifespan = _proxy_lifespan
+
+
 def create_proxy(
     target: (
         Client[ClientTransportT]
@@ -2261,11 +2288,21 @@ def create_proxy(
     """
     from fastmcp.server.providers.proxy import (
         FastMCPProxy,
+        ProxyProvider,
         _create_client_factory,
     )
 
     client_factory = _create_client_factory(target)
-    return FastMCPProxy(
+    explicit_instructions = "instructions" in settings
+    proxy = FastMCPProxy(
         client_factory=client_factory,
         **settings,
     )
+
+    if not explicit_instructions:
+        proxy_provider = next(
+            p for p in proxy.providers if isinstance(p, ProxyProvider)
+        )
+        _install_instructions_lifespan(proxy, proxy_provider)
+
+    return proxy

--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -245,6 +245,65 @@ async def test_proxy_with_async_client_factory():
     assert client.transport.url == "http://example.com/mcp/"
 
 
+class TestProxyInstructions:
+    async def test_proxy_inherits_remote_instructions(self):
+        """Proxy should inherit instructions from the remote server."""
+        server = FastMCP("RemoteServer", instructions="Remote server instructions")
+
+        @server.tool
+        def hello() -> str:
+            return "hi"
+
+        proxy = create_proxy(server)
+        assert proxy.instructions is None
+
+        async with Client(proxy) as client:
+            result = await client.initialize()
+            assert result.instructions == "Remote server instructions"
+
+    async def test_proxy_explicit_instructions_override_remote(self):
+        """Explicitly set instructions should take precedence over remote."""
+        server = FastMCP("RemoteServer", instructions="Remote instructions")
+
+        @server.tool
+        def hello() -> str:
+            return "hi"
+
+        proxy = create_proxy(server, instructions="My proxy instructions")
+
+        async with Client(proxy) as client:
+            result = await client.initialize()
+            assert result.instructions == "My proxy instructions"
+
+    async def test_proxy_no_instructions_when_remote_has_none(self):
+        """Proxy instructions should remain None if remote has none."""
+        server = FastMCP("RemoteServer")
+
+        @server.tool
+        def hello() -> str:
+            return "hi"
+
+        proxy = create_proxy(server)
+
+        async with Client(proxy) as client:
+            result = await client.initialize()
+            assert result.instructions is None
+
+    async def test_fastmcp_proxy_does_not_fetch_instructions(self):
+        """FastMCPProxy used directly should not auto-fetch instructions."""
+        server = FastMCP("RemoteServer", instructions="Remote instructions")
+
+        @server.tool
+        def hello() -> str:
+            return "hi"
+
+        proxy = FastMCPProxy(client_factory=lambda: Client(server))
+
+        async with Client(proxy) as client:
+            result = await client.initialize()
+            assert result.instructions is None
+
+
 class TestTools:
     async def test_get_tools(self, proxy_server):
         tools = await proxy_server.list_tools()


### PR DESCRIPTION
`create_proxy()` now automatically fetches the remote server's instructions at startup and exposes them to connecting clients. This was a clear oversight — proxies forwarded tools, resources, prompts, sampling, roots, and elicitation, but not instructions.

The fix keeps a clean separation of concerns: `ProxyProvider` exposes a `fetch_remote_instructions()` capability, and `create_proxy()` wires it into the server's lifespan. `FastMCPProxy` used directly doesn't auto-fetch — it's the lower-level escape hatch where users handle this themselves.

```python
from fastmcp.server import create_proxy

# Instructions automatically inherited from the backend
proxy = create_proxy("http://example.com/mcp")

# Explicit instructions take precedence
proxy = create_proxy("http://example.com/mcp", instructions="Custom instructions")
```

Closes #3559