### PR TITLE
Stop pydantic 2.13 from leaking _WrappedResult docstring into tool output schemas

### DIFF
--- a/.github/workflows/run-upgrade-checks.yml
+++ b/.github/workflows/run-upgrade-checks.yml
@@ -121,7 +121,7 @@ jobs:
 
             - **ty (type checker)**: New ty releases frequently add stricter checks that flag previously-accepted code. Run `uv run ty check` locally with the latest ty to reproduce. Fix the type errors or bump the ty version floor in `pyproject.toml`.
             - **ruff**: New lint rules or stricter defaults in a ruff upgrade.
-            - **mcp SDK**: Breaking changes in the `mcp` package (new method signatures, renamed types).
+            - **MCP SDK**: Breaking changes in the `mcp` package (new method signatures, renamed types).
 
             ### What to do
 

--- a/src/fastmcp/tools/function_parsing.py
+++ b/src/fastmcp/tools/function_parsing.py
@@ -67,8 +67,6 @@ logger = get_logger(__name__)
 
 @dataclass
 class _WrappedResult(Generic[T]):
-    """Generic wrapper for non-object return types."""
-
     result: T
 
 


### PR DESCRIPTION
Pydantic 2.13 started emitting dataclass docstrings as JSON-schema `description`. Our private `_WrappedResult` dataclass, which wraps non-object return types into the object shape MCP requires, had a docstring — so every tool returning e.g. `int`, `str`, or `list[...]` began advertising *"Generic wrapper for non-object return types."* as the description of its output schema. That's a fastmcp implementation detail leaking into the user-visible tool manifest.

Bumping the lockfile + snapping tests would only invert the problem (the `lowest-direct` CI job on pydantic 2.11.7 wouldn't emit the description and would go red). Dropping the docstring makes the schema version-insensitive across 2.11.7 → 2.13.0.

Before (pydantic 2.13):
```python
{"description": "Generic wrapper for non-object return types.", "properties": {"result": {"type": "integer"}}, "required": ["result"], "type": "object", "x-fastmcp-wrap-result": True}
```

After:
```python
{"properties": {"result": {"type": "integer"}}, "required": ["result"], "type": "object", "x-fastmcp-wrap-result": True}
```

Also capitalizes "MCP SDK" in the upgrade-check issue template while we're here.

Closes #3902