### PR TITLE
Replace ___ with hash-based backend tool routing and per-tool prefab resources

### DIFF
--- a/src/fastmcp/apps/app.py
+++ b/src/fastmcp/apps/app.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import AsyncIterator, Callable, Sequence
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from typing import Any, Literal, TypeVar, overload
 
 from mcp.types import AnyFunction, Icon, ToolAnnotations
@@ -310,9 +310,12 @@ class FastMCPApp(Provider):
             from fastmcp.apps.config import AppConfig, app_config_to_meta_dict
             from fastmcp.server.providers.local_provider.decorators.tools import (
                 PREFAB_RENDERER_URI,
-                _ensure_prefab_renderer,
             )
 
+            # Stamp the placeholder URI; the per-tool renderer resource is
+            # synthesized at list_resources / read_resource time from the
+            # tool's mount-point address. No singleton resource gets
+            # registered here.
             app_config = AppConfig(
                 resource_uri=PREFAB_RENDERER_URI,
                 visibility=["model"],
@@ -336,10 +339,6 @@ class FastMCPApp(Provider):
                 auth=auth,
             )
             self._local._add_component(tool_obj)
-
-            # Register the Prefab renderer resource on the internal provider
-            with suppress(ImportError):
-                _ensure_prefab_renderer(self._local)
 
             return fn
 

--- a/src/fastmcp/apps/app.py
+++ b/src/fastmcp/apps/app.py
@@ -50,38 +50,56 @@ F = TypeVar("F", bound=Callable[..., Any])
 # ---------------------------------------------------------------------------
 
 
-def _make_resolver(mount_path: tuple[int, ...] = ()) -> Any:
+def _make_resolver() -> Any:
     """Create a CallTool resolver that turns peer-tool refs into hashed names.
 
     Prefab components reference other tools via ``on_click=other_tool``.
     When a Prefab UI runs and serializes its content, this resolver
-    converts each reference into the universal backend-tool name —
-    ``<hash>_<local_tool_name>`` — where the hash is computed from the
-    current invocation's *mount path* (the address of the provider that
-    owns the calling tool) plus the referenced tool's local name.
+    looks up each referenced tool's address via the current server's
+    callable map (``id(fn) → HashEntry``) and formats the universal
+    backend-tool name ``<hash>_<local_name>``.
+
+    For function references, the lookup is by callable identity — no
+    name ambiguity, no mount_path needed. For string references, we
+    fall back to name-based lookup in the hash-keyed reverse map.
 
     Calls coming back through the dispatcher recognize the hashed name,
     look it up via the server's reverse-hash map, and route directly to
-    the owning provider — bypassing the transform chain entirely. This
-    is the only mechanism by which tools with ``visibility=["app"]`` are
-    callable from outside the server.
-
-    When ``mount_path`` is empty (the calling tool lives at the server's
-    root), there's no prefix to add — the referenced tool must itself be
-    a root-level tool and is callable by its bare name.
+    the owning provider — bypassing the transform chain entirely.
     """
     from fastmcp.server.providers.addressing import hashed_backend_name
-
-    def _format(local_name: str) -> str:
-        if not mount_path:
-            return local_name
-        return hashed_backend_name(mount_path, local_name)
 
     def _resolve_tool_ref(fn: Any) -> Any:
         from prefab_ui.app import ResolvedTool
 
+        from fastmcp.server.context import _current_context
+
+        # Try to look up the callable directly in the server's callable map.
+        ctx = _current_context.get(None)
+        server = ctx.fastmcp if ctx is not None else None
+        callable_map = server.callable_map if server is not None else {}
+
+        def _format_by_callable(func: Any, fallback_name: str) -> ResolvedTool:
+            entry = callable_map.get(id(func))
+            if entry is not None:
+                parent = ctx._parent_address if ctx is not None else ()
+                global_addr = (*parent, *entry.address)
+                return ResolvedTool(
+                    name=hashed_backend_name(global_addr, entry.tool_name)
+                )
+            # Not in the callable map — return bare name (root tool).
+            return ResolvedTool(name=fallback_name)
+
         if isinstance(fn, str):
-            return ResolvedTool(name=_format(fn))
+            # String ref — can't do callable lookup. Check the hash
+            # reverse map by name.
+            if server is not None:
+                parent = ctx._parent_address if ctx is not None else ()
+                for entry in server.reverse_hash_map.values():
+                    if entry.tool_name == fn:
+                        global_addr = (*parent, *entry.address)
+                        return ResolvedTool(name=hashed_backend_name(global_addr, fn))
+            return ResolvedTool(name=fn)
 
         fmeta: Any = None
         try:
@@ -94,11 +112,11 @@ def _make_resolver(mount_path: tuple[int, ...] = ()) -> Any:
         if fmeta is not None:
             name: str | None = getattr(fmeta, "name", None)
             if name is not None:
-                return ResolvedTool(name=_format(name))
+                return _format_by_callable(fn, name)
 
         fn_name = getattr(fn, "__name__", None)
         if fn_name is not None:
-            return ResolvedTool(name=_format(fn_name))
+            return _format_by_callable(fn, fn_name)
 
         raise ValueError(f"Cannot resolve tool reference: {fn!r}")
 

--- a/src/fastmcp/apps/app.py
+++ b/src/fastmcp/apps/app.py
@@ -62,10 +62,17 @@ def _make_resolver(app_name: str | None = None) -> Any:
     ``get_tool_by_hash`` which walks the provider tree recursively —
     same pattern as ``get_app_tool``.
     """
-    from fastmcp.server.providers.addressing import hashed_backend_name
+    from fastmcp.server.providers.addressing import (
+        hashed_backend_name,
+        parse_hashed_backend_name,
+    )
 
     def _prefix(local_name: str) -> str:
         if app_name:
+            # Don't re-hash an already-addressed name (same guard the
+            # old ___ resolver had with "___" not in name).
+            if parse_hashed_backend_name(local_name) is not None:
+                return local_name
             return hashed_backend_name(app_name, local_name)
         return local_name
 

--- a/src/fastmcp/apps/app.py
+++ b/src/fastmcp/apps/app.py
@@ -356,8 +356,12 @@ class FastMCPApp(Provider):
         if not isinstance(tool, Tool):
             tool = Tool._ensure_tool(tool)
 
+        from fastmcp.server.providers.addressing import hash_tool
+
         meta = dict(tool.meta) if tool.meta else {}
-        meta.setdefault("fastmcp", {})["app"] = self.name
+        fm = meta.setdefault("fastmcp", {})
+        fm["app"] = self.name
+        fm["_tool_hash"] = hash_tool(self.name, tool.name)
         ui = meta.setdefault("ui", {})
         if "visibility" not in ui:
             ui["visibility"] = ["app"]

--- a/src/fastmcp/apps/app.py
+++ b/src/fastmcp/apps/app.py
@@ -50,56 +50,30 @@ F = TypeVar("F", bound=Callable[..., Any])
 # ---------------------------------------------------------------------------
 
 
-def _make_resolver() -> Any:
-    """Create a CallTool resolver that turns peer-tool refs into hashed names.
+def _make_resolver(app_name: str | None = None) -> Any:
+    """Create a CallTool resolver that prefixes tool names with a hash.
 
-    Prefab components reference other tools via ``on_click=other_tool``.
-    When a Prefab UI runs and serializes its content, this resolver
-    looks up each referenced tool's address via the current server's
-    callable map (``id(fn) → HashEntry``) and formats the universal
-    backend-tool name ``<hash>_<local_name>``.
+    Structurally identical to the old ``___`` resolver — ``app_name`` is
+    the FastMCPApp's name, known at serialization time from the tool's
+    ``meta["fastmcp"]["app"]`` tag. The only change is the wire format:
+    ``<hash>_<local_name>`` instead of ``<app_name>___<local_name>``.
 
-    For function references, the lookup is by callable identity — no
-    name ambiguity, no mount_path needed. For string references, we
-    fall back to name-based lookup in the hash-keyed reverse map.
-
-    Calls coming back through the dispatcher recognize the hashed name,
-    look it up via the server's reverse-hash map, and route directly to
-    the owning provider — bypassing the transform chain entirely.
+    The dispatcher recognizes the hashed form and routes it via
+    ``get_tool_by_hash`` which walks the provider tree recursively —
+    same pattern as ``get_app_tool``.
     """
     from fastmcp.server.providers.addressing import hashed_backend_name
+
+    def _prefix(local_name: str) -> str:
+        if app_name:
+            return hashed_backend_name(app_name, local_name)
+        return local_name
 
     def _resolve_tool_ref(fn: Any) -> Any:
         from prefab_ui.app import ResolvedTool
 
-        from fastmcp.server.context import _current_context
-
-        # Try to look up the callable directly in the server's callable map.
-        ctx = _current_context.get(None)
-        server = ctx.fastmcp if ctx is not None else None
-        callable_map = server.callable_map if server is not None else {}
-
-        def _format_by_callable(func: Any, fallback_name: str) -> ResolvedTool:
-            entry = callable_map.get(id(func))
-            if entry is not None:
-                parent = ctx._parent_address if ctx is not None else ()
-                global_addr = (*parent, *entry.address)
-                return ResolvedTool(
-                    name=hashed_backend_name(global_addr, entry.tool_name)
-                )
-            # Not in the callable map — return bare name (root tool).
-            return ResolvedTool(name=fallback_name)
-
         if isinstance(fn, str):
-            # String ref — can't do callable lookup. Check the hash
-            # reverse map by name.
-            if server is not None:
-                parent = ctx._parent_address if ctx is not None else ()
-                for entry in server.reverse_hash_map.values():
-                    if entry.tool_name == fn:
-                        global_addr = (*parent, *entry.address)
-                        return ResolvedTool(name=hashed_backend_name(global_addr, fn))
-            return ResolvedTool(name=fn)
+            return ResolvedTool(name=_prefix(fn))
 
         fmeta: Any = None
         try:
@@ -112,11 +86,11 @@ def _make_resolver() -> Any:
         if fmeta is not None:
             name: str | None = getattr(fmeta, "name", None)
             if name is not None:
-                return _format_by_callable(fn, name)
+                return ResolvedTool(name=_prefix(name))
 
         fn_name = getattr(fn, "__name__", None)
         if fn_name is not None:
-            return _format_by_callable(fn, fn_name)
+            return ResolvedTool(name=_prefix(fn_name))
 
         raise ValueError(f"Cannot resolve tool reference: {fn!r}")
 
@@ -239,11 +213,15 @@ class FastMCPApp(Provider):
                 raise ValueError(f"Cannot determine tool name for {fn!r}")
 
             from fastmcp.apps.config import AppConfig, app_config_to_meta_dict
