### PR TITLE
Remove deprecated asyncio.iscoroutinefunction fallback

### DIFF
--- a/src/fastmcp/utilities/async_utils.py
+++ b/src/fastmcp/utilities/async_utils.py
@@ -1,6 +1,5 @@
 """Async utilities for FastMCP."""
 
-import asyncio
 import functools
 import inspect
 from collections.abc import Awaitable, Callable
@@ -21,7 +20,7 @@ def is_coroutine_function(fn: Any) -> bool:
     """
     while isinstance(fn, functools.partial):
         fn = fn.func
-    return inspect.iscoroutinefunction(fn) or asyncio.iscoroutinefunction(fn)
+    return inspect.iscoroutinefunction(fn)
 
 
 async def call_sync_fn_in_threadpool(


### PR DESCRIPTION
## Summary
- Remove redundant `asyncio.iscoroutinefunction` call that is deprecated in Python 3.14 and crashes under strict warning handling (`filterwarnings = ["error"]`)
- The `is_coroutine_function` helper already unwraps `functools.partial` layers manually, making the asyncio fallback redundant on all supported Python versions
- Also removes the now-unused `import asyncio`

Fixes #3765

## Test plan
- [x] Existing tests continue to pass (the asyncio path was unreachable)
- [ ] Verify no DeprecationWarning on Python 3.14 with `filterwarnings = ["error"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)