### PR TITLE
test: bump OpenAPI init perf threshold to 200ms for Windows CI

### DIFF
--- a/tests/server/providers/openapi/test_performance_comparison.py
+++ b/tests/server/providers/openapi/test_performance_comparison.py
@@ -185,14 +185,14 @@ class TestPerformance:
             times.append(end_time - start_time)
 
         avg_time = sum(times) / len(times)
-        max_acceptable_time = 0.1  # 100ms
+        max_acceptable_time = 0.2  # 200ms (Windows CI runners regularly clip 100ms)
 
         print(f"Average initialization time: {avg_time:.4f}s")
         print(f"Performance: {'✓' if avg_time < max_acceptable_time else '✗'}")
 
-        # Should initialize in under 100ms for serverless requirements
+        # Should initialize in under 200ms for serverless requirements
         assert avg_time < max_acceptable_time, (
-            f"Provider should initialize in under 100ms, got {avg_time:.4f}s"
+            f"Provider should initialize in under 200ms, got {avg_time:.4f}s"
         )
 
     def test_server_initialization_performance(self, comprehensive_spec):
@@ -214,12 +214,12 @@ class TestPerformance:
             times.append(end_time - start_time)
 
         avg_time = sum(times) / len(times)
-        max_acceptable_time = 0.1  # 100ms
+        max_acceptable_time = 0.2  # 200ms (Windows CI runners regularly clip 100ms)
 
         print(f"Average server initialization time: {avg_time:.4f}s")
 
         assert avg_time < max_acceptable_time, (
-            f"Server should initialize in under 100ms, got {avg_time:.4f}s"
+            f"Server should initialize in under 200ms, got {avg_time:.4f}s"
         )
 
     async def test_functionality_after_optimization(self, comprehensive_spec):


### PR DESCRIPTION
Windows runners consistently clip the 100ms ceiling in `test_provider_initialization_performance` and `test_server_initialization_performance` — the most recent run hit 100.2ms and failed. These are scheduling-noise flakes, not real regressions (same tests pass comfortably on Ubuntu 3.10 and 3.13 in the same run).

Bumping both thresholds to 200ms so the benchmarks catch real regressions instead of Windows variance.