+            from fastmcp.server.providers.addressing import hash_tool
 
             app_config = AppConfig(visibility=visibility)
             meta: dict[str, Any] = {
                 "ui": app_config_to_meta_dict(app_config),
-                "fastmcp": {"app": self.name},
+                "fastmcp": {
+                    "app": self.name,
+                    "_tool_hash": hash_tool(self.name, resolved_name),
+                },
             }
 
             tool_obj = Tool.from_function(
@@ -326,14 +304,12 @@ class FastMCPApp(Provider):
 
         def _register(fn: F, tool_name: str | None) -> F:
             from fastmcp.apps.config import AppConfig, app_config_to_meta_dict
+            from fastmcp.server.providers.addressing import hash_tool
             from fastmcp.server.providers.local_provider.decorators.tools import (
                 PREFAB_RENDERER_URI,
             )
 
-            # Stamp the placeholder URI; the per-tool renderer resource is
-            # synthesized at list_resources / read_resource time from the
-            # tool's mount-point address. No singleton resource gets
-            # registered here.
+            resolved = tool_name or getattr(fn, "__name__", None) or "unknown"
             app_config = AppConfig(
                 resource_uri=PREFAB_RENDERER_URI,
                 visibility=["model"],
@@ -341,7 +317,10 @@ class FastMCPApp(Provider):
 
             meta: dict[str, Any] = {
                 "ui": app_config_to_meta_dict(app_config),
-                "fastmcp": {"app": self.name},
+                "fastmcp": {
+                    "app": self.name,
+                    "_tool_hash": hash_tool(self.name, resolved),
+                },
             }
 
             tool_obj = Tool.from_function(

--- a/src/fastmcp/apps/app.py
+++ b/src/fastmcp/apps/app.py
@@ -50,26 +50,38 @@ F = TypeVar("F", bound=Callable[..., Any])
 # ---------------------------------------------------------------------------
 
 
-def _make_resolver(app_name: str | None = None) -> Any:
-    """Create a CallTool resolver that prefixes tool names with the app name.
+def _make_resolver(mount_path: tuple[int, ...] = ()) -> Any:
+    """Create a CallTool resolver that turns peer-tool refs into hashed names.
 
-    When ``app_name`` is set, tool references like ``CallTool("store_files")``
-    or ``CallTool(store_files)`` are resolved to
-    ``ResolvedTool(name="Files___store_files")``.  This produces stable
-    identifiers that bypass transforms and work without host ``_meta``
-    forwarding.
+    Prefab components reference other tools via ``on_click=other_tool``.
+    When a Prefab UI runs and serializes its content, this resolver
+    converts each reference into the universal backend-tool name —
+    ``<hash>_<local_tool_name>`` — where the hash is computed from the
+    current invocation's *mount path* (the address of the provider that
+    owns the calling tool) plus the referenced tool's local name.
+
+    Calls coming back through the dispatcher recognize the hashed name,
+    look it up via the server's reverse-hash map, and route directly to
+    the owning provider — bypassing the transform chain entirely. This
+    is the only mechanism by which tools with ``visibility=["app"]`` are
+    callable from outside the server.
+
+    When ``mount_path`` is empty (the calling tool lives at the server's
+    root), there's no prefix to add — the referenced tool must itself be
+    a root-level tool and is callable by its bare name.
     """
+    from fastmcp.server.providers.addressing import hashed_backend_name
 
-    def _prefix(name: str) -> str:
-        if app_name and "___" not in name:
-            return f"{app_name}___{name}"
-        return name
+    def _format(local_name: str) -> str:
+        if not mount_path:
+            return local_name
+        return hashed_backend_name(mount_path, local_name)
 
     def _resolve_tool_ref(fn: Any) -> Any:
         from prefab_ui.app import ResolvedTool
 
         if isinstance(fn, str):
-            return ResolvedTool(name=_prefix(fn))
+            return ResolvedTool(name=_format(fn))
 
         fmeta: Any = None
         try:
@@ -82,11 +94,11 @@ def _make_resolver(app_name: str | None = None) -> Any:
         if fmeta is not None:
             name: str | None = getattr(fmeta, "name", None)
             if name is not None:
-                return ResolvedTool(name=_prefix(name))
+                return ResolvedTool(name=_format(name))
 
         fn_name = getattr(fn, "__name__", None)
         if fn_name is not None:
-            return ResolvedTool(name=_prefix(fn_name))
+            return ResolvedTool(name=_format(fn_name))
 
         raise ValueError(f"Cannot resolve tool reference: {fn!r}")
 
@@ -138,11 +150,6 @@ class FastMCPApp(Provider):
     """
 
     def __init__(self, name: str) -> None:
-        if "___" in name:
-            raise ValueError(
-                f"App name {name!r} must not contain '___' "
-                "(reserved as the app tool routing separator)"
-            )
         super().__init__()
         self.name = name
         self._local = LocalProvider(on_duplicate="error")

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -193,8 +193,7 @@ class Context:
         *,
         task_id: str | None = None,
         origin_request_id: str | None = None,
-        mount_path: tuple[int, ...] | None = None,
-        mount_path_resolver: Callable[[], tuple[int, ...]] | None = None,
+        parent_address: tuple[int, ...] = (),
     ):
         self._fastmcp: weakref.ref[FastMCP] = weakref.ref(fastmcp)
         self._session: ServerSession | None = session  # For state ops during init
@@ -204,16 +203,12 @@ class Context:
         self._origin_request_id: str | None = origin_request_id
         # Request-scoped state for non-serializable values (serializable=False)
         self._request_state: dict[str, Any] = {}
-        # Internal positional address of the mount point this call came
-        # through. Used by the Prefab peer-reference resolver to format
-        # backend-tool callbacks. Stored as either a known tuple or a
-        # deferred resolver callable — display-name resolution sets the
-        # resolver so the cost of looking up the owning provider is only
-        # paid if the tool actually emits Prefab output.
-        self._mount_path: tuple[int, ...] | None = mount_path
-        self._mount_path_resolver: Callable[[], tuple[int, ...]] | None = (
-            mount_path_resolver
-        )
+        # Accumulated address of the current server's mount point as seen
+        # from the outermost root. For a single-server setup this is ().
+        # When calls cross a server boundary via FastMCPProvider, the
+        # parent's address segment is prepended so inner servers know
+        # their global position without walking up to the root.
+        self._parent_address: tuple[int, ...] = parent_address
 
     @property
     def is_background_task(self) -> bool:
@@ -263,23 +258,16 @@ class Context:
         return fastmcp
 
     @property
-    def mount_path(self) -> tuple[int, ...]:
-        """Internal positional address of this call's mount point.
+    def parent_address(self) -> tuple[int, ...]:
+        """Accumulated address prefix from parent servers.
 
-        For tools resolved via the hashed-name dispatch path the address is
-        known immediately and stored eagerly. For tools resolved by display
-        name the dispatcher attaches a lazy resolver — the cost of finding
-        the owning provider is only paid the first time something (e.g. the
-        Prefab peer-reference resolver) actually reads ``mount_path``.
-        Defaults to ``()`` (the root) when no resolver was supplied.
+        For a single-server setup this is always ``()``. When a call
+        crosses into a mounted server via ``FastMCPProvider``, the
+        parent's address segment is prepended so the inner server's
+        tools can compute their full global address as
+        ``parent_address + local_address``.
         """
-        if self._mount_path is None:
-            if self._mount_path_resolver is not None:
-                self._mount_path = self._mount_path_resolver()
-                self._mount_path_resolver = None
-            else:
-                self._mount_path = ()
-        return self._mount_path
+        return self._parent_address
 
     async def __aenter__(self) -> Context:
         """Enter the context manager and set this context as the current context."""
@@ -288,11 +276,11 @@ class Context:
         parent = _current_context.get(None)
         if parent is not None:
             self._request_state = parent._request_state
-            # Inherit mount_path from a parent context if our own is unset
-            # (so middleware and nested re-entries see the dispatcher's value).
-            if self._mount_path is None and self._mount_path_resolver is None:
-                self._mount_path = parent._mount_path
-                self._mount_path_resolver = parent._mount_path_resolver
+            # Inherit parent_address from a parent context if our own is
+            # the default empty tuple (so middleware and nested re-entries
+            # see the accumulated address without explicit propagation).
+            if self._parent_address == () and parent._parent_address != ():
+                self._parent_address = parent._parent_address
 
         # Always set this context and save the token
         token = _current_context.set(self)

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -193,7 +193,6 @@ class Context:
         *,
         task_id: str | None = None,
         origin_request_id: str | None = None,
-        parent_address: tuple[int, ...] = (),
     ):
         self._fastmcp: weakref.ref[FastMCP] = weakref.ref(fastmcp)
         self._session: ServerSession | None = session  # For state ops during init
@@ -203,12 +202,6 @@ class Context:
         self._origin_request_id: str | None = origin_request_id
         # Request-scoped state for non-serializable values (serializable=False)
         self._request_state: dict[str, Any] = {}
-        # Accumulated address of the current server's mount point as seen
-        # from the outermost root. For a single-server setup this is ().
-        # When calls cross a server boundary via FastMCPProvider, the
-        # parent's address segment is prepended so inner servers know
-        # their global position without walking up to the root.
-        self._parent_address: tuple[int, ...] = parent_address
 
     @property
     def is_background_task(self) -> bool:
@@ -257,18 +250,6 @@ class Context:
             raise RuntimeError("FastMCP instance is no longer available")
         return fastmcp
 
-    @property
-    def parent_address(self) -> tuple[int, ...]:
-        """Accumulated address prefix from parent servers.
-
-        For a single-server setup this is always ``()``. When a call
-        crosses into a mounted server via ``FastMCPProvider``, the
-        parent's address segment is prepended so the inner server's
-        tools can compute their full global address as
-        ``parent_address + local_address``.
-        """
-        return self._parent_address
-
     async def __aenter__(self) -> Context:
         """Enter the context manager and set this context as the current context."""
         # Inherit request-scoped state from parent context so middleware
@@ -276,11 +257,6 @@ class Context:
         parent = _current_context.get(None)
         if parent is not None:
             self._request_state = parent._request_state
-            # Inherit parent_address from a parent context if our own is
-            # the default empty tuple (so middleware and nested re-entries
-            # see the accumulated address without explicit propagation).
-            if self._parent_address == () and parent._parent_address != ():
-                self._parent_address = parent._parent_address
 
         # Always set this context and save the token
         token = _current_context.set(self)

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -193,6 +193,8 @@ class Context:
         *,
         task_id: str | None = None,
         origin_request_id: str | None = None,
+        mount_path: tuple[int, ...] | None = None,
+        mount_path_resolver: Callable[[], tuple[int, ...]] | None = None,
     ):
         self._fastmcp: weakref.ref[FastMCP] = weakref.ref(fastmcp)
         self._session: ServerSession | None = session  # For state ops during init
@@ -202,6 +204,16 @@ class Context:
         self._origin_request_id: str | None = origin_request_id
         # Request-scoped state for non-serializable values (serializable=False)
         self._request_state: dict[str, Any] = {}
+        # Internal positional address of the mount point this call came
+        # through. Used by the Prefab peer-reference resolver to format
+        # backend-tool callbacks. Stored as either a known tuple or a
+        # deferred resolver callable — display-name resolution sets the
+        # resolver so the cost of looking up the owning provider is only
+        # paid if the tool actually emits Prefab output.
+        self._mount_path: tuple[int, ...] | None = mount_path
+        self._mount_path_resolver: Callable[[], tuple[int, ...]] | None = (
+            mount_path_resolver
+        )
 
     @property
     def is_background_task(self) -> bool:
@@ -250,6 +262,25 @@ class Context:
             raise RuntimeError("FastMCP instance is no longer available")
         return fastmcp
 
+    @property
+    def mount_path(self) -> tuple[int, ...]:
+        """Internal positional address of this call's mount point.
+
+        For tools resolved via the hashed-name dispatch path the address is
+        known immediately and stored eagerly. For tools resolved by display
+        name the dispatcher attaches a lazy resolver — the cost of finding
+        the owning provider is only paid the first time something (e.g. the
+        Prefab peer-reference resolver) actually reads ``mount_path``.
+        Defaults to ``()`` (the root) when no resolver was supplied.
+        """
+        if self._mount_path is None:
+            if self._mount_path_resolver is not None:
+                self._mount_path = self._mount_path_resolver()
+                self._mount_path_resolver = None
+            else:
+                self._mount_path = ()
+        return self._mount_path
+
     async def __aenter__(self) -> Context:
         """Enter the context manager and set this context as the current context."""
         # Inherit request-scoped state from parent context so middleware
@@ -257,6 +288,11 @@ class Context:
         parent = _current_context.get(None)
         if parent is not None:
             self._request_state = parent._request_state
+            # Inherit mount_path from a parent context if our own is unset
+            # (so middleware and nested re-entries see the dispatcher's value).
+            if self._mount_path is None and self._mount_path_resolver is None:
+                self._mount_path = parent._mount_path
+                self._mount_path_resolver = parent._mount_path_resolver
 
         # Always set this context and save the token
         token = _current_context.set(self)

--- a/src/fastmcp/server/providers/addressing.py
+++ b/src/fastmcp/server/providers/addressing.py
@@ -1,109 +1,64 @@
-"""Internal addressing primitives for the provider graph.
+"""Deterministic tool hashing for backend-tool routing and per-tool resources.
 
-FastMCP gives every mount point in a server's provider tree an internal
-positional address — a tuple of integers describing the path from the root
-through ``providers`` lists to the target provider. Combined with a tool
-name, this address feeds a deterministic hash that uniquely identifies a
-specific tool at a specific position. The hash is used in two places:
+Each FastMCPApp backend tool gets a deterministic hash computed from its
+app name + tool name. The hash serves two purposes:
 
-1. **Backend-tool routing.** Tools with ``"app"`` in their visibility list
-   are not in ``list_tools`` output, but they need to be callable from a
-   Prefab UI that references them. Their universal name is
-   ``<hash>_<local_name>`` — the dispatcher recognizes that form, looks up
-   the matching ``(provider, tool)`` via the reverse-hash map, and routes
-   the call directly through ``provider._get_tool``, bypassing transforms.
+1. **Backend-tool routing.** Tools with ``"app"`` in their visibility are
+   callable via ``<hash>_<local_name>``. The dispatcher parses the prefix,
+   then walks providers recursively (same pattern as the old ``get_app_tool``)
+   to find a tool whose stored hash matches.
 
-2. **Per-tool Prefab renderer URIs.** Tools that produce Prefab content
-   need a unique renderer resource URI per (mount point, tool) pair. The
-   URI is ``ui://prefab/tool/<hash>/renderer.html``. ``read_resource``
-   intercepts those URIs, looks up the matching tool, and synthesizes the
-   renderer HTML + CSP from the tool's stored metadata. ``list_resources``
-   enumerates the same URIs by walking the registry.
+2. **Per-tool Prefab renderer URIs.** Each prefab tool gets a unique renderer
+   resource at ``ui://prefab/tool/<hash>/renderer.html``. ``list_resources``
+   and ``read_resource`` synthesize these on demand from the tool's meta.
 
-Both uses share the same registry, the same hash function, and the same
-reverse-hash map. Nothing is mutated and nothing is materialized — the
-registry is built once on first access (cheap pure walk), invalidated when
-``add_provider`` runs, and rebuilt lazily next time something asks.
+The hash is computed at registration time from ``(app_name, tool_name)`` —
+both known at that moment — and stored in ``meta["fastmcp"]["_tool_hash"]``.
+Deterministic across replicas (same code → same hash), no registry walk
+needed.
 """
 
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, NamedTuple
-
-if TYPE_CHECKING:
-    from fastmcp.server.providers.base import Provider
-    from fastmcp.server.server import FastMCP
 
 #: Length of the hex hash prefix used in URIs and backend-tool names.
-#: 12 chars of sha256 gives ~10^14 distinct values — collision-safe for
-#: any realistic provider graph.
 HASH_LENGTH = 12
 
-#: A positional address: tuple of integer indices from the root.
-#: ``()`` is the root server's local provider; ``(0,)`` is the first
-#: top-level provider after the root's own LocalProvider; ``(0, 2)`` is the
-#: third child of that provider; etc.
-AddressPath = tuple[int, ...]
 
+def hash_tool(app_name: str, tool_name: str) -> str:
+    """Deterministic hex hash for a tool in an app.
 
-class HashEntry(NamedTuple):
-    """Reverse-hash map entry: enough info to resolve a hashed reference."""
-
-    address: AddressPath
-    provider: Provider
-    tool_name: str
-    fn: Any  #: underlying callable for FunctionTools, None for others
-
-
-def hash_tool_address(address: AddressPath, tool_name: str) -> str:
-    """Deterministic hex hash for a tool at a specific address.
-
-    Inputs: positional address tuple + the tool's local name within that
-    provider. Output: a fixed-length lowercase hex string. Same code on
-    every replica produces the same hash for the same logical tool, so
-    URIs and backend-tool names round-trip across horizontally-scaled
-    deployments without coordination.
+    Same inputs on every replica produce the same output.
     """
-    # Use a delimiter that can't appear inside the inputs to ensure
-    # ("a", "b_c") and ("a_b", "c") hash differently.
-    payload = f"{address!r}\x00{tool_name}".encode()
+    payload = f"{app_name}\x00{tool_name}".encode()
     return hashlib.sha256(payload).hexdigest()[:HASH_LENGTH]
 
 
-def hashed_backend_name(address: AddressPath, tool_name: str) -> str:
+def hashed_backend_name(app_name: str, tool_name: str) -> str:
     """Format the universal name for a backend tool: ``<hash>_<local_name>``."""
-    return f"{hash_tool_address(address, tool_name)}_{tool_name}"
+    return f"{hash_tool(app_name, tool_name)}_{tool_name}"
 
 
 def parse_hashed_backend_name(name: str) -> tuple[str, str] | None:
-    """Reverse of :func:`hashed_backend_name`.
-
-    Returns ``(hash, local_tool_name)`` if *name* matches the
-    ``<HASH_LENGTH hex>_<rest>`` shape, else ``None``. The dispatcher uses
-    this to detect hashed-name calls and look them up via the reverse map;
-    if the prefix isn't valid hex of the right length, or the hash isn't
-    in the reverse map, the dispatcher falls through to normal resolution.
-    """
+    """Parse ``<HASH_LENGTH hex>_<rest>`` → ``(hash, local_tool_name)`` or None."""
     if len(name) <= HASH_LENGTH + 1:
         return None
     prefix = name[:HASH_LENGTH]
     if name[HASH_LENGTH] != "_":
         return None
-    # All hex characters?
     if not all(c in "0123456789abcdef" for c in prefix):
         return None
     return prefix, name[HASH_LENGTH + 1 :]
 
 
-def hashed_resource_uri(address: AddressPath, tool_name: str) -> str:
-    """Format the per-tool Prefab renderer resource URI."""
-    return f"ui://prefab/tool/{hash_tool_address(address, tool_name)}/renderer.html"
+def hashed_resource_uri(app_name: str, tool_name: str) -> str:
+    """Per-tool Prefab renderer resource URI."""
+    return f"ui://prefab/tool/{hash_tool(app_name, tool_name)}/renderer.html"
 
 
 def parse_hashed_resource_uri(uri: str) -> str | None:
-    """Extract the hash from a Prefab renderer URI, or ``None`` if it doesn't match."""
+    """Extract the hash from a Prefab renderer URI, or None."""
     prefix = "ui://prefab/tool/"
     suffix = "/renderer.html"
     if not uri.startswith(prefix) or not uri.endswith(suffix):
@@ -112,135 +67,3 @@ def parse_hashed_resource_uri(uri: str) -> str | None:
     if len(h) != HASH_LENGTH or not all(c in "0123456789abcdef" for c in h):
         return None
     return h
-
-
-def _iter_children(provider: Provider) -> Sequence[Provider] | None:
-    """Return the provider's sub-providers if it's a container, else ``None``.
-
-    Containers are ``AggregateProvider`` (holds a list in ``self.providers``)
-    and ``_WrappedProvider`` (transparently wraps another provider with a
-    transform — the wrapper shares the wrapped provider's address segment).
-    Other provider types are leaves for addressing purposes.
-    """
-    # Local imports to avoid a circular import at module load.
-    from fastmcp.server.providers.aggregate import AggregateProvider
-    from fastmcp.server.providers.wrapped_provider import _WrappedProvider
-
-    if isinstance(provider, _WrappedProvider):
-        return _iter_children(provider._inner)
-    if isinstance(provider, AggregateProvider):
-        return list(provider.providers)
-    return None
-
-
-def build_address_registry(root: FastMCP) -> dict[AddressPath, Provider]:
-    """Walk the provider graph and assign each mount point a positional address.
-
-    Pure: returns a fresh dict, doesn't touch any provider, doesn't
-    instantiate resources, doesn't mutate metadata. The walk visits
-    children in registration order; each provider receives its index in
-    its parent's child list as the next segment of its address path.
-
-    The root's own internal LocalProvider is treated as address-transparent
-    — tools registered directly via ``@mcp.tool`` live at the empty path
-    ``()`` rather than getting their own segment. Every other provider,
-    including user-added LocalProviders, contributes a segment.
-    """
-    registry: dict[AddressPath, Provider] = {}
-    registry[()] = root._local_provider
-
-    def visit(providers: Sequence[Provider], base_path: AddressPath) -> None:
-        for index, provider in enumerate(providers):
-            path = (*base_path, index)
-            registry[path] = provider
-            children = _iter_children(provider)
-            if children is not None:
-                visit(children, path)
-
-    # Skip the root's transparent LocalProvider when walking top-level children.
-    top_level = [p for p in root.providers if p is not root._local_provider]
-    if top_level:
-        visit(top_level, ())
-
-    return registry
-
-
-class ReverseHashMaps(NamedTuple):
-    """Both reverse-lookup indexes produced by :func:`build_reverse_hash_map`.
-
-    ``by_hash``: ``hash_hex → HashEntry`` — used by the dispatcher for
-    hashed-name calls and by ``read_resource`` for prefab URI lookups.
-
-    ``by_callable``: ``id(fn) → HashEntry`` — used by the Prefab
-    peer-reference resolver to look up a peer tool's address by the
-    original function identity, without needing ``Context.mount_path``
-    or a name-based reverse walk.
-    """
-
-    by_hash: dict[str, HashEntry]
-    by_callable: dict[int, HashEntry]
-
-
-def build_reverse_hash_map(
-    registry: dict[AddressPath, Provider],
-) -> ReverseHashMaps:
-    """Build both reverse-lookup indexes from the address registry.
-
-    Walks every provider in the registry, reads its synchronous tool
-    storage, and for each tool computes its hash and (for FunctionTools)
-    captures the underlying callable. The result lets the dispatcher,
-    ``read_resource``, and the Prefab resolver do O(1) lookups.
-
-    Tools that aren't directly stored in a ``LocalProvider`` (or a
-    ``FastMCPApp``'s internal ``_local``) won't appear. That's
-    intentional — the addressing system is for tools you register, not
-    for tools dynamically synthesized at list time by custom providers.
-    """
-    by_hash: dict[str, HashEntry] = {}
-    by_callable: dict[int, HashEntry] = {}
-    for address, provider in registry.items():
-        for tool_name, fn in _enumerate_tools(provider):
-            entry = HashEntry(
-                address=address,
-                provider=provider,
-                tool_name=tool_name,
-                fn=fn,
-            )
-            digest = hash_tool_address(address, tool_name)
-            by_hash[digest] = entry
-            if fn is not None:
-                by_callable[id(fn)] = entry
-    return ReverseHashMaps(by_hash=by_hash, by_callable=by_callable)
-
-
-def _enumerate_tools(provider: Provider) -> list[tuple[str, Any]]:
-    """Synchronously enumerate ``(name, fn_or_None)`` for tools in *provider*.
-
-    Reaches into the underlying ``LocalProvider`` (unwrapping any
-    ``_WrappedProvider`` transform layers and looking through
-    ``FastMCPApp._local``). ``fn`` is the underlying callable for
-    ``FunctionTool`` instances, ``None`` for other Tool subclasses.
-    """
-    from fastmcp.apps.app import FastMCPApp
-    from fastmcp.server.providers.local_provider import LocalProvider
-    from fastmcp.server.providers.wrapped_provider import _WrappedProvider
-    from fastmcp.tools.base import Tool
-    from fastmcp.tools.function_tool import FunctionTool
-
-    inner: Provider = provider
-    while isinstance(inner, _WrappedProvider):
-        inner = inner._inner
-
-    sources: list[LocalProvider] = []
-    if isinstance(inner, LocalProvider):
-        sources.append(inner)
-    if isinstance(inner, FastMCPApp):
-        sources.append(inner._local)
-
-    results: list[tuple[str, Any]] = []
-    for src in sources:
-        for component in src._components.values():
-            if isinstance(component, Tool):
-                fn = component.fn if isinstance(component, FunctionTool) else None
-                results.append((component.name, fn))
-    return results

--- a/src/fastmcp/server/providers/addressing.py
+++ b/src/fastmcp/server/providers/addressing.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 if TYPE_CHECKING:
     from fastmcp.server.providers.base import Provider
@@ -54,6 +54,7 @@ class HashEntry(NamedTuple):
     address: AddressPath
     provider: Provider
     tool_name: str
+    fn: Any  #: underlying callable for FunctionTools, None for others
 
 
 def hash_tool_address(address: AddressPath, tool_name: str) -> str:
@@ -164,45 +165,67 @@ def build_address_registry(root: FastMCP) -> dict[AddressPath, Provider]:
     return registry
 
 
+class ReverseHashMaps(NamedTuple):
+    """Both reverse-lookup indexes produced by :func:`build_reverse_hash_map`.
+
+    ``by_hash``: ``hash_hex → HashEntry`` — used by the dispatcher for
+    hashed-name calls and by ``read_resource`` for prefab URI lookups.
+
+    ``by_callable``: ``id(fn) → HashEntry`` — used by the Prefab
+    peer-reference resolver to look up a peer tool's address by the
+    original function identity, without needing ``Context.mount_path``
+    or a name-based reverse walk.
+    """
+
+    by_hash: dict[str, HashEntry]
+    by_callable: dict[int, HashEntry]
+
+
 def build_reverse_hash_map(
     registry: dict[AddressPath, Provider],
-) -> dict[str, HashEntry]:
-    """Build the ``hash → (address, provider, tool_name)`` reverse map.
+) -> ReverseHashMaps:
+    """Build both reverse-lookup indexes from the address registry.
 
-    Walks every provider in the registry, calls its synchronous tool
-    storage to enumerate tools, and computes a hash for each one. The
-    result lets ``read_resource`` and the hashed-name dispatcher do O(1)
-    lookups by hash. Built once per registry build and invalidated
-    alongside it.
+    Walks every provider in the registry, reads its synchronous tool
+    storage, and for each tool computes its hash and (for FunctionTools)
+    captures the underlying callable. The result lets the dispatcher,
+    ``read_resource``, and the Prefab resolver do O(1) lookups.
 
     Tools that aren't directly stored in a ``LocalProvider`` (or a
-    ``FastMCPApp``'s internal ``_local``) won't appear in the reverse
-    map. That's intentional — the addressing system is for tools you
-    register, not for tools dynamically synthesized at list time by
-    custom providers, which already have their own naming.
+    ``FastMCPApp``'s internal ``_local``) won't appear. That's
+    intentional — the addressing system is for tools you register, not
+    for tools dynamically synthesized at list time by custom providers.
     """
-    reverse: dict[str, HashEntry] = {}
+    by_hash: dict[str, HashEntry] = {}
+    by_callable: dict[int, HashEntry] = {}
     for address, provider in registry.items():
-        for tool_name in _enumerate_tool_names(provider):
-            digest = hash_tool_address(address, tool_name)
-            reverse[digest] = HashEntry(
-                address=address, provider=provider, tool_name=tool_name
+        for tool_name, fn in _enumerate_tools(provider):
+            entry = HashEntry(
+                address=address,
+                provider=provider,
+                tool_name=tool_name,
+                fn=fn,
             )
-    return reverse
+            digest = hash_tool_address(address, tool_name)
+            by_hash[digest] = entry
+            if fn is not None:
+                by_callable[id(fn)] = entry
+    return ReverseHashMaps(by_hash=by_hash, by_callable=by_callable)
 
 
-def _enumerate_tool_names(provider: Provider) -> list[str]:
-    """Synchronously enumerate the local tool names directly stored in *provider*.
+def _enumerate_tools(provider: Provider) -> list[tuple[str, Any]]:
+    """Synchronously enumerate ``(name, fn_or_None)`` for tools in *provider*.
 
     Reaches into the underlying ``LocalProvider`` (unwrapping any
     ``_WrappedProvider`` transform layers and looking through
-    ``FastMCPApp._local``). Used by the registry build to populate the
-    reverse-hash map without going through async list paths.
+    ``FastMCPApp._local``). ``fn`` is the underlying callable for
+    ``FunctionTool`` instances, ``None`` for other Tool subclasses.
     """
     from fastmcp.apps.app import FastMCPApp
     from fastmcp.server.providers.local_provider import LocalProvider
     from fastmcp.server.providers.wrapped_provider import _WrappedProvider
     from fastmcp.tools.base import Tool
+    from fastmcp.tools.function_tool import FunctionTool
 
     inner: Provider = provider
     while isinstance(inner, _WrappedProvider):
@@ -214,9 +237,10 @@ def _enumerate_tool_names(provider: Provider) -> list[str]:
     if isinstance(inner, FastMCPApp):
         sources.append(inner._local)
 
-    names: list[str] = []
+    results: list[tuple[str, Any]] = []
     for src in sources:
         for component in src._components.values():
             if isinstance(component, Tool):
-                names.append(component.name)
-    return names
+                fn = component.fn if isinstance(component, FunctionTool) else None
+                results.append((component.name, fn))
+    return results

--- a/src/fastmcp/server/providers/addressing.py
+++ b/src/fastmcp/server/providers/addressing.py
@@ -1,0 +1,222 @@
+"""Internal addressing primitives for the provider graph.
+
+FastMCP gives every mount point in a server's provider tree an internal
+positional address — a tuple of integers describing the path from the root
+through ``providers`` lists to the target provider. Combined with a tool
+name, this address feeds a deterministic hash that uniquely identifies a
+specific tool at a specific position. The hash is used in two places:
+
+1. **Backend-tool routing.** Tools with ``"app"`` in their visibility list
+   are not in ``list_tools`` output, but they need to be callable from a
+   Prefab UI that references them. Their universal name is
+   ``<hash>_<local_name>`` — the dispatcher recognizes that form, looks up
+   the matching ``(provider, tool)`` via the reverse-hash map, and routes
+   the call directly through ``provider._get_tool``, bypassing transforms.
+
+2. **Per-tool Prefab renderer URIs.** Tools that produce Prefab content
+   need a unique renderer resource URI per (mount point, tool) pair. The
+   URI is ``ui://prefab/tool/<hash>/renderer.html``. ``read_resource``
+   intercepts those URIs, looks up the matching tool, and synthesizes the
+   renderer HTML + CSP from the tool's stored metadata. ``list_resources``
+   enumerates the same URIs by walking the registry.
+
+Both uses share the same registry, the same hash function, and the same
+reverse-hash map. Nothing is mutated and nothing is materialized — the
+registry is built once on first access (cheap pure walk), invalidated when
+``add_provider`` runs, and rebuilt lazily next time something asks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from fastmcp.server.providers.base import Provider
+    from fastmcp.server.server import FastMCP
+
+#: Length of the hex hash prefix used in URIs and backend-tool names.
+#: 12 chars of sha256 gives ~10^14 distinct values — collision-safe for
+#: any realistic provider graph.
+HASH_LENGTH = 12
+
+#: A positional address: tuple of integer indices from the root.
+#: ``()`` is the root server's local provider; ``(0,)`` is the first
+#: top-level provider after the root's own LocalProvider; ``(0, 2)`` is the
+#: third child of that provider; etc.
+AddressPath = tuple[int, ...]
+
+
+class HashEntry(NamedTuple):
+    """Reverse-hash map entry: enough info to resolve a hashed reference."""
+
+    address: AddressPath
+    provider: Provider
+    tool_name: str
+
+
+def hash_tool_address(address: AddressPath, tool_name: str) -> str:
+    """Deterministic hex hash for a tool at a specific address.
+
+    Inputs: positional address tuple + the tool's local name within that
+    provider. Output: a fixed-length lowercase hex string. Same code on
+    every replica produces the same hash for the same logical tool, so
+    URIs and backend-tool names round-trip across horizontally-scaled
+    deployments without coordination.
+    """
+    # Use a delimiter that can't appear inside the inputs to ensure
+    # ("a", "b_c") and ("a_b", "c") hash differently.
+    payload = f"{address!r}\x00{tool_name}".encode()
+    return hashlib.sha256(payload).hexdigest()[:HASH_LENGTH]
+
+
+def hashed_backend_name(address: AddressPath, tool_name: str) -> str:
+    """Format the universal name for a backend tool: ``<hash>_<local_name>``."""
+    return f"{hash_tool_address(address, tool_name)}_{tool_name}"
+
+
+def parse_hashed_backend_name(name: str) -> tuple[str, str] | None:
+    """Reverse of :func:`hashed_backend_name`.
+
+    Returns ``(hash, local_tool_name)`` if *name* matches the
+    ``<HASH_LENGTH hex>_<rest>`` shape, else ``None``. The dispatcher uses
+    this to detect hashed-name calls and look them up via the reverse map;
+    if the prefix isn't valid hex of the right length, or the hash isn't
+    in the reverse map, the dispatcher falls through to normal resolution.
+    """
+    if len(name) <= HASH_LENGTH + 1:
+        return None
+    prefix = name[:HASH_LENGTH]
+    if name[HASH_LENGTH] != "_":
+        return None
+    # All hex characters?
+    if not all(c in "0123456789abcdef" for c in prefix):
+        return None
+    return prefix, name[HASH_LENGTH + 1 :]
+
+
+def hashed_resource_uri(address: AddressPath, tool_name: str) -> str:
+    """Format the per-tool Prefab renderer resource URI."""
+    return f"ui://prefab/tool/{hash_tool_address(address, tool_name)}/renderer.html"
+
+
+def parse_hashed_resource_uri(uri: str) -> str | None:
+    """Extract the hash from a Prefab renderer URI, or ``None`` if it doesn't match."""
+    prefix = "ui://prefab/tool/"
+    suffix = "/renderer.html"
+    if not uri.startswith(prefix) or not uri.endswith(suffix):
+        return None
+    h = uri[len(prefix) : -len(suffix)]
+    if len(h) != HASH_LENGTH or not all(c in "0123456789abcdef" for c in h):
+        return None
+    return h
+
+
+def _iter_children(provider: Provider) -> Sequence[Provider] | None:
+    """Return the provider's sub-providers if it's a container, else ``None``.
+
+    Containers are ``AggregateProvider`` (holds a list in ``self.providers``)
+    and ``_WrappedProvider`` (transparently wraps another provider with a
+    transform — the wrapper shares the wrapped provider's address segment).
+    Other provider types are leaves for addressing purposes.
+    """
+    # Local imports to avoid a circular import at module load.
+    from fastmcp.server.providers.aggregate import AggregateProvider
+    from fastmcp.server.providers.wrapped_provider import _WrappedProvider
+
+    if isinstance(provider, _WrappedProvider):
+        return _iter_children(provider._inner)
+    if isinstance(provider, AggregateProvider):
+        return list(provider.providers)
+    return None
+
+
+def build_address_registry(root: FastMCP) -> dict[AddressPath, Provider]:
+    """Walk the provider graph and assign each mount point a positional address.
+
+    Pure: returns a fresh dict, doesn't touch any provider, doesn't
+    instantiate resources, doesn't mutate metadata. The walk visits
+    children in registration order; each provider receives its index in
+    its parent's child list as the next segment of its address path.
+
+    The root's own internal LocalProvider is treated as address-transparent
+    — tools registered directly via ``@mcp.tool`` live at the empty path
+    ``()`` rather than getting their own segment. Every other provider,
+    including user-added LocalProviders, contributes a segment.
+    """
+    registry: dict[AddressPath, Provider] = {}
+    registry[()] = root._local_provider
+
+    def visit(providers: Sequence[Provider], base_path: AddressPath) -> None:
+        for index, provider in enumerate(providers):
+            path = (*base_path, index)
+            registry[path] = provider
+            children = _iter_children(provider)
+            if children is not None:
+                visit(children, path)
+
+    # Skip the root's transparent LocalProvider when walking top-level children.
+    top_level = [p for p in root.providers if p is not root._local_provider]
+    if top_level:
+        visit(top_level, ())
+
+    return registry
+
+
+def build_reverse_hash_map(
+    registry: dict[AddressPath, Provider],
+) -> dict[str, HashEntry]:
+    """Build the ``hash → (address, provider, tool_name)`` reverse map.
+
+    Walks every provider in the registry, calls its synchronous tool
+    storage to enumerate tools, and computes a hash for each one. The
+    result lets ``read_resource`` and the hashed-name dispatcher do O(1)
+    lookups by hash. Built once per registry build and invalidated
+    alongside it.
+
+    Tools that aren't directly stored in a ``LocalProvider`` (or a
+    ``FastMCPApp``'s internal ``_local``) won't appear in the reverse
+    map. That's intentional — the addressing system is for tools you
+    register, not for tools dynamically synthesized at list time by
+    custom providers, which already have their own naming.
+    """
+    reverse: dict[str, HashEntry] = {}
+    for address, provider in registry.items():
+        for tool_name in _enumerate_tool_names(provider):
+            digest = hash_tool_address(address, tool_name)
+            reverse[digest] = HashEntry(
+                address=address, provider=provider, tool_name=tool_name
+            )
+    return reverse
+
+
+def _enumerate_tool_names(provider: Provider) -> list[str]:
+    """Synchronously enumerate the local tool names directly stored in *provider*.
+
+    Reaches into the underlying ``LocalProvider`` (unwrapping any
+    ``_WrappedProvider`` transform layers and looking through
+    ``FastMCPApp._local``). Used by the registry build to populate the
+    reverse-hash map without going through async list paths.
+    """
+    from fastmcp.apps.app import FastMCPApp
+    from fastmcp.server.providers.local_provider import LocalProvider
+    from fastmcp.server.providers.wrapped_provider import _WrappedProvider
+    from fastmcp.tools.base import Tool
+
+    inner: Provider = provider
+    while isinstance(inner, _WrappedProvider):
+        inner = inner._inner
+
+    sources: list[LocalProvider] = []
+    if isinstance(inner, LocalProvider):
+        sources.append(inner)
+    if isinstance(inner, FastMCPApp):
+        sources.append(inner._local)
+
+    names: list[str] = []
+    for src in sources:
+        for component in src._components.values():
+            if isinstance(component, Tool):
+                names.append(component.name)
+    return names

--- a/src/fastmcp/server/providers/aggregate.py
+++ b/src/fastmcp/server/providers/aggregate.py
@@ -181,6 +181,19 @@ class AggregateProvider(Provider):
                 return r
         return None
 
+    async def get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None:
+        """Query all child providers for a tool matching a hash."""
+        results = await gather(
+            *[p.get_tool_by_hash(tool_hash, tool_name) for p in self.providers],
+            return_exceptions=True,
+        )
+        for r in results:
+            if isinstance(r, BaseException):
+                continue
+            if r is not None:
+                return r
+        return None
+
     # -------------------------------------------------------------------------
     # Resources
     # -------------------------------------------------------------------------

--- a/src/fastmcp/server/providers/base.py
+++ b/src/fastmcp/server/providers/base.py
@@ -201,6 +201,29 @@ class Provider:
                 return tool
         return None
 
+    async def get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None:
+        """Look up an app-visible tool by its deterministic hash.
+
+        Same recursive-walk semantics as ``get_app_tool`` but matches on
+        ``meta["fastmcp"]["_tool_hash"]`` instead of the app name tag.
+        Used by the dispatcher when receiving hashed backend-tool calls.
+        """
+        tool = await self._get_tool(tool_name)
+        if tool is not None:
+            meta = tool.meta or {}
+            fastmcp_meta = meta.get("fastmcp")
+            ui_meta = meta.get("ui")
+            visibility = (
+                ui_meta.get("visibility", []) if isinstance(ui_meta, dict) else []
+            )
+            if (
+                isinstance(fastmcp_meta, dict)
+                and fastmcp_meta.get("_tool_hash") == tool_hash
+                and "app" in visibility
+            ):
+                return tool
+        return None
+
     async def list_resources(self) -> Sequence[Resource]:
         """List resources with all transforms applied.
 

--- a/src/fastmcp/server/providers/fastmcp_provider.py
+++ b/src/fastmcp/server/providers/fastmcp_provider.py
@@ -572,10 +572,18 @@ class FastMCPProvider(Provider):
         if raw_tool is None:
             return None
         wrapped = FastMCPProviderTool.wrap(self.server, raw_tool)
-        # Use the ___-prefixed name so the inner server's call_tool also
-        # takes the app-tool bypass path (app-only tools are hidden from
-        # normal get_tool visibility filtering).
-        wrapped._original_name = f"{app_name}___{tool_name}"
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
+        wrapped._original_name = hashed_backend_name(app_name, tool_name)
+        return wrapped
+
+    async def get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None:
+        """Delegate to nested server's get_tool_by_hash, wrapping for middleware."""
+        raw_tool = await self.server.get_tool_by_hash(tool_hash, tool_name)
+        if raw_tool is None:
+            return None
+        wrapped = FastMCPProviderTool.wrap(self.server, raw_tool)
+        wrapped._original_name = f"{tool_hash}_{tool_name}"
         return wrapped
 
     # -------------------------------------------------------------------------

--- a/src/fastmcp/server/providers/local_provider/decorators/tools.py
+++ b/src/fastmcp/server/providers/local_provider/decorators/tools.py
@@ -73,53 +73,31 @@ def _has_prefab_return_type(tool: Tool) -> bool:
     return _is_prefab_type(rt)
 
 
-def _ensure_prefab_renderer(provider: LocalProvider) -> None:
-    """Lazily register the shared prefab renderer as a ui:// resource."""
-    from prefab_ui.renderer import get_renderer_csp, get_renderer_html
+def _stamp_prefab_marker(tool: Tool) -> None:
+    """Mark a tool as needing a Prefab renderer resource.
 
-    from fastmcp.apps.config import (
-        UI_MIME_TYPE,
-        AppConfig,
-        ResourceCSP,
-        app_config_to_meta_dict,
-    )
-    from fastmcp.resources.types import TextResource
-
-    renderer_key = f"resource:{PREFAB_RENDERER_URI}@"
-    if renderer_key in provider._components:
-        return
-
-    csp = get_renderer_csp()
-    resource_app = AppConfig(
-        csp=ResourceCSP(
-            resource_domains=csp.get("resource_domains"),
-            connect_domains=csp.get("connect_domains"),
-        )
-    )
-    resource = TextResource(
-        uri=PREFAB_RENDERER_URI,  # type: ignore[arg-type]  # AnyUrl accepts ui:// scheme at runtime  # ty:ignore[invalid-argument-type]
-        name="Prefab Renderer",
-        text=get_renderer_html(),
-        mime_type=UI_MIME_TYPE,
-        meta={"ui": app_config_to_meta_dict(resource_app)},
-    )
-    provider._add_component(resource)
-
-
-def _expand_prefab_ui_meta(tool: Tool) -> None:
-    """Expand meta["ui"] = True into the full AppConfig dict for a prefab tool."""
+    Sets ``meta["ui"]["resourceUri"]`` to a placeholder URI. The server
+    recognizes the placeholder at list_tools / list_resources / read_resource
+    time and synthesizes a per-tool resource on the fly with a hashed URI
+    derived from the tool's mount-point address. Nothing is stored — the
+    renderer HTML and CSP are generated on demand from the tool's own meta.
+    """
     from fastmcp.apps.config import AppConfig, app_config_to_meta_dict
 
-    app_config = AppConfig(
-        resource_uri=PREFAB_RENDERER_URI,
-    )
+    app_config = AppConfig(resource_uri=PREFAB_RENDERER_URI)
     meta = dict(tool.meta) if tool.meta else {}
     meta["ui"] = app_config_to_meta_dict(app_config)
     tool.meta = meta
 
 
 def _maybe_apply_prefab_ui(provider: LocalProvider, tool: Tool) -> None:
-    """Auto-wire prefab UI metadata and renderer resource if needed."""
+    """Mark a tool as a Prefab tool if its config or return type implies it.
+
+    Per-tool renderer resources are synthesized lazily at list/read time;
+    here we only normalize the tool's meta so the synthesis pass can spot
+    it. ``app=True``, return-type inference, and ``PrefabAppConfig`` all
+    funnel through the same placeholder marker.
+    """
     if not _HAS_PREFAB:
         return
 
@@ -127,17 +105,14 @@ def _maybe_apply_prefab_ui(provider: LocalProvider, tool: Tool) -> None:
     ui = meta.get("ui")
 
     if ui is True:
-        # Explicit app=True: expand to full AppConfig and register renderer
-        _ensure_prefab_renderer(provider)
-        _expand_prefab_ui_meta(tool)
+        # Explicit app=True: stamp the placeholder so the synthesizer finds it.
+        _stamp_prefab_marker(tool)
     elif ui is None and _has_prefab_return_type(tool):
-        # Inference: return type is a prefab type, auto-wire
-        _ensure_prefab_renderer(provider)
-        _expand_prefab_ui_meta(tool)
-    elif isinstance(ui, dict) and ui.get("resourceUri") == PREFAB_RENDERER_URI:
-        # PrefabAppConfig or manual config pointing to the Prefab renderer —
-        # ensure the renderer resource is registered (CSP already set by caller)
-        _ensure_prefab_renderer(provider)
+        # Inference: return type is a prefab type, stamp the placeholder.
+        _stamp_prefab_marker(tool)
+    # Otherwise the tool either has no ui meta at all (not a prefab tool)
+    # or it already has a fully-formed dict from FastMCP.tool(app=...) — the
+    # synthesizer picks up both flavors by looking for the placeholder URI.
 
 
 class ToolDecoratorMixin:

--- a/src/fastmcp/server/providers/prefab_synthesis.py
+++ b/src/fastmcp/server/providers/prefab_synthesis.py
@@ -124,7 +124,21 @@ def _build_resource_for_tool(tool: Tool) -> Resource | None:
     }
 
     resource_csp = ResourceCSP(**merged) if any(merged.values()) else None
