### PR TITLE
fix: retry when LLM returns text instead of calling final_response

### DIFF
--- a/src/fastmcp/server/sampling/run.py
+++ b/src/fastmcp/server/sampling/run.py
@@ -49,6 +49,9 @@ ResultT = TypeVar("ResultT")
 # Simplified tool choice type - just the mode string instead of the full MCP object
 ToolChoiceOption = Literal["auto", "required", "none"]
 
+# How many times we retry when the LLM returns text instead of calling final_response
+_MAX_TEXT_RESPONSE_RETRIES = 3
+
 
 @dataclass
 class SamplingResult(Generic[ResultT]):
@@ -611,6 +614,8 @@ async def sample_impl(
     # Convert messages for the loop
     current_messages: str | Sequence[str | SamplingMessage] = messages
 
+    text_response_retries = 0
+
     for _iteration in range(max_iterations):
         step = await sample_step_impl(
             context,
@@ -682,11 +687,28 @@ async def sample_impl(
         if not step.is_tool_use:
             # For structured output, the LLM must use the final_response tool
             if result_type is not None and result_type is not str:
-                raise RuntimeError(
-                    f"Expected structured output of type {result_type.__name__}, "
-                    "but the LLM returned a text response instead of calling "
-                    "the final_response tool."
+                text_response_retries += 1
+                if text_response_retries > _MAX_TEXT_RESPONSE_RETRIES:
+                    raise RuntimeError(
+                        f"Expected structured output of type {result_type.__name__}, "
+                        "but the LLM returned a text response instead of calling "
+                        f"the final_response tool ({text_response_retries} attempts)."
+                    )
+                # Nudge the LLM to use the tool
+                step.history.append(
+                    SamplingMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=(
+                                "You must call the `final_response` tool to provide "
+                                "your answer. Do not respond with text — use the tool."
+                            ),
+                        ),
+                    )
                 )
+                current_messages = step.history
+                continue
             return SamplingResult(
                 text=step.text,
                 result=cast(ResultT, step.text if step.text else ""),

--- a/tests/client/test_sampling_result_types.py
+++ b/tests/client/test_sampling_result_types.py
@@ -446,219 +446,104 @@ class TestSampleStep:
 class TestTextResponseRetry:
     """Tests for retry logic when LLM returns text instead of calling final_response."""
 
-    async def test_text_response_then_success(self):
-        """Handler returns text on first call, then final_response on second call.
+    @staticmethod
+    def _text_reply(text: str = "some text"):
+        from mcp.types import CreateMessageResultWithTools
 
-        Verifies that the retry mechanism works: after a text response, the LLM
-        is asked again and successfully calls final_response.
-        """
+        return CreateMessageResultWithTools(
+            role="assistant",
+            content=[TextContent(type="text", text=text)],
+            model="m",
+            stopReason="endTurn",
+        )
+
+    @staticmethod
+    def _tool_reply(value: int):
         from mcp.types import CreateMessageResultWithTools, ToolUseContent
+
+        return CreateMessageResultWithTools(
+            role="assistant",
+            content=[
+                ToolUseContent(
+                    type="tool_use", id="c1", name="final_response", input={"value": value}
+                )
+            ],
+            model="m",
+            stopReason="toolUse",
+        )
+
+    async def test_text_response_then_success(self):
+        """Text on first call, final_response on second -- verify call_count == 2."""
         from pydantic import BaseModel
 
-        class MyResult(BaseModel):
+        class R(BaseModel):
             value: int
 
         call_count = 0
 
-        def sampling_handler(
-            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
-        ) -> CreateMessageResultWithTools:
+        def handler(messages, params, ctx):
             nonlocal call_count
             call_count += 1
+            return self._text_reply() if call_count == 1 else self._tool_reply(42)
 
-            if call_count == 1:
-                # First call: return text (no tool use) - this should trigger retry
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[TextContent(type="text", text="I think the answer is 42")],
-                    model="test-model",
-                    stopReason="endTurn",
-                )
-            else:
-                # Second call: correctly call final_response
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id="call_1",
-                            name="final_response",
-                            input={"value": 42},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
-
-        mcp = FastMCP(sampling_handler=sampling_handler)
+        mcp = FastMCP(sampling_handler=handler)
 
         @mcp.tool
-        async def my_tool(context: Context) -> str:
-            result = await context.sample(
-                messages="What is the answer?",
-                result_type=MyResult,
-            )
-            assert isinstance(result.result, MyResult)
-            return str(result.result.value)
+        async def t(context: Context) -> str:
+            return str((await context.sample(messages="q", result_type=R)).result.value)
 
         async with Client(mcp) as client:
-            result = await client.call_tool("my_tool", {})
+            result = await client.call_tool("t", {})
 
         assert call_count == 2
         assert result.data == "42"
 
     async def test_text_response_exceeds_max_retries(self):
-        """Handler always returns text, never calls final_response.
-
-        Verifies that RuntimeError is raised after exceeding max retries,
-        and the error message includes the attempt count.
-        """
-        from mcp.types import CreateMessageResultWithTools
+        """Always text, never tool -- verify error after _MAX_TEXT_RESPONSE_RETRIES+1 calls."""
         from pydantic import BaseModel
 
         from fastmcp.exceptions import ToolError
+        from fastmcp.server.sampling.run import _MAX_TEXT_RESPONSE_RETRIES
 
-        class MyResult(BaseModel):
+        class R(BaseModel):
             value: int
 
         call_count = 0
 
-        def sampling_handler(
-            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
-        ) -> CreateMessageResultWithTools:
+        def handler(messages, params, ctx):
             nonlocal call_count
             call_count += 1
-            # Always return text, never call final_response
-            return CreateMessageResultWithTools(
-                role="assistant",
-                content=[TextContent(type="text", text="I refuse to use tools")],
-                model="test-model",
-                stopReason="endTurn",
-            )
+            return self._text_reply()
 
-        mcp = FastMCP(sampling_handler=sampling_handler)
+        mcp = FastMCP(sampling_handler=handler)
 
         @mcp.tool
-        async def my_tool(context: Context) -> str:
-            result = await context.sample(
-                messages="What is the answer?",
-                result_type=MyResult,
-            )
-            return str(result.result)
+        async def t(context: Context) -> str:
+            return str((await context.sample(messages="q", result_type=R)).result)
 
         async with Client(mcp) as client:
             with pytest.raises(ToolError, match="attempts"):
-                await client.call_tool("my_tool", {})
+                await client.call_tool("t", {})
 
-        # _MAX_TEXT_RESPONSE_RETRIES is 3, error is raised when retries > 3
-        # So we expect 4 calls: initial + 3 retries, then error on the 4th text response
-        assert call_count == 4
-
-    async def test_nudge_message_in_history(self):
-        """After a text response retry, the history contains the nudge message.
-
-        Verifies that the nudge ("You must call the `final_response` tool...")
-        is appended to the message history before the next sampling call.
-        """
-        from mcp.types import CreateMessageResultWithTools, ToolUseContent
-        from pydantic import BaseModel
-
-        class MyResult(BaseModel):
-            value: int
-
-        messages_per_call: list[list[SamplingMessage]] = []
-
-        def sampling_handler(
-            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
-        ) -> CreateMessageResultWithTools:
-            messages_per_call.append(list(messages))
-
-            if len(messages_per_call) == 1:
-                # First call: return text to trigger retry
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[TextContent(type="text", text="Let me think...")],
-                    model="test-model",
-                    stopReason="endTurn",
-                )
-            else:
-                # Second call: correctly call final_response
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id="call_1",
-                            name="final_response",
-                            input={"value": 7},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
-
-        mcp = FastMCP(sampling_handler=sampling_handler)
-
-        @mcp.tool
-        async def my_tool(context: Context) -> str:
-            result = await context.sample(
-                messages="Give me a number",
-                result_type=MyResult,
-            )
-            return str(result.result.value)
-
-        async with Client(mcp) as client:
-            result = await client.call_tool("my_tool", {})
-
-        assert result.data == "7"
-        assert len(messages_per_call) == 2
-
-        # The second call's messages should contain the nudge
-        second_call_messages = messages_per_call[1]
-        nudge_found = False
-        for msg in second_call_messages:
-            if isinstance(msg.content, TextContent) and msg.role == "user":
-                if "You must call the `final_response` tool" in msg.content.text:
-                    nudge_found = True
-                    break
-        assert nudge_found, (
-            "Expected nudge message 'You must call the `final_response` tool...' "
-            "in the history for the second sampling call"
-        )
+        assert call_count == _MAX_TEXT_RESPONSE_RETRIES + 1
 
     async def test_no_retry_when_result_type_is_none(self):
-        """Handler returns text with no result_type set.
-
-        Verifies that text responses are returned normally without retry
-        when result_type is None (the default).
-        """
-        from mcp.types import CreateMessageResultWithTools
-
+        """Text response with no result_type -- single call, normal return."""
         call_count = 0
 
-        def sampling_handler(
-            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
-        ) -> CreateMessageResultWithTools:
+        def handler(messages, params, ctx):
             nonlocal call_count
             call_count += 1
-            return CreateMessageResultWithTools(
-                role="assistant",
-                content=[TextContent(type="text", text="Just a text reply")],
-                model="test-model",
-                stopReason="endTurn",
-            )
+            return self._text_reply("hello")
 
-        mcp = FastMCP(sampling_handler=sampling_handler)
+        mcp = FastMCP(sampling_handler=handler)
 
         @mcp.tool
-        async def my_tool(context: Context) -> str:
-            # No result_type parameter - defaults to None
-            result = await context.sample(messages="Say something")
-            return result.text or ""
+        async def t(context: Context) -> str:
+            return (await context.sample(messages="q")).text or ""
 
         async with Client(mcp) as client:
-            result = await client.call_tool("my_tool", {})
+            result = await client.call_tool("t", {})
 
-        # Should return normally after a single call (no retry)
         assert call_count == 1
-        assert result.data == "Just a text reply"
+        assert result.data == "hello"

--- a/tests/client/test_sampling_result_types.py
+++ b/tests/client/test_sampling_result_types.py
@@ -1,3 +1,4 @@
+import pytest
 from mcp.types import TextContent
 
 from fastmcp import Client, Context, FastMCP
@@ -440,3 +441,224 @@ class TestSampleStep:
             result = await client.call_tool("test_step", {})
 
         assert result.data == "ok"
+
+
+class TestTextResponseRetry:
+    """Tests for retry logic when LLM returns text instead of calling final_response."""
+
+    async def test_text_response_then_success(self):
+        """Handler returns text on first call, then final_response on second call.
+
+        Verifies that the retry mechanism works: after a text response, the LLM
+        is asked again and successfully calls final_response.
+        """
+        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        from pydantic import BaseModel
+
+        class MyResult(BaseModel):
+            value: int
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+
+            if call_count == 1:
+                # First call: return text (no tool use) - this should trigger retry
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[TextContent(type="text", text="I think the answer is 42")],
+                    model="test-model",
+                    stopReason="endTurn",
+                )
+            else:
+                # Second call: correctly call final_response
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_1",
+                            name="final_response",
+                            input={"value": 42},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def my_tool(context: Context) -> str:
+            result = await context.sample(
+                messages="What is the answer?",
+                result_type=MyResult,
+            )
+            assert isinstance(result.result, MyResult)
+            return str(result.result.value)
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("my_tool", {})
+
+        assert call_count == 2
+        assert result.data == "42"
+
+    async def test_text_response_exceeds_max_retries(self):
+        """Handler always returns text, never calls final_response.
+
+        Verifies that RuntimeError is raised after exceeding max retries,
+        and the error message includes the attempt count.
+        """
+        from mcp.types import CreateMessageResultWithTools
+        from pydantic import BaseModel
+
+        from fastmcp.exceptions import ToolError
+
+        class MyResult(BaseModel):
+            value: int
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+            # Always return text, never call final_response
+            return CreateMessageResultWithTools(
+                role="assistant",
+                content=[TextContent(type="text", text="I refuse to use tools")],
+                model="test-model",
+                stopReason="endTurn",
+            )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def my_tool(context: Context) -> str:
+            result = await context.sample(
+                messages="What is the answer?",
+                result_type=MyResult,
+            )
+            return str(result.result)
+
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError, match="attempts"):
+                await client.call_tool("my_tool", {})
+
+        # _MAX_TEXT_RESPONSE_RETRIES is 3, error is raised when retries > 3
+        # So we expect 4 calls: initial + 3 retries, then error on the 4th text response
+        assert call_count == 4
+
+    async def test_nudge_message_in_history(self):
+        """After a text response retry, the history contains the nudge message.
+
+        Verifies that the nudge ("You must call the `final_response` tool...")
+        is appended to the message history before the next sampling call.
+        """
+        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        from pydantic import BaseModel
+
+        class MyResult(BaseModel):
+            value: int
+
+        messages_per_call: list[list[SamplingMessage]] = []
+
+        def sampling_handler(
+            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
+        ) -> CreateMessageResultWithTools:
+            messages_per_call.append(list(messages))
+
+            if len(messages_per_call) == 1:
+                # First call: return text to trigger retry
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[TextContent(type="text", text="Let me think...")],
+                    model="test-model",
+                    stopReason="endTurn",
+                )
+            else:
+                # Second call: correctly call final_response
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_1",
+                            name="final_response",
+                            input={"value": 7},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def my_tool(context: Context) -> str:
+            result = await context.sample(
+                messages="Give me a number",
+                result_type=MyResult,
+            )
+            return str(result.result.value)
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("my_tool", {})
+
+        assert result.data == "7"
+        assert len(messages_per_call) == 2
+
+        # The second call's messages should contain the nudge
+        second_call_messages = messages_per_call[1]
+        nudge_found = False
+        for msg in second_call_messages:
+            if isinstance(msg.content, TextContent) and msg.role == "user":
+                if "You must call the `final_response` tool" in msg.content.text:
+                    nudge_found = True
+                    break
+        assert nudge_found, (
+            "Expected nudge message 'You must call the `final_response` tool...' "
+            "in the history for the second sampling call"
+        )
+
+    async def test_no_retry_when_result_type_is_none(self):
+        """Handler returns text with no result_type set.
+
+        Verifies that text responses are returned normally without retry
+        when result_type is None (the default).
+        """
+        from mcp.types import CreateMessageResultWithTools
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+            return CreateMessageResultWithTools(
+                role="assistant",
+                content=[TextContent(type="text", text="Just a text reply")],
+                model="test-model",
+                stopReason="endTurn",
+            )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def my_tool(context: Context) -> str:
+            # No result_type parameter - defaults to None
+            result = await context.sample(messages="Say something")
+            return result.text or ""
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("my_tool", {})
+
+        # Should return normally after a single call (no retry)
+        assert call_count == 1
+        assert result.data == "Just a text reply"

