### PR TITLE
fix: GoogleGenaiSamplingHandler leaks thought parts and gives unhelpful errors on empty responses

### DIFF
--- a/src/fastmcp/client/sampling/handlers/google_genai.py
+++ b/src/fastmcp/client/sampling/handlers/google_genai.py
@@ -329,7 +329,9 @@ def _response_to_create_message_result(
             and any(getattr(p, "thought", False) for p in candidate.content.parts)
         )
         if has_thoughts:
-            msg = "Model returned only thinking/reasoning content with no response text."
+            msg = (
+                "Model returned only thinking/reasoning content with no response text."
+            )
         else:
             msg = f"No content in response (finish_reason={candidate.finish_reason})"
         raise ValueError(msg)

--- a/src/fastmcp/client/sampling/handlers/google_genai.py
+++ b/src/fastmcp/client/sampling/handlers/google_genai.py
@@ -322,7 +322,16 @@ def _response_to_create_message_result(
     """Convert Google GenAI response to CreateMessageResult (no tools)."""
     if not (text := response.text):
         candidate = _get_candidate_from_response(response)
-        msg = f"No content in response: {candidate.finish_reason}"
+        # Check if the response only contained thinking
+        has_thoughts = (
+            candidate.content
+            and candidate.content.parts
+            and any(getattr(p, "thought", False) for p in candidate.content.parts)
+        )
+        if has_thoughts:
+            msg = "Model returned only thinking/reasoning content with no response text."
+        else:
+            msg = f"No content in response (finish_reason={candidate.finish_reason})"
         raise ValueError(msg)
 
     return CreateMessageResult(
@@ -365,7 +374,7 @@ def _response_to_result_with_tools(
     if candidate.content and candidate.content.parts:
         for part in candidate.content.parts:
             # Note: Skip thought parts from thinking_config - not relevant for MCP responses
-            if part.text:
+            if part.text and not part.thought:
                 content.append(TextContent(type="text", text=part.text))
             elif part.function_call is not None:
                 fc = part.function_call
@@ -380,7 +389,9 @@ def _response_to_result_with_tools(
                 )
 
     if not content:
-        raise ValueError("No content in response from completion")
+        finish = candidate.finish_reason if candidate else "unknown"
+        msg = f"No content in response from completion (finish_reason={finish})"
+        raise ValueError(msg)
 
     return CreateMessageResultWithTools(
         content=content,

--- a/src/fastmcp/client/sampling/handlers/google_genai.py
+++ b/src/fastmcp/client/sampling/handlers/google_genai.py
@@ -326,7 +326,7 @@ def _response_to_create_message_result(
         has_thoughts = (
             candidate.content
             and candidate.content.parts
-            and any(getattr(p, "thought", False) for p in candidate.content.parts)
+            and all(getattr(p, "thought", False) for p in candidate.content.parts)
         )
         if has_thoughts:
             msg = (

--- a/tests/client/sampling/handlers/test_google_genai_handler.py
+++ b/tests/client/sampling/handlers/test_google_genai_handler.py
@@ -374,10 +374,10 @@ def test_response_to_result_with_tools_text_only():
     assert result.model == "gemini-2.0-flash"
     assert result.stopReason == "endTurn"
     assert isinstance(result.content, list)
-    assert len(result.content) == 1  # ty: ignore[invalid-argument-type]
-    assert result.content[0].type == "text"  # ty: ignore[not-subscriptable]
-    assert isinstance(result.content[0], TextContent)  # ty: ignore[not-subscriptable]
-    assert result.content[0].text == "Here's the answer"  # ty: ignore[not-subscriptable]
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "Here's the answer"
 
 
 def test_response_to_result_with_tools_function_call():
@@ -396,7 +396,7 @@ def test_response_to_result_with_tools_function_call():
 
     assert result.stopReason == "toolUse"
     assert isinstance(result.content, list)
-    assert len(result.content) == 1  # ty: ignore[invalid-argument-type]
+    assert len(result.content) == 1
     tool_use = result.content[0]
     assert isinstance(tool_use, ToolUseContent)
     assert tool_use.type == "tool_use"
@@ -423,7 +423,7 @@ def test_response_to_result_with_tools_mixed_content():
 
     assert result.stopReason == "toolUse"
     assert isinstance(result.content, list)
-    assert len(result.content) == 2  # ty: ignore[invalid-argument-type]
+    assert len(result.content) == 2
     text_content = result.content[0]
     assert isinstance(text_content, TextContent)
     assert text_content.type == "text"

--- a/tests/client/sampling/handlers/test_google_genai_handler.py
+++ b/tests/client/sampling/handlers/test_google_genai_handler.py
@@ -374,10 +374,10 @@ def test_response_to_result_with_tools_text_only():
     assert result.model == "gemini-2.0-flash"
     assert result.stopReason == "endTurn"
     assert isinstance(result.content, list)
-    assert len(result.content) == 1
-    assert result.content[0].type == "text"
-    assert isinstance(result.content[0], TextContent)
-    assert result.content[0].text == "Here's the answer"
+    assert len(result.content) == 1  # ty: ignore[invalid-argument-type]
+    assert result.content[0].type == "text"  # ty: ignore[not-subscriptable]
+    assert isinstance(result.content[0], TextContent)  # ty: ignore[not-subscriptable]
+    assert result.content[0].text == "Here's the answer"  # ty: ignore[not-subscriptable]
 
 
 def test_response_to_result_with_tools_function_call():
@@ -396,7 +396,7 @@ def test_response_to_result_with_tools_function_call():
 
     assert result.stopReason == "toolUse"
     assert isinstance(result.content, list)
-    assert len(result.content) == 1
+    assert len(result.content) == 1  # ty: ignore[invalid-argument-type]
     tool_use = result.content[0]
     assert isinstance(tool_use, ToolUseContent)
     assert tool_use.type == "tool_use"
@@ -423,7 +423,7 @@ def test_response_to_result_with_tools_mixed_content():
 
     assert result.stopReason == "toolUse"
     assert isinstance(result.content, list)
-    assert len(result.content) == 2
+    assert len(result.content) == 2  # ty: ignore[invalid-argument-type]
     text_content = result.content[0]
     assert isinstance(text_content, TextContent)
     assert text_content.type == "text"
@@ -483,9 +483,9 @@ def test_thought_parts_filtered_on_tool_path():
 
     result = _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
 
-    assert len(result.content) == 1
-    assert isinstance(result.content[0], TextContent)
-    assert result.content[0].text == "Here is the real answer"
+    assert len(result.content) == 1  # ty: ignore[invalid-argument-type]
+    assert isinstance(result.content[0], TextContent)  # ty: ignore[not-subscriptable]
+    assert result.content[0].text == "Here is the real answer"  # ty: ignore[not-subscriptable]
 
 
 def test_thought_only_response_on_tool_path_raises():
@@ -570,12 +570,12 @@ def test_normal_response_text_and_function_call():
 
     result = _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
 
-    assert len(result.content) == 2
-    assert isinstance(result.content[0], TextContent)
-    assert result.content[0].text == "Let me look that up."
-    assert isinstance(result.content[1], ToolUseContent)
-    assert result.content[1].name == "lookup"
-    assert result.content[1].input == {"q": "test"}
+    assert len(result.content) == 2  # ty: ignore[invalid-argument-type]
+    assert isinstance(result.content[0], TextContent)  # ty: ignore[not-subscriptable]
+    assert result.content[0].text == "Let me look that up."  # ty: ignore[not-subscriptable]
+    assert isinstance(result.content[1], ToolUseContent)  # ty: ignore[not-subscriptable]
+    assert result.content[1].name == "lookup"  # ty: ignore[not-subscriptable]
+    assert result.content[1].input == {"q": "test"}  # ty: ignore[not-subscriptable]
     assert result.stopReason == "toolUse"
 
 
@@ -595,7 +595,7 @@ def test_thought_with_function_call_keeps_function_call():
 
     result = _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
 
-    assert len(result.content) == 1
-    assert isinstance(result.content[0], ToolUseContent)
-    assert result.content[0].name == "get_weather"
+    assert len(result.content) == 1  # ty: ignore[invalid-argument-type]
+    assert isinstance(result.content[0], ToolUseContent)  # ty: ignore[not-subscriptable]
+    assert result.content[0].name == "get_weather"  # ty: ignore[not-subscriptable]
     assert result.stopReason == "toolUse"

--- a/tests/client/sampling/handlers/test_google_genai_handler.py
+++ b/tests/client/sampling/handlers/test_google_genai_handler.py
@@ -460,3 +460,142 @@ def test_convert_tool_strips_titles():
     assert "title" not in schema
     assert "title" not in schema["properties"]["query"]
     assert schema["properties"]["query"]["type"] == "string"
+
+
+# ────────────────────────────────────────────────────────────
+# Tests for thought-part filtering and improved error messages
+# (PR #3849)
+# ────────────────────────────────────────────────────────────
+
+
+def test_thought_parts_filtered_on_tool_path():
+    """Thought parts should be excluded; only the real text part should appear."""
+    mock_candidate = MagicMock(spec=Candidate)
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = [
+        Part(text="thinking about the problem...", thought=True),
+        Part(text="Here is the real answer"),
+    ]
+    mock_candidate.finish_reason = "STOP"
+
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.candidates = [mock_candidate]
+
+    result = _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
+
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "Here is the real answer"
+
+
+def test_thought_only_response_on_tool_path_raises():
+    """When the response contains ONLY thought parts the tool path should raise
+    a ValueError whose message includes the finish_reason."""
+    mock_candidate = MagicMock(spec=Candidate)
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = [
+        Part(text="deep thinking...", thought=True),
+    ]
+    mock_candidate.finish_reason = "STOP"
+
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.candidates = [mock_candidate]
+
+    with pytest.raises(ValueError, match="finish_reason=STOP"):
+        _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
+
+
+def test_thought_only_response_on_non_tool_path_raises():
+    """When the non-tool path receives only thoughts the error message should
+    mention 'thinking/reasoning content'."""
+    mock_candidate = MagicMock(spec=Candidate)
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = [
+        Part(text="internal reasoning...", thought=True),
+    ]
+    mock_candidate.finish_reason = "STOP"
+
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.text = None  # No real text available
+    mock_response.candidates = [mock_candidate]
+
+    with pytest.raises(ValueError, match="thinking/reasoning content"):
+        _response_to_create_message_result(mock_response, model="gemini-2.5-flash")
+
+
+def test_safety_filtered_response_on_tool_path_raises():
+    """A safety-filtered response (no parts) should raise with the finish_reason
+    included in the error message."""
+    mock_candidate = MagicMock(spec=Candidate)
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = []  # Empty parts after safety filtering
+    mock_candidate.finish_reason = "SAFETY"
+
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.candidates = [mock_candidate]
+
+    with pytest.raises(ValueError, match="finish_reason=SAFETY"):
+        _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
+
+
+def test_safety_filtered_response_on_non_tool_path_raises():
+    """A safety-filtered response on the non-tool path should include
+    finish_reason in the error."""
+    mock_candidate = MagicMock(spec=Candidate)
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = []
+    mock_candidate.finish_reason = "SAFETY"
+
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.text = None
+    mock_response.candidates = [mock_candidate]
+
+    with pytest.raises(ValueError, match="finish_reason=SAFETY"):
+        _response_to_create_message_result(mock_response, model="gemini-2.5-flash")
+
+
+def test_normal_response_text_and_function_call():
+    """A normal response with both real text and a function call should
+    produce both TextContent and ToolUseContent in the result."""
+    mock_candidate = MagicMock(spec=Candidate)
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = [
+        Part(text="Let me look that up."),
+        Part(function_call=FunctionCall(name="lookup", args={"q": "test"})),
+    ]
+    mock_candidate.finish_reason = "STOP"
+
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.candidates = [mock_candidate]
+
+    result = _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
+
+    assert len(result.content) == 2
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "Let me look that up."
+    assert isinstance(result.content[1], ToolUseContent)
+    assert result.content[1].name == "lookup"
+    assert result.content[1].input == {"q": "test"}
+    assert result.stopReason == "toolUse"
+
+
+def test_thought_with_function_call_keeps_function_call():
+    """When thinking parts accompany a function call, only the function call
+    should appear in the content (thought parts filtered out)."""
+    mock_candidate = MagicMock(spec=Candidate)
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = [
+        Part(text="reasoning about what tool to use...", thought=True),
+        Part(function_call=FunctionCall(name="get_weather", args={"city": "NYC"})),
+    ]
+    mock_candidate.finish_reason = "STOP"
+
+    mock_response = MagicMock(spec=GenerateContentResponse)
+    mock_response.candidates = [mock_candidate]
+
+    result = _response_to_result_with_tools(mock_response, model="gemini-2.5-flash")
+
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], ToolUseContent)
+    assert result.content[0].name == "get_weather"
+    assert result.stopReason == "toolUse"


### PR DESCRIPTION
Fixes #3846

## Problem

Three related bugs in `GoogleGenaiSamplingHandler`'s response conversion:

1. **Thought parts leak as TextContent** — Line 364 has a comment "Skip thought parts" but only checks `if part.text:` which is truthy for thought parts too. Internal reasoning text appears in MCP responses.

2. **Thinking-only responses crash** — When all parts have `thought=True`, `response.text` is `None` (Google SDK filters thoughts), causing `ValueError: No content in response: STOP` with no indication of why.

3. **Safety errors are unhelpful** — Tool-path error says "No content in response from completion" without including `finish_reason`. A safety-filtered response is indistinguishable from any other empty response.

## Fix

- Filter `part.thought == True` in `_response_to_result_with_tools`
- Include `finish_reason` in tool-path error message
- Detect thinking-only responses and provide a specific error message

## Tests

7 new unit tests covering thought filtering, safety errors, and normal response passthrough. Tests construct mock `GenerateContentResponse` objects directly — no API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)