### PR TITLE
fix: resolve CurrentFastMCP() and ctx.fastmcp to child server in mounted background tasks (#3571)

### DIFF
--- a/src/fastmcp/server/dependencies.py
+++ b/src/fastmcp/server/dependencies.py
@@ -174,6 +174,26 @@ def get_task_session(session_id: str) -> ServerSession | None:
 _current_server: ContextVar[weakref.ref[FastMCP] | None] = ContextVar(
     "server", default=None
 )
+
+# --- Background task server map ---
+
+
+_task_server_map: dict[str, weakref.ref[Any]] = {}
+
+
+def register_task_server(task_id: str, server: Any) -> None:
+    """Register the owning server for a background task.
+
+    Called at task-submission time so that background workers can resolve
+    CurrentFastMCP() / ctx.fastmcp to the child server for mounted tasks (#3571).
+
+    Args:
+        task_id: The server-generated task UUID
+        server: The FastMCP server that owns the component being executed
+    """
+    _task_server_map[task_id] = weakref.ref(server)
+
+
 _current_docket: ContextVar[Docket | None] = ContextVar("docket", default=None)
 _current_worker: ContextVar[Worker | None] = ContextVar("worker", default=None)
 _task_access_token: ContextVar[AccessToken | None] = ContextVar(
@@ -825,8 +845,13 @@ class _CurrentContext(Dependency["Context"]):
         if task_info is not None:
             # Get session from registry (registered when task was submitted)
             session = get_task_session(task_info.session_id)
-            # Get server from ContextVar
-            server = get_server()
+            # Prefer task-specific server (resolves child server for mounted tasks, #3571)
+            task_server_ref = _task_server_map.get(task_info.task_id)
+            if task_server_ref is not None:
+                task_server = task_server_ref()
+                server = task_server if task_server is not None else get_server()
+            else:
+                server = get_server()
             origin_request_id = await _restore_task_origin_request_id(
                 task_info.session_id, task_info.task_id
             )
@@ -1037,6 +1062,14 @@ class _CurrentFastMCP(Dependency["FastMCP"]):
     """Async context manager for FastMCP server dependency."""
 
     async def __aenter__(self) -> FastMCP:
+        # Prefer task-specific server (resolves child server for mounted tasks, #3571)
+        task_info = get_task_context()
+        if task_info is not None:
+            task_server_ref = _task_server_map.get(task_info.task_id)
+            if task_server_ref is not None:
+                task_server = task_server_ref()
+                if task_server is not None:
+                    return task_server
         server_ref = _current_server.get()
         if server_ref is None:
             raise RuntimeError("No FastMCP server instance in context")

--- a/src/fastmcp/server/tasks/handlers.py
+++ b/src/fastmcp/server/tasks/handlers.py
@@ -14,7 +14,12 @@ import mcp.types
 from mcp.shared.exceptions import McpError
 from mcp.types import INTERNAL_ERROR, ErrorData
 
-from fastmcp.server.dependencies import _current_docket, get_access_token, get_context
+from fastmcp.server.dependencies import (
+    _current_docket,
+    get_access_token,
+    get_context,
+    register_task_server,
+)
 from fastmcp.server.tasks.config import TaskMeta
 from fastmcp.server.tasks.keys import build_task_key
 from fastmcp.utilities.logging import get_logger
@@ -70,6 +75,9 @@ async def submit_to_docket(
         session_id = ctx.session_id
     except RuntimeError:
         session_id = "internal"
+
+    # Register owning server so background workers resolve CurrentFastMCP() correctly (#3571)
+    register_task_server(server_task_id, ctx.fastmcp)
 
     docket = _current_docket.get()
     if docket is None:

--- a/tests/server/tasks/test_task_mount.py
+++ b/tests/server/tasks/test_task_mount.py
@@ -342,6 +342,56 @@ class TestMountedTaskDependencies:
             assert received_server[0] is not None
 
 
+class TestMountedTaskServerContext:
+    """Test that background tasks on mounted servers bind to the child server (issue #3571)."""
+
+    async def test_current_fastmcp_resolves_to_child_server(self):
+        """CurrentFastMCP() inside a mounted background task returns the child server."""
+        child = FastMCP("child")
+        received_server = []
+
+        @child.tool(task=True)
+        async def whoami(server: CurrentFastMCP = CurrentFastMCP()) -> str:  # type: ignore[invalid-type-form]  # ty:ignore[invalid-type-form]
+            received_server.append(server)
+            return f"server name: {server.name}"
+
+        parent = FastMCP("parent")
+        parent.mount(child, namespace="child")
+
+        async with Client(parent) as client:
+            task = await client.call_tool("child_whoami", {}, task=True)
+            result = await task.result()
+
+        assert len(received_server) == 1
+        # Should resolve to the child server, not the parent
+        assert received_server[0].name == "child"
+        assert "server name: child" in str(result)
+
+    async def test_context_fastmcp_resolves_to_child_server(self):
+        """ctx.fastmcp inside a mounted background task returns the child server."""
+        from fastmcp import Context
+
+        child = FastMCP("child")
+        received_server = []
+
+        @child.tool(task=True)
+        async def whoami_ctx(ctx: Context) -> str:
+            received_server.append(ctx.fastmcp)
+            return f"context server: {ctx.fastmcp.name}"
+
+        parent = FastMCP("parent")
+        parent.mount(child, namespace="child")
+
+        async with Client(parent) as client:
+            task = await client.call_tool("child_whoami_ctx", {}, task=True)
+            result = await task.result()
+
+        assert len(received_server) == 1
+        # Should resolve to the child server, not the parent
+        assert received_server[0].name == "child"
+        assert "context server: child" in str(result)
+
+
 class TestMultipleMounts:
     """Test tasks with multiple mounted servers."""
 


### PR DESCRIPTION
When a background task is submitted from a mounted child server,
`CurrentFastMCP()` and `ctx.fastmcp` inside the task resolve to the
parent server instead of the child.
https://github.com/jlowin/fastmcp/issues/3571

Root cause: `_current_server` ContextVar is set to the parent at Docket
worker startup (`server/mixins/lifespan.py:51`). Foreground calls override
this per-request through `child_server.call_tool()`, but background task
workers skip that step.

Fix: at `submit_to_docket()` time — which runs inside the child's
`call_tool()` where `ctx.fastmcp` is already the child — store a
`task_id → weakref` mapping. `_CurrentFastMCP.__aenter__()` and
`_CurrentContext.__aenter__()` now check this map first before falling
back to `_current_server`.

Regression tests added in `tests/server/tasks/test_task_mount.py`
covering both `CurrentFastMCP()` and `ctx.fastmcp` resolution.

Closes #3571