### PR TITLE
fix: TransformedTool sync fn crash and schema mutation

### DIFF
--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -19,6 +19,10 @@ import fastmcp
 from fastmcp.exceptions import FastMCPDeprecationWarning
 from fastmcp.tools.base import Tool, ToolResult, _convert_to_content
 from fastmcp.tools.function_parsing import ParsedFunction
+from fastmcp.utilities.async_utils import (
+    call_sync_fn_in_threadpool,
+    is_coroutine_function,
+)
 from fastmcp.utilities.components import _convert_set_default_none
 from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.logging import get_logger
@@ -310,7 +314,12 @@ class TransformedTool(Tool):
 
         token = _current_tool.set(self)
         try:
-            result = await self.fn(**arguments)
+            if is_coroutine_function(self.fn):
+                result = await self.fn(**arguments)
+            else:
+                result = await call_sync_fn_in_threadpool(self.fn, **arguments)
+                if inspect.isawaitable(result):
+                    result = await result
 
             # If transform function returns ToolResult, respect our output_schema setting
             if isinstance(result, ToolResult):
@@ -385,17 +394,14 @@ class TransformedTool(Tool):
             version: New version for the tool. Defaults to parent tool's version.
             title: New title for the tool. Defaults to parent tool's title.
             transform_args: Optional transformations for parent tool arguments.
-                Only specified arguments are transformed, others pass through unchanged:
-                - Simple rename (str)
-                - Complex transformation (rename/description/default/drop) (ArgTransform)
-                - Drop the argument (None)
+                Only specified arguments are transformed, others pass through unchanged.
+                Use ArgTransform for rename, description, default, or hide operations.
             description: New description. Defaults to parent's description.
             tags: New tags. Defaults to parent's tags.
             annotations: New annotations. Defaults to parent's annotations.
             output_schema: Control output schema for structured outputs:
                 - None (default): Inherit from transform_fn if available, then parent tool
                 - dict: Use custom output schema
-                - False: Disable output schema and structured outputs
             serializer: Deprecated. Return ToolResult from your tools for full control over serialization.
             meta: Control meta information:
                 - NotSet (default): Inherit from parent tool
@@ -629,9 +635,9 @@ class TransformedTool(Tool):
         """
 
         # Build transformed schema and mapping
-        # Deep copy to prevent compress_schema from mutating parent tool's $defs
+        # Deep copy to prevent mutations from corrupting the parent tool's schema
         parent_defs = deepcopy(parent_tool.parameters.get("$defs", {}))
-        parent_props = parent_tool.parameters.get("properties", {}).copy()
+        parent_props = deepcopy(parent_tool.parameters.get("properties", {}))
         parent_required = set(parent_tool.parameters.get("required", []))
 
         new_props = {}

--- a/tests/tools/tool_transform/test_tool_transform.py
+++ b/tests/tools/tool_transform/test_tool_transform.py
@@ -618,3 +618,41 @@ class TestProxy:
             result = await client.call_tool("add_transformed", {"new_x": 1, "old_y": 2})
             assert isinstance(result.content[0], TextContent)
             assert result.content[0].text == "3"
+
+
+async def test_sync_transform_fn():
+    """Sync transform_fn should not crash when called (was unconditionally awaited)."""
+
+    @Tool.from_function
+    def parent(x: int, y: int = 10) -> int:
+        return x + y
+
+    def sync_transform(x: int, **kwargs) -> str:
+        return f"transformed: {x}"
+
+    transformed = Tool.from_tool(parent, transform_fn=sync_transform)
+    result = await transformed.run(arguments={"x": 7})
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "transformed: 7"
+
+
+async def test_transform_args_do_not_mutate_parent_schema():
+    """Mutating a transformed tool's schema must not corrupt the parent's schema."""
+
+    @Tool.from_function
+    def parent(x: int, y: int = 10) -> int:
+        return x + y
+
+    parent_props_before = {
+        k: dict(v) for k, v in parent.parameters["properties"].items()
+    }
+
+    transformed = Tool.from_tool(
+        parent,
+        transform_args={"x": ArgTransform(name="a")},
+    )
+
+    transformed.parameters["properties"]["a"]["description"] = "INJECTED"
+
+    parent_props_after = parent.parameters["properties"]
+    assert parent_props_after == parent_props_before


### PR DESCRIPTION
`TransformedTool` had two bugs that made tool transforms unreliable: sync `transform_fn` functions crashed on every call because `run()` unconditionally awaited them, and property schemas were shallow-copied so mutations to a transformed tool corrupted its parent.

Also removed inaccurate docstring claims that `transform_args` accepted `str` and `None` shorthand values (never implemented), and that `output_schema=False` was supported (filed as #3834).

```python
from fastmcp.tools.function_tool import FunctionTool
from fastmcp.tools.tool_transform import TransformedTool

def greet(name: str) -> str:
    return f"Hello, {name}!"

def loud_greet(name: str) -> str:
    return f"HELLO, {name}!"

parent = FunctionTool.from_function(greet)

# Before: TypeError: object str can't be used in 'await' expression
# After: works
transformed = TransformedTool.from_tool(parent, transform_fn=loud_greet)
```

Fixes #3821

🤖 Generated with [Claude Code](https://claude.com/claude-code)