### PR TITLE
docs: link fastmcp-keycloak-local companion project from Keycloak integration page

### DIFF
--- a/docs/integrations/keycloak.mdx
+++ b/docs/integrations/keycloak.mdx
@@ -60,6 +60,12 @@ async def get_access_token_claims() -> dict:
 **Production security**: Always configure the `audience` parameter in production. Without it, your server accepts tokens issued for any audience. Configure Keycloak audience mappers and set `audience` to your server's base URL to ensure tokens are specifically intended for your server.
 </Warning>
 
+## Local Development
+
+Local infrastructure tooling is deliberately kept out of the FastMCP core library to keep auth integrations slim and the associated maintenance burden as low as possible. That said, Keycloak is a popular identity provider for local development and testing, so a dedicated FastMCP-compatible setup blueprint lives in the companion project [**fastmcp-keycloak-local**](https://github.com/stephaneberle9/fastmcp-keycloak-local).
+
+It provides everything needed to develop and test FastMCP servers with Keycloak OAuth locally: a Docker-based Keycloak setup with a pre-configured `fastmcp` realm (Dynamic Client Registration enabled, test user included), cross-platform start scripts, and integration guides for the MCP Inspector, Claude Desktop, and Claude Code CLI.
+
 ## Testing
 
 ### Running the Server


### PR DESCRIPTION
Adds a **Local Development** section to `docs/integrations/keycloak.mdx`, linking to [fastmcp-keycloak-local](https://github.com/stephaneberle9/fastmcp-keycloak-local) as suggested by @jlowin in #1937.

The section explains why local infrastructure tooling is kept out of the core library (slim auth integrations, low maintenance burden), then points to the companion project for anyone who wants a ready-made local Keycloak setup — Docker-based, pre-configured `fastmcp` realm with DCR enabled, cross-platform scripts, and integration guides for the MCP Inspector, Claude Desktop, and Claude Code CLI.