### PR TITLE
fix: changeable allowed_client_redirect_uris on OAuthProxy

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -662,7 +662,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         client = await self._client_store.get(key=client_id)
 
         if client is not None:
-            if client.allowed_redirect_uri_patterns is None:
+            if self._allowed_client_redirect_uris is not None:
                 client.allowed_redirect_uri_patterns = (
                     self._allowed_client_redirect_uris
                 )

--- a/tests/server/auth/oauth_proxy/test_client_registration.py
+++ b/tests/server/auth/oauth_proxy/test_client_registration.py
@@ -41,3 +41,29 @@ class TestOAuthProxyClientRegistration:
         """Test that unregistered clients return None."""
         client = await oauth_proxy.get_client("unknown-client")
         assert client is None
+
+    async def test_enforcing_allowed_redirect_uris(self, oauth_proxy):
+        """Test enforcing allowed redirect uris configuration."""
+
+        oauth_proxy._allowed_client_redirect_uris = ["http://localhost:12345/callback"]
+
+        client_info = OAuthClientInformationFull(
+            client_id="original-client",
+            client_secret="original-secret",
+            redirect_uris=[AnyUrl("http://localhost:12345/callback")],
+        )
+
+        await oauth_proxy.register_client(client_info)
+        retrieved = await oauth_proxy.get_client("original-client")
+        assert retrieved.allowed_redirect_uri_patterns == [
+            "http://localhost:12345/callback"
+        ]
+
+        oauth_proxy._allowed_client_redirect_uris = [
+            "http://localhost:12345/updated_callback"
+        ]
+
+        retrieved = await oauth_proxy.get_client("original-client")
+        assert retrieved.allowed_redirect_uri_patterns == [
+            "http://localhost:12345/updated_callback"
+        ]


### PR DESCRIPTION
## Description

On `OAuthProxy.get_client()`, prioritized `self._allowed_client_redirect_uris` rather than stored `allowed_redirect_uri_patterns` from stored client. Without this fix, any updates to `allowed_client_redirect_uris` are prohibited, e.g., fixing typos, or client's url updates.

Closes #3771 

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
