### PR TITLE
Fix: Always return CallToolResult when structured_content exists (#3596)

### DIFF
--- a/src/fastmcp/tools/base.py
+++ b/src/fastmcp/tools/base.py
@@ -125,15 +125,15 @@ class ToolResult(BaseModel):
     ) -> (
         list[ContentBlock] | tuple[list[ContentBlock], dict[str, Any]] | CallToolResult
     ):
-        # Always return CallToolResult when structured_content exists to maintain
-        # consistent .data field in client (fixes #3596)
-        if self.structured_content is not None:
+        # Return CallToolResult when either meta or structured_content exists
+        # to maintain consistent client behavior (fixes #3596)
+        if self.meta is not None or self.structured_content is not None:
             return CallToolResult(
                 structuredContent=self.structured_content,
                 content=self.content,
                 _meta=self.meta,  # type: ignore[call-arg]  # _meta is Pydantic alias for meta field
             )
-        # Only return bare content list when no structured content
+        # Only return bare content when both are None
         return self.content
 
 


### PR DESCRIPTION
Fixes #3596

## Problem
`CallToolResult.data` returns `None` when structured data is present.

## Root Cause
`to_mcp_result()` returned tuple instead of `CallToolResult` when `meta=None` but `structured_content` exists.

## Solution
Return `CallToolResult` when either `meta` or `structured_content` is present (OR condition).

## MRE
```python
result = await client.call_tool("tool_name", {})
assert result.data is not None  # Now passes
```

Fixes both:
- Original bug (#3596 - structured_content without meta)  
- Regression caught by CI (meta without structured_content)

Co-authored-by: marvin-context-protocol[bot]