### PR TITLE
fix(google): use sub (user ID) for client_id instead of aud (app ID)

### DIFF
--- a/src/fastmcp/server/auth/providers/google.py
+++ b/src/fastmcp/server/auth/providers/google.py
@@ -173,7 +173,7 @@ class GoogleTokenVerifier(TokenVerifier):
 
                 access_token = AccessToken(
                     token=token,
-                    client_id=aud,
+                    client_id=sub,
                     scopes=token_scopes,
                     expires_at=expires_at,
                     claims={

--- a/tests/server/auth/providers/test_google.py
+++ b/tests/server/auth/providers/test_google.py
@@ -249,7 +249,7 @@ class TestGoogleTokenVerifier:
     USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
 
     async def test_valid_token_openid_only(self, httpx_mock: HTTPXMock):
-        """A token with only openid scope is accepted; client_id comes from 'aud'."""
+        """A token with only openid scope is accepted; client_id comes from 'sub'."""
         httpx_mock.add_response(
             url=_TOKENINFO_RE,
             json={
@@ -268,7 +268,7 @@ class TestGoogleTokenVerifier:
         result = await verifier.verify_token("valid-token")
 
         assert result is not None
-        assert result.client_id == "123.apps.googleusercontent.com"
+        assert result.client_id == "12345"
         assert result.scopes == ["openid"]
         assert result.expires_at is not None
         assert result.claims["sub"] == "12345"
@@ -305,7 +305,7 @@ class TestGoogleTokenVerifier:
         result = await verifier.verify_token("valid-token")
 
         assert result is not None
-        assert result.client_id == "123.apps.googleusercontent.com"
+        assert result.client_id == "12345"
         assert "openid" in result.scopes
         assert "https://www.googleapis.com/auth/userinfo.email" in result.scopes
         assert "https://www.googleapis.com/auth/userinfo.profile" in result.scopes


### PR DESCRIPTION
Fixes #3721

`GoogleProvider` sets `client_id=aud` (OAuth app ID), which is the same for all users. Multi-user servers can't distinguish users. `GitHubProvider` already uses the user ID.

Changed `client_id=aud` → `client_id=sub` and updated tests.