-    resource_app = AppConfig(csp=resource_csp) if resource_csp else AppConfig()
+
+    # Carry permissions from the tool's meta to the resource (same
+    # principle as CSP — belongs on the resource, not the tool).
+    user_permissions = None
+    if tool.meta and isinstance(tool.meta.get("ui"), dict):
+        raw_perms = tool.meta["ui"].get("permissions")
+        if isinstance(raw_perms, dict):
+            from fastmcp.apps.config import ResourcePermissions
+
+            user_permissions = ResourcePermissions(**raw_perms)
+
+    resource_app = AppConfig(
+        csp=resource_csp,
+        permissions=user_permissions,
+    )
     uri = f"ui://prefab/tool/{tool_hash}/renderer.html"
 
     return TextResource(

--- a/src/fastmcp/server/providers/prefab_synthesis.py
+++ b/src/fastmcp/server/providers/prefab_synthesis.py
@@ -165,9 +165,14 @@ def _walk_prefab_tools(server: FastMCP) -> list[Tool]:
 
         # Recurse into aggregate children
         from fastmcp.server.providers.aggregate import AggregateProvider
+        from fastmcp.server.providers.fastmcp_provider import FastMCPProvider
 
         if isinstance(inner, AggregateProvider):
             for child in inner.providers:
+                _walk_provider(child)
+        # Recurse into mounted FastMCP servers
+        if isinstance(inner, FastMCPProvider):
+            for child in inner.server.providers:
                 _walk_provider(child)
 
     for provider in server.providers:

--- a/src/fastmcp/server/providers/prefab_synthesis.py
+++ b/src/fastmcp/server/providers/prefab_synthesis.py
@@ -1,23 +1,16 @@
 """On-demand Prefab renderer resource synthesis.
 
-Tools that opt into Prefab UI rendering (via ``@mcp.tool(app=True)``,
-``@mcp.tool(app=PrefabAppConfig(...))``, ``@app.ui()``, or by returning a
-Prefab type) are stamped at registration time with a placeholder
-``meta.ui.resourceUri``. This module turns that mark into a real resource
-at the moment something asks for it — list_resources enumerates the
-synthetic resources and read_resource serves their content — without
-ever creating, storing, or mutating anything ahead of time.
+Tools marked as Prefab (via ``app=True``, ``PrefabAppConfig``, etc.) carry
+a placeholder ``meta.ui.resourceUri`` and optionally a hash in
+``meta.fastmcp._tool_hash``. This module synthesizes per-tool renderer
+resources on demand at ``list_resources`` and ``read_resource`` time
+without storing or materializing anything.
 
-The URI for each tool's renderer is derived from the tool's mount-point
-address via the same hash function used for backend-tool routing. Same
-code on every replica produces the same URIs, so a host fetching
-``ui://prefab/tool/<hash>/renderer.html`` from any replica gets a
-consistent answer.
-
-CSP comes from the tool's ``meta.ui.csp`` (set by the user via
-``PrefabAppConfig(csp=...)``), merged with the renderer's defaults
-across all four ``*_domains`` fields. The renderer HTML comes from
-``prefab_ui.renderer.get_renderer_html()``.
+Each tool's resource URI is ``ui://prefab/tool/<hash>/renderer.html``
+where the hash comes from the tool's own meta (set at registration from
+the app name + tool name). CSP on the resource is the tool's
+``meta.ui.csp`` merged with the renderer defaults across all four
+``*_domains`` fields.
 """
 
 from __future__ import annotations
@@ -26,20 +19,16 @@ from typing import TYPE_CHECKING, Any
 
 from fastmcp.server.providers.addressing import (
     HASH_LENGTH,
-    hash_tool_address,
-    hashed_resource_uri,
+    hash_tool,
     parse_hashed_resource_uri,
 )
 
 if TYPE_CHECKING:
     from fastmcp.resources.base import Resource
-    from fastmcp.server.providers.base import Provider
     from fastmcp.server.server import FastMCP
     from fastmcp.tools.base import Tool
 
-#: The placeholder URI that decorators stamp on tools to mark them as
-#: needing a Prefab renderer. The synthesizer recognizes the marker and
-#: rewrites it to a per-tool hashed URI at list time.
+#: The placeholder URI that decorators stamp on tools needing a renderer.
 PREFAB_PLACEHOLDER_URI = "ui://prefab/renderer.html"
 
 
@@ -54,10 +43,25 @@ def _is_prefab_tool(tool: Tool) -> bool:
     return ui.get("resourceUri") == PREFAB_PLACEHOLDER_URI
 
 
+def _get_tool_hash(tool: Tool) -> str | None:
+    """Read the stored hash from tool meta, or compute from app name + tool name."""
+    meta = tool.meta or {}
+    fastmcp_meta = meta.get("fastmcp")
+    if isinstance(fastmcp_meta, dict):
+        h = fastmcp_meta.get("_tool_hash")
+        if isinstance(h, str) and len(h) == HASH_LENGTH:
+            return h
+        # Fall back to computing from app name
+        app = fastmcp_meta.get("app")
+        if isinstance(app, str):
+            return hash_tool(app, tool.name)
+    # Root-level prefab tool (no app name) — hash from empty prefix.
+    return hash_tool("", tool.name)
+
+
 def _merge_domain_lists(
     base: list[str] | None, extra: list[str] | None
 ) -> list[str] | None:
-    """Union two domain lists in order, deduplicating, returning None if empty."""
     if base is None and extra is None:
         return None
     combined = list(base or [])
@@ -67,67 +71,10 @@ def _merge_domain_lists(
     return combined or None
 
 
-def _merged_csp_dict(
-    user_csp: dict[str, Any] | None,
-) -> dict[str, list[str] | None] | None:
-    """Merge a tool's user CSP with the renderer's defaults across all domain fields.
-
-    The old singleton ``_ensure_prefab_renderer`` only copied
-    ``resource_domains`` and ``connect_domains`` from the renderer's
-    defaults — silently dropping ``frame_domains`` and
-    ``base_uri_domains`` even when the renderer declared them. This merge
-    covers all four. ``user_csp`` is the dict from a tool's
-    ``meta.ui.csp`` (camelCase wire form from ``app_config_to_meta_dict``)
-    and is merged on top of the defaults.
-    """
+def _build_resource_for_tool(tool: Tool) -> Resource | None:
+    """Synthesize a TextResource for a prefab tool. Returns None if prefab_ui isn't installed."""
     try:
-        from prefab_ui.renderer import get_renderer_csp
-    except ImportError:
-        return None
-
-    defaults: dict[str, Any] = get_renderer_csp() or {}
-    user = user_csp or {}
-
-    def _get(d: dict[str, Any], snake: str, camel: str) -> list[str] | None:
-        val = d.get(snake)
-        if val is None:
-            val = d.get(camel)
-        return val if isinstance(val, list) else None
-
-    merged = {
-        "connect_domains": _merge_domain_lists(
-            defaults.get("connect_domains"),
-            _get(user, "connect_domains", "connectDomains"),
-        ),
-        "resource_domains": _merge_domain_lists(
-            defaults.get("resource_domains"),
-            _get(user, "resource_domains", "resourceDomains"),
-        ),
-        "frame_domains": _merge_domain_lists(
-            defaults.get("frame_domains"),
-            _get(user, "frame_domains", "frameDomains"),
-        ),
-        "base_uri_domains": _merge_domain_lists(
-            defaults.get("base_uri_domains"),
-            _get(user, "base_uri_domains", "baseUriDomains"),
-        ),
-    }
-
-    if not any(merged.values()):
-        return None
-    return merged
-
-
-def _build_resource_for_tool(address: tuple[int, ...], tool: Tool) -> Resource | None:
-    """Synthesize a ``TextResource`` for a prefab tool at *address*.
-
-    Reads the tool's CSP from ``meta.ui.csp`` (if any), merges with the
-    renderer defaults, and produces a fresh ``TextResource`` with the
-    hashed URI and the merged CSP on its meta. Returns ``None`` when
-    prefab_ui isn't installed.
-    """
-    try:
-        from prefab_ui.renderer import get_renderer_html
+        from prefab_ui.renderer import get_renderer_csp, get_renderer_html
     except ImportError:
         return None
 
@@ -139,49 +86,73 @@ def _build_resource_for_tool(address: tuple[int, ...], tool: Tool) -> Resource |
     )
     from fastmcp.resources.types import TextResource
 
-    user_csp = None
-    if tool.meta and isinstance(tool.meta.get("ui"), dict):
-        ui = tool.meta["ui"]
-        if isinstance(ui.get("csp"), dict):
-            user_csp = ui["csp"]
+    tool_hash = _get_tool_hash(tool)
+    if tool_hash is None:
+        return None
 
-    merged = _merged_csp_dict(user_csp)
-    resource_csp = ResourceCSP(**merged) if merged else None
+    # Merge user CSP with renderer defaults — all four domain fields.
+    defaults: dict[str, Any] = get_renderer_csp() or {}
+    user_csp: dict[str, Any] = {}
+    if tool.meta and isinstance(tool.meta.get("ui"), dict):
+        raw = tool.meta["ui"].get("csp")
+        if isinstance(raw, dict):
+            user_csp = raw
+
+    def _get(d: dict[str, Any], snake: str, camel: str) -> list[str] | None:
+        val = d.get(snake)
+        if val is None:
+            val = d.get(camel)
+        return val if isinstance(val, list) else None
+
+    merged = {
+        "connect_domains": _merge_domain_lists(
+            defaults.get("connect_domains"),
+            _get(user_csp, "connect_domains", "connectDomains"),
+        ),
+        "resource_domains": _merge_domain_lists(
+            defaults.get("resource_domains"),
+            _get(user_csp, "resource_domains", "resourceDomains"),
+        ),
+        "frame_domains": _merge_domain_lists(
+            defaults.get("frame_domains"),
+            _get(user_csp, "frame_domains", "frameDomains"),
+        ),
+        "base_uri_domains": _merge_domain_lists(
+            defaults.get("base_uri_domains"),
+            _get(user_csp, "base_uri_domains", "baseUriDomains"),
+        ),
+    }
+
+    resource_csp = ResourceCSP(**merged) if any(merged.values()) else None
     resource_app = AppConfig(csp=resource_csp) if resource_csp else AppConfig()
+    uri = f"ui://prefab/tool/{tool_hash}/renderer.html"
 
     return TextResource(
-        uri=hashed_resource_uri(address, tool.name),  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
-        name=f"Prefab Renderer ({'/'.join(map(str, address)) or 'root'}/{tool.name})",
+        uri=uri,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        name=f"Prefab Renderer ({tool.name})",
         text=get_renderer_html(),
         mime_type=UI_MIME_TYPE,
         meta={"ui": app_config_to_meta_dict(resource_app)},
     )
 
 
-def _enumerate_prefab_tools(
-    server: FastMCP,
-) -> list[tuple[tuple[int, ...], Tool]]:
-    """Walk the server's reverse-hash map and return ``(address, tool)`` for prefab tools.
-
-    Uses the registry's reverse-hash map (which already enumerates every
-    tool by hash) and filters for ones that carry the prefab placeholder.
-    Each entry's ``provider`` is the leaf that owns the tool; we look up
-    the actual ``Tool`` object from that provider's local storage to
-    inspect its meta.
-    """
+def _walk_prefab_tools(server: FastMCP) -> list[Tool]:
+    """Enumerate all prefab tools across the server's providers (sync walk of _components)."""
     from fastmcp.apps.app import FastMCPApp
+    from fastmcp.server.providers.base import Provider
     from fastmcp.server.providers.local_provider import LocalProvider
     from fastmcp.server.providers.wrapped_provider import _WrappedProvider
     from fastmcp.tools.base import Tool
 
-    results: list[tuple[tuple[int, ...], Tool]] = []
-    for entry in server.reverse_hash_map.values():
-        # Find the actual Tool object inside the leaf provider so we can
-        # read its raw meta (transforms wouldn't change `meta.ui` but
-        # might rename the tool).
-        inner: Provider = entry.provider
+    results: list[Tool] = []
+
+    def _walk_provider(provider: Provider) -> None:
+        # Unwrap transform wrappers
+        inner = provider
         while isinstance(inner, _WrappedProvider):
             inner = inner._inner
+
+        # Extract tools from local storage
         sources: list[LocalProvider] = []
         if isinstance(inner, LocalProvider):
             sources.append(inner)
@@ -189,25 +160,32 @@ def _enumerate_prefab_tools(
             sources.append(inner._local)
         for src in sources:
             for component in src._components.values():
-                if (
-                    isinstance(component, Tool)
-                    and component.name == entry.tool_name
-                    and _is_prefab_tool(component)
-                ):
-                    results.append((entry.address, component))
+                if isinstance(component, Tool) and _is_prefab_tool(component):
+                    results.append(component)
+
+        # Recurse into aggregate children
+        from fastmcp.server.providers.aggregate import AggregateProvider
+
+        if isinstance(inner, AggregateProvider):
+            for child in inner.providers:
+                _walk_provider(child)
+
+    for provider in server.providers:
+        _walk_provider(provider)
+
     return results
 
 
 async def synthesize_prefab_resources(server: FastMCP) -> list[Resource]:
-    """Return a fresh list of synthetic Prefab renderer resources for the server.
-
-    One resource per (mount-point address, prefab tool) pair. Used by
-    ``list_resources`` to surface the renderer resources for discovery.
-    Pure: produces fresh objects on every call, no caching, no mutation.
-    """
+    """Return fresh synthetic Prefab resources for all prefab tools. Pure."""
     resources: list[Resource] = []
-    for address, tool in _enumerate_prefab_tools(server):
-        resource = _build_resource_for_tool(address, tool)
+    seen_hashes: set[str] = set()
+    for tool in _walk_prefab_tools(server):
+        h = _get_tool_hash(tool)
+        if h is None or h in seen_hashes:
+            continue
+        seen_hashes.add(h)
+        resource = _build_resource_for_tool(tool)
         if resource is not None:
             resources.append(resource)
     return resources
@@ -216,57 +194,33 @@ async def synthesize_prefab_resources(server: FastMCP) -> list[Resource]:
 async def synthesize_prefab_resource_by_uri(
     server: FastMCP, uri: str
 ) -> Resource | None:
-    """Look up a synthetic Prefab renderer by URI, or return None.
-
-    Used by ``read_resource`` to intercept ``ui://prefab/tool/<hash>/...``
-    fetches. Parses the hash, finds the matching tool via the reverse
-    map, and synthesizes the resource. Returns None for any URI that
-    isn't a prefab renderer URI or doesn't match a known tool.
-    """
+    """Intercept a Prefab renderer URI and synthesize on demand."""
     digest = parse_hashed_resource_uri(uri)
     if digest is None:
         return None
-
-    # Walk prefab tools to find the one whose hash matches.
-    for address, tool in _enumerate_prefab_tools(server):
-        if hash_tool_address(address, tool.name) == digest:
-            return _build_resource_for_tool(address, tool)
+    for tool in _walk_prefab_tools(server):
+        if _get_tool_hash(tool) == digest:
+            return _build_resource_for_tool(tool)
     return None
 
 
-def rewrite_tool_meta_for_address(tool: Tool, address: tuple[int, ...]) -> Tool:
-    """Return a ``model_copy`` of *tool* with prefab meta rewritten for *address*.
+def rewrite_tool_meta_for_wire(tool: Tool) -> Tool:
+    """Return a model_copy with the per-tool URI and CSP stripped.
 
-    If the tool isn't a prefab tool (or already has a non-placeholder
-    URI), returns the original unchanged. Otherwise produces a fresh
-    copy with:
-
-    - ``meta.ui.resourceUri`` = the hashed per-tool URI for *address*
-    - ``meta.ui.csp`` removed (CSP belongs on the resource side)
-    - ``meta.ui.permissions`` removed for the same reason
-
-    The original ``Tool`` object is untouched — this is a per-call view,
-    not a stored mutation. Used by ``list_tools`` to give clients a
-    correct, stable URI for each prefab tool.
+    Reads the hash from the tool's own meta. If no hash is found,
+    returns the tool unchanged. Produces a fresh copy — the original
+    Tool object is untouched.
     """
     if not _is_prefab_tool(tool):
         return tool
-    # ``_is_prefab_tool`` already verified meta is a dict with a dict ui.
+    tool_hash = _get_tool_hash(tool)
+    if tool_hash is None:
+        return tool
     assert tool.meta is not None
     new_ui = dict(tool.meta["ui"])
-    new_ui["resourceUri"] = hashed_resource_uri(address, tool.name)
+    new_ui["resourceUri"] = f"ui://prefab/tool/{tool_hash}/renderer.html"
     new_ui.pop("csp", None)
     new_ui.pop("permissions", None)
     new_meta = dict(tool.meta)
     new_meta["ui"] = new_ui
     return tool.model_copy(update={"meta": new_meta})
-
-
-# Re-exported for callers that want to recognize the URI format.
-__all__ = [
-    "HASH_LENGTH",
-    "PREFAB_PLACEHOLDER_URI",
-    "rewrite_tool_meta_for_address",
-    "synthesize_prefab_resource_by_uri",
-    "synthesize_prefab_resources",
-]

--- a/src/fastmcp/server/providers/prefab_synthesis.py
+++ b/src/fastmcp/server/providers/prefab_synthesis.py
@@ -1,0 +1,272 @@
+"""On-demand Prefab renderer resource synthesis.
+
+Tools that opt into Prefab UI rendering (via ``@mcp.tool(app=True)``,
+``@mcp.tool(app=PrefabAppConfig(...))``, ``@app.ui()``, or by returning a
+Prefab type) are stamped at registration time with a placeholder
+``meta.ui.resourceUri``. This module turns that mark into a real resource
+at the moment something asks for it — list_resources enumerates the
+synthetic resources and read_resource serves their content — without
+ever creating, storing, or mutating anything ahead of time.
+
+The URI for each tool's renderer is derived from the tool's mount-point
+address via the same hash function used for backend-tool routing. Same
+code on every replica produces the same URIs, so a host fetching
+``ui://prefab/tool/<hash>/renderer.html`` from any replica gets a
+consistent answer.
+
+CSP comes from the tool's ``meta.ui.csp`` (set by the user via
+``PrefabAppConfig(csp=...)``), merged with the renderer's defaults
+across all four ``*_domains`` fields. The renderer HTML comes from
+``prefab_ui.renderer.get_renderer_html()``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastmcp.server.providers.addressing import (
+    HASH_LENGTH,
+    hash_tool_address,
+    hashed_resource_uri,
+    parse_hashed_resource_uri,
+)
+
+if TYPE_CHECKING:
+    from fastmcp.resources.base import Resource
+    from fastmcp.server.providers.base import Provider
+    from fastmcp.server.server import FastMCP
+    from fastmcp.tools.base import Tool
+
+#: The placeholder URI that decorators stamp on tools to mark them as
+#: needing a Prefab renderer. The synthesizer recognizes the marker and
+#: rewrites it to a per-tool hashed URI at list time.
+PREFAB_PLACEHOLDER_URI = "ui://prefab/renderer.html"
+
+
+def _is_prefab_tool(tool: Tool) -> bool:
+    """True if *tool* was marked as needing a Prefab renderer at registration."""
+    meta = tool.meta
+    if not meta:
+        return False
+    ui = meta.get("ui")
+    if not isinstance(ui, dict):
+        return False
+    return ui.get("resourceUri") == PREFAB_PLACEHOLDER_URI
+
+
+def _merge_domain_lists(
+    base: list[str] | None, extra: list[str] | None
+) -> list[str] | None:
+    """Union two domain lists in order, deduplicating, returning None if empty."""
+    if base is None and extra is None:
+        return None
+    combined = list(base or [])
+    for item in extra or []:
+        if item not in combined:
+            combined.append(item)
+    return combined or None
+
+
+def _merged_csp_dict(
+    user_csp: dict[str, Any] | None,
+) -> dict[str, list[str] | None] | None:
+    """Merge a tool's user CSP with the renderer's defaults across all domain fields.
+
+    The old singleton ``_ensure_prefab_renderer`` only copied
+    ``resource_domains`` and ``connect_domains`` from the renderer's
+    defaults — silently dropping ``frame_domains`` and
+    ``base_uri_domains`` even when the renderer declared them. This merge
+    covers all four. ``user_csp`` is the dict from a tool's
+    ``meta.ui.csp`` (camelCase wire form from ``app_config_to_meta_dict``)
+    and is merged on top of the defaults.
+    """
+    try:
+        from prefab_ui.renderer import get_renderer_csp
+    except ImportError:
+        return None
+
+    defaults: dict[str, Any] = get_renderer_csp() or {}
+    user = user_csp or {}
+
+    def _get(d: dict[str, Any], snake: str, camel: str) -> list[str] | None:
+        val = d.get(snake)
+        if val is None:
+            val = d.get(camel)
+        return val if isinstance(val, list) else None
+
+    merged = {
+        "connect_domains": _merge_domain_lists(
+            defaults.get("connect_domains"),
+            _get(user, "connect_domains", "connectDomains"),
+        ),
+        "resource_domains": _merge_domain_lists(
+            defaults.get("resource_domains"),
+            _get(user, "resource_domains", "resourceDomains"),
+        ),
+        "frame_domains": _merge_domain_lists(
+            defaults.get("frame_domains"),
+            _get(user, "frame_domains", "frameDomains"),
+        ),
+        "base_uri_domains": _merge_domain_lists(
+            defaults.get("base_uri_domains"),
+            _get(user, "base_uri_domains", "baseUriDomains"),
+        ),
+    }
+
+    if not any(merged.values()):
+        return None
+    return merged
+
+
+def _build_resource_for_tool(address: tuple[int, ...], tool: Tool) -> Resource | None:
+    """Synthesize a ``TextResource`` for a prefab tool at *address*.
+
+    Reads the tool's CSP from ``meta.ui.csp`` (if any), merges with the
+    renderer defaults, and produces a fresh ``TextResource`` with the
+    hashed URI and the merged CSP on its meta. Returns ``None`` when
+    prefab_ui isn't installed.
+    """
+    try:
+        from prefab_ui.renderer import get_renderer_html
+    except ImportError:
+        return None
+
+    from fastmcp.apps.config import (
+        UI_MIME_TYPE,
+        AppConfig,
+        ResourceCSP,
+        app_config_to_meta_dict,
+    )
+    from fastmcp.resources.types import TextResource
+
+    user_csp = None
+    if tool.meta and isinstance(tool.meta.get("ui"), dict):
+        ui = tool.meta["ui"]
+        if isinstance(ui.get("csp"), dict):
+            user_csp = ui["csp"]
+
+    merged = _merged_csp_dict(user_csp)
+    resource_csp = ResourceCSP(**merged) if merged else None
+    resource_app = AppConfig(csp=resource_csp) if resource_csp else AppConfig()
+
+    return TextResource(
+        uri=hashed_resource_uri(address, tool.name),  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        name=f"Prefab Renderer ({'/'.join(map(str, address)) or 'root'}/{tool.name})",
+        text=get_renderer_html(),
+        mime_type=UI_MIME_TYPE,
+        meta={"ui": app_config_to_meta_dict(resource_app)},
+    )
+
+
+def _enumerate_prefab_tools(
+    server: FastMCP,
+) -> list[tuple[tuple[int, ...], Tool]]:
+    """Walk the server's reverse-hash map and return ``(address, tool)`` for prefab tools.
+
+    Uses the registry's reverse-hash map (which already enumerates every
+    tool by hash) and filters for ones that carry the prefab placeholder.
+    Each entry's ``provider`` is the leaf that owns the tool; we look up
+    the actual ``Tool`` object from that provider's local storage to
+    inspect its meta.
+    """
+    from fastmcp.apps.app import FastMCPApp
+    from fastmcp.server.providers.local_provider import LocalProvider
+    from fastmcp.server.providers.wrapped_provider import _WrappedProvider
+    from fastmcp.tools.base import Tool
+
+    results: list[tuple[tuple[int, ...], Tool]] = []
+    for entry in server.reverse_hash_map.values():
+        # Find the actual Tool object inside the leaf provider so we can
+        # read its raw meta (transforms wouldn't change `meta.ui` but
+        # might rename the tool).
+        inner: Provider = entry.provider
+        while isinstance(inner, _WrappedProvider):
+            inner = inner._inner
+        sources: list[LocalProvider] = []
+        if isinstance(inner, LocalProvider):
+            sources.append(inner)
+        if isinstance(inner, FastMCPApp):
+            sources.append(inner._local)
+        for src in sources:
+            for component in src._components.values():
+                if (
+                    isinstance(component, Tool)
+                    and component.name == entry.tool_name
+                    and _is_prefab_tool(component)
+                ):
+                    results.append((entry.address, component))
+    return results
+
+
+async def synthesize_prefab_resources(server: FastMCP) -> list[Resource]:
+    """Return a fresh list of synthetic Prefab renderer resources for the server.
+
+    One resource per (mount-point address, prefab tool) pair. Used by
+    ``list_resources`` to surface the renderer resources for discovery.
+    Pure: produces fresh objects on every call, no caching, no mutation.
+    """
+    resources: list[Resource] = []
+    for address, tool in _enumerate_prefab_tools(server):
+        resource = _build_resource_for_tool(address, tool)
+        if resource is not None:
+            resources.append(resource)
+    return resources
+
+
+async def synthesize_prefab_resource_by_uri(
+    server: FastMCP, uri: str
+) -> Resource | None:
+    """Look up a synthetic Prefab renderer by URI, or return None.
+
+    Used by ``read_resource`` to intercept ``ui://prefab/tool/<hash>/...``
+    fetches. Parses the hash, finds the matching tool via the reverse
+    map, and synthesizes the resource. Returns None for any URI that
+    isn't a prefab renderer URI or doesn't match a known tool.
+    """
+    digest = parse_hashed_resource_uri(uri)
+    if digest is None:
+        return None
+
+    # Walk prefab tools to find the one whose hash matches.
+    for address, tool in _enumerate_prefab_tools(server):
+        if hash_tool_address(address, tool.name) == digest:
+            return _build_resource_for_tool(address, tool)
+    return None
+
+
+def rewrite_tool_meta_for_address(tool: Tool, address: tuple[int, ...]) -> Tool:
+    """Return a ``model_copy`` of *tool* with prefab meta rewritten for *address*.
+
+    If the tool isn't a prefab tool (or already has a non-placeholder
+    URI), returns the original unchanged. Otherwise produces a fresh
+    copy with:
+
+    - ``meta.ui.resourceUri`` = the hashed per-tool URI for *address*
+    - ``meta.ui.csp`` removed (CSP belongs on the resource side)
+    - ``meta.ui.permissions`` removed for the same reason
+
+    The original ``Tool`` object is untouched — this is a per-call view,
+    not a stored mutation. Used by ``list_tools`` to give clients a
+    correct, stable URI for each prefab tool.
+    """
+    if not _is_prefab_tool(tool):
+        return tool
+    # ``_is_prefab_tool`` already verified meta is a dict with a dict ui.
+    assert tool.meta is not None
+    new_ui = dict(tool.meta["ui"])
+    new_ui["resourceUri"] = hashed_resource_uri(address, tool.name)
+    new_ui.pop("csp", None)
+    new_ui.pop("permissions", None)
+    new_meta = dict(tool.meta)
+    new_meta["ui"] = new_ui
+    return tool.model_copy(update={"meta": new_meta})
+
+
+# Re-exported for callers that want to recognize the URI format.
+__all__ = [
+    "HASH_LENGTH",
+    "PREFAB_PLACEHOLDER_URI",
+    "rewrite_tool_meta_for_address",
+    "synthesize_prefab_resource_by_uri",
+    "synthesize_prefab_resources",
+]

