### PR TITLE
Promote 7 ty rules from ignore to warn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,15 @@ python-version = "3.10"
 # Some code uses `# ty: ignore[invalid-argument-type]` for this limitation.
 # TODO: Remove these ignores once ty supports union narrowing
 
+# Promote rules from default-ignore to warn (becomes error via error-on-warning)
+division-by-zero = "warn"
+possibly-missing-attribute = "warn"
+possibly-missing-import = "warn"
+possibly-unresolved-reference = "warn"
+unsupported-dynamic-base = "warn"
+unsupported-operator = "warn"
+unused-ignore-comment = "warn"
+
 [tool.ty.terminal]
 error-on-warning = true
 

--- a/src/fastmcp/mcp_config.py
+++ b/src/fastmcp/mcp_config.py
@@ -322,7 +322,7 @@ class MCPConfig(BaseModel):
     def from_file(cls, file_path: Path) -> Self:
         """Load configuration from JSON file."""
         if file_path.exists() and (content := file_path.read_text().strip()):
-            return cls.model_validate_json(content)
+            return cls.model_validate_json(content)  # ty: ignore[possibly-unresolved-reference]
 
         raise ValueError(f"No MCP servers defined in the config: {file_path}")
 

--- a/src/fastmcp/utilities/openapi/schemas.py
+++ b/src/fastmcp/utilities/openapi/schemas.py
@@ -247,7 +247,8 @@ def _combine_schemas_and_map_params(
         "header": set(),
         "cookie": set(),
     }
-    body_props = {}
+    body_schema: dict[str, Any] = {}
+    body_props: dict[str, Any] = {}
 
     for param in route.parameters:
         param_names_by_location[param.location].add(param.name)

--- a/tests/server/test_input_validation.py
+++ b/tests/server/test_input_validation.py
@@ -146,6 +146,7 @@ class TestPydanticModelArguments:
             )
 
             # This test verifies whether we handle stringified JSON
+            error_msg = ""
             try:
                 result = await client.call_tool("create_user", {"profile": stringified})
                 # If this succeeds, we're handling stringified JSON

--- a/tests/utilities/json_schema_type/test_real_world_schemas.py
+++ b/tests/utilities/json_schema_type/test_real_world_schemas.py
@@ -206,6 +206,7 @@ def _test_provider(provider: str) -> ProviderResult:
 
             result.schemas += 1
 
+            old_handler = signal.SIG_DFL
             if use_alarm:
                 old_handler = signal.signal(signal.SIGALRM, _alarm_handler)
                 signal.alarm(SCHEMA_TIMEOUT)


### PR DESCRIPTION
Enables stricter type checking by promoting 7 ty rules from their default `ignore` level to `warn` (which becomes `error` via the existing `error-on-warning = true` setting).

**Rules promoted:**
| Rule | Violations | What it catches |
|------|-----------|-----------------|
| `division-by-zero` | 0 | Literal division by zero |
| `possibly-missing-attribute` | 0 | Attribute access on types that may not have it |
| `possibly-missing-import` | 0 | Names that look like they should be imported |
| `possibly-unresolved-reference` | 9 | Variables used when possibly not defined |
| `unsupported-dynamic-base` | 0 | Classes with dynamic base classes |
| `unsupported-operator` | 0 | Operators on incompatible types |
| `unused-ignore-comment` | 0 | Stale `ty: ignore` comments |

**Fixes (9 total):**
- `openapi/schemas.py`: Initialize `body_schema` before conditional block (5 hits)
- `test_input_validation.py`: Initialize `error_msg` before try/except (2 hits)
- `test_real_world_schemas.py`: Initialize `old_handler` before conditional (1 hit)
- `mcp_config.py`: Suppress walrus-operator false positive with `ty: ignore` (1 hit)

Following the pattern from [scipy-stubs](https://github.com/scipy/scipy-stubs) which promotes all of these to `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)