### PR TITLE
fix(docs): correct misleading stateless_http header

### DIFF
--- a/docs/deployment/http.mdx
+++ b/docs/deployment/http.mdx
@@ -625,7 +625,7 @@ You might expect sticky sessions (session affinity) to solve this, but they don'
 
 For horizontally scaled deployments, enable stateless HTTP mode. In stateless mode, each request creates a fresh transport context, eliminating the need for session affinity entirely.
 
-**Option 1: Via constructor**
+**Option 1: Via `http_app()`**
 
 ```python
 from fastmcp import FastMCP


### PR DESCRIPTION
The "Enabling Stateless Mode" section labeled Option 1 as "Via constructor" but the code example correctly passes `stateless_http` to `http_app()`, not to `FastMCP()`. Updated the header to match the code.

Closes #3618

Generated with [Claude Code](https://claude.ai/code)