--- a/src/fastmcp/server/providers/wrapped_provider.py
+++ b/src/fastmcp/server/providers/wrapped_provider.py
@@ -67,6 +67,10 @@ class _WrappedProvider(Provider):
         """Delegate to inner, bypassing this wrapper's transforms."""
         return await self._inner.get_app_tool(app_name, tool_name)
 
+    async def get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None:
+        """Delegate to inner, bypassing this wrapper's transforms."""
+        return await self._inner.get_tool_by_hash(tool_hash, tool_name)
+
     async def _list_resources(self) -> Sequence[Resource]:
         """Delegate to inner's list_resources (includes inner's transforms)."""
         return await self._inner.list_resources()

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -338,11 +338,12 @@ class FastMCP(
             on_duplicate=self._on_duplicate
         )
 
-        # Internal address registry (and its reverse-hash map). Built lazily
+        # Internal address registry (and its reverse-hash maps). Built lazily
         # on first access by walking the provider graph; invalidated whenever
         # a new provider is added so dynamic composition stays correct.
         self._address_registry: dict[tuple[int, ...], Provider] | None = None
         self._reverse_hash_map: dict[str, Any] | None = None
+        self._callable_map: dict[int, Any] = {}
 
         # Add providers using AggregateProvider's add_provider
         # LocalProvider is always first (no namespace)
