### PR TITLE
docs: add warning about module name conflicts in FileSystemProvider

### DIFF
--- a/docs/servers/providers/filesystem.mdx
+++ b/docs/servers/providers/filesystem.mdx
@@ -37,6 +37,10 @@ from fastmcp.server.providers import FileSystemProvider
 mcp = FastMCP("MyServer", providers=[FileSystemProvider(Path(__file__).parent / "mcp")])
 ```
 
+<Warning>
+Avoid naming your components directory `mcp` if it contains an `__init__.py` file. This can cause import conflicts with the `mcp` package that FastMCP depends on. Use alternative names like `mcp_components`, `server`, or `components` instead.
+</Warning>
+
 In your `mcp/` directory, create Python files with decorated functions.
 
 ```python


### PR DESCRIPTION
## Summary

This PR adds a warning to the FileSystemProvider documentation about potential import conflicts when naming the components directory `mcp`.

## Problem

Users have reported confusion when using `mcp` as their components directory name with an `__init__.py` file. This causes import conflicts with the `mcp` package that FastMCP depends on, resulting in errors like:

```
ImportError: cannot import name 'McpError' from 'mcp'
```

## Solution

Add a clear warning in the Quick Start section advising users to avoid naming their components directory `mcp` when using package mode (with `__init__.py`).

## Changes

- Added `<Warning>` block in `docs/servers/providers/filesystem.mdx`
- Suggested alternative directory names: `mcp_components`, `server`, or `components`

## Checklist

- [x] Documentation change only
- [x] No code changes
- [x] Follows existing documentation style