### PR TITLE
fix: use explicit None checks for JWT exp validation

### DIFF
--- a/src/fastmcp/server/auth/jwt_issuer.py
+++ b/src/fastmcp/server/auth/jwt_issuer.py
@@ -246,7 +246,7 @@ class JWTIssuer:
 
             # Validate expiration
             exp = payload.get("exp")
-            if exp and exp < time.time():
+            if exp is not None and exp < time.time():
                 logger.debug("Token expired")
                 raise JoseError("Token has expired")
 

--- a/src/fastmcp/server/auth/providers/introspection.py
+++ b/src/fastmcp/server/auth/providers/introspection.py
@@ -286,7 +286,7 @@ class IntrospectionTokenVerifier(TokenVerifier):
                     token=token,
                     client_id=str(client_id),
                     scopes=scopes,
-                    expires_at=int(exp) if exp else None,
+                    expires_at=int(exp) if exp is not None else None,
                     claims=introspection_data,  # Store full response for extensibility
                 )
                 self._cache.set(token, result)

--- a/src/fastmcp/server/auth/providers/jwt.py
+++ b/src/fastmcp/server/auth/providers/jwt.py
@@ -421,7 +421,7 @@ class JWTVerifier(TokenVerifier):
 
             # Validate expiration
             exp = claims.get("exp")
-            if exp and exp < time.time():
+            if exp is not None and exp < time.time():
                 self.logger.debug(
                     "Token validation failed: expired token for client %s", client_id
                 )
@@ -501,7 +501,7 @@ class JWTVerifier(TokenVerifier):
                 token=token,
                 client_id=str(client_id),
                 scopes=scopes,
-                expires_at=int(exp) if exp else None,
+                expires_at=int(exp) if exp is not None else None,
                 claims=claims,
             )
 


### PR DESCRIPTION
JWT expiration checks in `jwt_issuer.py`, `providers/jwt.py`, and `providers/introspection.py` used Python truthiness (`if exp and exp < time.time()`) instead of explicit None checks. This meant `exp=0` would silently skip the expiration check rather than correctly treating it as expired.

Same issue affected `expires_at` assignment (`int(exp) if exp else None`) which would discard a legitimate `exp=0` value.