### PR TITLE
feat: implement resource subscriptions (resources/subscribe / resources/unsubscribe)

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -788,6 +788,38 @@ class Context:
         """
         await self.session.send_notification(mcp.types.ServerNotification(notification))
 
+    async def notify_resource_updated(self, uri: str) -> None:
+        """Notify all subscribed clients that a resource has been updated.
+
+        Sends ``notifications/resources/updated`` to every session that has
+        previously called ``resources/subscribe`` for *uri*.  Sessions that
+        have since disconnected are silently skipped.
+
+        Args:
+            uri: The resource URI that has changed.
+
+        Example:
+            ```python
+            @server.tool
+            async def update_config(new_value: str, ctx: Context) -> str:
+                # … persist the change …
+                await ctx.notify_resource_updated("config://app/settings")
+                return "updated"
+            ```
+        """
+        import contextlib
+
+        from pydantic import AnyUrl as _AnyUrl
+
+        from fastmcp.server.subscriptions import get_registry
+
+        registry = get_registry()
+        subscribers = registry.get_subscribers(uri)
+        anyurl = _AnyUrl(uri)
+        for session in subscribers:
+            with contextlib.suppress(Exception):
+                await session.send_resource_updated(anyurl)
+
     async def close_sse_stream(self) -> None:
         """Close the current response stream to trigger client reconnection.
 

--- a/src/fastmcp/server/low_level.py
+++ b/src/fastmcp/server/low_level.py
@@ -13,6 +13,7 @@ from mcp.server.lowlevel.server import (
     LifespanResultT,
     NotificationOptions,
     RequestT,
+    request_ctx,
 )
 from mcp.server.lowlevel.server import (
     Server as _Server,
@@ -165,6 +166,9 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
             tools_changed=True,
         )
 
+        # Register resource subscribe/unsubscribe handlers
+        self._register_subscription_handlers()
+
     @property
     def fastmcp(self) -> FastMCP:
         """Get the FastMCP instance."""
@@ -172,6 +176,26 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
         if fastmcp is None:
             raise RuntimeError("FastMCP instance is no longer available")
         return fastmcp
+
+    def _register_subscription_handlers(self) -> None:
+        """Register MCP protocol handlers for resources/subscribe and resources/unsubscribe."""
+        from fastmcp.server.subscriptions import get_registry
+
+        @self.subscribe_resource()
+        async def handle_subscribe(uri: AnyUrl) -> None:
+            ctx = request_ctx.get(None)
+            if ctx is None:
+                return
+            session = ctx.session
+            await get_registry().subscribe(str(uri), session)
+
+        @self.unsubscribe_resource()
+        async def handle_unsubscribe(uri: AnyUrl) -> None:
+            ctx = request_ctx.get(None)
+            if ctx is None:
+                return
+            session = ctx.session
+            await get_registry().unsubscribe(str(uri), session)
 
     def create_initialization_options(
         self,
@@ -207,6 +231,13 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
             notification_options,
             experimental_capabilities or {},
         )
+
+        # Advertise resource subscription support (MCP spec: resources/subscribe)
+        # The MCP SDK hardcodes subscribe=False; we override it here.
+        if capabilities.resources is not None:
+            capabilities.resources.subscribe = True
+        else:
+            capabilities.resources = mcp.types.ResourcesCapability(subscribe=True)
 
         # Set tasks as a first-class field (not experimental) per SEP-1686
         capabilities.tasks = get_task_capabilities()
@@ -245,18 +276,24 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
                 )
             )
 
-            async with anyio.create_task_group() as tg:
-                # Store task group on session for subscription tasks (SEP-1686)
-                session._subscription_task_group = tg
+            try:
+                async with anyio.create_task_group() as tg:
+                    # Store task group on session for subscription tasks (SEP-1686)
+                    session._subscription_task_group = tg
 
