### PR TITLE
Github integraiton documentation fix: use result.data otherwise CallToolResult not scriptable

### DIFF
--- a/docs/integrations/github.mdx
+++ b/docs/integrations/github.mdx
@@ -119,7 +119,7 @@ async def main():
         
         # Test the protected tool
         result = await client.call_tool("get_user_info")
-        print(f"GitHub user: {result['github_user']}")
+        print(f"GitHub user: {result.data['github_user']}")
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Description

<!-- What does this PR do? Link to the issue it addresses. -->

i think the return type of `CallToolResult` has changed but wasnt reflected in the docs. Need to use `result.data` dict to access keys otherwise this example fails

```
Traceback (most recent call last):
  File "/Users/dardanus/Projects/mcc/client.py", line 18, in <module>
    asyncio.run(main())
  File "/Users/dardanus/.asdf/installs/python/3.10.18/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/dardanus/.asdf/installs/python/3.10.18/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/dardanus/Projects/mcc/client.py", line 14, in main
    print(f"GitHub user: {result['github_user']}")
TypeError: 'CallToolResult' object is not subscriptable
```

just a oneline fix in the docs so that the example works:

[client.py](https://github.com/user-attachments/files/26458915/client.py)


Closes #

## Contribution type



- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ X] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [ X] This PR addresses an existing issue (or fixes a self-evident bug)
- [X ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [ X] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)
