### PR TITLE
Harden forced client disconnect cleanup

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -642,10 +642,20 @@ class Client(
             # stop the active session
             if self._session_state.session_task is None:
                 return
+            session_task = self._session_state.session_task
             self._session_state.stop_event.set()
             # wait for session to finish to ensure state has been reset
-            await self._session_state.session_task
-            self._session_state.session_task = None
+            try:
+                if force:
+                    await asyncio.shield(session_task)
+                else:
+                    await session_task
+            except asyncio.CancelledError:
+                if not force or not session_task.cancelled():
+                    raise
+            finally:
+                if session_task.done():
+                    self._session_state.session_task = None
 
     async def _session_runner(self):
         """

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -647,15 +647,14 @@ class Client(
             # wait for session to finish to ensure state has been reset
             try:
                 if force:
-                    await asyncio.shield(session_task)
+                    with anyio.CancelScope(shield=True):
+                        with anyio.move_on_after(self._disconnect_timeout):
+                            with suppress(asyncio.CancelledError):
+                                await session_task
                 else:
                     await session_task
-            except asyncio.CancelledError:
-                if not force or not session_task.cancelled():
-                    raise
             finally:
-                if session_task.done():
-                    self._session_state.session_task = None
+                self._session_state.session_task = None
 
     async def _session_runner(self):
         """

--- a/tests/client/client/test_client.py
+++ b/tests/client/client/test_client.py
@@ -439,6 +439,32 @@ class _DelayedConnectTransport(ClientTransport):
         await self._inner.close()
 
 
+class _DelayedDisconnectTransport(ClientTransport):
+    def __init__(
+        self,
+        inner: ClientTransport,
+        disconnect_started: anyio.Event,
+        allow_disconnect: anyio.Event,
+    ) -> None:
+        self._inner = inner
+        self._disconnect_started = disconnect_started
+        self._allow_disconnect = allow_disconnect
+
+    @contextlib.asynccontextmanager
+    async def connect_session(
+        self, **session_kwargs: Any
+    ) -> AsyncIterator[ClientSession]:
+        async with self._inner.connect_session(**session_kwargs) as session:
+            try:
+                yield session
+            finally:
+                self._disconnect_started.set()
+                await self._allow_disconnect.wait()
+
+    async def close(self) -> None:
+        await self._inner.close()
+
+
 async def test_client_nested_context_manager(fastmcp_server):
     """Test that the client connects and disconnects once in nested context manager."""
 
@@ -550,6 +576,45 @@ async def test_cancelled_context_entry_waiter_does_not_close_active_session(
     # task_b is fully cancelled; allow task_a to exercise the connected session.
     b_done.set()
     assert await a == 3
+
+
+async def test_force_close_cancelled_wait_starts_fresh_session(fastmcp_server):
+    disconnect_started = anyio.Event()
+    allow_disconnect = anyio.Event()
+    client = Client(
+        transport=_DelayedDisconnectTransport(
+            FastMCPTransport(fastmcp_server),
+            disconnect_started=disconnect_started,
+            allow_disconnect=allow_disconnect,
+        )
+    )
+
+    await client._connect()
+    original_session_task = client._session_state.session_task
+    assert original_session_task is not None
+
+    close_task = asyncio.create_task(client.close())
+    await disconnect_started.wait()
+
+    close_task.cancel()
+
+    async def reconnect_and_count_tools() -> int:
+        async with client:
+            assert client._session_state.session_task is not original_session_task
+            tools = await client.list_tools()
+            return len(tools)
+
+    reconnect_task = asyncio.create_task(reconnect_and_count_tools())
+    await asyncio.sleep(0)
+    assert not reconnect_task.done()
+
+    allow_disconnect.set()
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await close_task
+
+    assert await reconnect_task == 3
+    assert original_session_task.done()
 
 
 async def test_concurrent_client_context_managers():


### PR DESCRIPTION
This fixes forced `Client.close()` cleanup when caller cancellation arrives while the client is waiting for the background session task to unwind. The forced disconnect path now uses the same `anyio.CancelScope(shield=True)` + `move_on_after()` pattern used during connection-startup cancellation, then clears `session_task` before releasing the session lock so a concurrent reconnect cannot reuse a dying runner.

The regression test pauses session teardown, cancels a force-close mid-wait, immediately attempts a reconnect, and asserts the reconnect gets a fresh session task and can call `list_tools()`.

Validation: `uv run pytest tests/client/client/test_client.py::test_force_close_cancelled_wait_starts_fresh_session -q`, focused neighboring cancellation tests, `uv run pytest tests/client/client/test_client.py -q`, `uv run pytest tests/test_mcp_config.py::test_multi_client_force_close -q`, `uv run pytest -n auto tests/test_mcp_config.py`, `uv run pytest -n auto`, and `uv run prek run --all-files`.

Warning note: the full `tests/test_mcp_config.py` run under xdist still emits one `PytestUnraisableExceptionWarning` from `BaseSubprocessTransport.__del__` in `test_multi_client_lifespan`. I checked an `upstream/main` baseline in a separate worktree: the same subprocess/event-loop-closed warning class is already present there, and the baseline still fails `test_multi_client_force_close` with the original cancellation bug. The focused force-close test now passes without that warning.
