### PR TITLE
fix: remove dereference=True while calling compress_schema

### DIFF
--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -500,7 +500,6 @@ class ParsedFunction:
             input_schema,
             prune_params=prune_params,
             prune_titles=True,
-            dereference=True,
         )
 
         output_schema = None
@@ -561,7 +560,8 @@ class ParsedFunction:
                     output_schema = base_schema
 
                 output_schema = compress_schema(
-                    output_schema, prune_titles=True, dereference=True
+                    output_schema,
+                    prune_titles=True,
                 )
 
                 # Resolve root-level $ref to meet MCP spec requirement for type: object

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -194,15 +194,18 @@ class TestToolFromFunction:
                 "tags": set(),
                 "enabled": True,
                 "parameters": {
-                    "properties": {
-                        "user": {
+                    "$defs": {
+                        "UserInput": {
                             "properties": {
                                 "name": {"type": "string"},
                                 "age": {"type": "integer"},
                             },
                             "required": ["name", "age"],
                             "type": "object",
-                        },
+                        }
+                    },
+                    "properties": {
+                        "user": {"$ref": "#/$defs/UserInput"},
                         "flag": {"type": "boolean"},
                     },
                     "required": ["user", "flag"],


### PR DESCRIPTION
## Description
This addresses the issues found in #3760. Currently, if a self-referencing Pydantic data type is buried in a nested field, calling dereference_refs() introduces a circular reference to the final schema. This results in a serialization error that crashes the server during tools/list requests.

I checked v3.2.0 and noticed that dereference=True is no longer being passed to compress_schema(), which essentially reverts #3170. We should implement this same behavior for the 2.x versions. While the community will eventually migrate to 3.x, I think we still need to pull this fix in now because the bug causes a complete server crash whenever tools/list is called.

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)
