### PR TITLE
Bump pydocket>=0.19.0, drop fakeredis pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,7 @@ azure = ["azure-identity>=1.16.0", "PyJWT>=2.12.0"]
 code-mode = ["pydantic-monty==0.0.9"]
 gemini = ["google-genai>=1.18.0"]
 openai = ["openai>=1.102.0"]
-# fakeredis 2.35.0 renamed FakeConnection, which breaks pydocket's memory://
-# backend. Remove the ceiling once a fixed pydocket release ships.
-# See https://github.com/chrisguidry/docket/pull/382
-tasks = ["pydocket>=0.18.0", "fakeredis[lua]<2.35.0"]
+tasks = ["pydocket>=0.19.0"]
 
 [dependency-groups]
 dev = [

--- a/src/fastmcp/server/dependencies.py
+++ b/src/fastmcp/server/dependencies.py
@@ -422,11 +422,11 @@ def _get_sync_redis(url: str) -> Any:
 _DOCKET_AVAILABLE: bool | None = None
 
 
-_MIN_DOCKET_VERSION = Version("0.18.0")
+_MIN_DOCKET_VERSION = Version("0.19.0")
 
 
 def is_docket_available() -> bool:
-    """Check if a compatible pydocket (>= 0.18.0) is installed and importable.
+    """Check if a compatible pydocket (>= 0.19.0) is installed and importable.
 
     Three things have to be true for fastmcp's task features to work:
       1. pydocket distribution metadata is discoverable

--- a/tests/server/test_dependencies.py
+++ b/tests/server/test_dependencies.py
@@ -758,7 +758,7 @@ class TestDependencyInjection:
         assert is_docket_available() is True
 
     def test_is_docket_available_false_when_pydocket_too_old(self, monkeypatch):
-        """``is_docket_available()`` must treat pre-0.18.0 pydocket as unavailable.
+        """``is_docket_available()`` must treat pre-0.19.0 pydocket as unavailable.
 
         Older pydocket versions (e.g. 0.16.x, pulled in transitively by
         packages like prefect) import cleanly but lack the APIs fastmcp

--- a/uv.lock
+++ b/uv.lock
@@ -733,16 +733,16 @@ wheels = [
 
 [[package]]
 name = "fakeredis"
-version = "2.34.1"
+version = "2.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "redis" },
     { name = "sortedcontainers" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/40/fd09efa66205eb32253d2b2ebc63537281384d2040f0a88bcd2289e120e4/fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b", size = 177315, upload-time = "2026-02-25T13:17:51.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/b9/c40b92cd49155a8ebbdc983cb50c02fc1c87d3a53f19aa420aefb96b00a3/fakeredis-2.35.0.tar.gz", hash = "sha256:5d1a0192c2c559e55b2d05328d86282ddd2079c1712a91e6d1b3010e0dd45ca6", size = 189000, upload-time = "2026-04-09T18:02:14.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b5/82f89307d0d769cd9bf46a54fb9136be08e4e57c5570ae421db4c9a2ba62/fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12", size = 122160, upload-time = "2026-02-25T13:17:49.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/43/83508ccf8177a840aec118bf4d20b0c25ddca6ccecd13f1f89caabcb1a45/fakeredis-2.35.0-py3-none-any.whl", hash = "sha256:565d337a5492e8c19be33a89e7acc078374741c65cb6d4413bd8818346b8c252", size = 129578, upload-time = "2026-04-09T18:02:13.264Z" },
 ]
 
 [package.optional-dependencies]
@@ -827,7 +827,6 @@ openai = [
     { name = "openai" },
 ]
 tasks = [
-    { name = "fakeredis", extra = ["lua"] },
     { name = "pydocket" },
 ]
 
@@ -869,7 +868,6 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.16.0" },
     { name = "cyclopts", specifier = ">=4.0.0" },
     { name = "exceptiongroup", specifier = ">=1.2.2" },
-    { name = "fakeredis", extras = ["lua"], marker = "extra == 'tasks'", specifier = "<2.35.0" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.18.0" },
     { name = "httpx", specifier = ">=0.28.1,<1.0" },
     { name = "jsonref", specifier = ">=1.1.0" },
@@ -884,7 +882,7 @@ requires-dist = [
     { name = "py-key-value-aio", extras = ["filetree", "keyring", "memory"], specifier = ">=0.4.4,<0.5.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.7" },
     { name = "pydantic-monty", marker = "extra == 'code-mode'", specifier = "==0.0.9" },
-    { name = "pydocket", marker = "extra == 'tasks'", specifier = ">=0.18.0" },
+    { name = "pydocket", marker = "extra == 'tasks'", specifier = ">=0.19.0" },
     { name = "pyjwt", marker = "extra == 'azure'", specifier = ">=2.12.0" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
@@ -2211,7 +2209,7 @@ wheels = [
 
 [[package]]
 name = "pydocket"
-version = "0.18.2"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
@@ -2230,9 +2228,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "uncalled-for" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/5f/82dde9fb6099b960a4203596d3b755d1bd2c0d0210fea104d015d6515d7f/pydocket-0.18.2.tar.gz", hash = "sha256:cc2051d15557f83bb164a83b0743fa9c12c2bfe9a9145cff3a5922b4935ce4f5", size = 354762, upload-time = "2026-03-10T13:09:22.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/6e/0db603ce4d82072b1a61798340e408ec04b3a77647f537881ff5b93c31f6/pydocket-0.19.0.tar.gz", hash = "sha256:00bff620d80cd2fad34ccbbe526dce24a9de8cdc1d2b94d305739668a98e308a", size = 355531, upload-time = "2026-04-10T17:25:38.112Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/cf/8c1b6340baf81d7f6c97fe0181bda7cfd500d5e33bf469fbffbdae07b3c9/pydocket-0.18.2-py3-none-any.whl", hash = "sha256:19e48de15e83370f750e362610b777533ff9c0fa48bf36766ed581f91d266556", size = 99041, upload-time = "2026-03-10T13:09:20.598Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/7bed93ecff9015c4a8dcabfaab3d490b45ec8e5847b30ac9671b9c01def8/pydocket-0.19.0-py3-none-any.whl", hash = "sha256:8531e64b989673a17d055ee4498ca8c3505310c5af4e7fd09c7b00fb2f29aa19", size = 99271, upload-time = "2026-04-10T17:25:36.657Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
pydocket 0.19.0 fixes the fakeredis 2.35.0 `FakeConnection` rename internally (https://github.com/chrisguidry/docket/pull/382), so we no longer need to carry the `fakeredis[lua]<2.35.0` ceiling in the `tasks` extra. This simplifies the dependency to just `pydocket>=0.19.0` and lets fakeredis float as a transitive.

Also bumps the `_MIN_DOCKET_VERSION` floor to match.

Follows up on #3804.

🤖 Generated with Claude Code