### PR TITLE
Add prefab-ui version pinning warning to docs

### DIFF
--- a/docs/apps/overview.mdx
+++ b/docs/apps/overview.mdx
@@ -25,8 +25,18 @@ The examples throughout the Apps docs require the `apps` extra:
 pip install "fastmcp[apps]"
 ```
 
-This installs [Prefab UI](https://prefab.prefect.io), the component library used to build app UIs. Pin `prefab-ui` to a specific version in production — it's in early development and its API changes frequently.
+This installs [Prefab UI](https://prefab.prefect.io), the component library used to build app UIs.
 </Note>
+
+<Warning>
+FastMCP pins a **minimum** version of `prefab-ui` for compatibility but intentionally does **not** pin an upper bound. Prefab is a rapidly evolving library with frequent breaking changes. If you are deploying to production, you **must** pin `prefab-ui` to a specific version in your own dependencies:
+
+```
+prefab-ui==0.15.0
+```
+
+Without a pin, a `pip install --upgrade` or fresh deploy could pull a newer Prefab version that changes component APIs, breaking your app. FastMCP's minimum ensures baseline compatibility; your pin ensures stability.
+</Warning>
 
 ## Prefab Apps
 

--- a/docs/apps/prefab.mdx
+++ b/docs/apps/prefab.mdx
@@ -10,9 +10,9 @@ import { VersionBadge } from '/snippets/version-badge.mdx'
 
 <VersionBadge version="3.1.0" />
 
-<Tip>
-[Prefab](https://prefab.prefect.io) is in early, active development — its API changes frequently and breaking changes can occur with any release. Always pin `prefab-ui` to a specific version in your dependencies (see below).
-</Tip>
+<Warning>
+[Prefab](https://prefab.prefect.io) is in early, active development — breaking changes can occur with any release. FastMCP pins a minimum version of `prefab-ui` for compatibility but does not pin an upper bound. If you are deploying to production, **pin `prefab-ui` to a specific version** in your own dependencies (e.g. `prefab-ui==0.15.0`).
+</Warning>
 
 [Prefab UI](https://prefab.prefect.io) is the component library behind all FastMCP app features. You describe layouts, charts, tables, and forms in Python, and Prefab compiles them to interactive UIs that render in the host's conversation.
 


### PR DESCRIPTION
FastMCP intentionally pins only a minimum version of `prefab-ui` — no upper bound. Prefab is rapidly evolving with frequent breaking changes, so users deploying to production must pin it themselves.

Adds a `<Warning>` callout to both the Apps overview and Prefab UI pages making this explicit.