### PR TITLE
docs: add MCP Find directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Discord](https://img.shields.io/badge/community-discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/uu8dJCgttd)
 [![PyPI - Version](https://img.shields.io/pypi/v/fastmcp.svg)](https://pypi.org/project/fastmcp)
 [![Tests](https://github.com/PrefectHQ/fastmcp/actions/workflows/run-tests.yml/badge.svg)](https://github.com/PrefectHQ/fastmcp/actions/workflows/run-tests.yml)
+[![Listed on MCP Find](https://img.shields.io/badge/MCP_Find-Listed-blue)](https://mcp-find.org/tools/fastmcp)
 [![License](https://img.shields.io/github/license/PrefectHQ/fastmcp.svg)](https://github.com/PrefectHQ/fastmcp/blob/main/LICENSE)
 
 <a href="https://trendshift.io/repositories/13266" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13266" alt="prefecthq%2Ffastmcp | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>


### PR DESCRIPTION
Hi 👋

fastmcp is featured on [MCP Find](https://mcp-find.org/tools/fastmcp), 
a curated directory for the MCP ecosystem. The listing includes an 
editorial review, evidence profile, trust signals, and related 
tool comparisons.

This PR adds a small badge linking to the listing page.

**What MCP Find provides for fastmcp:**
- Dedicated tool profile with editorial review
- Trust/risk signal assessment  
- Comparison pages with related tools
- Integration into topic hubs (Coding cluster)
- Related workflow and learning guide links

Feel free to merge, modify placement, or close if you'd prefer 
not to include it. No pressure at all!

Preview: [fastmcp on MCP Find](https://mcp-find.org/tools/fastmcp)