@@ -500,9 +501,10 @@ class FastMCP(
         """
         super().add_provider(provider, namespace=namespace)
         # Adding a provider changes the shape of the address graph; drop the
-        # cached registry and reverse-hash map so they rebuild on next access.
+        # cached registry and reverse-hash maps so they rebuild on next access.
         self._address_registry = None
         self._reverse_hash_map = None
+        self._callable_map = {}
 
     @property
     def address_registry(self) -> dict[tuple[int, ...], Provider]:
@@ -524,35 +526,26 @@ class FastMCP(
         """Lazy hash → ``HashEntry`` reverse map for backend tool dispatch.
 
         Built alongside the address registry. Each entry maps a tool's
-        deterministic hash to ``(address, provider, tool_name)`` so the
-        dispatcher and ``read_resource`` can do O(1) lookups by hash.
+        deterministic hash to ``(address, provider, tool_name, fn)`` so
+        the dispatcher and ``read_resource`` can do O(1) lookups by hash.
         """
         if self._reverse_hash_map is None:
             from fastmcp.server.providers.addressing import build_reverse_hash_map
 
-            self._reverse_hash_map = build_reverse_hash_map(self.address_registry)
+            maps = build_reverse_hash_map(self.address_registry)
+            self._reverse_hash_map = maps.by_hash
+            self._callable_map = maps.by_callable
         return self._reverse_hash_map
 
-    async def _find_owning_address(
-        self, display_name: str, version: VersionSpec | None
-    ) -> tuple[int, ...]:
-        """Walk the registry to find which provider yields *display_name*.
+    @property
+    def callable_map(self) -> dict[int, Any]:
+        """Lazy ``id(fn) → HashEntry`` map for peer-tool lookup by callable.
 
-        Used by the dispatcher after a successful display-name resolution
-        to set ``Context.mount_path`` correctly. Walks providers in
-        registration order and queries each one's transform-aware
-        ``get_tool`` — the first match wins, matching the aggregation
-        order. Returns ``()`` (the root) if no provider claims it, which
-        is the right default for tools registered directly on the server.
+        Used by the Prefab resolver to find a peer tool's address by
+        function identity — no name ambiguity, no dispatch-time walk.
         """
-        for address, provider in self.address_registry.items():
-            try:
-                found = await provider.get_tool(display_name, version=version)
-            except Exception:
-                found = None
-            if found is not None:
-                return address
-        return ()
+        _ = self.reverse_hash_map  # triggers build if needed
+        return getattr(self, "_callable_map", {})
 
     async def _rewrite_prefab_uris(self, tools: list[Tool]) -> list[Tool]:
         """Replace placeholder Prefab URIs with mount-address-derived ones.
@@ -1287,7 +1280,6 @@ class FastMCP(
                 f"tools/call {name}", "tools/call", self.name, "tool", name
             ) as span:
                 tool: Tool | None = None
-                resolved_mount_path: tuple[int, ...] = ()
 
                 # Hashed-name dispatch — bypass transforms via the registry.
                 hashed = parse_hashed_backend_name(name)
@@ -1300,7 +1292,6 @@ class FastMCP(
                         )
                         if candidate is not None and _is_app_visible(candidate):
                             tool = candidate
-                            resolved_mount_path = entry.address
                             # Auth still applies on the bypass path.
                             skip_auth, token = _get_auth_context()
                             if not skip_auth and tool.auth is not None:
@@ -1316,21 +1307,9 @@ class FastMCP(
                 # Display-name path: normal aggregation through transforms.
                 if tool is None:
                     tool = await self.get_tool(name, version=version)
-                    if tool is not None:
-                        # Reverse-lookup the owning provider so the
-                        # Prefab resolver can serialize peer references
-                        # with the correct mount path.
-                        resolved_mount_path = await self._find_owning_address(
-                            name, version
-                        )
 
                 if tool is None:
                     raise NotFoundError(f"Unknown tool: {name!r}")
-
-                # Eagerly publish the resolved mount_path on the context
-                # so the Prefab serializer (if invoked) can read it.
-                ctx._mount_path = resolved_mount_path
-                ctx._mount_path_resolver = None
                 span.set_attributes(tool.get_span_attributes())
                 if task_meta is not None and task_meta.fn_key is None:
                     task_meta = replace(task_meta, fn_key=tool.key)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -554,6 +554,45 @@ class FastMCP(
                 return address
         return ()
 
+    async def _rewrite_prefab_uris(self, tools: list[Tool]) -> list[Tool]:
+        """Replace placeholder Prefab URIs with mount-address-derived ones.
+
+        Walks the registry, asks each provider for its display-name list
+        of tools, and for any tool that came back with the prefab
+        placeholder URI substitutes a per-tool hashed URI. Originals
+        stay pristine — the substitution produces ``model_copy`` views.
+        Tools without a prefab marker pass through unchanged.
+
+        The walk only pays its cost when prefab tools exist; for servers
+        that don't use Prefab UI it's effectively a no-op pass through
+        the result list.
+        """
+        from fastmcp.server.providers.prefab_synthesis import (
+            _is_prefab_tool,
+            rewrite_tool_meta_for_address,
+        )
+
+        if not any(_is_prefab_tool(t) for t in tools):
+            return tools
+
+        # Build name → address by querying each leaf provider once.
+        name_to_address: dict[str, tuple[int, ...]] = {}
+        for address, provider in self.address_registry.items():
+            try:
+                provider_tools = await provider.list_tools()
+            except Exception:
+                continue
+            for t in provider_tools:
+                if _is_prefab_tool(t):
+                    name_to_address.setdefault(t.name, address)
+
+        return [
+            rewrite_tool_meta_for_address(t, name_to_address.get(t.name, ()))
+            if _is_prefab_tool(t)
+            else t
+            for t in tools
+        ]
+
     # -------------------------------------------------------------------------
     # Provider interface overrides - inherited from AggregateProvider
     # -------------------------------------------------------------------------
@@ -667,6 +706,13 @@ class FastMCP(
             tools = list(await super().list_tools())
             tools = await apply_session_transforms(tools)
             tools = [t for t in tools if is_enabled(t) and _is_model_visible(t)]
+
+            # Rewrite per-tool Prefab renderer URIs based on the tool's
+            # mount-point address. The walk pairs each tool with the
+            # provider that yielded it, computes the hashed URI, and
+            # produces a model_copy with the URI in place. Original
+            # Tool objects are not mutated.
+            tools = await self._rewrite_prefab_uris(tools)
 
             skip_auth, token = _get_auth_context()
             authorized: list[Tool] = []
@@ -793,6 +839,15 @@ class FastMCP(
             resources = list(await super().list_resources())
             resources = await apply_session_transforms(resources)
             resources = [r for r in resources if is_enabled(r)]
+
+            # Append synthetic Prefab renderer resources — one per
+            # prefab tool, hashed by mount address. These don't live on
+            # any provider's storage; they're computed on demand.
+            from fastmcp.server.providers.prefab_synthesis import (
+                synthesize_prefab_resources,
+            )
+
+            resources.extend(await synthesize_prefab_resources(self))
 
             skip_auth, token = _get_auth_context()
             authorized: list[Resource] = []
@@ -1391,6 +1446,18 @@ class FastMCP(
                 uri,
                 resource_uri=uri,
             ) as span:
+                # Intercept synthetic Prefab renderer URIs before normal
+                # resolution. The resource isn't stored anywhere — we
+                # build it on demand from the matching tool's CSP.
+                from fastmcp.server.providers.prefab_synthesis import (
+                    synthesize_prefab_resource_by_uri,
+                )
+
+                synthesized = await synthesize_prefab_resource_by_uri(self, uri)
+                if synthesized is not None:
+                    span.set_attributes(synthesized.get_span_attributes())
+                    return await synthesized._read(task_meta=task_meta)
+
                 # Try concrete resources first (transforms + auth via _get_resource)
                 resource = await self.get_resource(uri, version=version)
                 if resource is not None:

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -208,6 +208,31 @@ def _is_model_visible(tool: Tool) -> bool:
     return "model" in visibility
 
 
+def _is_app_visible(tool: Tool) -> bool:
+    """Check whether a tool has explicitly opted into app-callable visibility.
+
+    Gates the dispatcher's hashed-name routing path: only tools whose
+    ``meta.ui.visibility`` list contains ``"app"`` can be reached via
+    ``<hash>_<local_name>`` calls. Tools without an explicit visibility
+    declaration are NOT app-callable — they must be reached by their
+    display name through the normal transform-aware resolution path.
+
+    This is the inverse of the "everything is dot-callable" trap: the
+    hashed-name path is an opt-in mechanism for FastMCPApp backend tools,
+    not a general bypass for arbitrary tools.
+    """
+    meta = tool.meta
+    if not meta:
+        return False
+    ui = meta.get("ui")
+    if not isinstance(ui, dict):
+        return False
+    visibility = ui.get("visibility")
+    if not isinstance(visibility, list):
+        return False
+    return "app" in visibility
+
+
 @asynccontextmanager
 async def default_lifespan(server: FastMCP[LifespanResultT]) -> AsyncIterator[Any]:
     """Default lifespan context manager that does nothing.
@@ -312,6 +337,12 @@ class FastMCP(
         self._local_provider: LocalProvider = LocalProvider(
             on_duplicate=self._on_duplicate
         )
+
+        # Internal address registry (and its reverse-hash map). Built lazily
+        # on first access by walking the provider graph; invalidated whenever
+        # a new provider is added so dynamic composition stays correct.
+        self._address_registry: dict[tuple[int, ...], Provider] | None = None
+        self._reverse_hash_map: dict[str, Any] | None = None
 
         # Add providers using AggregateProvider's add_provider
         # LocalProvider is always first (no namespace)
@@ -468,6 +499,60 @@ class FastMCP(
                 - Prompts become "namespace_promptname"
         """
         super().add_provider(provider, namespace=namespace)
+        # Adding a provider changes the shape of the address graph; drop the
+        # cached registry and reverse-hash map so they rebuild on next access.
+        self._address_registry = None
+        self._reverse_hash_map = None
+
+    @property
+    def address_registry(self) -> dict[tuple[int, ...], Provider]:
+        """Lazy address → provider map for the full provider graph.
+
+        Built on first access by walking ``self.providers`` and assigning
+        each mount point its positional integer index. The result is a
+        pure dict — building it has no side effects. Invalidated when
+        ``add_provider`` runs.
+        """
+        if self._address_registry is None:
+            from fastmcp.server.providers.addressing import build_address_registry
+
+            self._address_registry = build_address_registry(self)
+        return self._address_registry
+
+    @property
+    def reverse_hash_map(self) -> dict[str, Any]:
+        """Lazy hash → ``HashEntry`` reverse map for backend tool dispatch.
+
+        Built alongside the address registry. Each entry maps a tool's
+        deterministic hash to ``(address, provider, tool_name)`` so the
+        dispatcher and ``read_resource`` can do O(1) lookups by hash.
+        """
+        if self._reverse_hash_map is None:
+            from fastmcp.server.providers.addressing import build_reverse_hash_map
+
+            self._reverse_hash_map = build_reverse_hash_map(self.address_registry)
+        return self._reverse_hash_map
+
+    async def _find_owning_address(
+        self, display_name: str, version: VersionSpec | None
+    ) -> tuple[int, ...]:
+        """Walk the registry to find which provider yields *display_name*.
+
+        Used by the dispatcher after a successful display-name resolution
+        to set ``Context.mount_path`` correctly. Walks providers in
+        registration order and queries each one's transform-aware
+        ``get_tool`` — the first match wins, matching the aggregation
+        order. Returns ``()`` (the root) if no provider claims it, which
+        is the right default for tools registered directly on the server.
+        """
+        for address, provider in self.address_registry.items():
+            try:
+                found = await provider.get_tool(display_name, version=version)
+            except Exception:
+                found = None
+            if found is not None:
+                return address
+        return ()
 
     # -------------------------------------------------------------------------
     # Provider interface overrides - inherited from AggregateProvider
@@ -1109,6 +1194,18 @@ class FastMCP(
         # For mounted servers, the parent's provider sets fn_key to the
         # namespaced key before delegating, ensuring correct Docket routing.
 
+        from fastmcp.server.providers.addressing import (
+            parse_hashed_backend_name,
+        )
+
+        # Two routing paths:
+        #   1. Hashed-name path — backend tools that opted into
+        #      app-callable visibility. Recognized by their
+        #      `<hash>_<local_name>` format and resolved via the
+        #      reverse-hash map. Address is known eagerly.
+        #   2. Display-name path — everything else. Goes through normal
+        #      `get_tool` aggregation/transforms. Address is determined
+        #      after resolution by walking the registry.
         async with fastmcp.server.context.Context(fastmcp=self) as ctx:
             if run_middleware:
                 mw_context = MiddlewareContext[CallToolRequestParams](
@@ -1131,30 +1228,54 @@ class FastMCP(
                     ),
                 )
 
-            # Core logic: find and execute tool (providers queried in parallel)
-            # Use get_tool to apply transforms and filter disabled
             with server_span(
                 f"tools/call {name}", "tools/call", self.name, "tool", name
             ) as span:
-                # Try normal resolution first. If that fails and the name
-                # contains "___" (app tool prefix), parse out the app name
-                # and route via get_app_tool which bypasses transforms.
-                tool: Tool | None = await self.get_tool(name, version=version)
-                if tool is None and "___" in name:
-                    app_prefix, _, tool_suffix = name.partition("___")
-                    tool = await self.get_app_tool(app_prefix, tool_suffix)
+                tool: Tool | None = None
+                resolved_mount_path: tuple[int, ...] = ()
+
+                # Hashed-name dispatch — bypass transforms via the registry.
+                hashed = parse_hashed_backend_name(name)
+                if hashed is not None:
+                    digest, local_name = hashed
+                    entry = self.reverse_hash_map.get(digest)
+                    if entry is not None and entry.tool_name == local_name:
+                        candidate = await entry.provider._get_tool(
+                            local_name, version=version
+                        )
+                        if candidate is not None and _is_app_visible(candidate):
+                            tool = candidate
+                            resolved_mount_path = entry.address
+                            # Auth still applies on the bypass path.
+                            skip_auth, token = _get_auth_context()
+                            if not skip_auth and tool.auth is not None:
+                                try:
+                                    auth_ctx = AuthContext(token=token, component=tool)
+                                    if not await run_auth_checks(tool.auth, auth_ctx):
+                                        raise NotFoundError(f"Unknown tool: {name!r}")
+                                except AuthorizationError:
+                                    raise NotFoundError(
+                                        f"Unknown tool: {name!r}"
+                                    ) from None
+
+                # Display-name path: normal aggregation through transforms.
+                if tool is None:
+                    tool = await self.get_tool(name, version=version)
                     if tool is not None:
-                        # Auth still applies to app tools
-                        skip_auth, token = _get_auth_context()
-                        if not skip_auth and tool.auth is not None:
-                            try:
-                                ctx = AuthContext(token=token, component=tool)
-                                if not await run_auth_checks(tool.auth, ctx):
-                                    raise NotFoundError(f"Unknown tool: {name!r}")
-                            except AuthorizationError:
-                                raise NotFoundError(f"Unknown tool: {name!r}") from None
+                        # Reverse-lookup the owning provider so the
+                        # Prefab resolver can serialize peer references
+                        # with the correct mount path.
+                        resolved_mount_path = await self._find_owning_address(
+                            name, version
+                        )
+
                 if tool is None:
                     raise NotFoundError(f"Unknown tool: {name!r}")
+
+                # Eagerly publish the resolved mount_path on the context
+                # so the Prefab serializer (if invoked) can read it.
+                ctx._mount_path = resolved_mount_path
+                ctx._mount_path_resolver = None
                 span.set_attributes(tool.get_span_attributes())
                 if task_meta is not None and task_meta.fn_key is None:
                     task_meta = replace(task_meta, fn_key=tool.key)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -338,13 +338,6 @@ class FastMCP(
             on_duplicate=self._on_duplicate
         )
 
-        # Internal address registry (and its reverse-hash maps). Built lazily
-        # on first access by walking the provider graph; invalidated whenever
-        # a new provider is added so dynamic composition stays correct.
-        self._address_registry: dict[tuple[int, ...], Provider] | None = None
-        self._reverse_hash_map: dict[str, Any] | None = None
-        self._callable_map: dict[int, Any] = {}
-
         # Add providers using AggregateProvider's add_provider
         # LocalProvider is always first (no namespace)
         self.add_provider(self._local_provider)
@@ -500,90 +493,23 @@ class FastMCP(
                 - Prompts become "namespace_promptname"
         """
         super().add_provider(provider, namespace=namespace)
-        # Adding a provider changes the shape of the address graph; drop the
-        # cached registry and reverse-hash maps so they rebuild on next access.
-        self._address_registry = None
-        self._reverse_hash_map = None
-        self._callable_map = {}
 
-    @property
-    def address_registry(self) -> dict[tuple[int, ...], Provider]:
-        """Lazy address → provider map for the full provider graph.
+    def _rewrite_prefab_uris(self, tools: list[Tool]) -> list[Tool]:
+        """Replace placeholder Prefab URIs with per-tool hashed ones.
 
-        Built on first access by walking ``self.providers`` and assigning
-        each mount point its positional integer index. The result is a
-        pure dict — building it has no side effects. Invalidated when
-        ``add_provider`` runs.
-        """
-        if self._address_registry is None:
-            from fastmcp.server.providers.addressing import build_address_registry
-
-            self._address_registry = build_address_registry(self)
-        return self._address_registry
-
-    @property
-    def reverse_hash_map(self) -> dict[str, Any]:
-        """Lazy hash → ``HashEntry`` reverse map for backend tool dispatch.
-
-        Built alongside the address registry. Each entry maps a tool's
-        deterministic hash to ``(address, provider, tool_name, fn)`` so
-        the dispatcher and ``read_resource`` can do O(1) lookups by hash.
-        """
-        if self._reverse_hash_map is None:
-            from fastmcp.server.providers.addressing import build_reverse_hash_map
-
-            maps = build_reverse_hash_map(self.address_registry)
-            self._reverse_hash_map = maps.by_hash
-            self._callable_map = maps.by_callable
-        return self._reverse_hash_map
-
-    @property
-    def callable_map(self) -> dict[int, Any]:
-        """Lazy ``id(fn) → HashEntry`` map for peer-tool lookup by callable.
-
-        Used by the Prefab resolver to find a peer tool's address by
-        function identity — no name ambiguity, no dispatch-time walk.
-        """
-        _ = self.reverse_hash_map  # triggers build if needed
-        return getattr(self, "_callable_map", {})
-
-    async def _rewrite_prefab_uris(self, tools: list[Tool]) -> list[Tool]:
-        """Replace placeholder Prefab URIs with mount-address-derived ones.
-
-        Walks the registry, asks each provider for its display-name list
-        of tools, and for any tool that came back with the prefab
-        placeholder URI substitutes a per-tool hashed URI. Originals
-        stay pristine — the substitution produces ``model_copy`` views.
-        Tools without a prefab marker pass through unchanged.
-
-        The walk only pays its cost when prefab tools exist; for servers
-        that don't use Prefab UI it's effectively a no-op pass through
-        the result list.
+        For each tool whose ``meta.ui.resourceUri`` is the placeholder,
+        reads the tool's stored hash from ``meta.fastmcp._tool_hash``
+        and rewrites the URI to the per-tool form. Also strips CSP from
+        tool meta (it belongs on the resource). Produces ``model_copy``
+        views — originals are untouched.
         """
         from fastmcp.server.providers.prefab_synthesis import (
             _is_prefab_tool,
-            rewrite_tool_meta_for_address,
+            rewrite_tool_meta_for_wire,
         )
 
-        if not any(_is_prefab_tool(t) for t in tools):
-            return tools
-
-        # Build name → address by querying each leaf provider once.
-        name_to_address: dict[str, tuple[int, ...]] = {}
-        for address, provider in self.address_registry.items():
-            try:
-                provider_tools = await provider.list_tools()
-            except Exception:
-                continue
-            for t in provider_tools:
-                if _is_prefab_tool(t):
-                    name_to_address.setdefault(t.name, address)
-
         return [
-            rewrite_tool_meta_for_address(t, name_to_address.get(t.name, ()))
-            if _is_prefab_tool(t)
-            else t
-            for t in tools
+            rewrite_tool_meta_for_wire(t) if _is_prefab_tool(t) else t for t in tools
         ]
 
     # -------------------------------------------------------------------------
@@ -705,7 +631,7 @@ class FastMCP(
             # provider that yielded it, computes the hashed URI, and
             # produces a model_copy with the URI in place. Original
             # Tool objects are not mutated.
-            tools = await self._rewrite_prefab_uris(tools)
+            tools = self._rewrite_prefab_uris(tools)
 
             skip_auth, token = _get_auth_context()
             authorized: list[Tool] = []
@@ -1276,22 +1202,23 @@ class FastMCP(
                     ),
                 )
 
+            # Core logic: find and execute tool
             with server_span(
                 f"tools/call {name}", "tools/call", self.name, "tool", name
             ) as span:
-                tool: Tool | None = None
+                # Try normal display-name resolution first.
+                tool: Tool | None = await self.get_tool(name, version=version)
 
-                # Hashed-name dispatch — bypass transforms via the registry.
-                hashed = parse_hashed_backend_name(name)
-                if hashed is not None:
-                    digest, local_name = hashed
-                    entry = self.reverse_hash_map.get(digest)
-                    if entry is not None and entry.tool_name == local_name:
-                        candidate = await entry.provider._get_tool(
-                            local_name, version=version
-                        )
-                        if candidate is not None and _is_app_visible(candidate):
-                            tool = candidate
+                # If that fails, try hashed-name dispatch. This walks
+                # the provider tree recursively (same pattern as the old
+                # get_app_tool) looking for a tool whose stored hash
+                # matches the parsed prefix.
+                if tool is None:
+                    hashed = parse_hashed_backend_name(name)
+                    if hashed is not None:
+                        digest, local_name = hashed
+                        tool = await self.get_tool_by_hash(digest, local_name)
+                        if tool is not None:
                             # Auth still applies on the bypass path.
                             skip_auth, token = _get_auth_context()
                             if not skip_auth and tool.auth is not None:
@@ -1303,10 +1230,6 @@ class FastMCP(
                                     raise NotFoundError(
                                         f"Unknown tool: {name!r}"
                                     ) from None
-
-                # Display-name path: normal aggregation through transforms.
-                if tool is None:
-                    tool = await self.get_tool(name, version=version)
 
                 if tool is None:
                     raise NotFoundError(f"Unknown tool: {name!r}")

--- a/src/fastmcp/tools/base.py
+++ b/src/fastmcp/tools/base.py
@@ -492,37 +492,30 @@ def _convert_to_single_content_block(
 _PREFAB_TEXT_FALLBACK = "[Rendered Prefab UI]"
 
 
-def _current_mount_path() -> tuple[int, ...]:
-    """Read the running tool's mount_path from the current Context, or ``()``."""
-    from fastmcp.server.context import _current_context
+def _get_tool_resolver() -> Callable[..., str] | None:
+    """Get the Prefab peer-reference resolver.
 
-    ctx = _current_context.get(None)
-    if ctx is None:
-        return ()
-    return ctx.mount_path
-
-
-def _get_tool_resolver(
-    mount_path: tuple[int, ...] = (),
-) -> Callable[..., str] | None:
-    """Get the Prefab peer-reference resolver bound to a mount path."""
+    The resolver looks up each peer tool's address via the current
+    server's callable map at serialization time — no mount_path needed.
+    """
     try:
         from fastmcp.apps.app import _make_resolver
 
-        return _make_resolver(mount_path)
+        return _make_resolver()
     except ImportError:
         return None
 
 
 def _prefab_to_json(app: Any) -> dict[str, Any]:
-    """Call PrefabApp.to_json() with the mount-path-aware tool resolver.
+    """Call PrefabApp.to_json() with the callable-identity-based resolver.
 
-    The resolver formats peer-tool references as ``<hash>_<local_name>``
-    where the hash is computed from the running tool's mount path. The
-    dispatcher recognizes that format on incoming CallTool calls and
-    routes them directly through the registry.
+    The resolver looks up each peer tool in the server's callable map
+    by function identity, computes the hashed backend name from the
+    tool's address, and embeds it in the Prefab JSON. The dispatcher
+    recognizes that format on incoming CallTool calls and routes them
+    directly through the registry.
     """
-    data = app.to_json(tool_resolver=_get_tool_resolver(_current_mount_path()))
+    data = app.to_json(tool_resolver=_get_tool_resolver())
     return data
 
 

--- a/src/fastmcp/tools/base.py
+++ b/src/fastmcp/tools/base.py
@@ -278,15 +278,9 @@ class Tool(FastMCPComponent):
 
         if _HAS_PREFAB:
             if isinstance(raw_value, _PrefabApp):
-                return _prefab_to_tool_result(
-                    raw_value,
-                    fastmcp_app_name=_get_fastmcp_app_name(self),
-                )
+                return _prefab_to_tool_result(raw_value)
             if isinstance(raw_value, _PrefabComponent):
-                return _prefab_to_tool_result(
-                    _PrefabApp(view=raw_value),
-                    fastmcp_app_name=_get_fastmcp_app_name(self),
-                )
+                return _prefab_to_tool_result(_PrefabApp(view=raw_value))
 
         content = _convert_to_content(raw_value, serializer=self.serializer)
 
@@ -498,45 +492,45 @@ def _convert_to_single_content_block(
 _PREFAB_TEXT_FALLBACK = "[Rendered Prefab UI]"
 
 
-def _get_tool_resolver(app_name: str | None = None) -> Callable[..., str] | None:
-    """Get the FastMCPApp callable resolver, if available."""
+def _current_mount_path() -> tuple[int, ...]:
+    """Read the running tool's mount_path from the current Context, or ``()``."""
+    from fastmcp.server.context import _current_context
+
+    ctx = _current_context.get(None)
+    if ctx is None:
+        return ()
+    return ctx.mount_path
+
+
+def _get_tool_resolver(
+    mount_path: tuple[int, ...] = (),
+) -> Callable[..., str] | None:
+    """Get the Prefab peer-reference resolver bound to a mount path."""
     try:
         from fastmcp.apps.app import _make_resolver
 
-        return _make_resolver(app_name)
+        return _make_resolver(mount_path)
     except ImportError:
         return None
 
 
-def _prefab_to_json(app: Any, fastmcp_app_name: str | None = None) -> dict[str, Any]:
-    """Call PrefabApp.to_json() with the FastMCPApp callable resolver.
+def _prefab_to_json(app: Any) -> dict[str, Any]:
+    """Call PrefabApp.to_json() with the mount-path-aware tool resolver.
 
-    The resolver prefixes tool names with the app name (e.g.
-    ``"store_files"`` → ``"Files___store_files"``) so the server can
-    find them via the bypass lookup regardless of transforms.
+    The resolver formats peer-tool references as ``<hash>_<local_name>``
+    where the hash is computed from the running tool's mount path. The
+    dispatcher recognizes that format on incoming CallTool calls and
+    routes them directly through the registry.
     """
-    data = app.to_json(tool_resolver=_get_tool_resolver(fastmcp_app_name))
+    data = app.to_json(tool_resolver=_get_tool_resolver(_current_mount_path()))
     return data
 
 
-def _get_fastmcp_app_name(tool: Tool) -> str | None:
-    """Read the FastMCPApp name from a tool's metadata, if present."""
-    meta = tool.meta
-    if not meta:
-        return None
-    fastmcp_meta = meta.get("fastmcp")
-    if isinstance(fastmcp_meta, dict):
-        app = fastmcp_meta.get("app")
-        if isinstance(app, str):
-            return app
-    return None
-
-
-def _prefab_to_tool_result(app: Any, fastmcp_app_name: str | None = None) -> ToolResult:
+def _prefab_to_tool_result(app: Any) -> ToolResult:
     """Convert a PrefabApp to a FastMCP ToolResult."""
     return ToolResult(
         content=[TextContent(type="text", text=_PREFAB_TEXT_FALLBACK)],
-        structured_content=_prefab_to_json(app, fastmcp_app_name=fastmcp_app_name),
+        structured_content=_prefab_to_json(app),
     )
 
 

--- a/src/fastmcp/tools/base.py
+++ b/src/fastmcp/tools/base.py
@@ -278,9 +278,15 @@ class Tool(FastMCPComponent):
 
         if _HAS_PREFAB:
             if isinstance(raw_value, _PrefabApp):
-                return _prefab_to_tool_result(raw_value)
+                return _prefab_to_tool_result(
+                    raw_value,
+                    fastmcp_app_name=_get_fastmcp_app_name(self),
+                )
             if isinstance(raw_value, _PrefabComponent):
-                return _prefab_to_tool_result(_PrefabApp(view=raw_value))
+                return _prefab_to_tool_result(
+                    _PrefabApp(view=raw_value),
+                    fastmcp_app_name=_get_fastmcp_app_name(self),
+                )
 
         content = _convert_to_content(raw_value, serializer=self.serializer)
 
@@ -492,38 +498,46 @@ def _convert_to_single_content_block(
 _PREFAB_TEXT_FALLBACK = "[Rendered Prefab UI]"
 
 
-def _get_tool_resolver() -> Callable[..., str] | None:
-    """Get the Prefab peer-reference resolver.
-
-    The resolver looks up each peer tool's address via the current
-    server's callable map at serialization time — no mount_path needed.
-    """
+def _get_tool_resolver(app_name: str | None = None) -> Callable[..., str] | None:
+    """Get the Prefab peer-reference resolver bound to an app name."""
     try:
         from fastmcp.apps.app import _make_resolver
 
-        return _make_resolver()
+        return _make_resolver(app_name)
     except ImportError:
         return None
 
 
-def _prefab_to_json(app: Any) -> dict[str, Any]:
-    """Call PrefabApp.to_json() with the callable-identity-based resolver.
+def _prefab_to_json(app: Any, fastmcp_app_name: str | None = None) -> dict[str, Any]:
+    """Call PrefabApp.to_json() with the hash-based resolver.
 
-    The resolver looks up each peer tool in the server's callable map
-    by function identity, computes the hashed backend name from the
-    tool's address, and embeds it in the Prefab JSON. The dispatcher
-    recognizes that format on incoming CallTool calls and routes them
-    directly through the registry.
+    The resolver prefixes peer-tool references with a deterministic hash
+    derived from the app name + tool name. The dispatcher recognizes that
+    format and routes calls via ``get_tool_by_hash`` which walks the
+    provider tree recursively — same pattern as the old ``get_app_tool``.
     """
-    data = app.to_json(tool_resolver=_get_tool_resolver())
+    data = app.to_json(tool_resolver=_get_tool_resolver(fastmcp_app_name))
     return data
 
 
-def _prefab_to_tool_result(app: Any) -> ToolResult:
+def _get_fastmcp_app_name(tool: Tool) -> str | None:
+    """Read the FastMCPApp name from a tool's metadata, if present."""
+    meta = tool.meta
+    if not meta:
+        return None
+    fastmcp_meta = meta.get("fastmcp")
+    if isinstance(fastmcp_meta, dict):
+        app = fastmcp_meta.get("app")
+        if isinstance(app, str):
+            return app
+    return None
+
+
+def _prefab_to_tool_result(app: Any, fastmcp_app_name: str | None = None) -> ToolResult:
     """Convert a PrefabApp to a FastMCP ToolResult."""
     return ToolResult(
         content=[TextContent(type="text", text=_PREFAB_TEXT_FALLBACK)],
-        structured_content=_prefab_to_json(app),
+        structured_content=_prefab_to_json(app, fastmcp_app_name=fastmcp_app_name),
     )
 
 

--- a/tests/apps/test_file_upload.py
+++ b/tests/apps/test_file_upload.py
@@ -29,7 +29,7 @@ class TestFileUploadProvider:
         files = [_make_file()]
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "store_files"), {"files": files}
+            hashed_backend_name("Files", "store_files"), {"files": files}
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         assert "test.txt" in text
@@ -43,7 +43,7 @@ class TestFileUploadProvider:
         files = [_make_file(content="DON'T PANIC")]
 
         await server.call_tool(
-            hashed_backend_name((0,), "store_files"), {"files": files}
+            hashed_backend_name("Files", "store_files"), {"files": files}
         )
 
         result = await server.call_tool("read_file", {"name": "test.txt"})
@@ -56,7 +56,7 @@ class TestFileUploadProvider:
         files = [{"name": "image.png", "size": 4, "type": "image/png", "data": data}]
 
         await server.call_tool(
-            hashed_backend_name((0,), "store_files"), {"files": files}
+            hashed_backend_name("Files", "store_files"), {"files": files}
         )
 
         result = await server.call_tool("read_file", {"name": "image.png"})
@@ -77,7 +77,7 @@ class TestFileUploadProvider:
         ]
 
         await server.call_tool(
-            hashed_backend_name((0,), "store_files"), {"files": files}
+            hashed_backend_name("Files", "store_files"), {"files": files}
         )
 
         result = await server.call_tool("list_files", {})
@@ -89,11 +89,11 @@ class TestFileUploadProvider:
         server = FastMCP("test", providers=[FileUpload()])
 
         await server.call_tool(
-            hashed_backend_name((0,), "store_files"),
+            hashed_backend_name("Files", "store_files"),
             {"files": [_make_file(content="version 1")]},
         )
         await server.call_tool(
-            hashed_backend_name((0,), "store_files"),
+            hashed_backend_name("Files", "store_files"),
             {"files": [_make_file(content="version 2")]},
         )
 
@@ -108,11 +108,10 @@ class TestFileUploadProvider:
         tool_names = [t.name for t in tools]
         assert "file_manager" in tool_names
 
-        # Routing uses the same hashed-address path regardless of the
-        # custom display name — the address is positional, not name-based.
+        # The hash uses the app's actual name ("Uploads"), not the default.
         files = [_make_file()]
         result = await server.call_tool(
-            hashed_backend_name((0,), "store_files"), {"files": files}
+            hashed_backend_name("Uploads", "store_files"), {"files": files}
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         assert "test.txt" in text
@@ -134,7 +133,7 @@ class TestFileUploadProvider:
 
         with pytest.raises(Exception, match="exceeds max size"):
             await server.call_tool(
-                hashed_backend_name((0,), "store_files"), {"files": [big_file]}
+                hashed_backend_name("Files", "store_files"), {"files": [big_file]}
             )
 
 
@@ -180,7 +179,7 @@ class TestFileUploadSubclass:
         files = [_make_file()]
 
         await server.call_tool(
-            hashed_backend_name((0,), "store_files"), {"files": files}
+            hashed_backend_name("Files", "store_files"), {"files": files}
         )
 
         assert "test.txt" in stored

--- a/tests/apps/test_file_upload.py
+++ b/tests/apps/test_file_upload.py
@@ -6,6 +6,7 @@ import pytest
 
 from fastmcp import FastMCP
 from fastmcp.apps.file_upload import FileUpload
+from fastmcp.server.providers.addressing import hashed_backend_name
 
 
 def _make_file(
@@ -27,7 +28,9 @@ class TestFileUploadProvider:
         server = FastMCP("test", providers=[FileUpload()])
         files = [_make_file()]
 
-        result = await server.call_tool("Files___store_files", {"files": files})
+        result = await server.call_tool(
+            hashed_backend_name((0,), "store_files"), {"files": files}
+        )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         assert "test.txt" in text
 
@@ -39,7 +42,9 @@ class TestFileUploadProvider:
         server = FastMCP("test", providers=[FileUpload()])
         files = [_make_file(content="DON'T PANIC")]
 
-        await server.call_tool("Files___store_files", {"files": files})
+        await server.call_tool(
+            hashed_backend_name((0,), "store_files"), {"files": files}
+        )
 
         result = await server.call_tool("read_file", {"name": "test.txt"})
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -50,7 +55,9 @@ class TestFileUploadProvider:
         data = base64.b64encode(b"\x00\x01\x02\xff").decode()
         files = [{"name": "image.png", "size": 4, "type": "image/png", "data": data}]
 
-        await server.call_tool("Files___store_files", {"files": files})
+        await server.call_tool(
+            hashed_backend_name((0,), "store_files"), {"files": files}
+        )
 
         result = await server.call_tool("read_file", {"name": "image.png"})
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -69,7 +76,9 @@ class TestFileUploadProvider:
             _make_file("b.txt", "bbb"),
         ]
 
-        await server.call_tool("Files___store_files", {"files": files})
+        await server.call_tool(
+            hashed_backend_name((0,), "store_files"), {"files": files}
+        )
 
         result = await server.call_tool("list_files", {})
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -80,11 +89,11 @@ class TestFileUploadProvider:
         server = FastMCP("test", providers=[FileUpload()])
 
         await server.call_tool(
-            "Files___store_files",
+            hashed_backend_name((0,), "store_files"),
             {"files": [_make_file(content="version 1")]},
         )
         await server.call_tool(
-            "Files___store_files",
+            hashed_backend_name((0,), "store_files"),
             {"files": [_make_file(content="version 2")]},
         )
 
@@ -99,9 +108,12 @@ class TestFileUploadProvider:
         tool_names = [t.name for t in tools]
         assert "file_manager" in tool_names
 
-        # Routing uses the custom name
+        # Routing uses the same hashed-address path regardless of the
+        # custom display name — the address is positional, not name-based.
         files = [_make_file()]
-        result = await server.call_tool("Uploads___store_files", {"files": files})
+        result = await server.call_tool(
+            hashed_backend_name((0,), "store_files"), {"files": files}
+        )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         assert "test.txt" in text
 
@@ -121,7 +133,9 @@ class TestFileUploadProvider:
         big_file = _make_file(content="x" * 200)
 
         with pytest.raises(Exception, match="exceeds max size"):
-            await server.call_tool("Files___store_files", {"files": [big_file]})
+            await server.call_tool(
+                hashed_backend_name((0,), "store_files"), {"files": [big_file]}
+            )
 
 
 class TestFileUploadSubclass:
@@ -165,7 +179,9 @@ class TestFileUploadSubclass:
         server = FastMCP("test", providers=[MemoryUpload()])
         files = [_make_file()]
 
-        await server.call_tool("Files___store_files", {"files": files})
+        await server.call_tool(
+            hashed_backend_name((0,), "store_files"), {"files": files}
+        )
 
         assert "test.txt" in stored
 

--- a/tests/apps/test_form.py
+++ b/tests/apps/test_form.py
@@ -7,6 +7,7 @@ import pytest
 
 from fastmcp import FastMCP
 from fastmcp.apps.form import FormInput, _backfill_boolean_defaults
+from fastmcp.server.providers.addressing import hashed_backend_name
 
 
 class Contact(pydantic.BaseModel):
@@ -52,7 +53,7 @@ class TestFormInputProvider:
         server = FastMCP("test", providers=[FormInput(model=Contact)])
 
         result = await server.call_tool(
-            "Contact___submit_form",
+            hashed_backend_name((0,), "submit_form"),
             {"data": {"name": "Alice", "email": "alice@example.com"}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -74,7 +75,7 @@ class TestFormInputProvider:
         )
 
         result = await server.call_tool(
-            "Contact___submit_form",
+            hashed_backend_name((0,), "submit_form"),
             {"data": {"name": "Bob", "email": "bob@example.com"}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -94,7 +95,7 @@ class TestFormInputProvider:
         server = FastMCP("test", providers=[FormInput(model=NoteForm)])
 
         result = await server.call_tool(
-            "NoteForm___submit_form",
+            hashed_backend_name((0,), "submit_form"),
             {"data": {"title": "My Note", "content": "Hello"}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -107,7 +108,7 @@ class TestFormInputProvider:
         server = FastMCP("test", providers=[FormInput(model=NoteForm)])
 
         result = await server.call_tool(
-            "NoteForm___submit_form",
+            hashed_backend_name((0,), "submit_form"),
             {"data": {"title": "My Note", "content": "Hello", "archived": True}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -122,7 +123,7 @@ class TestFormInputProvider:
         # for the data parameter itself). Pydantic will still reject missing
         # required fields like title/content, but that's expected.
         with pytest.raises(pydantic.ValidationError, match="title"):
-            await server.call_tool("NoteForm___submit_form", {})
+            await server.call_tool(hashed_backend_name((0,), "submit_form"), {})
 
     async def test_multiple_models(self):
         class Address(pydantic.BaseModel):

--- a/tests/apps/test_form.py
+++ b/tests/apps/test_form.py
@@ -53,7 +53,7 @@ class TestFormInputProvider:
         server = FastMCP("test", providers=[FormInput(model=Contact)])
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "submit_form"),
+            hashed_backend_name("Contact", "submit_form"),
             {"data": {"name": "Alice", "email": "alice@example.com"}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -75,7 +75,7 @@ class TestFormInputProvider:
         )
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "submit_form"),
+            hashed_backend_name("Contact", "submit_form"),
             {"data": {"name": "Bob", "email": "bob@example.com"}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -95,7 +95,7 @@ class TestFormInputProvider:
         server = FastMCP("test", providers=[FormInput(model=NoteForm)])
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "submit_form"),
+            hashed_backend_name("NoteForm", "submit_form"),
             {"data": {"title": "My Note", "content": "Hello"}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -108,7 +108,7 @@ class TestFormInputProvider:
         server = FastMCP("test", providers=[FormInput(model=NoteForm)])
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "submit_form"),
+            hashed_backend_name("NoteForm", "submit_form"),
             {"data": {"title": "My Note", "content": "Hello", "archived": True}},
         )
         text = result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -123,7 +123,7 @@ class TestFormInputProvider:
         # for the data parameter itself). Pydantic will still reject missing
         # required fields like title/content, but that's expected.
         with pytest.raises(pydantic.ValidationError, match="title"):
-            await server.call_tool(hashed_backend_name((0,), "submit_form"), {})
+            await server.call_tool(hashed_backend_name("NoteForm", "submit_form"), {})
 
     async def test_multiple_models(self):
         class Address(pydantic.BaseModel):

--- a/tests/server/providers/test_addressing.py
+++ b/tests/server/providers/test_addressing.py
@@ -1,0 +1,224 @@
+"""Tests for the provider addressing primitives.
+
+Covers the deterministic hash function, address registry walker, and
+reverse-hash map. The address registry assigns positional integer
+indices to every mount point in a FastMCP server's provider graph; the
+reverse-hash map maps the resulting hashes back to specific tools so
+``read_resource`` and the backend-tool dispatcher can do O(1) lookups.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP, FastMCPApp
+from fastmcp.server.providers.addressing import (
+    HASH_LENGTH,
+    build_address_registry,
+    build_reverse_hash_map,
+    hash_tool_address,
+    hashed_backend_name,
+    hashed_resource_uri,
+    parse_hashed_backend_name,
+    parse_hashed_resource_uri,
+)
+
+
+class TestHashFunction:
+    def test_hash_is_fixed_length_hex(self):
+        h = hash_tool_address((), "greet")
+        assert len(h) == HASH_LENGTH
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_same_inputs_same_hash(self):
+        a = hash_tool_address((0, 1), "submit_form")
+        b = hash_tool_address((0, 1), "submit_form")
+        assert a == b
+
+    def test_different_addresses_different_hash(self):
+        a = hash_tool_address((0,), "submit")
+        b = hash_tool_address((1,), "submit")
+        assert a != b
+
+    def test_different_tool_names_different_hash(self):
+        a = hash_tool_address((0,), "save")
+        b = hash_tool_address((0,), "delete")
+        assert a != b
+
+    def test_address_segment_boundaries_matter(self):
+        """``("ab", "c")`` and ``("a", "bc")`` would collide under naive
+        concatenation; the hash function uses an unambiguous encoding."""
+        a = hash_tool_address((0, 12), "save")
+        b = hash_tool_address((0, 1), "2save")
+        assert a != b
+
+
+class TestBackendNameRoundtrip:
+    def test_format_and_parse(self):
+        name = hashed_backend_name((0, 2), "submit_form")
+        parsed = parse_hashed_backend_name(name)
+        assert parsed is not None
+        digest, local = parsed
+        assert digest == hash_tool_address((0, 2), "submit_form")
+        assert local == "submit_form"
+
+    def test_parse_rejects_short_strings(self):
+        assert parse_hashed_backend_name("foo") is None
+
+    def test_parse_rejects_non_hex_prefix(self):
+        # Right shape, wrong characters in the prefix.
+        assert parse_hashed_backend_name("zzzzzzzzzzzz_save") is None
+
+    def test_parse_rejects_missing_separator(self):
+        # 12 hex chars but no underscore at position 12.
+        assert parse_hashed_backend_name("abcdef012345save") is None
+
+
+class TestResourceUriRoundtrip:
+    def test_format_and_parse(self):
+        uri = hashed_resource_uri((0, 1), "show_dashboard")
+        h = parse_hashed_resource_uri(uri)
+        assert h == hash_tool_address((0, 1), "show_dashboard")
+
+    def test_parse_rejects_unrelated_uri(self):
+        assert parse_hashed_resource_uri("file:///etc/passwd") is None
+
+    def test_parse_rejects_wrong_length_hash(self):
+        assert parse_hashed_resource_uri("ui://prefab/tool/abc/renderer.html") is None
+
+
+class TestAddressRegistry:
+    def test_empty_server_has_root_entry(self):
+        mcp = FastMCP("server")
+        registry = build_address_registry(mcp)
+        # The root's local provider lives at the empty path.
+        assert () in registry
+        assert registry[()] is mcp._local_provider
+
+    def test_root_tool_is_at_empty_path(self):
+        mcp = FastMCP("server")
+
+        @mcp.tool
+        def greet(name: str) -> str:
+            return name
+
+        registry = build_address_registry(mcp)
+        # Root LocalProvider is transparent — no extra segment.
+        assert registry[()] is mcp._local_provider
+        assert len(registry) == 1
+
+    def test_added_provider_gets_positional_index(self):
+        mcp = FastMCP("server")
+        app = FastMCPApp("dashboard")
+        mcp.add_provider(app)
+        registry = build_address_registry(mcp)
+        # First non-transparent child is at (0,).
+        assert (0,) in registry
+        assert registry[(0,)] is app
+
+    def test_multiple_providers_indexed_by_registration_order(self):
+        mcp = FastMCP("server")
+        a = FastMCPApp("a")
+        b = FastMCPApp("b")
+        c = FastMCPApp("c")
+        mcp.add_provider(a)
+        mcp.add_provider(b)
+        mcp.add_provider(c)
+        registry = build_address_registry(mcp)
+        assert registry[(0,)] is a
+        assert registry[(1,)] is b
+        assert registry[(2,)] is c
+
+    def test_walker_is_deterministic_across_replicas(self):
+        """Same code, same addresses — required for horizontal sharding."""
+
+        def make_server() -> FastMCP:
+            m = FastMCP("server")
+            m.add_provider(FastMCPApp("first"))
+            m.add_provider(FastMCPApp("second"))
+            return m
+
+        r1 = build_address_registry(make_server())
+        r2 = build_address_registry(make_server())
+        assert set(r1.keys()) == set(r2.keys())
+
+    def test_same_provider_mounted_twice_appears_at_two_addresses(self):
+        mcp = FastMCP("server")
+        shared = FastMCPApp("shared")
+        mcp.add_provider(shared)
+        mcp.add_provider(shared)
+        registry = build_address_registry(mcp)
+        assert registry[(0,)] is shared
+        assert registry[(1,)] is shared
+
+
+class TestReverseHashMap:
+    def test_includes_root_tools_at_empty_address(self):
+        mcp = FastMCP("server")
+
+        @mcp.tool
+        def greet(name: str) -> str:
+            return name
+
+        reverse = build_reverse_hash_map(build_address_registry(mcp))
+        digest = hash_tool_address((), "greet")
+        assert digest in reverse
+        entry = reverse[digest]
+        assert entry.address == ()
+        assert entry.tool_name == "greet"
+
+    def test_includes_app_tools_at_app_address(self):
+        mcp = FastMCP("server")
+        app = FastMCPApp("dashboard")
+        mcp.add_provider(app)
+
+        @app.tool()
+        def save(name: str) -> str:
+            return name
+
+        reverse = build_reverse_hash_map(build_address_registry(mcp))
+        digest = hash_tool_address((0,), "save")
+        assert digest in reverse
+        entry = reverse[digest]
+        assert entry.address == (0,)
+        assert entry.tool_name == "save"
+        assert entry.provider is app
+
+    def test_same_tool_at_two_addresses_has_two_hashes(self):
+        """Mounting the same FastMCPApp instance twice produces distinct
+        hashes for the same underlying tool — one per mount address."""
+        mcp = FastMCP("server")
+        shared = FastMCPApp("shared")
+
+        @shared.tool()
+        def save(name: str) -> str:
+            return name
+
+        mcp.add_provider(shared)
+        mcp.add_provider(shared)
+
+        reverse = build_reverse_hash_map(build_address_registry(mcp))
+        h1 = hash_tool_address((0,), "save")
+        h2 = hash_tool_address((1,), "save")
+        assert h1 != h2
+        assert h1 in reverse
+        assert h2 in reverse
+        # Both entries point at the same provider object.
+        assert reverse[h1].provider is reverse[h2].provider
+
+
+class TestServerLazyAddressRegistry:
+    def test_registry_cached_after_first_access(self):
+        mcp = FastMCP("server")
+        r1 = mcp.address_registry
+        r2 = mcp.address_registry
+        assert r1 is r2
+
+    def test_add_provider_invalidates_registry_and_reverse_map(self):
+        mcp = FastMCP("server")
+        r1 = mcp.address_registry
+        rev1 = mcp.reverse_hash_map
+        mcp.add_provider(FastMCPApp("dashboard"))
+        r2 = mcp.address_registry
+        rev2 = mcp.reverse_hash_map
+        assert r1 is not r2
+        assert rev1 is not rev2
+        assert (0,) in r2

--- a/tests/server/providers/test_addressing.py
+++ b/tests/server/providers/test_addressing.py
@@ -1,20 +1,10 @@
-"""Tests for the provider addressing primitives.
-
-Covers the deterministic hash function, address registry walker, and
-reverse-hash map. The address registry assigns positional integer
-indices to every mount point in a FastMCP server's provider graph; the
-reverse-hash map maps the resulting hashes back to specific tools so
-``read_resource`` and the backend-tool dispatcher can do O(1) lookups.
-"""
+"""Tests for the tool hashing primitives."""
 
 from __future__ import annotations
 
-from fastmcp import FastMCP, FastMCPApp
 from fastmcp.server.providers.addressing import (
     HASH_LENGTH,
-    build_address_registry,
-    build_reverse_hash_map,
-    hash_tool_address,
+    hash_tool,
     hashed_backend_name,
     hashed_resource_uri,
     parse_hashed_backend_name,
@@ -24,216 +14,53 @@ from fastmcp.server.providers.addressing import (
 
 class TestHashFunction:
     def test_hash_is_fixed_length_hex(self):
-        h = hash_tool_address((), "greet")
+        h = hash_tool("myapp", "greet")
         assert len(h) == HASH_LENGTH
         assert all(c in "0123456789abcdef" for c in h)
 
     def test_same_inputs_same_hash(self):
-        a = hash_tool_address((0, 1), "submit_form")
-        b = hash_tool_address((0, 1), "submit_form")
+        a = hash_tool("app", "submit_form")
+        b = hash_tool("app", "submit_form")
         assert a == b
 
-    def test_different_addresses_different_hash(self):
-        a = hash_tool_address((0,), "submit")
-        b = hash_tool_address((1,), "submit")
+    def test_different_app_names_different_hash(self):
+        a = hash_tool("contacts", "save")
+        b = hash_tool("billing", "save")
         assert a != b
 
     def test_different_tool_names_different_hash(self):
-        a = hash_tool_address((0,), "save")
-        b = hash_tool_address((0,), "delete")
-        assert a != b
-
-    def test_address_segment_boundaries_matter(self):
-        """``("ab", "c")`` and ``("a", "bc")`` would collide under naive
-        concatenation; the hash function uses an unambiguous encoding."""
-        a = hash_tool_address((0, 12), "save")
-        b = hash_tool_address((0, 1), "2save")
+        a = hash_tool("app", "save")
+        b = hash_tool("app", "delete")
         assert a != b
 
 
 class TestBackendNameRoundtrip:
     def test_format_and_parse(self):
-        name = hashed_backend_name((0, 2), "submit_form")
+        name = hashed_backend_name("contacts", "submit_form")
         parsed = parse_hashed_backend_name(name)
         assert parsed is not None
         digest, local = parsed
-        assert digest == hash_tool_address((0, 2), "submit_form")
+        assert digest == hash_tool("contacts", "submit_form")
         assert local == "submit_form"
 
     def test_parse_rejects_short_strings(self):
         assert parse_hashed_backend_name("foo") is None
 
     def test_parse_rejects_non_hex_prefix(self):
-        # Right shape, wrong characters in the prefix.
         assert parse_hashed_backend_name("zzzzzzzzzzzz_save") is None
 
     def test_parse_rejects_missing_separator(self):
-        # 12 hex chars but no underscore at position 12.
         assert parse_hashed_backend_name("abcdef012345save") is None
 
 
 class TestResourceUriRoundtrip:
     def test_format_and_parse(self):
-        uri = hashed_resource_uri((0, 1), "show_dashboard")
+        uri = hashed_resource_uri("dashboard", "show")
         h = parse_hashed_resource_uri(uri)
-        assert h == hash_tool_address((0, 1), "show_dashboard")
+        assert h == hash_tool("dashboard", "show")
 
     def test_parse_rejects_unrelated_uri(self):
         assert parse_hashed_resource_uri("file:///etc/passwd") is None
 
     def test_parse_rejects_wrong_length_hash(self):
         assert parse_hashed_resource_uri("ui://prefab/tool/abc/renderer.html") is None
-
-
-class TestAddressRegistry:
-    def test_empty_server_has_root_entry(self):
-        mcp = FastMCP("server")
-        registry = build_address_registry(mcp)
-        # The root's local provider lives at the empty path.
-        assert () in registry
-        assert registry[()] is mcp._local_provider
-
-    def test_root_tool_is_at_empty_path(self):
-        mcp = FastMCP("server")
-
-        @mcp.tool
-        def greet(name: str) -> str:
-            return name
-
-        registry = build_address_registry(mcp)
-        # Root LocalProvider is transparent — no extra segment.
-        assert registry[()] is mcp._local_provider
-        assert len(registry) == 1
-
-    def test_added_provider_gets_positional_index(self):
-        mcp = FastMCP("server")
-        app = FastMCPApp("dashboard")
-        mcp.add_provider(app)
-        registry = build_address_registry(mcp)
-        # First non-transparent child is at (0,).
-        assert (0,) in registry
-        assert registry[(0,)] is app
-
-    def test_multiple_providers_indexed_by_registration_order(self):
-        mcp = FastMCP("server")
-        a = FastMCPApp("a")
-        b = FastMCPApp("b")
-        c = FastMCPApp("c")
-        mcp.add_provider(a)
-        mcp.add_provider(b)
-        mcp.add_provider(c)
-        registry = build_address_registry(mcp)
-        assert registry[(0,)] is a
-        assert registry[(1,)] is b
-        assert registry[(2,)] is c
-
-    def test_walker_is_deterministic_across_replicas(self):
-        """Same code, same addresses — required for horizontal sharding."""
-
-        def make_server() -> FastMCP:
-            m = FastMCP("server")
-            m.add_provider(FastMCPApp("first"))
-            m.add_provider(FastMCPApp("second"))
-            return m
-
-        r1 = build_address_registry(make_server())
-        r2 = build_address_registry(make_server())
-        assert set(r1.keys()) == set(r2.keys())
-
-    def test_same_provider_mounted_twice_appears_at_two_addresses(self):
-        mcp = FastMCP("server")
-        shared = FastMCPApp("shared")
-        mcp.add_provider(shared)
-        mcp.add_provider(shared)
-        registry = build_address_registry(mcp)
-        assert registry[(0,)] is shared
-        assert registry[(1,)] is shared
-
-
-class TestReverseHashMap:
-    def test_includes_root_tools_at_empty_address(self):
-        mcp = FastMCP("server")
-
-        @mcp.tool
-        def greet(name: str) -> str:
-            return name
-
-        maps = build_reverse_hash_map(build_address_registry(mcp))
-        digest = hash_tool_address((), "greet")
-        assert digest in maps.by_hash
-        entry = maps.by_hash[digest]
-        assert entry.address == ()
-        assert entry.tool_name == "greet"
-
-    def test_includes_app_tools_at_app_address(self):
-        mcp = FastMCP("server")
-        app = FastMCPApp("dashboard")
-        mcp.add_provider(app)
-
-        @app.tool()
-        def save(name: str) -> str:
-            return name
-
-        maps = build_reverse_hash_map(build_address_registry(mcp))
-        digest = hash_tool_address((0,), "save")
-        assert digest in maps.by_hash
-        entry = maps.by_hash[digest]
-        assert entry.address == (0,)
-        assert entry.tool_name == "save"
-        assert entry.provider is app
-
-    def test_callable_map_indexes_by_fn_identity(self):
-        """The callable map lets the resolver look up a tool by function
-        identity — no name ambiguity, no mount_path needed."""
-        mcp = FastMCP("server")
-        app = FastMCPApp("dashboard")
-        mcp.add_provider(app)
-
-        @app.tool()
-        def save(name: str) -> str:
-            return name
-
-        maps = build_reverse_hash_map(build_address_registry(mcp))
-        assert id(save) in maps.by_callable
-        assert maps.by_callable[id(save)].tool_name == "save"
-
-    def test_same_tool_at_two_addresses_has_two_hashes(self):
-        """Mounting the same FastMCPApp instance twice produces distinct
-        hashes for the same underlying tool — one per mount address."""
-        mcp = FastMCP("server")
-        shared = FastMCPApp("shared")
-
-        @shared.tool()
-        def save(name: str) -> str:
-            return name
-
-        mcp.add_provider(shared)
-        mcp.add_provider(shared)
-
-        maps = build_reverse_hash_map(build_address_registry(mcp))
-        h1 = hash_tool_address((0,), "save")
-        h2 = hash_tool_address((1,), "save")
-        assert h1 != h2
-        assert h1 in maps.by_hash
-        assert h2 in maps.by_hash
-        # Both entries point at the same provider object.
-        assert maps.by_hash[h1].provider is maps.by_hash[h2].provider
-
-
-class TestServerLazyAddressRegistry:
-    def test_registry_cached_after_first_access(self):
-        mcp = FastMCP("server")
-        r1 = mcp.address_registry
-        r2 = mcp.address_registry
-        assert r1 is r2
-
-    def test_add_provider_invalidates_registry_and_reverse_map(self):
-        mcp = FastMCP("server")
-        r1 = mcp.address_registry
-        rev1 = mcp.reverse_hash_map
-        mcp.add_provider(FastMCPApp("dashboard"))
-        r2 = mcp.address_registry
-        rev2 = mcp.reverse_hash_map
-        assert r1 is not r2
-        assert rev1 is not rev2
-        assert (0,) in r2

--- a/tests/server/providers/test_addressing.py
+++ b/tests/server/providers/test_addressing.py
@@ -158,10 +158,10 @@ class TestReverseHashMap:
         def greet(name: str) -> str:
             return name
 
-        reverse = build_reverse_hash_map(build_address_registry(mcp))
+        maps = build_reverse_hash_map(build_address_registry(mcp))
         digest = hash_tool_address((), "greet")
-        assert digest in reverse
-        entry = reverse[digest]
+        assert digest in maps.by_hash
+        entry = maps.by_hash[digest]
         assert entry.address == ()
         assert entry.tool_name == "greet"
 
@@ -174,13 +174,28 @@ class TestReverseHashMap:
         def save(name: str) -> str:
             return name
 
-        reverse = build_reverse_hash_map(build_address_registry(mcp))
+        maps = build_reverse_hash_map(build_address_registry(mcp))
         digest = hash_tool_address((0,), "save")
-        assert digest in reverse
-        entry = reverse[digest]
+        assert digest in maps.by_hash
+        entry = maps.by_hash[digest]
         assert entry.address == (0,)
         assert entry.tool_name == "save"
         assert entry.provider is app
+
+    def test_callable_map_indexes_by_fn_identity(self):
+        """The callable map lets the resolver look up a tool by function
+        identity — no name ambiguity, no mount_path needed."""
+        mcp = FastMCP("server")
+        app = FastMCPApp("dashboard")
+        mcp.add_provider(app)
+
+        @app.tool()
+        def save(name: str) -> str:
+            return name
+
+        maps = build_reverse_hash_map(build_address_registry(mcp))
+        assert id(save) in maps.by_callable
+        assert maps.by_callable[id(save)].tool_name == "save"
 
     def test_same_tool_at_two_addresses_has_two_hashes(self):
         """Mounting the same FastMCPApp instance twice produces distinct
@@ -195,14 +210,14 @@ class TestReverseHashMap:
         mcp.add_provider(shared)
         mcp.add_provider(shared)
 
-        reverse = build_reverse_hash_map(build_address_registry(mcp))
+        maps = build_reverse_hash_map(build_address_registry(mcp))
         h1 = hash_tool_address((0,), "save")
         h2 = hash_tool_address((1,), "save")
         assert h1 != h2
-        assert h1 in reverse
-        assert h2 in reverse
+        assert h1 in maps.by_hash
+        assert h2 in maps.by_hash
         # Both entries point at the same provider object.
-        assert reverse[h1].provider is reverse[h2].provider
+        assert maps.by_hash[h1].provider is maps.by_hash[h2].provider
 
 
 class TestServerLazyAddressRegistry:

--- a/tests/server/providers/test_prefab_roundtrip.py
+++ b/tests/server/providers/test_prefab_roundtrip.py
@@ -1,0 +1,185 @@
+"""End-to-end round-trip tests for Prefab peer-tool references.
+
+These simulate what a real host does: call the UI tool, extract the
+hashed backend-tool name from structured_content, call back with
+that name, and verify the backend tool actually executes. Covers
+single-server, namespaced mounts, and cross-server mounts.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from fastmcp import FastMCP, FastMCPApp
+from fastmcp.server.providers.addressing import hashed_backend_name
+
+prefab_ui = pytest.importorskip("prefab_ui")
+from prefab_ui.actions.mcp import CallTool  # noqa: E402
+from prefab_ui.components import Button, Column, Text  # noqa: E402
+
+
+class TestSingleServerRoundTrip:
+    async def test_ui_tool_serializes_hashed_peer_reference(self):
+        """The resolver converts a CallTool string reference to a hashed
+        name that appears in the tool result's structured_content."""
+        app = FastMCPApp("contacts")
+
+        @app.tool()
+        def save_contact(name: str) -> str:
+            return f"saved {name}"
+
+        @app.ui()
+        def contact_form() -> Column:
+            return Column(
+                children=[Button(label="Save", on_click=CallTool(tool="save_contact"))]
+            )
+
+        server = FastMCP("Platform")
+        server.add_provider(app)
+
+        result = await server.call_tool("contact_form", {})
+        assert result.structured_content is not None
+
+        # The hashed name should appear somewhere in the serialized output.
+        sc_json = json.dumps(result.structured_content)
+        expected_hash = hashed_backend_name("contacts", "save_contact")
+        assert expected_hash in sc_json, (
+            f"Expected {expected_hash!r} in structured_content but got: {sc_json[:200]}"
+        )
+
+    async def test_hashed_name_from_result_is_callable(self):
+        """The hashed name that appears in structured_content actually
+        resolves when called back — the full round-trip works."""
+        app = FastMCPApp("contacts")
+
+        @app.tool()
+        def save_contact(name: str) -> str:
+            return f"saved {name}"
+
+        @app.ui()
+        def contact_form() -> Column:
+            return Column(
+                children=[Button(label="Save", on_click=CallTool(tool="save_contact"))]
+            )
+
+        server = FastMCP("Platform")
+        server.add_provider(app)
+
+        # Step 1: call UI tool, get structured_content with hashed ref
+        await server.call_tool("contact_form", {})
+
+        # Step 2: call the backend tool by its hashed name
+        hashed_name = hashed_backend_name("contacts", "save_contact")
+        backend_result = await server.call_tool(hashed_name, {"name": "Alice"})
+        assert backend_result.content[0].text == "saved Alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
+
+
+class TestNamespacedMountRoundTrip:
+    async def test_namespaced_app_backend_tool_round_trip(self):
+        """A FastMCPApp mounted with a namespace: the UI tool is called
+        by its namespaced display name, the backend tool is called by
+        its hashed name — both work."""
+        app = FastMCPApp("crm")
+
+        @app.tool()
+        def save(name: str) -> str:
+            return f"saved {name}"
+
+        @app.ui()
+        def form() -> Text:
+            return Text(content="Enter details")
+
+        server = FastMCP("Platform")
+        server.add_provider(app, namespace="crm")
+
+        # UI tool visible under namespace
+        result = await server.call_tool("crm_form", {})
+        assert result.structured_content is not None
+
+        # Backend tool reachable via hash
+        hashed_name = hashed_backend_name("crm", "save")
+        backend_result = await server.call_tool(hashed_name, {"name": "Bob"})
+        assert backend_result.content[0].text == "saved Bob"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
+
+
+class TestMountedServerRoundTrip:
+    async def test_backend_tool_reachable_through_mounted_server(self):
+        """A FastMCPApp inside a mounted FastMCP server: the outer
+        server's dispatcher walks through FastMCPProvider to find
+        the backend tool by hash."""
+        app = FastMCPApp("contacts")
+
+        @app.tool()
+        def save(name: str) -> str:
+            return f"saved {name}"
+
+        @app.ui()
+        def form() -> Text:
+            return Text(content="Form")
+
+        inner = FastMCP("Inner")
+        inner.add_provider(app)
+
+        outer = FastMCP("Outer")
+        outer.mount(inner, namespace="inner")
+
+        # Backend tool callable through the mount via hash dispatch
+        hashed_name = hashed_backend_name("contacts", "save")
+        result = await outer.call_tool(hashed_name, {"name": "Carol"})
+        assert result.content[0].text == "saved Carol"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
+
+
+class TestDynamicToolAdd:
+    async def test_tool_added_after_first_call_is_reachable(self):
+        """Tools added to an already-mounted app after the first call
+        are still reachable via their hashed name — get_tool_by_hash
+        does a live walk, not a cached lookup."""
+        app = FastMCPApp("contacts")
+
+        server = FastMCP("Platform")
+        server.add_provider(app)
+
+        # First call — nothing to call yet, just prime any caches.
+        tools = await server.list_tools()
+        assert len(tools) == 0
+
+        # Now add a backend tool dynamically.
+        @app.tool()
+        def save(name: str) -> str:
+            return f"saved {name}"
+
+        # The dynamically-added tool should be reachable.
+        hashed_name = hashed_backend_name("contacts", "save")
+        result = await server.call_tool(hashed_name, {"name": "Dan"})
+        assert result.content[0].text == "saved Dan"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
+
+
+class TestCollision:
+    async def test_same_app_name_same_tool_name_first_wins(self):
+        """Two apps with the same name and same tool name: the hash is
+        identical, so get_tool_by_hash returns the first match. This is
+        the same first-match behavior the old get_app_tool had."""
+        app_a = FastMCPApp("shared")
+        app_b = FastMCPApp("shared")
+
+        @app_a.tool()
+        def save(name: str) -> str:
+            return f"from A: {name}"
+
+        @app_b.tool()
+        def save_b(name: str) -> str:
+            return f"from B: {name}"
+
+        # Register under a different local tool name to avoid
+        # actual collision at the provider level. The hash collision
+        # only happens when both app name AND tool name match.
+        # This test just verifies one app's tool is reachable.
+        server = FastMCP("Platform")
+        server.add_provider(app_a)
+        server.add_provider(app_b)
+
+        hashed_name = hashed_backend_name("shared", "save")
+        result = await server.call_tool(hashed_name, {"name": "Eve"})
+        assert result.content[0].text == "from A: Eve"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]

--- a/tests/server/providers/test_prefab_synthesis.py
+++ b/tests/server/providers/test_prefab_synthesis.py
@@ -1,0 +1,198 @@
+"""End-to-end tests for the on-demand Prefab renderer synthesis.
+
+The whole architecture exists to fix #3735 / PR #3754: a user passing a
+``PrefabAppConfig(csp=ResourceCSP(frame_domains=[...]))`` should see
+their ``frame_domains`` actually arrive on the renderer resource's CSP,
+and CSP should NOT leak into the tool's wire metadata. These tests
+exercise the synthesis path directly through the public server API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp import FastMCP, FastMCPApp
+
+prefab_ui = pytest.importorskip("prefab_ui")
+from fastmcp.apps.config import PrefabAppConfig, ResourceCSP  # noqa: E402
+
+
+class TestUserCSPReachesResource:
+    """The original bug: user CSP must land on the resource, not vanish."""
+
+    async def test_frame_domains_reach_resource(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool(
+            app=PrefabAppConfig(
+                csp=ResourceCSP(frame_domains=["https://example1234.com"])
+            )
+        )
+        def show_widget() -> str:
+            return "widget"
+
+        # Find the synthesized prefab resource for this tool.
+        resources = list(await mcp.list_resources())
+        renderer = next((r for r in resources if "prefab/tool" in str(r.uri)), None)
+        assert renderer is not None, "no prefab resource was synthesized"
+        assert renderer.meta is not None
+
+        csp = renderer.meta["ui"]["csp"]
+        assert "https://example1234.com" in csp.get("frameDomains", []), (
+            f"frame_domains missing from resource CSP: {csp}"
+        )
+
+    async def test_all_four_domain_fields_preserved(self):
+        """The old singleton silently dropped frame_domains and
+        base_uri_domains; the synthesizer covers all four fields."""
+        mcp = FastMCP("test")
+
+        @mcp.tool(
+            app=PrefabAppConfig(
+                csp=ResourceCSP(
+                    connect_domains=["https://api.example.com"],
+                    resource_domains=["https://cdn.example.com"],
+                    frame_domains=["https://embed.example.com"],
+                    base_uri_domains=["https://base.example.com"],
+                )
+            )
+        )
+        def widget() -> str:
+            return "x"
+
+        resources = list(await mcp.list_resources())
+        renderer = next(r for r in resources if "prefab/tool" in str(r.uri))
+        assert renderer.meta is not None
+        csp = renderer.meta["ui"]["csp"]
+
+        assert "https://api.example.com" in csp.get("connectDomains", [])
+        assert "https://cdn.example.com" in csp.get("resourceDomains", [])
+        assert "https://embed.example.com" in csp.get("frameDomains", [])
+        assert "https://base.example.com" in csp.get("baseUriDomains", [])
+
+
+class TestCSPStrippedFromToolMeta:
+    """CSP belongs on the resource, not the tool. The wire format that
+    clients see for tools must not contain it."""
+
+    async def test_csp_not_in_listed_tool_meta(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool(
+            app=PrefabAppConfig(csp=ResourceCSP(frame_domains=["https://example.com"]))
+        )
+        def show_widget() -> str:
+            return "widget"
+
+        tools = list(await mcp.list_tools())
+        tool = next(t for t in tools if t.name == "show_widget")
+        assert tool.meta is not None
+        ui = tool.meta["ui"]
+        assert "csp" not in ui, f"csp leaked into tool meta: {ui}"
+        assert "permissions" not in ui
+
+
+class TestPerToolURIs:
+    """Each prefab tool gets its own URI — distinct CSP per tool becomes
+    possible because no two tools share a renderer resource."""
+
+    async def test_two_tools_get_distinct_uris(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool(app=True)
+        def tool_a() -> str:
+            return "a"
+
+        @mcp.tool(app=True)
+        def tool_b() -> str:
+            return "b"
+
+        tools = list(await mcp.list_tools())
+        a = next(t for t in tools if t.name == "tool_a")
+        b = next(t for t in tools if t.name == "tool_b")
+        assert a.meta is not None
+        assert b.meta is not None
+        uri_a = a.meta["ui"]["resourceUri"]
+        uri_b = b.meta["ui"]["resourceUri"]
+        assert uri_a != uri_b
+        assert uri_a.startswith("ui://prefab/tool/")
+        assert uri_b.startswith("ui://prefab/tool/")
+
+
+class TestFastMCPAppMounts:
+    """Tools inside FastMCPApps get URIs derived from the app's mount address."""
+
+    async def test_app_tool_uri_uses_address(self):
+        app = FastMCPApp("dashboard")
+
+        @app.ui()
+        def show() -> str:
+            return "rendered"
+
+        mcp = FastMCP("Platform")
+        mcp.add_provider(app)
+
+        resources = list(await mcp.list_resources())
+        prefab = [r for r in resources if "prefab/tool" in str(r.uri)]
+        assert len(prefab) == 1
+
+    async def test_namespaced_mount_still_synthesizes_resource(self):
+        app = FastMCPApp("crm")
+
+        @app.ui()
+        def contact_form() -> str:
+            return "form"
+
+        mcp = FastMCP("Platform")
+        mcp.add_provider(app, namespace="customers")
+
+        resources = list(await mcp.list_resources())
+        prefab = [r for r in resources if "prefab/tool" in str(r.uri)]
+        assert len(prefab) == 1
+
+
+class TestReadResource:
+    """The synthesized resources are actually fetchable via read_resource."""
+
+    async def test_read_resource_returns_renderer_html(self):
+        from fastmcp import Client
+
+        mcp = FastMCP("test")
+
+        @mcp.tool(app=True)
+        def my_tool() -> str:
+            return "hi"
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            uri = next(t for t in tools if t.name == "my_tool").meta["ui"][
+                "resourceUri"
+            ]
+            contents = await client.read_resource(uri)
+
+        assert len(contents) > 0
+        text = contents[0].text if hasattr(contents[0], "text") else ""
+        assert "<html" in text.lower() or "<!doctype" in text.lower()
+
+
+class TestNonPrefabToolsUntouched:
+    async def test_plain_tool_has_no_ui_meta(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        def greet(name: str) -> str:
+            return name
+
+        tools = list(await mcp.list_tools())
+        tool = next(t for t in tools if t.name == "greet")
+        assert not tool.meta or "ui" not in (tool.meta or {})
+
+    async def test_plain_server_has_no_synthesized_resources(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        def greet(name: str) -> str:
+            return name
+
+        resources = list(await mcp.list_resources())
+        assert not any("prefab/tool" in str(r.uri) for r in resources)

--- a/tests/server/test_providers.py
+++ b/tests/server/test_providers.py
@@ -211,16 +211,19 @@ class TestProvider:
     async def test_call_tool_uses_get_tool_for_efficient_lookup(
         self, base_server: FastMCP, dynamic_tools: list[Tool]
     ):
-        """Test that call_tool uses get_tool() for efficient single-tool lookup."""
+        """Test that call_tool uses get_tool() (not list_tools) for lookup."""
         provider = SimpleToolProvider(tools=dynamic_tools)
         base_server.add_provider(provider)
 
         await base_server.call_tool(name="dynamic_multiply", arguments={"a": 2, "b": 3})
 
-        # get_tool is called once for efficient lookup:
-        # call_tool() calls provider.get_tool() to get the tool and execute it
-        # Key point: list_tools is NOT called during tool execution (efficient lookup)
-        assert provider.get_tool_call_count == 1
+        # get_tool may be called more than once — once for the initial
+        # resolution and once again by the dispatcher's reverse-lookup to
+        # find the tool's owning provider for Context.mount_path. Both
+        # are bounded by provider count, much cheaper than list_tools.
+        # The key invariant: list_tools is NOT called during dispatch.
+        assert provider.get_tool_call_count >= 1
+        assert provider.list_tools_call_count == 0
 
     async def test_default_get_tool_falls_back_to_list(self, base_server: FastMCP):
         """Test that BaseToolProvider's default get_tool calls list_tools."""

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -585,7 +585,8 @@ class TestPrefabAppConfig:
         assert config.csp is not None
         assert config.csp.frame_domains == ["https://example.com"]
 
-    async def test_auto_registers_renderer_resource(self):
+    async def test_auto_synthesizes_renderer_resource(self):
+        """Each prefab tool gets a per-tool renderer resource on demand."""
         from fastmcp.apps import PrefabAppConfig
 
         server = FastMCP("test")
@@ -595,11 +596,11 @@ class TestPrefabAppConfig:
             return "hello"
 
         resources = list(await server.list_resources())
-        uris = [str(r.uri) for r in resources]
-        assert any("ui://prefab/renderer.html" in u for u in uris)
+        prefab = [r for r in resources if "prefab/tool" in str(r.uri)]
+        assert len(prefab) == 1
 
     async def test_equivalent_to_app_true(self):
-        """PrefabAppConfig() should produce the same tool metadata as app=True."""
+        """PrefabAppConfig() and app=True both synthesize a per-tool renderer."""
         from fastmcp.apps import PrefabAppConfig
 
         server1 = FastMCP("test1")
@@ -621,4 +622,6 @@ class TestPrefabAppConfig:
         assert tools2[0].meta is not None
         ui2 = tools2[0].meta.get("ui", {})
 
-        assert ui1.get("resourceUri") == ui2.get("resourceUri")
+        # Both produce per-tool URIs in the prefab/tool/<hash>/ form.
+        assert ui1.get("resourceUri", "").startswith("ui://prefab/tool/")
+        assert ui2.get("resourceUri", "").startswith("ui://prefab/tool/")

--- a/tests/test_apps_prefab.py
+++ b/tests/test_apps_prefab.py
@@ -119,42 +119,49 @@ class TestAppTrue:
         assert "ui" in tool.meta
         assert tool.meta["ui"]["resourceUri"] == PREFAB_RENDERER_URI
 
-    def test_app_true_registers_renderer_resource(self):
+    async def test_app_true_synthesizes_renderer_resource(self):
+        """Each prefab tool gets a per-tool renderer resource synthesized
+        on demand at list_resources time. Resources don't live on any
+        provider's storage — they're computed from the registry walk."""
         mcp = FastMCP("test")
 
         @mcp.tool(app=True)
         def my_tool() -> str:
             return "hello"
 
-        renderer_key = f"resource:{PREFAB_RENDERER_URI}@"
-        assert renderer_key in mcp._local_provider._components
+        resources = list(await mcp.list_resources())
+        prefab_resources = [r for r in resources if "prefab/tool" in str(r.uri)]
+        assert len(prefab_resources) == 1
+        assert "renderer.html" in str(prefab_resources[0].uri)
 
-    def test_renderer_resource_has_correct_mime_type(self):
+    async def test_renderer_resource_has_correct_mime_type(self):
         mcp = FastMCP("test")
 
         @mcp.tool(app=True)
         def my_tool() -> str:
             return "hello"
 
-        renderer_key = f"resource:{PREFAB_RENDERER_URI}@"
-        resource = mcp._local_provider._components[renderer_key]
-        assert isinstance(resource, TextResource)
-        assert resource.mime_type == UI_MIME_TYPE
+        resources = list(await mcp.list_resources())
+        renderer = next(r for r in resources if "prefab/tool" in str(r.uri))
+        assert isinstance(renderer, TextResource)
+        assert renderer.mime_type == UI_MIME_TYPE
 
-    def test_renderer_resource_has_csp(self):
+    async def test_renderer_resource_has_csp(self):
         mcp = FastMCP("test")
 
         @mcp.tool(app=True)
         def my_tool() -> str:
             return "hello"
 
-        renderer_key = f"resource:{PREFAB_RENDERER_URI}@"
-        resource = mcp._local_provider._components[renderer_key]
-        assert resource.meta is not None
-        assert "ui" in resource.meta
-        assert "csp" in resource.meta["ui"]
+        resources = list(await mcp.list_resources())
+        renderer = next(r for r in resources if "prefab/tool" in str(r.uri))
+        assert renderer.meta is not None
+        assert "ui" in renderer.meta
+        assert "csp" in renderer.meta["ui"]
 
-    def test_multiple_tools_share_renderer(self):
+    async def test_multiple_tools_get_dedicated_resources(self):
+        """Each prefab tool gets its own resource at a distinct hashed
+        URI — no shared singleton, so per-tool CSP becomes possible."""
         mcp = FastMCP("test")
 
         @mcp.tool(app=True)
@@ -165,10 +172,9 @@ class TestAppTrue:
         def tool_b() -> str:
             return "b"
 
-        renderer_keys = [
-            k for k in mcp._local_provider._components if k.startswith("resource:ui://")
-        ]
-        assert len(renderer_keys) == 1
+        resources = list(await mcp.list_resources())
+        prefab_uris = {str(r.uri) for r in resources if "prefab/tool" in str(r.uri)}
+        assert len(prefab_uris) == 2
 
     def test_explicit_app_config_not_overridden(self):
         mcp = FastMCP("test")
@@ -421,7 +427,9 @@ class TestIntegration:
         tool = next(t for t in tools if t.name == "my_tool")
         meta = tool.meta or {}
         assert "ui" in meta
-        assert meta["ui"]["resourceUri"] == PREFAB_RENDERER_URI
+        # URI is the per-tool hashed form, not the singleton.
+        assert meta["ui"]["resourceUri"].startswith("ui://prefab/tool/")
+        assert meta["ui"]["resourceUri"].endswith("/renderer.html")
 
     async def test_renderer_resource_readable(self):
         mcp = FastMCP("test")
@@ -431,7 +439,13 @@ class TestIntegration:
             return "hello"
 
         async with Client(mcp) as client:
-            contents = await client.read_resource(PREFAB_RENDERER_URI)
+            # Look up the URI by listing first — the hash isn't
+            # computable from outside without the address registry.
+            tools = await client.list_tools()
+            uri = next(t for t in tools if t.name == "my_tool").meta["ui"][
+                "resourceUri"
+            ]
+            contents = await client.read_resource(uri)
 
         assert len(contents) > 0
         text = contents[0].text if hasattr(contents[0], "text") else ""

--- a/tests/test_fastmcp_app.py
+++ b/tests/test_fastmcp_app.py
@@ -30,13 +30,13 @@ from fastmcp.tools.base import Tool
 
 
 class TestFastMCPAppInit:
-    def test_app_name_with_triple_underscore_rejected(self):
-        with pytest.raises(ValueError, match="must not contain '___'"):
-            FastMCPApp("my___app")
-
-    def test_app_name_with_single_or_double_underscore_ok(self):
+    def test_app_name_with_underscores_ok(self):
+        # The old `___` separator is gone — backend tool routing now uses
+        # a hashed positional address rather than a name-based prefix, so
+        # any character is fine inside an app name.
         FastMCPApp("my_app")
         FastMCPApp("my__app")
+        FastMCPApp("my___app")
 
 
 class TestAppTool:
@@ -287,25 +287,34 @@ class TestAppUI:
 
 
 class TestResolveToolRef:
-    def test_resolve_string_no_app_name(self):
-        """Without an app name, strings pass through unprefixed."""
+    def test_resolve_string_at_root(self):
+        """Empty mount_path means the calling tool is at the server root,
+        so peer references stay bare — they refer to root-level tools
+        callable by their normal display name."""
         result = _make_resolver()("save_contact")
         assert isinstance(result, ResolvedTool)
         assert result.name == "save_contact"
 
-    def test_resolve_string_with_app_name(self):
-        """With an app name, strings get the ___-prefix."""
-        result = _make_resolver("Files")("store_files")
-        assert isinstance(result, ResolvedTool)
-        assert result.name == "Files___store_files"
+    def test_resolve_string_with_mount_path(self):
+        """With a mount path the resolver formats peer references as the
+        deterministic ``<hash>_<local_name>`` so the dispatcher can route
+        them via the reverse-hash map regardless of transforms."""
+        from fastmcp.server.providers.addressing import hashed_backend_name
 
-    def test_resolve_string_already_prefixed(self):
-        """Strings that already contain ___ are not double-prefixed."""
-        result = _make_resolver("Files")("Other___store_files")
+        result = _make_resolver((0,))("store_files")
         assert isinstance(result, ResolvedTool)
-        assert result.name == "Other___store_files"
+        assert result.name == hashed_backend_name((0,), "store_files")
 
-    def test_resolve_callable_no_app_name(self):
+    def test_resolve_string_at_nested_mount_path(self):
+        """Nested mount paths feed into the same hash function — the
+        result is opaque from the outside but deterministic per-position."""
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
+        result = _make_resolver((0, 1, 2))("save_contact")
+        assert isinstance(result, ResolvedTool)
+        assert result.name == hashed_backend_name((0, 1, 2), "save_contact")
+
+    def test_resolve_callable_at_root(self):
         def my_tool():
             pass
 
@@ -313,15 +322,15 @@ class TestResolveToolRef:
         assert isinstance(result, ResolvedTool)
         assert result.name == "my_tool"
 
-    def test_resolve_callable_with_app_name(self):
-        """Callables also get the ___-prefix when an app name is set."""
+    def test_resolve_callable_with_mount_path(self):
+        from fastmcp.server.providers.addressing import hashed_backend_name
 
         def store_files():
             pass
 
-        result = _make_resolver("Files")(store_files)
+        result = _make_resolver((0,))(store_files)
         assert isinstance(result, ResolvedTool)
-        assert result.name == "Files___store_files"
+        assert result.name == hashed_backend_name((0,), "store_files")
 
     def test_resolve_fastmcp_metadata(self):
         from fastmcp.tools.function_tool import ToolMeta
@@ -335,7 +344,8 @@ class TestResolveToolRef:
         assert isinstance(result, ResolvedTool)
         assert result.name == "custom_name"
 
-    def test_resolve_fastmcp_metadata_with_app_name(self):
+    def test_resolve_fastmcp_metadata_with_mount_path(self):
+        from fastmcp.server.providers.addressing import hashed_backend_name
         from fastmcp.tools.function_tool import ToolMeta
 
         def my_tool():
@@ -343,9 +353,9 @@ class TestResolveToolRef:
 
         my_tool.__fastmcp__ = ToolMeta(name="custom_name")  # type: ignore[attr-defined]  # ty:ignore[unresolved-attribute]
 
-        result = _make_resolver("MyApp")(my_tool)
+        result = _make_resolver((0,))(my_tool)
         assert isinstance(result, ResolvedTool)
-        assert result.name == "MyApp___custom_name"
+        assert result.name == hashed_backend_name((0,), "custom_name")
 
     def test_resolve_unresolvable_raises(self):
         with pytest.raises(ValueError):
@@ -491,8 +501,12 @@ class TestProviderInterface:
 
 
 class TestCallToolAppRouting:
-    async def test_call_tool_with_app_name(self):
-        """Server.call_tool routes via get_app_tool when app_name is set."""
+    async def test_call_tool_with_hashed_name(self):
+        """A backend tool with visibility=['app'] is callable via its
+        hashed-name address — the same form a Prefab UI's resolver would
+        produce when serializing a peer reference."""
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
         app = FastMCPApp("contacts")
 
         @app.tool()
@@ -502,11 +516,13 @@ class TestCallToolAppRouting:
         server = FastMCP("Platform")
         server.add_provider(app)
 
-        result = await server.call_tool("contacts___save", {"name": "alice"})
+        result = await server.call_tool(
+            hashed_backend_name((0,), "save"), {"name": "alice"}
+        )
         assert result.content[0].text == "saved alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
-    async def test_call_tool_without_app_name_model_visible(self):
-        """Regular name-based resolution works for model-visible tools."""
+    async def test_call_tool_model_visible_uses_display_name(self):
+        """Tools with visibility=['app','model'] are callable by display name."""
         app = FastMCPApp("test")
 
         @app.tool(model=True)
@@ -519,8 +535,12 @@ class TestCallToolAppRouting:
         result = await server.call_tool("save", {"name": "bob"})
         assert result.content[0].text == "saved bob"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
-    async def test_app_name_survives_namespace(self):
-        """app_name routing bypasses namespace transforms."""
+    async def test_hashed_name_survives_namespace_mount(self):
+        """The hashed-name path bypasses display-layer transforms entirely.
+        A FastMCPApp mounted under a Namespace transform still has its
+        backend tools reachable via the same hash."""
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
         app = FastMCPApp("crm")
 
         @app.tool()
@@ -530,11 +550,13 @@ class TestCallToolAppRouting:
         server = FastMCP("Platform")
         server.add_provider(app, namespace="crm")
 
-        result = await server.call_tool("crm___save_contact", {"name": "alice"})
+        result = await server.call_tool(
+            hashed_backend_name((0,), "save_contact"), {"name": "alice"}
+        )
         assert result.content[0].text == "saved alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
-    async def test_namespaced_name_also_works(self):
-        """Namespaced tool name works through normal resolution."""
+    async def test_namespaced_display_name_also_works(self):
+        """Model-visible tools still resolve through Namespace as before."""
         app = FastMCPApp("crm")
 
         @app.tool(model=True)
@@ -547,10 +569,11 @@ class TestCallToolAppRouting:
         result = await server.call_tool("crm_save_contact", {"name": "bob"})
         assert result.content[0].text == "saved bob"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
-    async def test_app_name_auth_blocks_unauthorized(self):
-        """Auth checks run even when routing via app_name."""
+    async def test_hashed_name_auth_blocks_unauthorized(self):
+        """Auth checks run on the hashed-name dispatch path too."""
         from fastmcp.exceptions import NotFoundError
         from fastmcp.server.context import _current_transport
+        from fastmcp.server.providers.addressing import hashed_backend_name
 
         app = FastMCPApp("test")
         deny_all = AsyncMock(return_value=False)
@@ -565,12 +588,16 @@ class TestCallToolAppRouting:
         token = _current_transport.set("streamable-http")
         try:
             with pytest.raises(NotFoundError):
-                await server.call_tool("test___secret", {})
+                await server.call_tool(hashed_backend_name((0,), "secret"), {})
         finally:
             _current_transport.reset(token)
 
-    async def test_two_apps_same_tool_name_routed_correctly(self):
-        """Two apps with same tool name disambiguated by app_name."""
+    async def test_two_apps_same_tool_name_routed_by_address(self):
+        """Two FastMCPApps each with a `save` tool live at distinct
+        addresses, so they hash differently and the dispatcher routes
+        each call to the right app without name collisions."""
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
         contacts = FastMCPApp("contacts")
         billing = FastMCPApp("billing")
 
@@ -583,33 +610,18 @@ class TestCallToolAppRouting:
             return f"invoice: {amount}"
 
         server = FastMCP("Platform")
-        server.add_provider(contacts)
-        server.add_provider(billing)
+        server.add_provider(contacts)  # → address (0,)
+        server.add_provider(billing)  # → address (1,)
 
-        r1 = await server.call_tool("contacts___save", {"name": "alice"})
-        r2 = await server.call_tool("billing___save", {"amount": "100"})
+        r1 = await server.call_tool(
+            hashed_backend_name((0,), "save"), {"name": "alice"}
+        )
+        r2 = await server.call_tool(
+            hashed_backend_name((1,), "save"), {"amount": "100"}
+        )
 
         assert r1.content[0].text == "contact: alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         assert r2.content[0].text == "invoice: 100"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
-
-    async def test_deeply_nested_app(self):
-        """App tool is found even through multiple levels of nesting."""
-        app = FastMCPApp("deep")
-
-        @app.tool()
-        def hidden(x: str) -> str:
-            return x
-
-        inner = FastMCP("Inner")
-        inner.add_provider(app, namespace="app")
-
-        outer = FastMCP("Outer")
-        outer.mount(inner, namespace="inner")
-
-        # Normal resolution: would need "inner_app_hidden"
-        # App routing: bypasses all transforms
-        result = await outer.call_tool("deep___hidden", {"x": "found"})
-        assert result.content[0].text == "found"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
 
 # ---------------------------------------------------------------------------
@@ -679,8 +691,12 @@ class TestAppOnlyToolFiltering:
         names = [t.name for t in tools]
         assert "save" not in names
 
-        # But still callable via app_name routing
-        result = await server.call_tool("contacts___save", {"name": "alice"})
+        # But still callable via the hashed-address routing path.
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
+        result = await server.call_tool(
+            hashed_backend_name((0,), "save"), {"name": "alice"}
+        )
         assert result.content[0].text == "saved alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
     async def test_app_only_tool_hidden_from_get_tool(self):
@@ -831,8 +847,15 @@ class TestComposition:
         server.add_provider(crm, namespace="crm")
         server.add_provider(billing, namespace="billing")
 
-        r1 = await server.call_tool("CRM___save_contact", {"name": "alice"})
-        r2 = await server.call_tool("Billing___create_invoice", {"amount": 100})
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
+        # CRM is at address (0,), billing at (1,) — registration order.
+        r1 = await server.call_tool(
+            hashed_backend_name((0,), "save_contact"), {"name": "alice"}
+        )
+        r2 = await server.call_tool(
+            hashed_backend_name((1,), "create_invoice"), {"amount": 100}
+        )
 
         assert r1.content[0].text == "alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         assert r2.content[0].text == "100"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -874,7 +897,9 @@ class TestAppIntegration:
     async def test_full_app_lifecycle_through_client(self):
         """End-to-end: mount an app on a namespaced server, call UI tool
         through a client (verifying structured_content is returned), then
-        call the backend tool via the ___-prefixed name."""
+        call the backend tool via its hashed-address name."""
+        from fastmcp.server.providers.addressing import hashed_backend_name
+
         app = FastMCPApp("contacts")
 
         @app.ui()
@@ -901,10 +926,10 @@ class TestAppIntegration:
             sc = result.structuredContent
             assert sc is not None
 
-        # Call the backend tool via prefixed name
-        # (bypasses namespace transforms and visibility filtering)
+        # Call the backend tool via its hashed address — bypasses namespace
+        # transforms and visibility filtering by going through the registry.
         backend_result = await server.call_tool(
-            "contacts___save_contact",
+            hashed_backend_name((0,), "save_contact"),
             {"name": "Alice", "email": "alice@example.com"},
         )
         result_text = backend_result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]

--- a/tests/test_fastmcp_app.py
+++ b/tests/test_fastmcp_app.py
@@ -293,28 +293,13 @@ class TestResolveToolRef:
         assert isinstance(result, ResolvedTool)
         assert result.name == "save_contact"
 
-    async def test_resolve_callable_via_callable_map(self):
-        """When a Context is active, the resolver looks up the peer tool
-        by callable identity in the server's callable map and produces
-        a hashed backend name."""
+    def test_resolve_string_with_app_name(self):
+        """With an app name the resolver produces a hashed backend name."""
         from fastmcp.server.providers.addressing import hashed_backend_name
 
-        app = FastMCPApp("contacts")
-
-        @app.tool()
-        def save_contact(name: str) -> str:
-            return name
-
-        server = FastMCP("Platform")
-        server.add_provider(app)
-
-        import fastmcp.server.context
-
-        async with fastmcp.server.context.Context(fastmcp=server):
-            result = _make_resolver()(save_contact)
-
+        result = _make_resolver("contacts")("save_contact")
         assert isinstance(result, ResolvedTool)
-        assert result.name == hashed_backend_name((0,), "save_contact")
+        assert result.name == hashed_backend_name("contacts", "save_contact")
 
     def test_resolve_callable_no_context(self):
         """Without context, callables resolve to their bare __name__."""
@@ -486,7 +471,7 @@ class TestCallToolAppRouting:
         server.add_provider(app)
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "save"), {"name": "alice"}
+            hashed_backend_name("contacts", "save"), {"name": "alice"}
         )
         assert result.content[0].text == "saved alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
@@ -520,7 +505,7 @@ class TestCallToolAppRouting:
         server.add_provider(app, namespace="crm")
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "save_contact"), {"name": "alice"}
+            hashed_backend_name("crm", "save_contact"), {"name": "alice"}
         )
         assert result.content[0].text == "saved alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
@@ -557,7 +542,7 @@ class TestCallToolAppRouting:
         token = _current_transport.set("streamable-http")
         try:
             with pytest.raises(NotFoundError):
-                await server.call_tool(hashed_backend_name((0,), "secret"), {})
+                await server.call_tool(hashed_backend_name("test", "secret"), {})
         finally:
             _current_transport.reset(token)
 
@@ -583,10 +568,10 @@ class TestCallToolAppRouting:
         server.add_provider(billing)  # → address (1,)
 
         r1 = await server.call_tool(
-            hashed_backend_name((0,), "save"), {"name": "alice"}
+            hashed_backend_name("contacts", "save"), {"name": "alice"}
         )
         r2 = await server.call_tool(
-            hashed_backend_name((1,), "save"), {"amount": "100"}
+            hashed_backend_name("billing", "save"), {"amount": "100"}
         )
 
         assert r1.content[0].text == "contact: alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -664,7 +649,7 @@ class TestAppOnlyToolFiltering:
         from fastmcp.server.providers.addressing import hashed_backend_name
 
         result = await server.call_tool(
-            hashed_backend_name((0,), "save"), {"name": "alice"}
+            hashed_backend_name("contacts", "save"), {"name": "alice"}
         )
         assert result.content[0].text == "saved alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
@@ -820,10 +805,10 @@ class TestComposition:
 
         # CRM is at address (0,), billing at (1,) — registration order.
         r1 = await server.call_tool(
-            hashed_backend_name((0,), "save_contact"), {"name": "alice"}
+            hashed_backend_name("CRM", "save_contact"), {"name": "alice"}
         )
         r2 = await server.call_tool(
-            hashed_backend_name((1,), "create_invoice"), {"amount": 100}
+            hashed_backend_name("Billing", "create_invoice"), {"amount": 100}
         )
 
         assert r1.content[0].text == "alice"  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
@@ -903,7 +888,7 @@ class TestAppIntegration:
         # Call the backend tool via its hashed address — bypasses namespace
         # transforms and visibility filtering by going through the registry.
         backend_result = await server.call_tool(
-            hashed_backend_name((0,), "save_contact"),
+            hashed_backend_name("contacts", "save_contact"),
             {"name": "Alice", "email": "alice@example.com"},
         )
         result_text = backend_result.content[0].text  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]

--- a/tests/test_fastmcp_app.py
+++ b/tests/test_fastmcp_app.py
@@ -876,16 +876,21 @@ class TestComposition:
         names = {t.name for t in tools}
         assert names == {"dashboard", "save"}
 
-    async def test_ui_registers_prefab_renderer_resource(self):
+    async def test_ui_synthesizes_per_tool_renderer_resource(self):
+        """Each @app.ui() tool gets its own renderer resource synthesized
+        on demand from the server's address registry."""
         app = FastMCPApp("test")
 
         @app.ui()
         def dashboard() -> str:
             return "ui"
 
-        resources = await app._list_resources()
-        uris = [str(r.uri) for r in resources]
-        assert any("ui://prefab/renderer.html" in uri for uri in uris)
+        server = FastMCP("Platform")
+        server.add_provider(app)
+
+        resources = list(await server.list_resources())
+        prefab = [r for r in resources if "prefab/tool" in str(r.uri)]
+        assert len(prefab) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fastmcp_app.py
+++ b/tests/test_fastmcp_app.py
@@ -287,75 +287,44 @@ class TestAppUI:
 
 
 class TestResolveToolRef:
-    def test_resolve_string_at_root(self):
-        """Empty mount_path means the calling tool is at the server root,
-        so peer references stay bare — they refer to root-level tools
-        callable by their normal display name."""
+    def test_resolve_string_no_context(self):
+        """Without a running Context the resolver returns bare names."""
         result = _make_resolver()("save_contact")
         assert isinstance(result, ResolvedTool)
         assert result.name == "save_contact"
 
-    def test_resolve_string_with_mount_path(self):
-        """With a mount path the resolver formats peer references as the
-        deterministic ``<hash>_<local_name>`` so the dispatcher can route
-        them via the reverse-hash map regardless of transforms."""
+    async def test_resolve_callable_via_callable_map(self):
+        """When a Context is active, the resolver looks up the peer tool
+        by callable identity in the server's callable map and produces
+        a hashed backend name."""
         from fastmcp.server.providers.addressing import hashed_backend_name
 
-        result = _make_resolver((0,))("store_files")
+        app = FastMCPApp("contacts")
+
+        @app.tool()
+        def save_contact(name: str) -> str:
+            return name
+
+        server = FastMCP("Platform")
+        server.add_provider(app)
+
+        import fastmcp.server.context
+
+        async with fastmcp.server.context.Context(fastmcp=server):
+            result = _make_resolver()(save_contact)
+
         assert isinstance(result, ResolvedTool)
-        assert result.name == hashed_backend_name((0,), "store_files")
+        assert result.name == hashed_backend_name((0,), "save_contact")
 
-    def test_resolve_string_at_nested_mount_path(self):
-        """Nested mount paths feed into the same hash function — the
-        result is opaque from the outside but deterministic per-position."""
-        from fastmcp.server.providers.addressing import hashed_backend_name
+    def test_resolve_callable_no_context(self):
+        """Without context, callables resolve to their bare __name__."""
 
-        result = _make_resolver((0, 1, 2))("save_contact")
-        assert isinstance(result, ResolvedTool)
-        assert result.name == hashed_backend_name((0, 1, 2), "save_contact")
-
-    def test_resolve_callable_at_root(self):
         def my_tool():
             pass
 
         result = _make_resolver()(my_tool)
         assert isinstance(result, ResolvedTool)
         assert result.name == "my_tool"
-
-    def test_resolve_callable_with_mount_path(self):
-        from fastmcp.server.providers.addressing import hashed_backend_name
-
-        def store_files():
-            pass
-
-        result = _make_resolver((0,))(store_files)
-        assert isinstance(result, ResolvedTool)
-        assert result.name == hashed_backend_name((0,), "store_files")
-
-    def test_resolve_fastmcp_metadata(self):
-        from fastmcp.tools.function_tool import ToolMeta
-
-        def my_tool():
-            pass
-
-        my_tool.__fastmcp__ = ToolMeta(name="custom_name")  # type: ignore[attr-defined]  # ty:ignore[unresolved-attribute]
-
-        result = _make_resolver()(my_tool)
-        assert isinstance(result, ResolvedTool)
-        assert result.name == "custom_name"
-
-    def test_resolve_fastmcp_metadata_with_mount_path(self):
-        from fastmcp.server.providers.addressing import hashed_backend_name
-        from fastmcp.tools.function_tool import ToolMeta
-
-        def my_tool():
-            pass
-
-        my_tool.__fastmcp__ = ToolMeta(name="custom_name")  # type: ignore[attr-defined]  # ty:ignore[unresolved-attribute]
-
-        result = _make_resolver((0,))(my_tool)
-        assert isinstance(result, ResolvedTool)
-        assert result.name == hashed_backend_name((0,), "custom_name")
 
     def test_resolve_unresolvable_raises(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
The old `___` separator for FastMCPApp backend tool routing encoded the app's display name into the wire format. It worked but had no path to per-tool CSP because every prefab tool shared a single renderer resource at `ui://prefab/renderer.html`.

This replaces both the `___` wire format and the singleton renderer with a hash-based system that's structurally identical to the old approach — same registration-time tagging, same recursive provider-tree walk for dispatch, same resolver shape — but uses a deterministic `hash(app_name, tool_name)` prefix instead of the literal app name, and gives each prefab tool its own renderer resource.

**Backend tool routing.** Tools with `visibility=["app"]` are now callable via `<12-hex-hash>_<local_name>` instead of `<app_name>___<local_name>`. The hash is computed from the app name + tool name at registration and stored in `meta.fastmcp._tool_hash`. The dispatcher parses the prefix and calls `get_tool_by_hash` which walks the provider tree recursively — same delegation pattern as `get_app_tool`, through `AggregateProvider`, `_WrappedProvider`, and `FastMCPProvider`. Nested mounts work the same way they always did.

**Per-tool prefab resources.** Each prefab tool gets its own renderer resource at `ui://prefab/tool/<hash>/renderer.html`, synthesized on demand — `list_resources` walks providers and returns fresh `TextResource` entries, `read_resource` intercepts matching URIs and produces the HTML + CSP from the tool's stored meta. Nothing is materialized or stored. `list_tools` rewrites tool meta via `model_copy` so the wire format shows the per-tool URI with CSP stripped.

This fixes the bug from PR #3754 where `PrefabAppConfig(csp=ResourceCSP(frame_domains=[...]))` never actually applied — the user's CSP now lands on the resource where the MCP Apps spec says it belongs, and all four `*_domains` fields are preserved (the old singleton silently dropped `frame_domains` and `base_uri_domains`).

```python
@mcp.tool(app=PrefabAppConfig(
    csp=ResourceCSP(frame_domains=["https://example.com"])
))
def my_widget() -> Component:
    return Column(Heading("Hello"))

# The renderer resource at ui://prefab/tool/<hash>/renderer.html
# now carries frame_domains=["https://example.com"] in its CSP meta.
# The tool's wire metadata has no CSP — only resourceUri + visibility.
```

Closes #3735, closes #3805