-                async for message in session.incoming_messages:
-                    tg.start_soon(
-                        self._handle_message,
-                        message,
-                        session,
-                        lifespan_context,
-                        raise_exceptions,
-                    )
+                    async for message in session.incoming_messages:
+                        tg.start_soon(
+                            self._handle_message,
+                            message,
+                            session,
+                            lifespan_context,
+                            raise_exceptions,
+                        )
+            finally:
+                # Clean up resource subscriptions for this session on disconnect
+                from fastmcp.server.subscriptions import get_registry
+
+                await get_registry().remove_session(session)
 
     def read_resource(
         self,

--- a/src/fastmcp/server/subscriptions.py
+++ b/src/fastmcp/server/subscriptions.py
@@ -1,0 +1,95 @@
+"""Resource subscription registry for FastMCP.
+
+Tracks which client sessions have subscribed to which resource URIs,
+enabling the server to push ``notifications/resources/updated`` when
+a resource changes.
+
+Design notes
+------------
+- Sessions are stored as ``weakref`` objects so that a disconnected
+  session is automatically removed without explicit cleanup.
+- A per-URI lock is used so that concurrent subscribe/unsubscribe
+  calls on the same URI are race-free without blocking unrelated URIs.
+- The registry is a module-level singleton; import :func:`get_registry`
+  to access it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp.server.session import ServerSession
+
+
+class ResourceSubscriptionRegistry:
+    """In-memory per-URI registry of subscribed sessions.
+
+    Sessions are stored as weak references so that garbage-collected
+    (disconnected) sessions are automatically evicted.
+    """
+
+    def __init__(self) -> None:
+        # uri -> set of weak refs to ServerSession
+        self._subscriptions: dict[str, set[weakref.ref[ServerSession]]] = defaultdict(
+            set
+        )
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self, uri: str, session: ServerSession) -> None:
+        """Record that *session* wants to receive updates for *uri*."""
+        async with self._lock:
+            self._subscriptions[uri].add(weakref.ref(session))
+
+    async def unsubscribe(self, uri: str, session: ServerSession) -> None:
+        """Remove *session*'s subscription for *uri* (no-op if not subscribed)."""
+        async with self._lock:
+            subscribers = self._subscriptions.get(uri)
+            if subscribers is None:
+                return
+            # Remove any ref that points to this session (or is dead)
+            self._subscriptions[uri] = {
+                ref for ref in subscribers if ref() not in (None, session)
+            }
+            if not self._subscriptions[uri]:
+                del self._subscriptions[uri]
+
+    def get_subscribers(self, uri: str) -> list[ServerSession]:
+        """Return live sessions subscribed to *uri*.
+
+        Dead weak references are silently skipped.
+        """
+        refs = self._subscriptions.get(uri, set())
+        live: list[ServerSession] = []
+        for ref in list(refs):
+            session = ref()
+            if session is not None:
+                live.append(session)
+        return live
+
+    async def remove_session(self, session: ServerSession) -> None:
+        """Remove all subscriptions for *session* (called on disconnect)."""
+        async with self._lock:
+            to_delete: list[str] = []
+            for uri, refs in self._subscriptions.items():
+                self._subscriptions[uri] = {
+                    ref for ref in refs if ref() not in (None, session)
+                }
+                if not self._subscriptions[uri]:
+                    to_delete.append(uri)
+            for uri in to_delete:
+                del self._subscriptions[uri]
+
+
+_registry: ResourceSubscriptionRegistry | None = None
+
+
+def get_registry() -> ResourceSubscriptionRegistry:
+    """Return the module-level singleton registry, creating it if needed."""
+    global _registry
+    if _registry is None:
+        _registry = ResourceSubscriptionRegistry()
+    return _registry

--- a/tests/conformance/expected-failures.yml
+++ b/tests/conformance/expected-failures.yml
@@ -1,6 +1,4 @@
 server:
   - completion-complete
   - server-sse-polling
-  - resources-subscribe
-  - resources-unsubscribe
   - dns-rebinding-protection

--- a/tests/server/test_subscriptions.py
+++ b/tests/server/test_subscriptions.py
@@ -1,0 +1,241 @@
+"""Tests for resource subscription support (resources/subscribe / resources/unsubscribe).
+
+Covers:
+- ResourceSubscriptionRegistry data-structure correctness
+- subscribe/unsubscribe/remove_session semantics
+- Weak-reference eviction of dead sessions
+- subscribe=True advertised in server capabilities
+- subscribe/unsubscribe round-trip via FastMCP Client
+- notify_resource_updated() dispatches notifications only to subscribers
+"""
+
+from __future__ import annotations
+
+import gc
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from fastmcp import Client, FastMCP
+from fastmcp.server.subscriptions import ResourceSubscriptionRegistry, get_registry
+
+# ---------------------------------------------------------------------------
+# Registry unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestResourceSubscriptionRegistry:
+    @pytest.fixture
+    def registry(self) -> ResourceSubscriptionRegistry:
+        return ResourceSubscriptionRegistry()
+
+    def _make_session(self) -> MagicMock:
+        session = MagicMock()
+        session.send_resource_updated = AsyncMock()
+        return session
+
+    async def test_subscribe_and_get_subscribers(self, registry):
+        session = self._make_session()
+        await registry.subscribe("resource://foo", session)
+        assert session in registry.get_subscribers("resource://foo")
+
+    async def test_subscribe_idempotent(self, registry):
+        session = self._make_session()
+        await registry.subscribe("resource://foo", session)
+        await registry.subscribe("resource://foo", session)
+        # Only one entry for the same session
+        assert registry.get_subscribers("resource://foo").count(session) == 1
+
+    async def test_unsubscribe_removes_session(self, registry):
+        session = self._make_session()
+        await registry.subscribe("resource://foo", session)
+        await registry.unsubscribe("resource://foo", session)
+        assert session not in registry.get_subscribers("resource://foo")
+
+    async def test_unsubscribe_no_op_when_not_subscribed(self, registry):
+        session = self._make_session()
+        # Should not raise
+        await registry.unsubscribe("resource://foo", session)
+
+    async def test_unsubscribe_cleans_up_empty_uri(self, registry):
+        session = self._make_session()
+        await registry.subscribe("resource://foo", session)
+        await registry.unsubscribe("resource://foo", session)
+        assert "resource://foo" not in registry._subscriptions
+
+    async def test_multiple_sessions_same_uri(self, registry):
+        s1 = self._make_session()
+        s2 = self._make_session()
+        await registry.subscribe("resource://bar", s1)
+        await registry.subscribe("resource://bar", s2)
+        subscribers = registry.get_subscribers("resource://bar")
+        assert s1 in subscribers
+        assert s2 in subscribers
+
+    async def test_remove_session_clears_all_uris(self, registry):
+        session = self._make_session()
+        await registry.subscribe("resource://a", session)
+        await registry.subscribe("resource://b", session)
+        await registry.remove_session(session)
+        assert session not in registry.get_subscribers("resource://a")
+        assert session not in registry.get_subscribers("resource://b")
+
+    async def test_weakref_dead_session_not_returned(self, registry):
+        """A session that has been garbage-collected must not appear in subscribers."""
+        session = self._make_session()
+        await registry.subscribe("resource://foo", session)
+        # Delete the strong reference and force GC
+        del session
+        gc.collect()
+        # get_subscribers should return only live sessions
+        live = registry.get_subscribers("resource://foo")
+        assert len(live) == 0
+
+    async def test_get_registry_returns_singleton(self):
+        r1 = get_registry()
+        r2 = get_registry()
+        assert r1 is r2
+
+
+# ---------------------------------------------------------------------------
+# Server capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeCapability:
+    async def test_capabilities_advertise_subscribe_true(self):
+        """Server must advertise subscribe=True in ServerCapabilities."""
+        mcp = FastMCP()
+
+        @mcp.resource("resource://test")
+        def my_resource() -> str:
+            return "hello"
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            caps = result.capabilities
+            assert caps.resources is not None
+            assert caps.resources.subscribe is True
+
+
+# ---------------------------------------------------------------------------
+# Subscribe / unsubscribe round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeRoundTrip:
+    async def test_subscribe_registers_in_registry(self):
+        """resources/subscribe must add the session to the registry."""
+        mcp = FastMCP()
+
+        @mcp.resource("resource://live")
+        def live_resource() -> str:
+            return "data"
+
+        registry = get_registry()
+        # Clear any state from previous tests
+        registry._subscriptions.clear()
+
+        async with Client(mcp) as client:
+            await client.session.subscribe_resource("resource://live")
+            subscribers = registry.get_subscribers("resource://live")
+            assert len(subscribers) == 1
+
+    async def test_unsubscribe_removes_from_registry(self):
+        """resources/unsubscribe must remove the session from the registry."""
+        mcp = FastMCP()
+
+        @mcp.resource("resource://live2")
+        def live_resource2() -> str:
+            return "data"
+
+        registry = get_registry()
+        registry._subscriptions.clear()
+
+        async with Client(mcp) as client:
+            await client.session.subscribe_resource("resource://live2")
+            assert len(registry.get_subscribers("resource://live2")) == 1
+
+            await client.session.unsubscribe_resource("resource://live2")
+            assert len(registry.get_subscribers("resource://live2")) == 0
+
+    async def test_session_cleanup_on_disconnect(self):
+        """Registry must be empty for the session after client disconnects."""
+        mcp = FastMCP()
+
+        @mcp.resource("resource://cleanup")
+        def cleanup_resource() -> str:
+            return "data"
+
+        registry = get_registry()
+        registry._subscriptions.clear()
+
+        async with Client(mcp) as client:
+            await client.session.subscribe_resource("resource://cleanup")
+            assert len(registry.get_subscribers("resource://cleanup")) == 1
+
+        # After exiting the context manager the session is gone
+        assert len(registry.get_subscribers("resource://cleanup")) == 0
+
+
+# ---------------------------------------------------------------------------
+# notify_resource_updated
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyResourceUpdated:
+    async def test_notify_sends_to_subscribers(self):
+        """notify_resource_updated() must send to subscribed sessions."""
+        from fastmcp.server.context import Context
+
+        mcp = FastMCP()
+        registry = get_registry()
+        registry._subscriptions.clear()
+
+        mock_session = MagicMock()
+        mock_session.send_resource_updated = AsyncMock()
+
+        await registry.subscribe("resource://notify-test", mock_session)
+
+        ctx = Context(fastmcp=mcp)
+        await ctx.notify_resource_updated("resource://notify-test")
+
+        mock_session.send_resource_updated.assert_called_once()
+        call_arg = mock_session.send_resource_updated.call_args[0][0]
+        assert str(call_arg) == "resource://notify-test"
+
+    async def test_notify_skips_unsubscribed_sessions(self):
+        """notify_resource_updated() must not send to unrelated sessions."""
+        from fastmcp.server.context import Context
+
+        mcp = FastMCP()
+        registry = get_registry()
+        registry._subscriptions.clear()
+
+        mock_session = MagicMock()
+        mock_session.send_resource_updated = AsyncMock()
+
+        await registry.subscribe("resource://other", mock_session)
+
+        ctx = Context(fastmcp=mcp)
+        await ctx.notify_resource_updated("resource://notify-no-match")
+
+        mock_session.send_resource_updated.assert_not_called()
+
+    async def test_notify_tolerates_send_failure(self):
+        """notify_resource_updated() must not raise if a session send fails."""
+        from fastmcp.server.context import Context
+
+        mcp = FastMCP()
+        registry = get_registry()
+        registry._subscriptions.clear()
+
+        mock_session = MagicMock()
+        mock_session.send_resource_updated = AsyncMock(side_effect=RuntimeError("gone"))
+
+        await registry.subscribe("resource://err-test", mock_session)
+
+        ctx = Context(fastmcp=mcp)
+        # Should not raise
+        await ctx.notify_resource_updated("resource://err-test")


### PR DESCRIPTION
FastMCP didn't implement `resources/subscribe` or `resources/unsubscribe`, leaving both as expected failures in the conformance suite. This PR adds full support for both endpoints, removing them from `expected-failures.yml` so the conformance runner exercises them for real.

Subscriptions are tracked in a `ResourceSubscriptionRegistry` — a weakref-based singleton that maps resource URIs to subscriber sessions. The low-level server registers handlers for both MCP methods and cleans up a session's subscriptions on disconnect. Capabilities are advertised as `subscribe: true`. To push change notifications to subscribers, call `ctx.notify_resource_updated(uri)` from any resource or tool handler:

```python
@mcp.tool
async def update_data(ctx: Context) -> str:
    # ... mutate the resource ...
    await ctx.notify_resource_updated("myapp://data/live")
    return "updated"
```

Closes #3641