### PR TITLE
Fix CIMD clients getting required_scopes instead of valid_scopes

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -360,7 +360,9 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             else None
         )
         self._upstream_revocation_endpoint: str | None = upstream_revocation_endpoint
-        self._default_scope_str: str = " ".join(self.required_scopes or [])
+        self._default_scope_str: str = " ".join(
+            valid_scopes or self.required_scopes or []
+        )
 
         # Store redirect configuration
         if not redirect_path:

--- a/tests/server/auth/oauth_proxy/test_oauth_proxy.py
+++ b/tests/server/auth/oauth_proxy/test_oauth_proxy.py
@@ -63,6 +63,39 @@ class TestOAuthProxyInitialization:
         assert proxy.client_registration_options is not None
         assert proxy.client_registration_options.valid_scopes == ["custom", "scopes"]
 
+    def test_default_scope_str_prefers_valid_scopes(self, jwt_verifier):
+        """When valid_scopes is provided, _default_scope_str should use it
+        instead of required_scopes. This ensures CIMD clients (which bypass
+        RegistrationHandler) get registered with the full set of valid scopes."""
+        jwt_verifier.required_scopes = ["openid"]
+        proxy = OAuthProxy(
+            upstream_authorization_endpoint="https://auth.example.com/authorize",
+            upstream_token_endpoint="https://auth.example.com/token",
+            upstream_client_id="client-123",
+            upstream_client_secret="secret-456",
+            token_verifier=jwt_verifier,
+            base_url="https://api.example.com",
+            valid_scopes=["openid", "email", "calendar"],
+            jwt_signing_key="test-secret",
+            client_storage=MemoryStore(),
+        )
+        assert proxy._default_scope_str == "openid email calendar"
+
+    def test_default_scope_str_falls_back_to_required_scopes(self, jwt_verifier):
+        """Without valid_scopes, _default_scope_str falls back to required_scopes."""
+        jwt_verifier.required_scopes = ["openid"]
+        proxy = OAuthProxy(
+            upstream_authorization_endpoint="https://auth.example.com/authorize",
+            upstream_token_endpoint="https://auth.example.com/token",
+            upstream_client_id="client-123",
+            upstream_client_secret="secret-456",
+            token_verifier=jwt_verifier,
+            base_url="https://api.example.com",
+            jwt_signing_key="test-secret",
+            client_storage=MemoryStore(),
+        )
+        assert proxy._default_scope_str == "openid"
+
     def test_redirect_path_normalization(self, jwt_verifier):
         """Test that redirect_path is normalized with leading slash."""
         proxy = OAuthProxy(


### PR DESCRIPTION
When a CIMD client (like Claude Code) connects to an OAuthProxy with both `required_scopes` and `valid_scopes` configured, it gets registered with only `required_scopes`. This happens because CIMD clients bypass the `RegistrationHandler` (which applies `valid_scopes` via `ClientRegistrationOptions`), and the `_default_scope_str` fallback was built from `required_scopes` alone. Any authorization request for a scope beyond the required set gets rejected with `invalid_scope` before it ever reaches the upstream IdP.

The fix is a one-line change: `_default_scope_str` now prefers `valid_scopes`, matching the logic already used when constructing `ClientRegistrationOptions`.

Closes #3828