### PR TITLE
Fix query parameter serialization to respect OpenAPI explode setting

### DIFF
--- a/src/fastmcp/utilities/openapi/director.py
+++ b/src/fastmcp/utilities/openapi/director.py
@@ -238,18 +238,29 @@ class RequestDirector:
         serialized: dict[str, Any] = {}
         for key, value in query_params.items():
             param_info = param_lookup.get(key)
-            if param_info is not None and isinstance(value, list):
-                # OpenAPI default for form style: explode=true
+            if param_info is not None:
                 explode = param_info.explode if param_info.explode is not None else True
                 if not explode:
-                    if not value:
-                        continue
                     style = param_info.style or "form"
                     delimiter = self._STYLE_DELIMITERS.get(style, ",")
-                    serialized[key] = delimiter.join(
-                        _query_scalar_to_str(v) for v in value
-                    )
-                    continue
+                    if isinstance(value, list):
+                        if not value:
+                            continue
+                        serialized[key] = delimiter.join(
+                            _query_scalar_to_str(v) for v in value
+                        )
+                        continue
+                    elif isinstance(value, dict):
+                        if not value:
+                            continue
+                        # form,explode=false on objects: key,value pairs
+                        # e.g. {"R": 100, "G": 200} → "R,100,G,200"
+                        parts: list[str] = []
+                        for k, v in value.items():
+                            parts.append(_query_scalar_to_str(k))
+                            parts.append(_query_scalar_to_str(v))
+                        serialized[key] = delimiter.join(parts)
+                        continue
             serialized[key] = value
         return serialized
 

--- a/tests/utilities/openapi/test_director.py
+++ b/tests/utilities/openapi/test_director.py
@@ -621,6 +621,68 @@ class TestQueryParameterSerialization:
         request = director.build(route, {"ids": []}, "https://example.com")
         assert "ids" not in str(request.url)
 
+    def test_explode_false_dict_value(self, director):
+        """style=form, explode=false on objects serializes as key,value pairs."""
+        route = HTTPRoute(
+            path="/items",
+            method="GET",
+            operation_id="list_items",
+            parameters=[
+                ParameterInfo(
+                    name="color",
+                    location="query",
+                    required=True,
+                    schema={
+                        "type": "object",
+                        "properties": {
+                            "R": {"type": "integer"},
+                            "G": {"type": "integer"},
+                            "B": {"type": "integer"},
+                        },
+                    },
+                    explode=False,
+                    style="form",
+                )
+            ],
+            parameter_map={
+                "color": {"location": "query", "openapi_name": "color"},
+            },
+        )
+
+        request = director.build(
+            route,
+            {"color": {"R": 100, "G": 200, "B": 150}},
+            "https://example.com",
+        )
+        url = str(request.url)
+        assert "color=R" in url
+        assert url.count("color=") == 1
+        # Should contain alternating key,value pairs
+        assert "100" in url and "200" in url and "150" in url
+
+    def test_explode_false_empty_dict_omitted(self, director):
+        """Empty dict with explode=false omits the parameter."""
+        route = HTTPRoute(
+            path="/items",
+            method="GET",
+            operation_id="list_items",
+            parameters=[
+                ParameterInfo(
+                    name="filter",
+                    location="query",
+                    required=False,
+                    schema={"type": "object"},
+                    explode=False,
+                )
+            ],
+            parameter_map={
+                "filter": {"location": "query", "openapi_name": "filter"},
+            },
+        )
+
+        request = director.build(route, {"filter": {}}, "https://example.com")
+        assert "filter" not in str(request.url)
+
 
 class TestRequestDirectorIntegration:
     """Test RequestDirector with real parsed routes."""


### PR DESCRIPTION
`RequestDirector.build` was ignoring the `explode` and `style` fields on query parameters, so array values always serialized in exploded form (`values=a&values=b`) regardless of what the OpenAPI spec declared. When `explode=false`, the correct serialization depends on the parameter's `style`:

- `form` (default): comma-delimited → `ids=1,2,3`
- `pipeDelimited`: pipe-delimited → `ids=1|2|3`
- `spaceDelimited`: space-delimited → `ids=1%202%203`

The model and parser already extracted and stored these fields — the director just never consulted them. This adds a `_serialize_query_params` step between unflattening and URL construction that checks each query parameter's `ParameterInfo.explode` and `style` settings and joins list values with the appropriate delimiter.

```python
# Before: both endpoints get ?values=hello&values=world
# After:  explode=false endpoint gets ?values=hello,world

mcp = FastMCP.from_openapi(openapi_spec=spec, client=client)
async with Client(mcp) as c:
    await c.call_tool("not_explode", {"values": ["hello", "world"]})
    # GET /not_explode?values=hello,world
```

Closes #3594, closes #1543