### PR TITLE
fix: drop configurable dedupe from AggregateProvider, always warn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ When modifying MCP functionality, changes typically need to be applied across al
 - **Resource Templates** (`src/resources/`)
 - **Prompts** (`src/prompts/`)
 
+**Before writing cross-component logic (dedupe, grouping, lookups, identity checks), read `FastMCPComponent` in `src/fastmcp/utilities/components.py`.** The base class defines the shared surface — `name`, `version`, `tags`, `meta`, and critically the `key` property which is the canonical MCP identity (encodes type, identifier, and version). Prefer `item.key` over ad-hoc `name or uri or uri_template` fallbacks; overrides in `Resource` and `ResourceTemplate` already handle URI-based identity, and `.key` includes the version suffix so variants of the same component don't falsely collide.
+
 ## Development Rules
 
 **Read `CONTRIBUTING.md` before opening issues or PRs.** It describes when PRs are appropriate, what we expect from enhancement proposals, and what we'll close without review.

--- a/src/fastmcp/server/providers/aggregate.py
+++ b/src/fastmcp/server/providers/aggregate.py
@@ -43,6 +43,26 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def _mcp_identity(item: object) -> str | None:
+    """Return the MCP-level identity a client would key on for *item*.
+
+    Tools and prompts are addressed by ``name``. Resources are addressed by
+    ``uri``, and resource templates by ``uri_template``. Using the right key
+    per type avoids false-positive/negative collision reports when two
+    providers expose, for example, differently-named resources at the same URI.
+    """
+    uri = getattr(item, "uri", None)
+    if uri is not None:
+        return str(uri)
+    uri_template = getattr(item, "uri_template", None)
+    if uri_template is not None:
+        return str(uri_template)
+    name = getattr(item, "name", None)
+    if name is not None:
+        return str(name)
+    return None
+
+
 class AggregateProvider(Provider):
     """Utility provider that combines multiple providers into one.
 
@@ -74,7 +94,6 @@ class AggregateProvider(Provider):
         """
         super().__init__()
         self.providers: list[Provider] = list(providers or [])
-        self._on_duplicate: str = "warn"
 
     def add_provider(self, provider: Provider, *, namespace: str = "") -> None:
         """Add a provider with optional namespace.
@@ -109,12 +128,15 @@ class AggregateProvider(Provider):
     ) -> list[T]:
         """Collect successful list results, logging any exceptions.
 
-        Detects duplicate component names across providers and applies
-        the on_duplicate behavior (error/warn/replace/ignore).
+        Emits a warning when the same MCP identity is returned by more than
+        one provider — surfaces composition mistakes to the server author.
+        This is always a warning: cross-provider collisions happen at runtime
+        (sometimes dynamically), so an errorable/strict mode would give the
+        author no way to react and would crash list calls in production.
         """
         collected: list[T] = []
-        # Track (name, provider_index) to allow version variants from same provider
-        seen_names: dict[str, int] = {}  # name -> provider index of first occurrence
+        # MCP-level identity per item: the value a client would key on.
+        seen_identity: dict[str, int] = {}
         for i, result in enumerate(results):
             if isinstance(result, BaseException):
                 logger.warning(
@@ -123,27 +145,17 @@ class AggregateProvider(Provider):
                 )
                 continue
             for item in result:
-                # Extract identity key: name, uri, or uri_template
-                name = (
-                    getattr(item, "name", None)
-                    or getattr(item, "uri", None)
-                    or getattr(item, "uri_template", None)
-                )
-                if name is not None:
-                    name = str(name)
-                    if name in seen_names and seen_names[name] != i:
-                        # Duplicate from a DIFFERENT provider — flag it
-                        msg = (
-                            f"Duplicate {operation} component '{name}' "
+                identity = _mcp_identity(item)
+                if identity is not None and identity in seen_identity:
+                    first = seen_identity[identity]
+                    if first != i:
+                        logger.warning(
+                            f"Duplicate {operation} identity {identity!r} "
                             f"from provider {self.providers[i]} "
-                            f"(first seen from provider "
-                            f"{self.providers[seen_names[name]]})"
+                            f"(first seen from provider {self.providers[first]})"
                         )
-                        if self._on_duplicate == "error":
-                            raise ValueError(msg)
-                        elif self._on_duplicate == "warn":
-                            logger.warning(msg)
-                    seen_names.setdefault(name, i)
+                elif identity is not None:
+                    seen_identity[identity] = i
                 collected.append(item)
         return collected
 

--- a/src/fastmcp/server/providers/aggregate.py
+++ b/src/fastmcp/server/providers/aggregate.py
@@ -43,26 +43,6 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def _mcp_identity(item: object) -> str | None:
-    """Return the MCP-level identity a client would key on for *item*.
-
-    Tools and prompts are addressed by ``name``. Resources are addressed by
-    ``uri``, and resource templates by ``uri_template``. Using the right key
-    per type avoids false-positive/negative collision reports when two
-    providers expose, for example, differently-named resources at the same URI.
-    """
-    uri = getattr(item, "uri", None)
-    if uri is not None:
-        return str(uri)
-    uri_template = getattr(item, "uri_template", None)
-    if uri_template is not None:
-        return str(uri_template)
-    name = getattr(item, "name", None)
-    if name is not None:
-        return str(name)
-    return None
-
-
 class AggregateProvider(Provider):
     """Utility provider that combines multiple providers into one.
 
