### PR TITLE
[DO NOT MERGE] Fix ErrorHandlingMiddleware classifying by __cause__ type

### DIFF
--- a/src/fastmcp/server/middleware/error_handling.py
+++ b/src/fastmcp/server/middleware/error_handling.py
@@ -89,7 +89,7 @@ class ErrorHandlingMiddleware(Middleware):
             return error
 
         # Map common exceptions to appropriate MCP error codes
-        error_type = type(error.__cause__) if error.__cause__ else type(error)
+        error_type = type(error)
 
         if error_type in (ValueError, TypeError):
             return McpError(


### PR DESCRIPTION
`ErrorHandlingMiddleware._transform_error` inspects `error.__cause__` to determine the error type when `transform_errors` is enabled. This means that when a developer deliberately raises one exception chained from another — e.g., `raise ValueError("bad input") from KeyError("missing_key")` — the middleware classifies the error based on the `KeyError` (the cause) rather than the `ValueError` (the exception that was actually raised). The outer exception is the one the developer chose to represent the error, and it should determine the MCP error code.

The fix removes the `__cause__` lookup so `_transform_error` always classifies by the type of the exception itself:

```python
# Before: a chained ValueError gets classified as KeyError
raise ValueError("bad input") from KeyError("k")
# _transform_error saw KeyError → mapped to "resource not found" (-32002)

# After: the raised exception determines the error code
raise ValueError("bad input") from KeyError("k")
# _transform_error sees ValueError → mapped to "invalid params" (-32602)
```

Fixes #3663

🤖 Generated with Claude Code