### PR TITLE
fix: ProxyTool crashes on non-TextContent error responses

### DIFF
--- a/src/fastmcp/server/providers/proxy.py
+++ b/src/fastmcp/server/providers/proxy.py
@@ -164,9 +164,7 @@ class ProxyTool(Tool):
                 elif first is None:
                     raise ToolError("Tool returned an error with no content")
                 else:
-                    raise ToolError(
-                        f"Tool returned an error ({type(first).__name__})"
-                    )
+                    raise ToolError(f"Tool returned an error ({type(first).__name__})")
             # Preserve backend's meta (includes task metadata for background tasks)
             return ToolResult(
                 content=result.content,

--- a/src/fastmcp/server/providers/proxy.py
+++ b/src/fastmcp/server/providers/proxy.py
@@ -161,8 +161,12 @@ class ProxyTool(Tool):
                 first = result.content[0] if result.content else None
                 if isinstance(first, mcp.types.TextContent):
                     raise ToolError(first.text)
+                elif first is None:
+                    raise ToolError("Tool returned an error with no content")
                 else:
-                    raise ToolError(str(first))
+                    raise ToolError(
+                        f"Tool returned an error ({type(first).__name__})"
+                    )
             # Preserve backend's meta (includes task metadata for background tasks)
             return ToolResult(
                 content=result.content,

--- a/src/fastmcp/server/providers/proxy.py
+++ b/src/fastmcp/server/providers/proxy.py
@@ -158,7 +158,11 @@ class ProxyTool(Tool):
                     name=backend_name, arguments=arguments, meta=meta
                 )
             if result.isError:
-                raise ToolError(cast(mcp.types.TextContent, result.content[0]).text)
+                first = result.content[0] if result.content else None
+                if isinstance(first, mcp.types.TextContent):
+                    raise ToolError(first.text)
+                else:
+                    raise ToolError(str(first))
             # Preserve backend's meta (includes task metadata for background tasks)
             return ToolResult(
                 content=result.content,

--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -330,6 +330,36 @@ class TestTools:
             async with Client(proxy_server) as client:
                 await client.call_tool("error_tool", {})
 
+    async def test_error_tool_with_image_content(self, proxy_server):
+        """Non-TextContent error responses should not crash with AttributeError."""
+        error_result = mcp_types.CallToolResult(
+            content=[
+                mcp_types.ImageContent(
+                    type="image", data="abc123", mimeType="image/png"
+                )
+            ],
+            isError=True,
+        )
+        with patch.object(
+            Client, "call_tool_mcp", new_callable=AsyncMock, return_value=error_result
+        ):
+            with pytest.raises(ToolError):
+                async with Client(proxy_server) as client:
+                    await client.call_tool("error_tool", {})
+
+    async def test_error_tool_with_empty_content(self, proxy_server):
+        """Error responses with empty content should not crash."""
+        error_result = mcp_types.CallToolResult(
+            content=[],
+            isError=True,
+        )
+        with patch.object(
+            Client, "call_tool_mcp", new_callable=AsyncMock, return_value=error_result
+        ):
+            with pytest.raises(ToolError):
+                async with Client(proxy_server) as client:
+                    await client.call_tool("error_tool", {})
+
     async def test_call_tool_forwards_meta(self, fastmcp_server, proxy_server):
         """Test that metadata from proxied tool results is properly forwarded."""
 


### PR DESCRIPTION
The `ProxyTool.run` error handler used `cast(mcp.types.TextContent, ...)` which is a no-op at runtime — if the error content is `ImageContent` or `EmbeddedResource`, accessing `.text` raises `AttributeError`. This replaces the unsafe cast with a proper `isinstance` check, falling back to `str()` for non-text content.

Fixes #3922

```python
# Before (crashes on non-TextContent)
raise ToolError(cast(mcp.types.TextContent, result.content[0]).text)

# After
first = result.content[0] if result.content else None
if isinstance(first, mcp.types.TextContent):
    raise ToolError(first.text)
else:
    raise ToolError(str(first))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)