### PR TITLE
feat: auto-generate tool catalog in instructions

### DIFF
--- a/src/fastmcp/server/low_level.py
+++ b/src/fastmcp/server/low_level.py
@@ -182,6 +182,15 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
         # ensure we use the FastMCP notification options
         if notification_options is None:
             notification_options = self.notification_options
+
+        # Auto-catalog: append a concise tool summary to instructions so LLMs
+        # can discover tools from the initialize response alone.
+        if self.fastmcp._auto_catalog:
+            catalog = self.fastmcp._build_tool_catalog()
+            if catalog is not None:
+                original = self.instructions or ""
+                self.instructions = original + catalog
+
         return super().create_initialization_options(
             notification_options=notification_options,
             experimental_capabilities=experimental_capabilities,

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -274,6 +274,7 @@ class FastMCP(
         tools: Sequence[Tool | Callable[..., Any]] | None = None,
         on_duplicate: DuplicateBehavior | None = None,
         mask_error_details: bool | None = None,
+        auto_catalog: bool = False,
         dereference_schemas: bool = True,
         strict_input_validation: bool | None = None,
         list_page_size: int | None = None,
@@ -333,6 +334,11 @@ class FastMCP(
         if list_page_size is not None and list_page_size <= 0:
             raise ValueError("list_page_size must be a positive integer")
         self._list_page_size: int | None = list_page_size
+
+        # Auto-catalog: when enabled, a concise tool summary is appended to
+        # `instructions` at server start so LLMs can discover available tools
+        # from the initialize response alone.
+        self._auto_catalog: bool = auto_catalog
 
         # Handle Lifespan instances (they're callable) or regular lifespan functions
         if lifespan is not None:
@@ -411,6 +417,77 @@ class FastMCP(
     @instructions.setter
     def instructions(self, value: str | None) -> None:
         self._mcp_server.instructions = value
+
+    def _collect_tools_sync(self) -> list[Tool]:
+        """Synchronously collect tools from all providers.
+
+        Walks ``_components`` dicts on :class:`LocalProvider` instances and
+        recursively traverses :class:`AggregateProvider` trees.  This is used
+        by the ``auto_catalog`` feature to build a tool summary without
+        requiring an async context.
+        """
+        from fastmcp.server.providers.local_provider.local_provider import (
+            LocalProvider as _LP,
+        )
+
+        tools: list[Tool] = []
+        stack: list[Provider] = list(self.providers)
+        while stack:
+            provider = stack.pop()
+            # Unwrap wrapped providers (namespace / transform wrappers)
+            inner = getattr(provider, "_provider", None)
+            if inner is not None:
+                stack.append(inner)
+                continue
+            if isinstance(provider, AggregateProvider):
+                stack.extend(provider.providers)
+                continue
+            if isinstance(provider, _LP):
+                tools.extend(
+                    v for v in provider._components.values() if isinstance(v, Tool)
+                )
+        return tools
+
+    def _build_tool_catalog(self, budget: int = 2048) -> str | None:
+        """Build a concise tool catalog string for the ``instructions`` field.
+
+        Returns ``None`` when there are no tools.  The result is trimmed so
+        that the total ``instructions`` length stays within *budget* bytes
+        (default 2 048, matching Claude Code's cap).
+        """
+        tools = self._collect_tools_sync()
+        if not tools:
+            return None
+
+        # Sort alphabetically for stable output
+        tools.sort(key=lambda t: t.name)
+
+        header = "\n\nAvailable tools:\n"
+        base_instructions = self._mcp_server.instructions or ""
+        remaining = budget - len(base_instructions.encode("utf-8")) - len(
+            header.encode("utf-8")
+        )
+
+        lines: list[str] = []
+        for tool in tools:
+            desc = (tool.description or "").strip()
+            # Take only the first sentence
+            first_sentence = desc.split(". ")[0].rstrip(".")
+            if first_sentence:
+                first_sentence += "."
+            line = f"  {tool.name}: {first_sentence}" if first_sentence else f"  {tool.name}"
+            line_bytes = len(line.encode("utf-8")) + 1  # +1 for newline
+            if line_bytes > remaining:
+                if lines:
+                    lines.append("  ...")
+                break
+            remaining -= line_bytes
+            lines.append(line)
+
+        if not lines:
+            return None
+
+        return header + "\n".join(lines)
 
     @property
     def version(self) -> str | None:

--- a/tests/server/test_auto_catalog.py
+++ b/tests/server/test_auto_catalog.py
@@ -1,0 +1,168 @@
+"""Tests for the auto_catalog feature that appends tool summaries to instructions."""
+
+from fastmcp import Client, FastMCP
+
+
+class TestAutoCatalog:
+    async def test_auto_catalog_disabled_by_default(self):
+        """auto_catalog defaults to False and instructions are unchanged."""
+        mcp = FastMCP(instructions="Base instructions")
+
+        @mcp.tool(description="Say hello.")
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            assert result.instructions == "Base instructions"
+
+    async def test_auto_catalog_appends_tool_summary(self):
+        """When enabled, a tool catalog is appended to instructions."""
+        mcp = FastMCP(instructions="Base instructions", auto_catalog=True)
+
+        @mcp.tool(description="Say hello to a person.")
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        @mcp.tool(description="Add two numbers. Returns their sum.")
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            instructions = result.instructions
+            assert instructions is not None
+            assert instructions.startswith("Base instructions")
+            assert "\n\nAvailable tools:\n" in instructions
+            assert "  add: Add two numbers." in instructions
+            assert "  greet: Say hello to a person." in instructions
+
+    async def test_auto_catalog_no_base_instructions(self):
+        """Catalog works when no base instructions are provided."""
+        mcp = FastMCP(auto_catalog=True)
+
+        @mcp.tool(description="Ping the server.")
+        def ping() -> str:
+            return "pong"
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            instructions = result.instructions
+            assert instructions is not None
+            assert "  ping: Ping the server." in instructions
+
+    async def test_auto_catalog_no_tools(self):
+        """Catalog is omitted when there are no tools."""
+        mcp = FastMCP(instructions="Base", auto_catalog=True)
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            assert result.instructions == "Base"
+
+    async def test_auto_catalog_truncates_at_budget(self):
+        """Long catalogs are truncated to stay within the 2KB budget."""
+        mcp = FastMCP(auto_catalog=True)
+
+        # Register many tools with long descriptions to exceed budget
+        for i in range(200):
+            desc = f"Tool number {i} does something very specific and important."
+
+            def make_fn(idx: int, description: str):
+                def fn() -> str:
+                    return f"result-{idx}"
+
+                fn.__name__ = f"tool_{idx:03d}"
+                fn.__doc__ = description
+                return fn
+
+            mcp.add_tool(make_fn(i, desc))
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            instructions = result.instructions
+            assert instructions is not None
+            # Must stay within 2048 bytes
+            assert len(instructions.encode("utf-8")) <= 2048
+            # Should end with truncation marker
+            assert "  ..." in instructions
+
+    async def test_auto_catalog_tool_without_description(self):
+        """Tools without descriptions show just the name."""
+        mcp = FastMCP(auto_catalog=True)
+
+        @mcp.tool
+        def mystery() -> str:
+            return "?"
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            instructions = result.instructions
+            assert instructions is not None
+            assert "  mystery" in instructions
+
+    async def test_auto_catalog_with_provider_tools(self):
+        """Tools from additional providers are included in the catalog."""
+        from fastmcp.server.providers import LocalProvider
+
+        provider = LocalProvider()
+
+        @provider.tool(description="External tool.")
+        def external() -> str:
+            return "ext"
+
+        mcp = FastMCP(auto_catalog=True, providers=[provider])
+
+        @mcp.tool(description="Internal tool.")
+        def internal() -> str:
+            return "int"
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            instructions = result.instructions
+            assert instructions is not None
+            assert "  external: External tool." in instructions
+            assert "  internal: Internal tool." in instructions
+
+    async def test_auto_catalog_sorted_alphabetically(self):
+        """Tool entries are sorted alphabetically."""
+        mcp = FastMCP(auto_catalog=True)
+
+        @mcp.tool(description="Zeta tool.")
+        def zeta() -> str:
+            return "z"
+
+        @mcp.tool(description="Alpha tool.")
+        def alpha() -> str:
+            return "a"
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            instructions = result.instructions
+            assert instructions is not None
+            alpha_pos = instructions.index("alpha")
+            zeta_pos = instructions.index("zeta")
+            assert alpha_pos < zeta_pos
+
+    async def test_auto_catalog_first_sentence_only(self):
+        """Only the first sentence of the description is included."""
+        mcp = FastMCP(auto_catalog=True)
+
+        @mcp.tool(description="Search the database. Supports full-text and vector search. Returns top 10.")
+        def search(query: str) -> str:
+            return "results"
+
+        async with Client(mcp) as client:
+            result = client.initialize_result
+            assert result is not None
+            instructions = result.instructions
+            assert instructions is not None
+            assert "  search: Search the database." in instructions
+            assert "Supports full-text" not in instructions


### PR DESCRIPTION
## Summary

Adds an opt-in `auto_catalog` parameter to `FastMCP.__init__` that auto-appends a concise tool summary to the `instructions` field in the `initialize` response.

- **New parameter:** `FastMCP(auto_catalog=True)` -- defaults to `False` (fully backwards-compatible)
- **Catalog format:** `\n\nAvailable tools:\n  tool_name: First sentence of description.`
- **Budget-aware:** Truncates with `...` to stay within 2KB (the cap Claude Code enforces on instructions)
- **Sorted:** Tools listed alphabetically for stable, predictable output
- **Provider-aware:** Collects tools from all `LocalProvider` instances, including those added via `providers=[]`

## Motivation

The MCP spec's `instructions` field in the `initialize` response is designed to help LLMs understand what a server offers. Claude Code surfaces it in the system prompt. However:

1. **Server authors rarely write useful instructions** -- most leave it as `None` or a generic string
2. **FastMCP treats it as a static string** -- it doesn't reflect what tools are actually registered
3. **When tools are deferred/lazy-loaded**, the LLM only sees tool names without descriptions, making tools undiscoverable until explicitly listed

With `auto_catalog=True`, a server like:

```python
mcp = FastMCP("my-server", instructions="Data analysis tools", auto_catalog=True)

@mcp.tool(description="Run a SQL query against the database. Supports SELECT only.")
def query(sql: str) -> str: ...

@mcp.tool(description="List all available tables.")
def list_tables() -> str: ...
```

produces this `instructions` in the initialize response:

```
Data analysis tools

Available tools:
  list_tables: List all available tables.
  query: Run a SQL query against the database.
```

## Implementation

- `FastMCP.__init__` accepts `auto_catalog: bool = False`
- `FastMCP._collect_tools_sync()` walks the provider tree synchronously (no async context needed)
- `FastMCP._build_tool_catalog()` builds the catalog string with budget-aware truncation
- `LowLevelServer.create_initialization_options()` appends the catalog to `instructions` at server start
- 9 new tests covering: default off, appending, no base instructions, no tools, truncation, no-description tools, provider tools, alphabetical sort, first-sentence extraction

## Test plan

- [x] All 9 new tests pass (`tests/server/test_auto_catalog.py`)
- [x] All 26 existing server tests pass (`tests/server/test_server.py`)
- [x] All 10 client initialization tests pass (`tests/client/client/test_initialize.py`)
- [ ] Review: verify catalog renders correctly with mounted sub-servers


🤖 Generated with [Claude Code](https://claude.com/claude-code)