### PR TITLE
fix: dev apps log panel UX improvements

### DIFF
--- a/src/fastmcp/cli/apps_dev.py
+++ b/src/fastmcp/cli/apps_dev.py
@@ -1698,7 +1698,10 @@ async def run_dev_apps(
         # Check ports before starting anything
         import socket
 
-        for port, label in [(mcp_port, "MCP server"), (dev_port, "dev UI")]:
+        for port, label, flag in [
+            (mcp_port, "MCP server", "--mcp-port"),
+            (dev_port, "dev UI", "--dev-port"),
+        ]:
             in_use = False
             for family, addr in (
                 (socket.AF_INET, ("127.0.0.1", port)),
@@ -1714,7 +1717,7 @@ async def run_dev_apps(
             if in_use:
                 logger.error(
                     f"Port {port} ({label}) is already in use. "
-                    f"Try --mcp-port or --dev-port to use different ports."
+                    f"Try {flag} to use a different port."
                 )
                 sys.exit(1)
 


### PR DESCRIPTION
The dev apps inspector log panel had a couple of UX issues.

The log panel starts hidden while entries accumulate in the background. When you open it, `scrollTop` is 0 (top of the list) and the "near bottom" auto-scroll heuristic never recovers — so you're stuck manually scrolling to see new entries. Now opening the panel scrolls to the latest entry, and the poll loop treats a hidden panel as "at bottom" so it stays caught up.

Panel state was also lost on refresh: open/closed, which filters are active, and the log level all reset to defaults. The URL now reflects this via search params (`?log=open&filters=tools,errors&level=warning`), synced with `history.replaceState`. Params are only present when non-default, keeping URLs clean. On load, params are read back and applied before anything renders.

Separately, the port-conflict error message now suggests the correct flag instead of both:

```
# before
Port 8000 (MCP server) is already in use. Try --mcp-port or --dev-port to use different ports.

# after
Port 8000 (MCP server) is already in use. Try --mcp-port to use a different port.
```