--- a/tests/client/test_sampling_result_types.py
+++ b/tests/client/test_sampling_result_types.py
@@ -465,7 +465,10 @@ class TestTextResponseRetry:
             role="assistant",
             content=[
                 ToolUseContent(
-                    type="tool_use", id="c1", name="final_response", input={"value": value}
+                    type="tool_use",
+                    id="c1",
+                    name="final_response",
+                    input={"value": value},
                 )
             ],
             model="m",

--- a/tests/server/tasks/test_task_return_types.py
+++ b/tests/server/tasks/test_task_return_types.py
@@ -259,8 +259,9 @@ async def binary_type_server():
         (
             "return_bytes",
             type(None),
-            lambda r: r.data is None
-            and any("Hello bytes!" in c.text for c in r.content),
+            lambda r: (
+                r.data is None and any("Hello bytes!" in c.text for c in r.content)
+            ),
         ),
         (
             "return_uuid",


### PR DESCRIPTION
Fixes #3847

## Problem

`sample_impl` at line 685 raises `RuntimeError` immediately when structured output is expected but the LLM returns text instead of calling `final_response`. No retry, no nudge — just a crash.

This contrasts with validation errors (lines 657-679) which append feedback to history and retry. Some models occasionally ignore `tool_choice="required"` and return text, especially on later iterations of the tool loop after gathering information.

## Fix

Add a retry loop (capped at 3 attempts) that appends a nudge message asking the model to use the `final_response` tool, matching the existing pattern for validation error retries.

```python
_MAX_TEXT_RESPONSE_RETRIES = 3
```

After exhausting retries, raises `RuntimeError` with the attempt count.

## Tests

3 tests: retry-then-succeed, exceed-max-retries, and no-retry-when-result_type-is-None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)