### PR TITLE
fix: cap consecutive final_response validation retries

### DIFF
--- a/src/fastmcp/server/sampling/run.py
+++ b/src/fastmcp/server/sampling/run.py
@@ -46,6 +46,10 @@ if TYPE_CHECKING:
 
 ResultT = TypeVar("ResultT")
 
+# Maximum number of consecutive final_response validation failures before
+# we abort instead of burning more tokens on a model that can't satisfy the schema.
+_MAX_VALIDATION_RETRIES = 3
+
 # Simplified tool choice type - just the mode string instead of the full MCP object
 ToolChoiceOption = Literal["auto", "required", "none"]
 
@@ -615,6 +619,7 @@ async def sample_impl(
     current_messages: str | Sequence[str | SamplingMessage] = messages
 
     text_response_retries = 0
+    consecutive_validation_failures = 0
 
     for _iteration in range(max_iterations):
         step = await sample_step_impl(
@@ -631,9 +636,11 @@ async def sample_impl(
         )
 
         # Check for final_response tool call for structured output
+        had_final_response = False
         if result_type is not None and result_type is not str and step.is_tool_use:
             for tool_call in step.tool_calls:
                 if tool_call.name == "final_response":
+                    had_final_response = True
                     # Validate and return the structured result
                     type_adapter = get_cached_typeadapter(result_type)
 
@@ -660,6 +667,13 @@ async def sample_impl(
                             history=step.history,
                         )
                     except ValidationError as e:
+                        consecutive_validation_failures += 1
+                        if consecutive_validation_failures > _MAX_VALIDATION_RETRIES:
+                            raise RuntimeError(
+                                f"Structured output validation failed "
+                                f"{consecutive_validation_failures} consecutive "
+                                f"times for type {result_type.__name__}: {e}"
+                            ) from e
                         # Validation failed - add error as tool result
                         step.history.append(
                             SamplingMessage(
@@ -682,6 +696,10 @@ async def sample_impl(
                                 ],
                             )
                         )
+
+        # The LLM called tools but not final_response — reset validation counter
+        if not had_final_response:
+            consecutive_validation_failures = 0
 
         # If not a tool use response, we're done
         if not step.is_tool_use:

--- a/src/fastmcp/server/sampling/run.py
+++ b/src/fastmcp/server/sampling/run.py
@@ -668,7 +668,7 @@ async def sample_impl(
                         )
                     except ValidationError as e:
                         consecutive_validation_failures += 1
-                        if consecutive_validation_failures > _MAX_VALIDATION_RETRIES:
+                        if consecutive_validation_failures >= _MAX_VALIDATION_RETRIES:
                             raise RuntimeError(
                                 f"Structured output validation failed "
                                 f"{consecutive_validation_failures} consecutive "

--- a/src/fastmcp/server/sampling/run.py
+++ b/src/fastmcp/server/sampling/run.py
@@ -46,8 +46,8 @@ if TYPE_CHECKING:
 
 ResultT = TypeVar("ResultT")
 
-# Maximum number of consecutive final_response validation failures before
-# we abort instead of burning more tokens on a model that can't satisfy the schema.
+# Maximum number of consecutive final_response validation retries (not
+# counting the initial attempt) before aborting.  Total attempts = N + 1.
 _MAX_VALIDATION_RETRIES = 3
 
 # Simplified tool choice type - just the mode string instead of the full MCP object
@@ -668,7 +668,7 @@ async def sample_impl(
                         )
                     except ValidationError as e:
                         consecutive_validation_failures += 1
-                        if consecutive_validation_failures >= _MAX_VALIDATION_RETRIES:
+                        if consecutive_validation_failures > _MAX_VALIDATION_RETRIES:
                             raise RuntimeError(
                                 f"Structured output validation failed "
                                 f"{consecutive_validation_failures} consecutive "

--- a/tests/client/test_sampling_result_types.py
+++ b/tests/client/test_sampling_result_types.py
@@ -639,7 +639,8 @@ class TestValidationRetryCap:
             with pytest.raises(ToolError, match="consecutive"):
                 await client.call_tool("t", {})
 
-        assert call_count == _MAX_VALIDATION_RETRIES
+        # 1 initial attempt + _MAX_VALIDATION_RETRIES retries
+        assert call_count == _MAX_VALIDATION_RETRIES + 1
 
     async def test_validation_counter_resets_after_other_tool_call(self):
         """A tool call between validation failures resets the counter."""

--- a/tests/client/test_sampling_result_types.py
+++ b/tests/client/test_sampling_result_types.py
@@ -552,236 +552,125 @@ class TestTextResponseRetry:
         assert result.data == "hello"
 
 
+def _final_response(call_id: str, input_data: dict) -> "CreateMessageResultWithTools":
+    """Build a final_response tool-use reply."""
+    from mcp.types import CreateMessageResultWithTools, ToolUseContent
+
+    return CreateMessageResultWithTools(
+        role="assistant",
+        content=[ToolUseContent(type="tool_use", id=call_id, name="final_response", input=input_data)],
+        model="test-model",
+        stopReason="toolUse",
+    )
+
+
+def _tool_call(call_id: str, name: str, input_data: dict) -> "CreateMessageResultWithTools":
+    """Build a regular tool-use reply."""
+    from mcp.types import CreateMessageResultWithTools, ToolUseContent
+
+    return CreateMessageResultWithTools(
+        role="assistant",
+        content=[ToolUseContent(type="tool_use", id=call_id, name=name, input=input_data)],
+        model="test-model",
+        stopReason="toolUse",
+    )
+
+
 class TestValidationRetryCap:
     """Tests for the consecutive validation retry cap (PR #3851)."""
 
     async def test_validation_failures_within_cap_then_success(self):
-        """Two consecutive validation failures followed by a valid response succeeds."""
-        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        """Two consecutive failures followed by a valid response succeeds."""
         from pydantic import BaseModel
 
-        class NumberResult(BaseModel):
+        class R(BaseModel):
             value: int
 
         call_count = 0
 
-        def sampling_handler(
-            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
-        ) -> CreateMessageResultWithTools:
+        def handler(messages, params, ctx):
             nonlocal call_count
             call_count += 1
-
             if call_count <= 2:
-                # First two calls: return invalid data (string instead of int)
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id=f"call_{call_count}",
-                            name="final_response",
-                            input={"value": "not_a_number"},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
-            else:
-                # Third call: return valid data
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id=f"call_{call_count}",
-                            name="final_response",
-                            input={"value": 99},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
+                return _final_response(f"c{call_count}", {"value": "bad"})
+            return _final_response(f"c{call_count}", {"value": 99})
 
-        mcp = FastMCP(sampling_handler=sampling_handler)
+        mcp = FastMCP(sampling_handler=handler)
 
         @mcp.tool
-        async def validate_tool(context: Context) -> str:
-            result = await context.sample(
-                messages="Give me a number",
-                result_type=NumberResult,
-            )
-            assert isinstance(result.result, NumberResult)
-            return str(result.result.value)
+        async def t(context: Context) -> str:
+            r = await context.sample(messages="go", result_type=R)
+            return str(r.result.value)
 
         async with Client(mcp) as client:
-            result = await client.call_tool("validate_tool", {})
+            result = await client.call_tool("t", {})
 
         assert call_count == 3
         assert result.data == "99"
 
     async def test_consecutive_validation_failures_exceed_cap(self):
-        """Always-invalid responses raise RuntimeError after exceeding the cap."""
-        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        """Always-invalid responses raise ToolError after exceeding the cap."""
         from pydantic import BaseModel
 
         from fastmcp.exceptions import ToolError
         from fastmcp.server.sampling.run import _MAX_VALIDATION_RETRIES
 
-        class StrictResult(BaseModel):
+        class R(BaseModel):
             value: int
 
         call_count = 0
 
-        def sampling_handler(
-            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
-        ) -> CreateMessageResultWithTools:
+        def handler(messages, params, ctx):
             nonlocal call_count
             call_count += 1
+            return _final_response(f"c{call_count}", {"value": "wrong"})
 
-            # Always return invalid data
-            return CreateMessageResultWithTools(
-                role="assistant",
-                content=[
-                    ToolUseContent(
-                        type="tool_use",
-                        id=f"call_{call_count}",
-                        name="final_response",
-                        input={"value": "always_wrong"},
-                    )
-                ],
-                model="test-model",
-                stopReason="toolUse",
-            )
-
-        mcp = FastMCP(sampling_handler=sampling_handler)
+        mcp = FastMCP(sampling_handler=handler)
 
         @mcp.tool
-        async def validate_tool(context: Context) -> str:
-            result = await context.sample(
-                messages="Give me a number",
-                result_type=StrictResult,
-            )
-            return str(result.result)
+        async def t(context: Context) -> str:
+            return str((await context.sample(messages="go", result_type=R)).result)
 
         async with Client(mcp) as client:
             with pytest.raises(ToolError, match="consecutive"):
-                await client.call_tool("validate_tool", {})
+                await client.call_tool("t", {})
 
-        # Should have been called _MAX_VALIDATION_RETRIES + 1 times
-        # (the first call plus _MAX_VALIDATION_RETRIES retries, then the
-        # next failure triggers the cap)
         assert call_count == _MAX_VALIDATION_RETRIES + 1
 
     async def test_validation_counter_resets_after_other_tool_call(self):
-        """Non-consecutive validation failures (interleaved with tool calls) don't trigger the cap."""
-        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        """A tool call between validation failures resets the counter."""
         from pydantic import BaseModel
 
-        class NumberResult(BaseModel):
+        class R(BaseModel):
             value: int
-
-        call_count = 0
 
         def helper_tool(x: int) -> str:
             """A helper tool."""
             return f"result:{x}"
 
-        def sampling_handler(
-            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
-        ) -> CreateMessageResultWithTools:
+        call_count = 0
+
+        def handler(messages, params, ctx):
             nonlocal call_count
             call_count += 1
-
+            # fail -> other tool (resets counter) -> fail -> succeed
             if call_count == 1:
-                # Call 1: invalid final_response
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id="call_1",
-                            name="final_response",
-                            input={"value": "bad"},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
-            elif call_count == 2:
-                # Call 2: use a regular tool (resets consecutive counter)
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id="call_2",
-                            name="helper_tool",
-                            input={"x": 1},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
-            elif call_count == 3:
-                # Call 3: invalid final_response again (but counter was reset)
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id="call_3",
-                            name="final_response",
-                            input={"value": "also_bad"},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
-            elif call_count == 4:
-                # Call 4: use a regular tool again (resets counter again)
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id="call_4",
-                            name="helper_tool",
-                            input={"x": 2},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
-            else:
-                # Call 5: valid final_response
-                return CreateMessageResultWithTools(
-                    role="assistant",
-                    content=[
-                        ToolUseContent(
-                            type="tool_use",
-                            id="call_5",
-                            name="final_response",
-                            input={"value": 42},
-                        )
-                    ],
-                    model="test-model",
-                    stopReason="toolUse",
-                )
+                return _final_response("c1", {"value": "bad"})
+            if call_count == 2:
+                return _tool_call("c2", "helper_tool", {"x": 1})
+            if call_count == 3:
+                return _final_response("c3", {"value": "bad"})
+            return _final_response("c4", {"value": 42})
 
-        mcp = FastMCP(sampling_handler=sampling_handler)
+        mcp = FastMCP(sampling_handler=handler)
 
         @mcp.tool
-        async def validate_tool(context: Context) -> str:
-            result = await context.sample(
-                messages="Give me a number",
-                tools=[helper_tool],
-                result_type=NumberResult,
-            )
-            assert isinstance(result.result, NumberResult)
-            return str(result.result.value)
+        async def t(context: Context) -> str:
+            r = await context.sample(messages="go", tools=[helper_tool], result_type=R)
+            return str(r.result.value)
 
         async with Client(mcp) as client:
-            result = await client.call_tool("validate_tool", {})
+            result = await client.call_tool("t", {})
 
-        assert call_count == 5
+        assert call_count == 4
         assert result.data == "42"

--- a/tests/client/test_sampling_result_types.py
+++ b/tests/client/test_sampling_result_types.py
@@ -1,5 +1,5 @@
 import pytest
-from mcp.types import TextContent
+from mcp.types import CreateMessageResultWithTools, TextContent, ToolUseContent
 
 from fastmcp import Client, Context, FastMCP
 from fastmcp.client.sampling import RequestContext, SamplingMessage, SamplingParams
@@ -552,25 +552,29 @@ class TestTextResponseRetry:
         assert result.data == "hello"
 
 
-def _final_response(call_id: str, input_data: dict) -> "CreateMessageResultWithTools":
+def _final_response(call_id: str, input_data: dict) -> CreateMessageResultWithTools:
     """Build a final_response tool-use reply."""
-    from mcp.types import CreateMessageResultWithTools, ToolUseContent
-
     return CreateMessageResultWithTools(
         role="assistant",
-        content=[ToolUseContent(type="tool_use", id=call_id, name="final_response", input=input_data)],
+        content=[
+            ToolUseContent(
+                type="tool_use", id=call_id, name="final_response", input=input_data
+            )
+        ],
         model="test-model",
         stopReason="toolUse",
     )
 
 
-def _tool_call(call_id: str, name: str, input_data: dict) -> "CreateMessageResultWithTools":
+def _tool_call(
+    call_id: str, name: str, input_data: dict
+) -> CreateMessageResultWithTools:
     """Build a regular tool-use reply."""
-    from mcp.types import CreateMessageResultWithTools, ToolUseContent
-
     return CreateMessageResultWithTools(
         role="assistant",
-        content=[ToolUseContent(type="tool_use", id=call_id, name=name, input=input_data)],
+        content=[
+            ToolUseContent(type="tool_use", id=call_id, name=name, input=input_data)
+        ],
         model="test-model",
         stopReason="toolUse",
     )
@@ -635,7 +639,7 @@ class TestValidationRetryCap:
             with pytest.raises(ToolError, match="consecutive"):
                 await client.call_tool("t", {})
 
-        assert call_count == _MAX_VALIDATION_RETRIES + 1
+        assert call_count == _MAX_VALIDATION_RETRIES
 
     async def test_validation_counter_resets_after_other_tool_call(self):
         """A tool call between validation failures resets the counter."""

--- a/tests/client/test_sampling_result_types.py
+++ b/tests/client/test_sampling_result_types.py
@@ -550,3 +550,238 @@ class TestTextResponseRetry:
 
         assert call_count == 1
         assert result.data == "hello"
+
+
+class TestValidationRetryCap:
+    """Tests for the consecutive validation retry cap (PR #3851)."""
+
+    async def test_validation_failures_within_cap_then_success(self):
+        """Two consecutive validation failures followed by a valid response succeeds."""
+        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        from pydantic import BaseModel
+
+        class NumberResult(BaseModel):
+            value: int
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+
+            if call_count <= 2:
+                # First two calls: return invalid data (string instead of int)
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id=f"call_{call_count}",
+                            name="final_response",
+                            input={"value": "not_a_number"},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+            else:
+                # Third call: return valid data
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id=f"call_{call_count}",
+                            name="final_response",
+                            input={"value": 99},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def validate_tool(context: Context) -> str:
+            result = await context.sample(
+                messages="Give me a number",
+                result_type=NumberResult,
+            )
+            assert isinstance(result.result, NumberResult)
+            return str(result.result.value)
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("validate_tool", {})
+
+        assert call_count == 3
+        assert result.data == "99"
+
+    async def test_consecutive_validation_failures_exceed_cap(self):
+        """Always-invalid responses raise RuntimeError after exceeding the cap."""
+        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        from pydantic import BaseModel
+
+        from fastmcp.exceptions import ToolError
+        from fastmcp.server.sampling.run import _MAX_VALIDATION_RETRIES
+
+        class StrictResult(BaseModel):
+            value: int
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+
+            # Always return invalid data
+            return CreateMessageResultWithTools(
+                role="assistant",
+                content=[
+                    ToolUseContent(
+                        type="tool_use",
+                        id=f"call_{call_count}",
+                        name="final_response",
+                        input={"value": "always_wrong"},
+                    )
+                ],
+                model="test-model",
+                stopReason="toolUse",
+            )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def validate_tool(context: Context) -> str:
+            result = await context.sample(
+                messages="Give me a number",
+                result_type=StrictResult,
+            )
+            return str(result.result)
+
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError, match="consecutive"):
+                await client.call_tool("validate_tool", {})
+
+        # Should have been called _MAX_VALIDATION_RETRIES + 1 times
+        # (the first call plus _MAX_VALIDATION_RETRIES retries, then the
+        # next failure triggers the cap)
+        assert call_count == _MAX_VALIDATION_RETRIES + 1
+
+    async def test_validation_counter_resets_after_other_tool_call(self):
+        """Non-consecutive validation failures (interleaved with tool calls) don't trigger the cap."""
+        from mcp.types import CreateMessageResultWithTools, ToolUseContent
+        from pydantic import BaseModel
+
+        class NumberResult(BaseModel):
+            value: int
+
+        call_count = 0
+
+        def helper_tool(x: int) -> str:
+            """A helper tool."""
+            return f"result:{x}"
+
+        def sampling_handler(
+            messages: list[SamplingMessage], params: SamplingParams, ctx: RequestContext
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+
+            if call_count == 1:
+                # Call 1: invalid final_response
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_1",
+                            name="final_response",
+                            input={"value": "bad"},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+            elif call_count == 2:
+                # Call 2: use a regular tool (resets consecutive counter)
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_2",
+                            name="helper_tool",
+                            input={"x": 1},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+            elif call_count == 3:
+                # Call 3: invalid final_response again (but counter was reset)
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_3",
+                            name="final_response",
+                            input={"value": "also_bad"},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+            elif call_count == 4:
+                # Call 4: use a regular tool again (resets counter again)
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_4",
+                            name="helper_tool",
+                            input={"x": 2},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+            else:
+                # Call 5: valid final_response
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_5",
+                            name="final_response",
+                            input={"value": 42},
+                        )
+                    ],
+                    model="test-model",
+                    stopReason="toolUse",
+                )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def validate_tool(context: Context) -> str:
+            result = await context.sample(
+                messages="Give me a number",
+                tools=[helper_tool],
+                result_type=NumberResult,
+            )
+            assert isinstance(result.result, NumberResult)
+            return str(result.result.value)
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("validate_tool", {})
+
+        assert call_count == 5
+        assert result.data == "42"


### PR DESCRIPTION
Fixes #3848

## Problem

When `result_type` is set and the LLM repeatedly calls `final_response` with invalid data, the only limit is the shared `max_iterations = 100`. A model that can't satisfy a schema burns through 100 LLM calls (with growing context each time) before failing.

## Fix

Add a separate counter for consecutive validation failures, capped at 3:

```python
_MAX_VALIDATION_RETRIES = 3
```

The counter resets when the LLM calls other tools between validation attempts, so it only triggers on **consecutive** failures — not total failures across a session with interleaved tool use.

## Tests

3 tests: within-cap-then-success, exceed-cap, and counter-reset-after-other-tool-call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)