### PR TITLE
fix: filesystem provider import machinery

### DIFF
--- a/src/fastmcp/server/providers/filesystem_discovery.py
+++ b/src/fastmcp/server/providers/filesystem_discovery.py
@@ -140,6 +140,8 @@ def import_module_from_file(
         ImportError: If the module cannot be imported.
     """
     file_path = file_path.resolve()
+    if provider_root is not None:
+        provider_root = provider_root.resolve()
 
     # Check if this file is part of a package
     package_root = _find_package_root(file_path, stop_at=provider_root)

--- a/tests/fs/test_discovery.py
+++ b/tests/fs/test_discovery.py
@@ -7,7 +7,6 @@ from fastmcp.prompts.base import Prompt
 from fastmcp.resources.base import Resource
 from fastmcp.resources.template import FunctionResourceTemplate, ResourceTemplate
 from fastmcp.server.providers.filesystem_discovery import (
-    _find_package_root,
     discover_and_import,
     discover_files,
     extract_components,
@@ -513,7 +512,7 @@ class TestImportMachineryFixes:
         """A provider file named json.py must not overwrite sys.modules['json']."""
         import json as stdlib_json
 
-        saved = sys.modules.get("json")
+        saved = sys.modules["json"]
         try:
             (tmp_path / "json.py").write_text(
                 "from fastmcp.tools import tool\n@tool\ndef parse(): return 'provider'"
@@ -521,11 +520,14 @@ class TestImportMachineryFixes:
             import_module_from_file(tmp_path / "json.py")
             assert sys.modules.get("json") is stdlib_json
         finally:
-            if saved is not None:
-                sys.modules["json"] = saved
+            sys.modules["json"] = saved
 
     def test_same_stem_files_get_independent_modules(self, tmp_path: Path):
-        """Two files with the same stem in different directories must not collide in sys.modules."""
+        """Two files with the same stem in different directories must not collide in sys.modules.
+
+        The first-imported file keeps the bare stem key; the second gets a private key.
+        Both modules must be independently accessible with correct content.
+        """
         dir_a = tmp_path / "a"
         dir_b = tmp_path / "b"
         dir_a.mkdir()
@@ -538,19 +540,39 @@ class TestImportMachineryFixes:
 
         assert mod_a.ORIGIN == "a"
         assert mod_b.ORIGIN == "b"
+        # The first module retains the bare stem key; the second uses a private key.
+        # They must be distinct objects — the second import must not have clobbered the first.
+        assert mod_a is not mod_b
+        assert sys.modules.get("helpers") is not mod_b
 
     def test_package_root_bounded_by_provider_root(self, tmp_path: Path):
-        """_find_package_root must not walk above stop_at even when ancestors have __init__.py."""
+        """When the provider root is nested inside a larger package, import_module_from_file
+        with provider_root must not escape into ancestor packages.
+
+        The generated module name should be relative to the provider root (e.g. "myprovider.tools"),
+        not to an ancestor package (e.g. "myproject.myprovider.tools"), and tmp_path (the
+        ancestor's parent) must not be added to sys.path.
+        """
+        # Use a name that won't collide with any installed package
         project = tmp_path / "myproject"
         project.mkdir()
         (project / "__init__.py").write_text("")
-        mcp = project / "mcp"
-        mcp.mkdir()
-        (mcp / "__init__.py").write_text("")
-        (mcp / "tools.py").write_text("")
+        provider = project / "myprovider"
+        provider.mkdir()
+        (provider / "__init__.py").write_text("")
+        (provider / "tools.py").write_text("VALUE = 42")
 
-        found = _find_package_root(mcp / "tools.py", stop_at=mcp)
-        assert found == mcp
+        path_before = set(sys.path)
+        mod = import_module_from_file(provider / "tools.py", provider_root=provider)
+        path_after = set(sys.path)
+
+        # Module was correctly imported
+        assert mod.VALUE == 42
+        # sys.path should not contain tmp_path (the ancestor's grandparent);
+        # that would only happen if the package root escaped past the provider boundary
+        assert str(tmp_path) not in (path_after - path_before)
+        # The module name is bounded to the provider root, not "myproject.myprovider.tools"
+        assert mod.__name__ == "myprovider.tools"
 
     def test_non_package_reload_returns_updated_content(self, tmp_path: Path):
         """Re-importing a non-package file should reflect file changes (exec_module path)."""


### PR DESCRIPTION
`FileSystemProvider` had three related bugs in `import_module_from_file` that caused permanent process-wide side effects.

**`sys.path` was never cleaned up.** Every imported file added its parent directory (or package root's parent) to `sys.path[0]` and left it there for the lifetime of the process. In a typical layout with `tools/`, `resources/`, and `prompts/` subdirectories, three entries accumulated per provider instance, affecting all subsequent imports everywhere.

**Non-package files polluted `sys.modules` under their bare stem.** A file named `json.py` would be registered as `sys.modules["json"]`, silently replacing the stdlib module. Any subsequent `import json` in the process would get the provider file instead. Common risky names include `os`, `json`, `http`, `re`, `time`, `asyncio`.

**`_find_package_root` walked above the provider boundary.** When the provider root was nested inside a larger Python package (ancestor directories have `__init__.py`), the function escaped past the provider root — returning the ancestor as the package root, adding the wrong directory to `sys.path`, and generating module names like `myproject.mcp.tools` instead of `mcp.tools`.

The fix addresses all three together. `sys.path` additions are now wrapped in `try/finally` so the entry is always removed after `exec_module` completes. Non-package files fall back to a private hash-based `sys.modules` key (`_fastmcp_{stem}_{sha1[:12]}`) when their stem is already claimed by a different module, preventing stdlib shadowing. Private-key reload uses `spec.loader.exec_module(existing)` directly instead of `importlib.reload`, which searches `sys.path` for the module's name and fails for synthetic keys. `_find_package_root` gains a `stop_at` parameter; `discover_and_import` passes `provider_root` through.

Fixes #3625 (issues 2, 3, 6).

🤖 Generated with Claude Code