### PR TITLE
Add release instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ gh release create v3.2.0 --target main --title "v3.2.0: Theme Here" --generate-n
 
 Most releases target `main`, but maintenance or backport releases may target a different branch (e.g., `release/2.x`). Confirm the target with the maintainer if there's any ambiguity.
 
-The handwritten notes go *above* the auto-generated changelog and are the part that matters. Work with the maintainer to draft them — propose a draft, get feedback, iterate. Do not publish without the maintainer's sign-off.
+The handwritten notes are prepended above the auto-generated changelog and are the part that matters. Do not include a title in the notes body — the release title (`v{version}: {pun}`) already serves as the heading. Work with the maintainer to draft the notes — propose a draft, get feedback, iterate. Do not publish without the maintainer's sign-off.
 
 **Before drafting, always read recent existing releases** (`gh release list` then `gh release view <tag>`) to absorb the voice, structure, and level of detail. Each release builds on the tone of previous ones — don't guess at the style from these instructions alone.
 


### PR DESCRIPTION
Agents cutting releases had no guidance on FastMCP's conventions — the tag format, the pun titles, or the distinction between narrative point-release notes and terse patch notes. This adds a Releases section to CLAUDE.md that documents the process and, importantly, makes clear that release notes are a collaborative artifact: the agent drafts, the maintainer approves the title and signs off on the prose.