### PR TITLE
fix(deps): cap fakeredis to <2.35.0 to prevent startup crash on 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "openapi-pydantic>=0.5.1",
     "platformdirs>=4.0.0",
     "pydocket>=0.17.2",
+    "fakeredis[lua]<2.35.0",
     "rich>=13.9.4",
     "cyclopts>=4.0.0",
     "authlib>=1.6.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -688,6 +688,7 @@ dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "fakeredis", extra = ["lua"] },
     { name = "httpx" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -746,6 +747,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5" },
     { name = "cyclopts", specifier = ">=4.0.0" },
     { name = "exceptiongroup", specifier = ">=1.2.2" },
+    { name = "fakeredis", extras = ["lua"], specifier = "<2.35.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jsonref", specifier = ">=1.1.0" },
     { name = "jsonschema-path", specifier = ">=0.3.4" },


### PR DESCRIPTION
fix(deps): cap fakeredis to <2.35.0 to prevent startup crash on 2.x

Closes #3862

## Summary

`fakeredis 2.35.0` introduced a breaking change in `fakeredis.aioredis` that
renamed/moved `FakeConnection` and `FakeServer`. Because `pydocket < 0.19.0`
still imports those symbols, FastMCP HTTP apps crash during ASGI lifespan
startup before any tools become available.

This PR adds a direct `"fakeredis[lua]<2.35.0"` dependency constraint on the
`release/2.x` branch so users don't hit this transient import mismatch.

## What changed

- Added `"fakeredis[lua]<2.35.0"` to `dependencies` in `pyproject.toml`
- Updated `uv.lock` to reflect the new constraint (revision bump + explicit
  `fakeredis` dependency)

## Why on `release/2.x` only

`main` already resolves this via #3804 + #3822 by bumping `pydocket` to
`>=0.19.0`, which handles the new `fakeredis` API internally. The 2.x release
line still depends on `pydocket>=0.17.2`, so it needs this compatibility cap
instead.

## Verification

- `uv lock` resolves cleanly ✅
- The constraint keeps `fakeredis` on the 2.33.x/2.34.x line that still
  exports `FakeConnection` and `FakeServer` ✅

Let me know if you'd prefer a different approach (e.g., backporting the
pydocket bump instead). Happy to adjust! 🙏
