### PR TITLE
Fix MCP tool on docs welcome page

### DIFF
--- a/docs/v2/getting-started/welcome.mdx
+++ b/docs/v2/getting-started/welcome.mdx
@@ -96,7 +96,7 @@ from fastmcp import Client
 async def main():
     async with Client("https://gofastmcp.com/mcp") as client:
         result = await client.call_tool(
-            name="SearchFastMcp", 
+            name="search_fast_mcp",
             arguments={"query": "deploy a FastMCP server"}
         )
     print(result)


### PR DESCRIPTION
## Description

Trying out the example on the welcome page of FastMCP's docs, I ended up with the exception:

```
…
    raise McpError(response_or_error.error)
mcp.shared.exceptions.McpError: MCP error -32602: Tool SearchFastMcp not found
```

This patch fixes the problem by using the correct tool name `search_fast_mcp`.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [x] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have self-reviewed my changes