@@ -135,8 +115,10 @@ class AggregateProvider(Provider):
         author no way to react and would crash list calls in production.
         """
         collected: list[T] = []
-        # MCP-level identity per item: the value a client would key on.
-        seen_identity: dict[str, int] = {}
+        # FastMCPComponent.key encodes type, identifier, and version —
+        # so version variants of the same component are NOT reported as
+        # collisions (matching _get_highest_version_result behavior).
+        seen_keys: dict[str, int] = {}
         for i, result in enumerate(results):
             if isinstance(result, BaseException):
                 logger.warning(
@@ -145,17 +127,15 @@ class AggregateProvider(Provider):
                 )
                 continue
             for item in result:
-                identity = _mcp_identity(item)
-                if identity is not None and identity in seen_identity:
-                    first = seen_identity[identity]
+                key = getattr(item, "key", None)
+                if key is not None:
+                    first = seen_keys.setdefault(key, i)
                     if first != i:
                         logger.warning(
-                            f"Duplicate {operation} identity {identity!r} "
+                            f"Duplicate {operation} component {key!r} "
                             f"from provider {self.providers[i]} "
                             f"(first seen from provider {self.providers[first]})"
                         )
-                elif identity is not None:
-                    seen_identity[identity] = i
                 collected.append(item)
         return collected
 

--- a/src/fastmcp/utilities/components.py
+++ b/src/fastmcp/utilities/components.py
@@ -147,6 +147,13 @@ class FastMCPComponent(FastMCPBaseModel):
 
         Subclasses should override this to use their specific identifier.
         Base implementation uses name.
+
+        Prefer `.key` over ad-hoc `name or uri or uri_template` logic for any
+        cross-component identity work (dedupe, grouping, collision detection,
+        lookup tables). It encodes type, identifier, and version, so variants
+        of the same component don't falsely collide with each other, and
+        cross-type identifiers (e.g. a tool and a resource both named "foo")
+        can't clash.
         """
         base_key = self.make_key(self.name)
         return f"{base_key}@{self.version or ''}"

--- a/tests/server/mount/test_mount.py
+++ b/tests/server/mount/test_mount.py
@@ -544,31 +544,17 @@ class TestPrefixConflictResolution:
 
 
 class TestCrossProviderDuplicateDetection:
-    """Test that on_duplicate catches duplicates across mounted providers."""
+    """Cross-provider collisions always log a warning — diagnostic signal only.
 
-    async def test_on_duplicate_error_raises_for_same_namespace(self):
-        """Mounting two servers with the same namespace and tool name raises."""
-        main = FastMCP("Main", on_duplicate="error")
-        sub1 = FastMCP("Sub1")
-        sub2 = FastMCP("Sub2")
+    `on_duplicate` is a registration-time setting for LocalProvider (two
+    decorators on the same server), not a knob for AggregateProvider
+    composition. Mounted-provider collisions happen at runtime (sometimes
+    dynamically), so an error mode would give the author no way to react.
+    """
 
-        @sub1.tool(name="greet")
-        def greet_v1() -> str:
-            return "from sub1"
-
-        @sub2.tool(name="greet")
-        def greet_v2() -> str:
-            return "from sub2"
-
-        main.mount(sub1, "ns")
-        main.mount(sub2, "ns")
-
-        with pytest.raises(ValueError, match="Duplicate"):
-            await main.list_tools()
-
-    async def test_on_duplicate_warn_logs_for_same_namespace(self, caplog):
-        """Mounting with on_duplicate='warn' logs a warning instead of raising."""
-        main = FastMCP("Main", on_duplicate="warn")
+    async def test_cross_provider_duplicate_warns(self, caplog):
+        """Two mounted providers exposing the same tool identity log a warning."""
+        main = FastMCP("Main")
         sub1 = FastMCP("Sub1")
         sub2 = FastMCP("Sub2")
 
@@ -589,8 +575,8 @@ class TestCrossProviderDuplicateDetection:
         assert any("Duplicate" in r.message for r in caplog.records)
 
     async def test_no_false_positive_for_different_names(self):
-        """Different tool names in the same namespace don't trigger duplicate."""
-        main = FastMCP("Main", on_duplicate="error")
+        """Different tool names in the same namespace don't trigger a warning."""
+        main = FastMCP("Main")
         sub1 = FastMCP("Sub1")
         sub2 = FastMCP("Sub2")
 


### PR DESCRIPTION
Follow-up to [#3827](https://github.com/PrefectHQ/fastmcp/pull/3827).

#3827 wired FastMCP's `on_duplicate` kwarg into AggregateProvider so that cross-provider collisions could raise `ValueError` on `list_*` calls. That overloaded the kwarg: `on_duplicate` was designed for LocalProvider's registration-time behavior, where the author writes both decorators and can meaningfully react to an error at code time. AggregateProvider composition is different — mounted providers can be dynamic (file-system watchers, remote mirrors, etc.), so a strict-mode runtime error would crash production with no actionable recovery path for the author.

This change makes the cross-provider signal warn-only and non-configurable. `on_duplicate` still controls LocalProvider registration as before; AggregateProvider just emits a warning when two mounted providers return the same MCP component. Collision detection now uses `FastMCPComponent.key`, which is the canonical MCP identity — it encodes type (`tool:` / `resource:` / `template:` / `prompt:`), identifier (name for tools/prompts, `uri` for resources, `uri_template` for templates), and version. That replaces the ad-hoc `name or uri or uri_template` fallback from #3827 and gives version-awareness for free: `greet@1.0` from provider A and `greet@2.0` from provider B are variants, not duplicates — matching what `_get_highest_version_result` already does on the `get_*` side.

```python
# Before — FastMCP(on_duplicate="error") crashed list_tools() on collision.
# After  — collision always logs a warning, never raises.

main = FastMCP("main")
main.mount(sub1, "ns")
main.mount(sub2, "ns")  # both expose "greet"
await main.list_tools()  # logs: Duplicate list_tools component 'tool:ns_greet@' from ...
```
