### PR TITLE
Remove hardcoded prefab-ui version from pinning warnings

### DIFF
--- a/docs/apps/overview.mdx
+++ b/docs/apps/overview.mdx
@@ -29,13 +29,7 @@ This installs [Prefab UI](https://prefab.prefect.io), the component library used
 </Note>
 
 <Warning>
-FastMCP pins a **minimum** version of `prefab-ui` for compatibility but intentionally does **not** pin an upper bound. Prefab is a rapidly evolving library with frequent breaking changes. If you are deploying to production, you **must** pin `prefab-ui` to a specific version in your own dependencies:
-
-```
-prefab-ui==0.15.0
-```
-
-Without a pin, a `pip install --upgrade` or fresh deploy could pull a newer Prefab version that changes component APIs, breaking your app. FastMCP's minimum ensures baseline compatibility; your pin ensures stability.
+FastMCP pins a **minimum** version of `prefab-ui` for compatibility but intentionally does **not** pin an upper bound. Prefab is a rapidly evolving library with frequent breaking changes. If you are deploying to production, you **must** pin `prefab-ui` to a specific version in your own dependencies. Without a pin, a fresh deploy could pull a newer Prefab version that changes component APIs, breaking your app.
 </Warning>
 
 ## Which Approach?

--- a/docs/apps/prefab.mdx
+++ b/docs/apps/prefab.mdx
@@ -11,7 +11,7 @@ import { VersionBadge } from '/snippets/version-badge.mdx'
 <VersionBadge version="3.1.0" />
 
 <Warning>
-[Prefab](https://prefab.prefect.io) is in early, active development — breaking changes can occur with any release. FastMCP pins a minimum version of `prefab-ui` for compatibility but does not pin an upper bound. If you are deploying to production, **pin `prefab-ui` to a specific version** in your own dependencies (e.g. `prefab-ui==0.15.0`).
+[Prefab](https://prefab.prefect.io) is in early, active development — breaking changes can occur with any release. FastMCP pins a minimum version of `prefab-ui` for compatibility but does not pin an upper bound. If you are deploying to production, **pin `prefab-ui` to a specific version** in your own dependencies.
 </Warning>
 
 [Prefab UI](https://prefab.prefect.io) is the component library behind all FastMCP app features. You describe layouts, charts, tables, and forms in Python, and Prefab compiles them to interactive UIs that render in the host's conversation.


### PR DESCRIPTION
The docs warned users to pin prefab-ui with a specific version number that goes stale with every release. Now just says to pin to a specific version without naming one.