### PR TITLE
fix: use ContextVar in Progress to prevent concurrent task interference

### DIFF
--- a/src/fastmcp/server/dependencies.py
+++ b/src/fastmcp/server/dependencies.py
@@ -1387,6 +1387,17 @@ class InMemoryProgress:
         self._message = message
 
 
+_progress_impl: ContextVar[ProgressLike | None] = ContextVar(
+    "_progress_impl", default=None
+)
+
+# Stores the ContextVar token per-context so __aexit__ can properly reset
+# the ContextVar without clobbering other concurrent tasks.
+_progress_cv_token: ContextVar[Token[ProgressLike | None] | None] = ContextVar(
+    "_progress_cv_token", default=None
+)
+
+
 class Progress(Dependency["Progress"]):
     """FastMCP Progress dependency that works in both server and worker contexts.
 
@@ -1398,26 +1409,35 @@ class Progress(Dependency["Progress"]):
     This allows tools to use Progress() regardless of whether they're called
     immediately or as background tasks, and regardless of whether pydocket
     is installed.
-    """
 
-    _impl: ProgressLike | None = None
+    Uses ContextVars to store the implementation so that concurrent Docket
+    background tasks sharing the same default ``Progress()`` instance do not
+    interfere with each other.  Previously, ``_impl`` was stored as an
+    instance attribute, so one task's ``__aexit__`` (setting ``_impl = None``)
+    would cause ``AssertionError`` in other still-running tasks (#3656).
+    """
 
     async def __aenter__(self) -> Progress:
         server_ref = _current_server.get()
         if server_ref is None or server_ref() is None:
             raise RuntimeError("Progress dependency requires a FastMCP server context.")
 
+        impl: ProgressLike | None = None
+
         if is_docket_available():
             from docket.dependencies import Progress as DocketProgress
 
             try:
                 docket_progress = DocketProgress()
-                self._impl = await docket_progress.__aenter__()
-                return self
+                impl = await docket_progress.__aenter__()
             except LookupError:
                 pass
 
-        self._impl = InMemoryProgress()
+        if impl is None:
+            impl = InMemoryProgress()
+
+        cv_token = _progress_impl.set(impl)
+        _progress_cv_token.set(cv_token)
         return self
 
     async def __aexit__(
@@ -1426,40 +1446,42 @@ class Progress(Dependency["Progress"]):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        self._impl = None
+        cv_token = _progress_cv_token.get()
+        if cv_token is not None:
+            _progress_impl.reset(cv_token)
+            _progress_cv_token.set(None)
+
+    def _get_impl(self) -> ProgressLike:
+        impl = _progress_impl.get()
+        assert impl is not None, "Progress must be used as a dependency"
+        return impl
 
     @property
     def current(self) -> int | None:
         """Current progress value."""
-        assert self._impl is not None, "Progress must be used as a dependency"
-        return self._impl.current
+        return self._get_impl().current
 
     @property
     def total(self) -> int:
         """Total/target progress value."""
-        assert self._impl is not None, "Progress must be used as a dependency"
-        return self._impl.total
+        return self._get_impl().total
 
     @property
     def message(self) -> str | None:
         """Current progress message."""
-        assert self._impl is not None, "Progress must be used as a dependency"
-        return self._impl.message
+        return self._get_impl().message
 
     async def set_total(self, total: int) -> None:
         """Set the total/target value for progress tracking."""
-        assert self._impl is not None, "Progress must be used as a dependency"
-        await self._impl.set_total(total)
+        await self._get_impl().set_total(total)
 
     async def increment(self, amount: int = 1) -> None:
         """Atomically increment the current progress value."""
-        assert self._impl is not None, "Progress must be used as a dependency"
-        await self._impl.increment(amount)
+        await self._get_impl().increment(amount)
 
     async def set_message(self, message: str | None) -> None:
         """Update the progress status message."""
-        assert self._impl is not None, "Progress must be used as a dependency"
-        await self._impl.set_message(message)
+        await self._get_impl().set_message(message)
 
 
 # --- Access Token dependency ---

--- a/tests/server/tasks/test_progress_dependency.py
+++ b/tests/server/tasks/test_progress_dependency.py
@@ -108,6 +108,40 @@ async def test_progress_status_message_in_background_task():
         assert result.content[0].text == "done"
 
 
+async def test_progress_concurrent_tasks_no_interference():
+    """Test that concurrent tasks sharing a Progress() default don't interfere.
+
+    Regression test for #3656: when multiple Docket background tasks run
+    concurrently, one task's __aexit__ (setting _impl = None) caused
+    AssertionError in other tasks still calling progress.increment().
+    """
+    import asyncio
+
+    mcp = FastMCP("test")
+    shared_progress = Progress()
+
+    @mcp.tool()
+    async def slow_tool(progress: Progress = shared_progress) -> str:
+        await progress.set_total(5)
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+            await progress.increment()
+        return "done"
+
+    async with Client(mcp) as client:
+        # Run 4 concurrent calls — previously this would raise
+        # AssertionError when a fast task's __aexit__ cleared _impl
+        # while slower tasks were still using it.
+        results = await asyncio.gather(
+            *[client.call_tool("slow_tool", {}) for _ in range(4)]
+        )
+        from mcp.types import TextContent
+
+        for result in results:
+            assert isinstance(result.content[0], TextContent)
+            assert result.content[0].text == "done"
+
+
 async def test_inmemory_progress_state():
     """Test that in-memory progress stores and returns state correctly."""
     mcp = FastMCP("test")


### PR DESCRIPTION
## Summary

Fixes #3656

When multiple Docket background tasks run concurrently and share the same default `Progress()` instance (as a function parameter default), one task's `__aexit__` sets `_impl = None` on the shared instance while other tasks are still calling `progress.increment()`, causing `AssertionError: Progress must be used as a dependency`.

## Root Cause

The `Progress` class stored its backing implementation (`_impl`) as a plain instance attribute. Since Python reuses the same default parameter object across all calls, concurrent tasks all operated on the same `Progress` instance. When the fastest task completed and its `__aexit__` cleared `_impl`, slower tasks would hit the assertion on next access.

## Fix

Replace the instance attribute `_impl` with a `ContextVar` (`_progress_impl`), so each async execution context gets its own isolated progress implementation. A second `ContextVar` (`_progress_cv_token`) stores the reset token per-context so `__aexit__` correctly restores only its own `ContextVar` state without affecting other concurrent tasks.

## Changes

- **`src/fastmcp/server/dependencies.py`**: Replace `self._impl` with `_progress_impl` ContextVar and `_progress_cv_token` ContextVar. Add `_get_impl()` helper that reads from the ContextVar.
- **`tests/server/tasks/test_progress_dependency.py`**: Add `test_progress_concurrent_tasks_no_interference` that runs 4 concurrent tool calls sharing the same `Progress()` default — this would fail with `AssertionError` before the fix.