### PR TITLE
docs: require agents to respect DNM markers on PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,8 @@ When modifying MCP functionality, changes typically need to be applied across al
 - **NEVER** force-push on collaborative repos
 - **ALWAYS** run prek before PRs
 - **NEVER** create a release, comment on an issue, or open a PR unless specifically instructed to do so.
-- **NEVER** merge a PR marked as do-not-merge. Check title, body, AND labels for `[DNM]`, `DNM`, `DO NOT MERGE`, `DON'T MERGE`, `DONT MERGE`, `do-not-merge`, or `dont-merge` (case-insensitive, any variation). Authors use these as hard stops — respect them even if CI is green and review looks clean. When triaging a batch of PRs, filter these out up front and re-check each one's labels immediately before merging.
+- **NEVER** merge a PR marked as do-not-merge or draft. Check title, body, AND labels for `[DNM]`, `DNM`, `DO NOT MERGE`, `DON'T MERGE`, `DONT MERGE`, `do-not-merge`, `dont-merge`, `[DRAFT]`, or `DRAFT` (case-insensitive, any variation — some authors use `[DRAFT]` in the title even when `isDraft` is false). Authors use these as hard stops — respect them even if CI is green and review looks clean. When triaging a batch of PRs, filter these out up front AND re-check each one's labels immediately before merging, since labels can change mid-session.
+- **ALWAYS** read review-bot comments before approving a PR. CodeRabbit and chatgpt-codex-connector (Codex) leave substantive review comments on most PRs in this repo — these bots have read the diff and often flag real issues that aren't in the PR description. Use `gh pr view <num> --comments` and read the bot feedback as part of review. Unlike proposed solutions from issue reporters, review-bot feedback should be evaluated on its merits, not discounted.
 
 ### Releases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ When modifying MCP functionality, changes typically need to be applied across al
 - **NEVER** force-push on collaborative repos
 - **ALWAYS** run prek before PRs
 - **NEVER** create a release, comment on an issue, or open a PR unless specifically instructed to do so.
+- **NEVER** merge a PR marked as do-not-merge. Check title, body, AND labels for `[DNM]`, `DNM`, `DO NOT MERGE`, `DON'T MERGE`, `DONT MERGE`, `do-not-merge`, or `dont-merge` (case-insensitive, any variation). Authors use these as hard stops — respect them even if CI is green and review looks clean. When triaging a batch of PRs, filter these out up front and re-check each one's labels immediately before merging.
 
 ### Releases
 


### PR DESCRIPTION
Agents reviewing or merging PRs need a clear, unambiguous rule about do-not-merge markers. Authors use these as hard stops — often because a PR is part of a coordinated sequence, has a pending dependency, or is intentionally up for review without being ready to merge. Missing one of these markers can easily result in a premature merge that the author then has to reshape around.

This adds an explicit rule to `CLAUDE.md` that agents must check title, body, AND labels for all common variations of "do not merge" before merging, and that this check must happen immediately before the merge — not just at triage time, since labels can change mid-session.