### PR TITLE
Fix prompt caching round-trip on cache miss

### DIFF
--- a/src/fastmcp/server/middleware/caching.py
+++ b/src/fastmcp/server/middleware/caching.py
@@ -480,14 +480,15 @@ class ResponseCachingMiddleware(Middleware):
             return cached_value.unwrap()
 
         value: PromptResult = await call_next(context=context)
+        cached_value = CachablePromptResult.wrap(value)
 
         await self._get_prompt_cache.put(
             key=cache_key,
-            value=CachablePromptResult.wrap(value),
+            value=cached_value,
             ttl=self._get_prompt_settings.get("ttl", ONE_HOUR_IN_SECONDS),
         )
 
-        return value
+        return cached_value.unwrap()
 
     def _matches_tool_cache_settings(self, tool_name: str) -> bool:
         """Check if the tool matches the cache settings for tool calls."""


### PR DESCRIPTION
`ResponseCachingMiddleware.on_get_prompt` has an inconsistency with the other cache-miss paths in `on_call_tool` and `on_read_resource`. Those methods wrap the result into a cacheable form, store it, and then `unwrap()` before returning — ensuring the caller always gets a value that has been through the same serialization round-trip regardless of whether it came from cache or from upstream. `on_get_prompt` skips the `unwrap()` on the initial miss path, returning the raw `PromptResult` directly. This means the first call returns a structurally different object than subsequent cached calls, which can surface as subtle type or equality mismatches downstream.

The fix aligns `on_get_prompt` with the existing pattern:

```python
# Before — raw value returned on miss, unwrapped value on hit
value: PromptResult = await call_next(context=context)
await self._get_prompt_cache.put(key=cache_key, value=CachablePromptResult.wrap(value), ...)
return value

# After — unwrapped value returned in both paths
value: PromptResult = await call_next(context=context)
cached_value = CachablePromptResult.wrap(value)
await self._get_prompt_cache.put(key=cache_key, value=cached_value, ...)
return cached_value.unwrap()
```

Closes #3664

🤖 Generated with Claude Code