### PR TITLE
fix: increase sleep duration in proxy cache tests

### DIFF
--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -815,7 +815,7 @@ class TestProxyProviderCache:
         assert provider._tools_cache is not None
         original_ts = provider._tools_cache.timestamp
 
-        time.sleep(0.01)
+        time.sleep(0.05)
 
         await provider._get_tool("greet")
         assert provider._tools_cache.timestamp > original_ts
@@ -829,7 +829,7 @@ class TestProxyProviderCache:
         first_ts = provider._tools_cache.timestamp  # type: ignore[union-attr]
 
         # Tiny sleep so monotonic clock advances
-        time.sleep(0.01)
+        time.sleep(0.05)
 
         await provider._list_tools()
         assert provider._tools_cache.timestamp > first_ts  # type: ignore[union-attr]


### PR DESCRIPTION
The tests for proxy cache expiration were failing intermittently on Windows runners due to the system monotonic clock resolution.

The original `time.sleep(0.01)` was occasionally shorter than the Windows ~15.6ms timer resolution, causing the monotonic clock to appear stopped and the `timestamp > original_ts` assertions to fail. By increasing the sleep duration to 50ms, the tests now securely exceed the minimum timer resolution and pass deterministically across all platforms.
