### PR TITLE
Fix docs gaps in app provider pages

### DIFF
--- a/docs/apps/generative.mdx
+++ b/docs/apps/generative.mdx
@@ -121,6 +121,10 @@ Generative UI requires `fastmcp[apps]` which installs `prefab-ui`. The Pyodide s
 
 The streaming renderer loads Pyodide from CDN in the browser. The CSP is configured automatically by the provider — no manual setup needed.
 
+## Sandbox Limitations
+
+The Pyodide sandbox includes the Python standard library and Prefab. External packages (NumPy, pandas, requests, etc.) are **not available** — the LLM's code must work with only built-in Python and Prefab components. If the LLM tries to import an unavailable package, the sandbox will raise an `ImportError`.
+
 ## Next Steps
 
 - **[GenerativeUI Provider Reference](/apps/providers/generative)** — Configuration options and quick setup

--- a/docs/apps/providers/choice.mdx
+++ b/docs/apps/providers/choice.mdx
@@ -37,7 +37,7 @@ The LLM calls `choose` with a prompt and a list of options. The user sees a card
 ```
 
 <Note>
-Like [Approval](/apps/providers/approval), this is an advisory interaction — the conversation isn't blocked while the card is open. The tool description instructs the LLM to wait for the "I selected:" response before proceeding.
+This is an advisory interaction, not an enforcement mechanism. The conversation isn't blocked while the card is open — the user can keep typing, and the LLM could proceed without waiting. The tool description instructs the LLM to stop and wait for the "I selected:" response, but for hard enforcement, implement selection logic server-side.
 </Note>
 
 ## Configuration

--- a/docs/apps/providers/file-upload.mdx
+++ b/docs/apps/providers/file-upload.mdx
@@ -53,7 +53,11 @@ The `max_file_size` limit is enforced both in the UI (the DropZone rejects overs
 
 By default, files are stored in memory and scoped by MCP session ID. Each session gets its own isolated file store — files uploaded in one conversation aren't visible in another.
 
-This works with **stdio**, **SSE**, and **stateful HTTP** transports, where sessions persist across requests. In **stateless HTTP** mode, each request creates a new session, so the default scoping won't work.
+This works with **stdio**, **SSE**, and **stateful HTTP** transports, where sessions persist across requests.
+
+<Warning>
+In **stateless HTTP** mode, each request creates a new session object with a new ID. Files stored during one request (e.g. the UI upload) will be invisible to the next request (e.g. the LLM calling `list_files`). You **must** override `_get_scope_key` to use a stable identifier like a user ID from your auth token.
+</Warning>
 
 For stateless deployments, override `_get_scope_key` to return a stable identifier. For example, to scope files by authenticated user:
 

--- a/docs/apps/providers/form.mdx
+++ b/docs/apps/providers/form.mdx
@@ -40,7 +40,7 @@ This registers two tools:
 | `collect_bugreport` | Model | Opens the form UI |
 | `submit_form` | App only | Validates and processes the submission |
 
-The tool name is derived from the model: `collect_{ModelName.lower()}`. The LLM calls it with a prompt explaining what it needs, and the user gets a form with fields matching the model.
+The tool name is derived from the model class name, lowercased: `collect_{modelname}`. So `BugReport` becomes `collect_bugreport`, `ShippingAddress` becomes `collect_shippingaddress`. Use `tool_name` to override if needed. The LLM calls it with a prompt explaining what it needs, and the user gets a form with fields matching the model.
 
 ## Field Mapping
 


### PR DESCRIPTION
Four targeted fixes from the comprehensive docs review:

- **FileUpload**: Stateless HTTP scoping issue now a `<Warning>` callout instead of buried in a paragraph
- **FormInput**: Explicit note on naming convention (`BugReport` → `collect_bugreport`, not `collect_bug_report`)
- **Generative UI**: New "Sandbox Limitations" section — only stdlib + Prefab available, no NumPy/pandas/etc.
- **Choice**: Full advisory note instead of just "like Approval"