### PR TITLE
Fix mounted background tasks binding to parent server instead of child

### DIFF
--- a/log/task1.md
+++ b/log/task1.md
@@ -1,0 +1,155 @@
+# Task 1 — Fix Issue #3571
+
+**Issue**: [Mounted background tasks bind CurrentFastMCP() and Context.fastmcp to the parent server instead of the mounted child](https://github.com/PrefectHQ/fastmcp/issues/3571)
+**Reporter**: nkaras (Nick Karastamatis)
+**Assignee**: chrisguidry (Chris Guidry)
+**Labels**: bug, server
+
+---
+
+## Problem Description
+
+When a task-enabled tool is defined on a child FastMCP server and mounted into a parent server,
+background task execution (`task=True`) resolves the server context to the **parent** server
+instead of the **child** server.
+
+Affects:
+- `CurrentFastMCP()` dependency injection
+- `ctx.fastmcp` on an injected `Context`
+
+Foreground execution is fine — this only manifests in background task mode (`task=True`).
+
+---
+
+## Reproduction Script
+
+```python
+import asyncio
+from fastmcp import Client, Context, FastMCP
+from fastmcp.dependencies import CurrentFastMCP
+
+child = FastMCP("child")
+
+@child.tool(name="whoami", task=True)
+async def whoami(server=CurrentFastMCP()) -> str:
+    return f"server name: {server.name}"
+
+@child.tool(name="whoami_ctx", task=True)
+async def whoami_ctx(ctx: Context) -> str:
+    return f"context server: {ctx.fastmcp.name}"
+
+parent = FastMCP("parent")
+parent.mount(child, namespace="child")
+
+async def demo():
+    async with Client(parent) as client:
+        result1 = await (await client.call_tool("child_whoami", {}, task=True)).result()
+        result2 = await (await client.call_tool("child_whoami_ctx", {}, task=True)).result()
+        print(result1.content[0].text)
+        print(result2.content[0].text)
+
+if __name__ == "__main__":
+    asyncio.run(demo())
+```
+
+### Expected Output
+```
+server name: child
+context server: child
+```
+
+### Actual Output
+```
+server name: parent
+context server: parent
+```
+
+---
+
+## Investigation Steps
+
+### Step 1 — Reproduce the bug
+
+- [ ] Run the reproduction script and confirm the bug
+- [ ] Identify relevant source files
+
+### Step 2 — Trace the root cause
+
+- [ ] Find where `CurrentFastMCP` context var is set during background task execution
+- [ ] Find where `Context.fastmcp` is bound
+- [ ] Identify why the child server context is not propagated
+
+### Step 3 — Implement fix
+
+- [ ] Write failing test first (TDD approach per CLAUDE.md)
+- [ ] Implement the fix
+- [ ] Verify the test passes
+
+### Step 4 — Run full test suite
+
+- [ ] `uv run pytest -n auto`
+- [ ] `uv run prek run --all-files`
+
+### Step 5 — Open PR
+
+- [ ] Create branch
+- [ ] Push to fork
+- [ ] Open PR referencing #3571
+
+---
+
+## Investigation Log
+
+### 2026-03-26
+
+#### Environment Setup
+- Installed uv 0.11.1
+- Ran `uv sync` — all dependencies installed
+- Ran `uv run prek install` — pre-commit hooks active
+
+#### Root Cause Analysis
+
+**Call chain (background task mode):**
+
+1. Parent server receives `call_tool("child_whoami", task=True)`
+2. `mcp_operations.py` runs within parent's request context (`_current_server = parent`)
+3. Finds `FastMCPProviderTool` → delegates to `child_server.call_tool("whoami", task_meta=...)`
+4. `child_server.call_tool()` creates `Context(fastmcp=child)` → sets `_current_server = child`
+5. Tool is found, `submit_to_docket()` is called — at this point `ctx.fastmcp = child` ✅
+6. Task is queued; Docket worker later runs the tool function
+7. **Worker context**: `_current_server` is the **parent server** (set by parent's `_docket_lifespan()`)
+8. `_CurrentContext.__aenter__()` calls `get_server()` → returns **parent** ❌
+9. `Context(fastmcp=parent)` created → `ctx.fastmcp` returns parent ❌
+
+**Two independent code paths both broken:**
+- `ctx: Context` → goes through `_CurrentContext.__aenter__()` → `get_server()` → parent
+- `server: CurrentFastMCP = CurrentFastMCP()` → `_CurrentFastMCP.__aenter__()` → `_current_server.get()` → parent
+
+#### Fix Implemented
+
+**Pattern**: Mirror the existing `_task_sessions` registry.
+
+**Files modified:**
+- `src/fastmcp/server/dependencies.py`:
+  - Added `_task_servers: dict[str, weakref.ref[FastMCP]] = {}` registry
+  - Added `register_task_server(session_id, task_id, server)` function
+  - Added `get_task_server(session_id, task_id)` function
+  - Updated `_CurrentContext.__aenter__()`: try `get_task_server()` before `get_server()`
+  - Updated `_CurrentFastMCP.__aenter__()`: check task registry before `_current_server.get()`
+  - Added new functions to `__all__`
+
+- `src/fastmcp/server/tasks/handlers.py`:
+  - Call `register_task_server(session_id, server_task_id, ctx.fastmcp)` in `submit_to_docket()`
+  - At submission time `ctx.fastmcp` is the child server (correct)
+
+**Tests added to `tests/server/tasks/test_task_mount.py`:**
+- `test_mounted_task_receives_server_dependency` — strengthened to assert child server identity
+- `test_mounted_task_context_fastmcp_is_child` — new test for `ctx.fastmcp`
+
+#### Test Results
+- All 3 new/updated tests pass ✅
+- All 40 tests in `test_task_mount.py` pass ✅
+- All 272 tests in `tests/server/tasks/` pass ✅
+- Full test suite: 5140 passed, 0 failed ✅
+- `uv run prek run --all-files` clean ✅
+

--- a/log/tasks.md
+++ b/log/tasks.md
@@ -1,0 +1,39 @@
+# FastMCP Contribution Tasks
+
+## Overview
+
+Working on bug fixes for the FastMCP project (PrefectHQ/fastmcp).
+Fork: https://github.com/syhstanley/fastmcp
+
+---
+
+## Tasks
+
+| # | Issue | Title | Status |
+|---|-------|-------|--------|
+| 1 | [#3571](https://github.com/PrefectHQ/fastmcp/issues/3571) | Mounted background tasks bind CurrentFastMCP() and Context.fastmcp to parent instead of child | 🔄 In Progress |
+
+---
+
+## Environment Setup
+
+- **Date**: 2026-03-26
+- **uv**: 0.11.1 (installed via astral.sh)
+- **prek**: installed (pre-commit hooks active)
+- **Python**: managed by uv
+
+### Setup Commands Run
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+cd /home/stanley/opensource/fastmcp
+uv sync
+uv run prek install
+```
+
+---
+
+## References
+
+- Contributing guide: https://gofastmcp.com/development/contributing
+- CLAUDE.md / AGENTS.md: See repo root
+- CONTRIBUTING.md: See repo root

--- a/src/fastmcp/server/dependencies.py
+++ b/src/fastmcp/server/dependencies.py
@@ -70,8 +70,10 @@ __all__ = [
     "get_http_request",
     "get_server",
     "get_task_context",
+    "get_task_server",
     "get_task_session",
     "is_docket_available",
+    "register_task_server",
     "register_task_session",
     "require_docket",
     "resolve_dependencies",
@@ -135,6 +137,10 @@ def get_task_context() -> TaskContextInfo | None:
 
 _task_sessions: dict[str, weakref.ref[ServerSession]] = {}
 
+# --- Server registry for background task Context ---
+
+_task_servers: dict[str, weakref.ref[FastMCP]] = {}
+
 
 def register_task_session(session_id: str, session: ServerSession) -> None:
     """Register a session for Context access in background tasks.
@@ -167,6 +173,44 @@ def get_task_session(session_id: str) -> ServerSession | None:
         # Session was garbage collected, clean up entry
         _task_sessions.pop(session_id, None)
     return session
+
+
+def register_task_server(session_id: str, task_id: str, server: FastMCP) -> None:
+    """Register a server for Context access in background tasks.
+
+    Called automatically when a task is submitted to Docket. Captures the
+    server that owns the task (which may be a mounted child server), so that
+    background task workers can reconstruct the correct Context instead of
+    falling back to the root server set by the lifespan ContextVar.
+
+    The server is stored as a weakref so it doesn't prevent garbage collection.
+
+    Args:
+        session_id: The session identifier
+        task_id: The server-generated task ID (UUID)
+        server: The FastMCP server instance that owns the task
+    """
+    _task_servers[f"{session_id}:{task_id}"] = weakref.ref(server)
+
+
+def get_task_server(session_id: str, task_id: str) -> FastMCP | None:
+    """Get the server registered for a background task if still alive.
+
+    Args:
+        session_id: The session identifier
+        task_id: The server-generated task ID (UUID)
+
+    Returns:
+        The FastMCP server if found and alive, None otherwise
+    """
+    key = f"{session_id}:{task_id}"
+    ref = _task_servers.get(key)
+    if ref is None:
+        return None
+    server = ref()
+    if server is None:
+        _task_servers.pop(key, None)
+    return server
 
 
 # --- ContextVars ---
@@ -825,8 +869,12 @@ class _CurrentContext(Dependency["Context"]):
         if task_info is not None:
             # Get session from registry (registered when task was submitted)
             session = get_task_session(task_info.session_id)
-            # Get server from ContextVar
-            server = get_server()
+            # Get server: prefer the task-specific registration which captures the
+            # child server that owns the task. Fall back to the ContextVar which
+            # is set by the lifespan and points to the root server.
+            server = (
+                get_task_server(task_info.session_id, task_info.task_id) or get_server()
+            )
             origin_request_id = await _restore_task_origin_request_id(
                 task_info.session_id, task_info.task_id
             )
@@ -1037,6 +1085,15 @@ class _CurrentFastMCP(Dependency["FastMCP"]):
     """Async context manager for FastMCP server dependency."""
 
     async def __aenter__(self) -> FastMCP:
+        # In background task context, check the task-specific server registry first.
+        # This preserves the child server identity when a mounted child tool runs
+        # as a background task, instead of returning the root server from lifespan.
+        task_info = get_task_context()
+        if task_info is not None:
+            task_server = get_task_server(task_info.session_id, task_info.task_id)
+            if task_server is not None:
+                return task_server
+
         server_ref = _current_server.get()
         if server_ref is None:
             raise RuntimeError("No FastMCP server instance in context")

--- a/src/fastmcp/server/tasks/handlers.py
+++ b/src/fastmcp/server/tasks/handlers.py
@@ -14,7 +14,12 @@ import mcp.types
 from mcp.shared.exceptions import McpError
 from mcp.types import INTERNAL_ERROR, ErrorData
 
-from fastmcp.server.dependencies import _current_docket, get_access_token, get_context
+from fastmcp.server.dependencies import (
+    _current_docket,
+    get_access_token,
+    get_context,
+    register_task_server,
+)
 from fastmcp.server.tasks.config import TaskMeta
 from fastmcp.server.tasks.keys import build_task_key
 from fastmcp.utilities.logging import get_logger
@@ -130,6 +135,12 @@ async def submit_to_docket(
         from fastmcp.server.dependencies import register_task_session
 
         register_task_session(session_id, ctx.session)
+
+    # Register the server that owns this task so background workers reconstruct
+    # the correct Context. ctx.fastmcp is the child server when the task is
+    # submitted from a mounted server's call_tool(), not the root server.
+    if ctx.fastmcp is not None:
+        register_task_server(session_id, server_task_id, ctx.fastmcp)
 
     # Send an initial tasks/status notification before queueing.
     # This guarantees clients can observe task creation immediately.

--- a/tests/server/tasks/test_task_mount.py
+++ b/tests/server/tasks/test_task_mount.py
@@ -15,6 +15,7 @@ from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.prompts.base import PromptResult
 from fastmcp.resources.base import ResourceResult
+from fastmcp.server.context import Context
 from fastmcp.server.dependencies import CurrentDocket, CurrentFastMCP
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.server.tasks import TaskConfig
@@ -320,7 +321,7 @@ class TestMountedTaskDependencies:
             assert received_docket[0] is not None
 
     async def test_mounted_task_receives_server_dependency(self):
-        """Mounted tool task receives CurrentFastMCP dependency."""
+        """Mounted tool task receives the child server via CurrentFastMCP dependency."""
         child = FastMCP("server-dep-child")
         received_server = []
 
@@ -334,12 +335,32 @@ class TestMountedTaskDependencies:
 
         async with Client(parent) as client:
             task = await client.call_tool("child_tool_with_server", {}, task=True)
-            await task.result()
+            result = await task.result()
 
-            # The server should be the child server since that's where the tool is defined
+            assert "server name: server-dep-child" in str(result)
             assert len(received_server) == 1
-            # Note: It might be parent or child depending on implementation
-            assert received_server[0] is not None
+            assert received_server[0] is child
+
+    async def test_mounted_task_context_fastmcp_is_child(self):
+        """ctx.fastmcp in a mounted background task is the child server, not the parent."""
+        child = FastMCP("ctx-child")
+        received = []
+
+        @child.tool(task=True)
+        async def whoami_ctx(ctx: Context) -> str:  # type: ignore[name-defined]
+            received.append(ctx.fastmcp)
+            return f"context server: {ctx.fastmcp.name}"
+
+        parent = FastMCP("ctx-parent")
+        parent.mount(child, namespace="child")
+
+        async with Client(parent) as client:
+            task = await client.call_tool("child_whoami_ctx", {}, task=True)
+            result = await task.result()
+
+            assert "context server: ctx-child" in str(result)
+            assert len(received) == 1
+            assert received[0] is child
 
 
 class TestMultipleMounts:


### PR DESCRIPTION
When a task-enabled tool is defined on a child server and that server is mounted into a parent, background task execution resolves `CurrentFastMCP()` and `ctx.fastmcp` to the parent server instead of the child. Foreground execution is unaffected.

The root cause: when a Docket worker picks up a background task, the `_current_server` ContextVar contains the root server (set by the parent's `_docket_lifespan()`). At task submission time the correct child server is available via `ctx.fastmcp`, but nothing preserved it for the worker.

The fix mirrors the existing `_task_sessions` registry pattern. A new `_task_servers` registry captures `ctx.fastmcp` (the child server) at `submit_to_docket()` time, keyed by `session_id:task_id`. Both `_CurrentContext` and `_CurrentFastMCP` now consult this registry before falling back to the lifespan ContextVar.

```python
child = FastMCP("child")

@child.tool(name="whoami", task=True)
async def whoami(server=CurrentFastMCP()) -> str:
    return f"server name: {server.name}"  # was "parent", now "child"

parent = FastMCP("parent")
parent.mount(child, namespace="child")
```

Closes #3571.

🤖 Generated with Claude Code