### PR TITLE
Transparently refresh upstream token in OAuthProxy.load_access_token()

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -1629,7 +1629,14 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                                 verification_token
                             )
 
-                        if not validated:
+                        # Only refresh if the (possibly reloaded) token is
+                        # still expired — a non-expiry failure on a fresh
+                        # token (scope mismatch, revocation) won't be
+                        # helped by refreshing.
+                        if (
+                            not validated
+                            and upstream_token_set.expires_at <= time.time()
+                        ):
                             upstream_token_set = await self._try_transparent_refresh(
                                 upstream_token_set
                             )
@@ -1642,6 +1649,23 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                                 )
                 except Exception as e:
                     logger.debug("Transparent upstream refresh failed: %s", e)
+                    # In a distributed deployment, another worker may have
+                    # already refreshed and rotated the token, causing our
+                    # stale refresh token to fail. Re-read and re-validate.
+                    try:
+                        reloaded = await self._upstream_token_store.get(
+                            key=upstream_token_set.upstream_token_id
+                        )
+                        if reloaded:
+                            verification_token = self._get_verification_token(reloaded)
+                            if verification_token is not None:
+                                validated = await self._token_validator.verify_token(
+                                    verification_token
+                                )
+                                if validated:
+                                    upstream_token_set = reloaded
+                    except Exception:
+                        pass
 
             if not validated:
                 logger.debug("Upstream token validation failed")

--- a/tests/server/auth/oauth_proxy/test_tokens.py
+++ b/tests/server/auth/oauth_proxy/test_tokens.py
@@ -806,3 +806,52 @@ class TestTransparentUpstreamRefresh:
         assert result is None
         # Refresh should NOT have been attempted
         mock_oauth_client.refresh_token.assert_not_called()
+
+    async def test_reload_from_storage_after_refresh_failure(self, proxy):
+        """If refresh fails, re-read from storage in case another worker refreshed."""
+        fastmcp_jwt = await self._setup_expired_session(proxy)
+
+        # Simulate: refresh fails (stale refresh token), but another worker
+        # already wrote a fresh upstream token to storage.
+        refreshed_token_set = UpstreamTokenSet(
+            upstream_token_id="upstream-tok-id",
+            access_token="refreshed-upstream-access",
+            refresh_token="new-refresh-tok",
+            refresh_token_expires_at=time.time() + 86400,
+            expires_at=time.time() + 3600,
+            token_type="Bearer",
+            scope="read",
+            client_id="test-client",
+            created_at=time.time(),
+        )
+
+        # The store is read three times:
+        # 1. Initial lookup in load_access_token
+        # 2. Re-read inside the advisory lock
+        # 3. Re-read after refresh failure (recovery path)
+        original_get = proxy._upstream_token_store.get
+        call_count = 0
+
+        async def mock_get(key: str) -> UpstreamTokenSet | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return await original_get(key)
+            # After refresh failure, return the "other worker's" refreshed token
+            return refreshed_token_set
+
+        mock_oauth_client = AsyncMock()
+        mock_oauth_client.refresh_token = AsyncMock(
+            side_effect=Exception("refresh token rotated by another worker")
+        )
+
+        with (
+            patch.object(
+                proxy, "_create_upstream_oauth_client", return_value=mock_oauth_client
+            ),
+            patch.object(proxy._upstream_token_store, "get", side_effect=mock_get),
+        ):
+            result = await proxy.load_access_token(fastmcp_jwt)
+
+        assert result is not None
+        assert result.token == "refreshed-upstream-access"


### PR DESCRIPTION
When the upstream IdP token expires, `OAuthProxy.load_access_token()` re-validates it on every request and returns `None` — causing a 401 that forces clients into a full re-authentication flow (PRM discovery → OASM discovery → DCR → browser redirect). This is the root cause of session death reported in #3581, and is distinct from the storage TTL bug fixed in #2796.

The fix: when upstream token validation fails and a refresh token is available, the proxy now transparently refreshes the upstream token before giving up. The refreshed token is re-validated and stored, so subsequent requests use the fresh token without any client-visible interruption.

```python
# Before: upstream expires → immediate 401
validated = await self._token_validator.verify_token(verification_token)
if not validated:
    return None  # client forced into full re-auth

# After: upstream expires → try refresh first
validated = await self._token_validator.verify_token(verification_token)
if not validated and upstream_token_set.refresh_token:
    upstream_token_set = await self._try_transparent_refresh(upstream_token_set)
    validated = await self._token_validator.verify_token(refreshed_token)
if not validated:
    return None  # only after refresh also fails
```

Closes #3581