### PR TITLE
fix: reject self-mount to prevent infinite recursion

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -476,7 +476,8 @@ class FastMCP(
         return await chain(context)
 
     def add_middleware(self, middleware: Middleware) -> None:
-        self.middleware.append(middleware)
+        if middleware not in self.middleware:
+            self.middleware.append(middleware)
 
     def add_provider(self, provider: Provider, *, namespace: str = "") -> None:
         """Add a provider for dynamic tools, resources, and prompts.
@@ -2046,6 +2047,15 @@ class FastMCP(
         import warnings
 
         from fastmcp.server.providers.fastmcp_provider import FastMCPProvider
+
+        if not isinstance(server, FastMCP):
+            raise TypeError(
+                f"mount() expected a FastMCP server as the first argument, got {type(server).__name__}. "
+                f"Usage: mount(server, namespace='...')"
+            )
+
+        if server is self:
+            raise ValueError("Cannot mount a server onto itself")
 
         # Handle deprecated prefix parameter
         if prefix is not None:

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -476,8 +476,7 @@ class FastMCP(
         return await chain(context)
 
     def add_middleware(self, middleware: Middleware) -> None:
-        if middleware not in self.middleware:
-            self.middleware.append(middleware)
+        self.middleware.append(middleware)
 
     def add_provider(self, provider: Provider, *, namespace: str = "") -> None:
         """Add a provider for dynamic tools, resources, and prompts.
@@ -2047,12 +2046,6 @@ class FastMCP(
         import warnings
 
         from fastmcp.server.providers.fastmcp_provider import FastMCPProvider
-
-        if not isinstance(server, FastMCP):
-            raise TypeError(
-                f"mount() expected a FastMCP server as the first argument, got {type(server).__name__}. "
-                f"Usage: mount(server, namespace='...')"
-            )
 
         if server is self:
             raise ValueError("Cannot mount a server onto itself")

--- a/tests/server/test_server_safety.py
+++ b/tests/server/test_server_safety.py
@@ -1,0 +1,39 @@
+import pytest
+
+from fastmcp import FastMCP
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+
+
+class TestMountSafety:
+    def test_self_mount_raises(self):
+        mcp = FastMCP("test")
+        with pytest.raises(ValueError, match="Cannot mount a server onto itself"):
+            mcp.mount(mcp)
+
+    def test_mount_wrong_arg_order_raises(self):
+        parent = FastMCP("parent")
+        child = FastMCP("child")
+        with pytest.raises(TypeError, match="expected a FastMCP server"):
+            parent.mount("namespace", child)  # type: ignore
+
+
+class TestMiddlewareDedupe:
+    def test_duplicate_middleware_not_added(self):
+        mcp = FastMCP("test")
+        mw = ErrorHandlingMiddleware()
+        mcp.add_middleware(mw)
+        mcp.add_middleware(mw)
+        # Count only our ErrorHandlingMiddleware (server may add defaults)
+        count = sum(1 for m in mcp.middleware if m is mw)
+        assert count == 1
+
+    def test_different_instances_both_added(self):
+        mcp = FastMCP("test")
+        mw1 = ErrorHandlingMiddleware()
+        mw2 = ErrorHandlingMiddleware()
+        mcp.add_middleware(mw1)
+        mcp.add_middleware(mw2)
+        count = sum(
+            1 for m in mcp.middleware if isinstance(m, ErrorHandlingMiddleware)
+        )
+        assert count == 2

--- a/tests/server/test_server_safety.py
+++ b/tests/server/test_server_safety.py
@@ -1,7 +1,6 @@
 import pytest
 
 from fastmcp import FastMCP
-from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 
 
 class TestMountSafety:
@@ -9,31 +8,3 @@ class TestMountSafety:
         mcp = FastMCP("test")
         with pytest.raises(ValueError, match="Cannot mount a server onto itself"):
             mcp.mount(mcp)
-
-    def test_mount_wrong_arg_order_raises(self):
-        parent = FastMCP("parent")
-        child = FastMCP("child")
-        with pytest.raises(TypeError, match="expected a FastMCP server"):
-            parent.mount("namespace", child)  # type: ignore
-
-
-class TestMiddlewareDedupe:
-    def test_duplicate_middleware_not_added(self):
-        mcp = FastMCP("test")
-        mw = ErrorHandlingMiddleware()
-        mcp.add_middleware(mw)
-        mcp.add_middleware(mw)
-        # Count only our ErrorHandlingMiddleware (server may add defaults)
-        count = sum(1 for m in mcp.middleware if m is mw)
-        assert count == 1
-
-    def test_different_instances_both_added(self):
-        mcp = FastMCP("test")
-        mw1 = ErrorHandlingMiddleware()
-        mw2 = ErrorHandlingMiddleware()
-        mcp.add_middleware(mw1)
-        mcp.add_middleware(mw2)
-        count = sum(
-            1 for m in mcp.middleware if isinstance(m, ErrorHandlingMiddleware)
-        )
-        assert count == 2


### PR DESCRIPTION
`mcp.mount(mcp)` is silently accepted, producing infinite recursion when listing tools. A simple identity check in `mount()` catches this at mount time with a clear error.

```python
mcp = FastMCP("test")
mcp.mount(mcp)           # Before: silently accepted
await mcp.list_tools()   # Before: infinite recursion
# After: ValueError("Cannot mount a server onto itself")
```

Closes #3920