### PR TITLE
Raise on unhandled content types in sampling handler dispatch chains

### DIFF
--- a/src/fastmcp/client/sampling/handlers/anthropic.py
+++ b/src/fastmcp/client/sampling/handlers/anthropic.py
@@ -235,6 +235,10 @@ class AnthropicSamplingHandler:
                                 is_error=item.isError if item.isError else False,
                             )
                         )
+                    else:
+                        raise ValueError(
+                            f"Unsupported content type for Anthropic: {type(item).__name__}"
+                        )
 
                 if content_blocks:
                     anthropic_messages.append(

--- a/src/fastmcp/client/sampling/handlers/openai.py
+++ b/src/fastmcp/client/sampling/handlers/openai.py
@@ -243,6 +243,10 @@ class OpenAISamplingHandler:
                                 content=content_text,
                             )
                         )
+                    else:
+                        raise ValueError(
+                            f"Unsupported content type for OpenAI: {type(item).__name__}"
+                        )
 
                 # Add assistant message with tool calls if present
                 # OpenAI requires: assistant (with tool_calls) -> tool messages

--- a/tests/client/sampling/handlers/test_anthropic_handler.py
+++ b/tests/client/sampling/handlers/test_anthropic_handler.py
@@ -8,14 +8,17 @@ from mcp.types import (
     AudioContent,
     CreateMessageResult,
     CreateMessageResultWithTools,
+    EmbeddedResource,
     ImageContent,
     ModelHint,
     ModelPreferences,
     SamplingMessage,
     TextContent,
+    TextResourceContents,
     ToolResultContent,
     ToolUseContent,
 )
+from pydantic import AnyUrl
 
 from fastmcp.client.sampling.handlers.anthropic import (
     AnthropicSamplingHandler,
@@ -372,3 +375,28 @@ def test_convert_messages_with_tool_result_content():
             "is_error": False,
         }
     ]
+
+
+def test_convert_messages_raises_on_unsupported_content_type():
+    """Unsupported content types should raise ValueError.
+
+    SamplingMessage validates content against a union of known types, so
+    we use model_construct to bypass validation and simulate a future
+    SDK content type that the handler doesn't know about yet.
+    """
+    embedded = EmbeddedResource(
+        type="resource",
+        resource=TextResourceContents(
+            uri=AnyUrl("file:///test.txt"), text="hello", mimeType="text/plain"
+        ),
+    )
+    # Must be inside a list content — single-content messages hit a
+    # different check.  Use model_construct to bypass Pydantic's
+    # union validation (EmbeddedResource is not in the content union).
+    msg = SamplingMessage.model_construct(
+        role="user",
+        content=[TextContent(type="text", text="prefix"), embedded],
+    )
+
+    with pytest.raises(ValueError, match="Unsupported content type for Anthropic"):
+        AnthropicSamplingHandler._convert_to_anthropic_messages([msg])

--- a/tests/client/sampling/handlers/test_openai_handler.py
+++ b/tests/client/sampling/handlers/test_openai_handler.py
@@ -6,11 +6,13 @@ from mcp.types import (
     AudioContent,
     CreateMessageRequestParams,
     CreateMessageResult,
+    EmbeddedResource,
     ImageContent,
     ModelHint,
     ModelPreferences,
     SamplingMessage,
     TextContent,
+    TextResourceContents,
     ToolUseContent,
 )
 from openai import AsyncOpenAI
@@ -25,6 +27,7 @@ from openai.types.chat import (
     ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion import Choice
+from pydantic import AnyUrl
 
 from fastmcp.client.sampling.handlers.openai import (
     OpenAISamplingHandler,
@@ -316,3 +319,25 @@ async def test_chat_completion_to_create_message_result():
         role="assistant",
         model="gpt-4o-mini",
     )
+
+
+def test_convert_messages_raises_on_unsupported_content_type():
+    """Unsupported content types should raise ValueError.
+
+    SamplingMessage validates content against a union of known types, so
+    we use model_construct to bypass validation and simulate a future
+    SDK content type that the handler doesn't know about yet.
+    """
+    embedded = EmbeddedResource(
+        type="resource",
+        resource=TextResourceContents(
+            uri=AnyUrl("file:///test.txt"), text="hello", mimeType="text/plain"
+        ),
+    )
+    msg = SamplingMessage.model_construct(
+        role="user",
+        content=[TextContent(type="text", text="prefix"), embedded],
+    )
+
+    with pytest.raises(ValueError, match="Unsupported content type for OpenAI"):
+        OpenAISamplingHandler._convert_to_openai_messages(None, [msg])


### PR DESCRIPTION
The Anthropic and OpenAI sampling handlers have isinstance chains that dispatch on MCP content types (`TextContent`, `ImageContent`, `AudioContent`, `ToolUseContent`, `ToolResultContent`) but silently drop unhandled variants like `EmbeddedResource` and `ResourceLink`.

This adds explicit `else: raise ValueError` to the two list-content dispatch loops that were missing catch-all branches, matching the behavior of:
- The Gemini handler (already raises on all unhandled types)
- The single-content dispatch paths in both Anthropic and OpenAI (already raise)

**Why raise instead of warn-and-skip:** These handlers convert MCP messages to vendor API formats for LLM calls. A partial conversion produces a plausible-but-wrong response — the LLM confidently answers based on incomplete input, and the user has no reason to doubt it. A clear error is less surprising than a subtly wrong answer.

```python
# Before: EmbeddedResource silently dropped
for item in content:
    if isinstance(item, ToolUseContent): ...
    elif isinstance(item, TextContent): ...
    elif isinstance(item, ImageContent): ...
    elif isinstance(item, AudioContent): ...
    elif isinstance(item, ToolResultContent): ...
    # EmbeddedResource falls through silently

# After: explicit guard
    else:
        raise ValueError(
            f"Unsupported content type for Anthropic: {type(item).__name__}"
        )
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)