### PR TITLE
Forward enable_cimd to OAuthProxy in all provider subclasses

### DIFF
--- a/src/fastmcp/server/auth/providers/azure.py
+++ b/src/fastmcp/server/auth/providers/azure.py
@@ -111,6 +111,7 @@ class AzureProvider(OAuthProxy):
         consent_csp_policy: str | None = None,
         base_authority: str = "login.microsoftonline.com",
         http_client: httpx.AsyncClient | None = None,
+        enable_cimd: bool = True,
     ) -> None:
         """Initialize Azure OAuth provider.
 
@@ -163,6 +164,8 @@ class AzureProvider(OAuthProxy):
             http_client: Optional httpx.AsyncClient for connection pooling in JWKS fetches.
                 When provided, the client is reused for JWT key fetches and the caller
                 is responsible for its lifecycle. When None (default), a fresh client is created per fetch.
+            enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
+                client IDs (default True). Set to False to disable.
         """
         # Parse scopes if provided as string
         parsed_required_scopes = parse_scopes(required_scopes)
@@ -243,6 +246,7 @@ class AzureProvider(OAuthProxy):
             require_authorization_consent=require_authorization_consent,
             consent_csp_policy=consent_csp_policy,
             valid_scopes=parsed_required_scopes,
+            enable_cimd=enable_cimd,
         )
 
         authority_info = ""

--- a/src/fastmcp/server/auth/providers/discord.py
+++ b/src/fastmcp/server/auth/providers/discord.py
@@ -206,6 +206,7 @@ class DiscordProvider(OAuthProxy):
         require_authorization_consent: bool | Literal["external"] = True,
         consent_csp_policy: str | None = None,
         http_client: httpx.AsyncClient | None = None,
+        enable_cimd: bool = True,
     ):
         """Initialize Discord OAuth provider.
 
@@ -238,6 +239,8 @@ class DiscordProvider(OAuthProxy):
             http_client: Optional httpx.AsyncClient for connection pooling in token verification.
                 When provided, the client is reused across verify_token calls and the caller
                 is responsible for its lifecycle. When None (default), a fresh client is created per call.
+            enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
+                client IDs (default True). Set to False to disable.
         """
         # Parse scopes if provided as string
         required_scopes_final = (
@@ -269,6 +272,7 @@ class DiscordProvider(OAuthProxy):
             jwt_signing_key=jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             consent_csp_policy=consent_csp_policy,
+            enable_cimd=enable_cimd,
         )
 
         logger.debug(

--- a/src/fastmcp/server/auth/providers/github.py
+++ b/src/fastmcp/server/auth/providers/github.py
@@ -221,6 +221,7 @@ class GitHubProvider(OAuthProxy):
         require_authorization_consent: bool | Literal["external"] = True,
         consent_csp_policy: str | None = None,
         http_client: httpx.AsyncClient | None = None,
+        enable_cimd: bool = True,
     ):
         """Initialize GitHub OAuth provider.
 
@@ -254,6 +255,8 @@ class GitHubProvider(OAuthProxy):
             http_client: Optional httpx.AsyncClient for connection pooling in token verification.
                 When provided, the client is reused across verify_token calls and the caller
                 is responsible for its lifecycle. When None (default), a fresh client is created per call.
+            enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
+                client IDs (default True). Set to False to disable.
         """
         # Parse scopes if provided as string
         required_scopes_final = (
@@ -284,6 +287,7 @@ class GitHubProvider(OAuthProxy):
             jwt_signing_key=jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             consent_csp_policy=consent_csp_policy,
+            enable_cimd=enable_cimd,
         )
 
         logger.debug(

--- a/src/fastmcp/server/auth/providers/google.py
+++ b/src/fastmcp/server/auth/providers/google.py
@@ -233,6 +233,7 @@ class GoogleProvider(OAuthProxy):
         consent_csp_policy: str | None = None,
         extra_authorize_params: dict[str, str] | None = None,
         http_client: httpx.AsyncClient | None = None,
+        enable_cimd: bool = True,
     ):
         """Initialize Google OAuth provider.
 
@@ -277,6 +278,8 @@ class GoogleProvider(OAuthProxy):
             http_client: Optional httpx.AsyncClient for connection pooling in token verification.
                 When provided, the client is reused across verify_token calls and the caller
                 is responsible for its lifecycle. When None (default), a fresh client is created per call.
+            enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
+                client IDs (default True). Set to False to disable.
         """
         # Parse scopes if provided as string
         # Google requires at least one scope - openid is the minimal OIDC scope
@@ -332,6 +335,7 @@ class GoogleProvider(OAuthProxy):
             consent_csp_policy=consent_csp_policy,
             extra_authorize_params=extra_authorize_params_final,
             valid_scopes=valid_scopes_final,
+            enable_cimd=enable_cimd,
         )
 
         logger.debug(

--- a/src/fastmcp/server/auth/providers/workos.py
+++ b/src/fastmcp/server/auth/providers/workos.py
@@ -174,6 +174,7 @@ class WorkOSProvider(OAuthProxy):
         require_authorization_consent: bool | Literal["external"] = True,
         consent_csp_policy: str | None = None,
         http_client: httpx.AsyncClient | None = None,
+        enable_cimd: bool = True,
     ):
         """Initialize WorkOS OAuth provider.
 
@@ -204,6 +205,8 @@ class WorkOSProvider(OAuthProxy):
             http_client: Optional httpx.AsyncClient for connection pooling in token verification.
                 When provided, the client is reused across verify_token calls and the caller
                 is responsible for its lifecycle. When None (default), a fresh client is created per call.
+            enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
+                client IDs (default True). Set to False to disable.
         """
         # Apply defaults and ensure authkit_domain is a full URL
         authkit_domain_str = authkit_domain
@@ -237,6 +240,7 @@ class WorkOSProvider(OAuthProxy):
             jwt_signing_key=jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             consent_csp_policy=consent_csp_policy,
+            enable_cimd=enable_cimd,
         )
 
         logger.debug(


### PR DESCRIPTION
`OAuthProxy` accepts `enable_cimd` to control CIMD (Client ID Metadata Document) support, but none of the concrete provider subclasses exposed it — so the only way to disable CIMD was reaching into private internals after construction.

This adds `enable_cimd: bool = True` to the `__init__` of `AzureProvider`, `GitHubProvider`, `GoogleProvider`, `DiscordProvider`, and `WorkOSProvider`, forwarding it through to `super().__init__()`. (`OIDCProxy` already had it.)

```python
auth = AzureProvider(
    client_id="...",
    client_secret="...",
    tenant_id="...",
    required_scopes=["read"],
    base_url="http://localhost:8000",
    enable_cimd=False,  # now works
)
```

Closes #3602