### PR TITLE
fix: narrow OpenAI audio format dict to Literal for ty

### DIFF
--- a/src/fastmcp/client/sampling/handlers/openai.py
+++ b/src/fastmcp/client/sampling/handlers/openai.py
@@ -2,7 +2,7 @@
 
 import json
 from collections.abc import Iterator, Sequence
-from typing import Any, get_args
+from typing import Any, Literal, get_args
 
 from mcp import ClientSession, ServerSession
 from mcp.shared.context import LifespanContextT, RequestContext
@@ -48,7 +48,7 @@ except ImportError as e:
     ) from e
 
 # OpenAI only supports wav and mp3 for input audio
-_OPENAI_AUDIO_FORMATS: dict[str, str] = {
+_OPENAI_AUDIO_FORMATS: dict[str, Literal["wav", "mp3"]] = {
     "audio/wav": "wav",
     "audio/x-wav": "wav",
     "audio/mp3": "mp3",

--- a/src/fastmcp/server/auth/auth.py
+++ b/src/fastmcp/server/auth/auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from mcp.server.auth.handlers.token import TokenErrorResponse
@@ -789,7 +789,7 @@ class OAuthProvider(
             )
             protected_routes = create_protected_resource_routes(
                 resource_url=self._resource_url,
-                authorization_servers=[cast(AnyHttpUrl, self.issuer_url)],
+                authorization_servers=[self.issuer_url],
                 scopes_supported=supported_scopes,
             )
             oauth_routes.extend(protected_routes)


### PR DESCRIPTION
The OpenAI SDK tightened `ChatCompletionContentPartInputAudioParam.input_audio["format"]` from `str` to `Literal["wav", "mp3"]`, which broke `ty check` on `main`. Our lookup dict `_OPENAI_AUDIO_FORMATS` was typed `dict[str, str]`, so `.get(mimeType)` returned a plain `str` that no longer fits the narrowed slot.

The runtime values are already exactly `"wav"` or `"mp3"` — only the declared type was too wide. Narrowing the dict's value type is a type-only change with no behavior impact.

Also drops a redundant `cast(AnyHttpUrl, self.issuer_url)` in `server/auth/auth.py` that a stricter ty release started treating as blocking. `self.issuer_url` is already `AnyHttpUrl`, so the cast was a no-op at runtime and spurious to the type checker.

```python
_OPENAI_AUDIO_FORMATS: dict[str, Literal["wav", "mp3"]] = {
    "audio/wav": "wav",
    ...
}
```

Closes #3935.