### PR TITLE
fix: FileSystemProvider reload race condition

### DIFF
--- a/src/fastmcp/server/providers/filesystem.py
+++ b/src/fastmcp/server/providers/filesystem.py
@@ -97,6 +97,8 @@ class FileSystemProvider(LocalProvider):
         self._warned_files: dict[Path, float] = {}
         # Lock for serializing reload operations (created lazily)
         self._reload_lock: asyncio.Lock | None = None
+        # Generation counter to deduplicate concurrent reloads
+        self._reload_generation: int = 0
 
         # Always load once at init to catch errors early
         self._load_components()
@@ -157,17 +159,16 @@ class FileSystemProvider(LocalProvider):
         else:
             logger.debug("Ignoring unknown component type: %r", type(component))
 
-    async def _maybe_reload(self) -> None:
-        """Reload components if needed. Caller must hold ``_reload_lock``."""
-        if self._reload or not self._loaded:
-            await asyncio.to_thread(self._load_components)
-
     async def _with_reload(self, coro_fn: Callable[..., Any], *args: Any) -> Any:
         """Acquire the reload lock, reload if needed, then run *coro_fn*.
 
         Holding the lock across both the reload and the read prevents
         concurrent readers from seeing a partially-rebuilt ``_components``
         dict (the ``clear()`` + re-register window).
+
+        A generation counter deduplicates concurrent reload requests:
+        if another caller already reloaded while we waited for the lock,
+        we skip the redundant reload.
         """
         if not self._reload and self._loaded:
             return await coro_fn(*args)
@@ -176,8 +177,14 @@ class FileSystemProvider(LocalProvider):
         if self._reload_lock is None:
             self._reload_lock = asyncio.Lock()
 
+        generation_before = self._reload_generation
+
         async with self._reload_lock:
-            await self._maybe_reload()
+            if not self._loaded or (
+                self._reload and self._reload_generation == generation_before
+            ):
+                await asyncio.to_thread(self._load_components)
+                self._reload_generation += 1
             return await coro_fn(*args)
 
     # Override provider methods to support reload mode

--- a/src/fastmcp/server/providers/filesystem.py
+++ b/src/fastmcp/server/providers/filesystem.py
@@ -28,8 +28,9 @@ Example:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Any
 
 from fastmcp.prompts.base import Prompt
 from fastmcp.resources.base import Resource
@@ -102,9 +103,11 @@ class FileSystemProvider(LocalProvider):
 
     def _load_components(self) -> None:
         """Discover and register all components from the filesystem."""
-        # Clear existing components if reloading
         if self._loaded:
             self._components.clear()
+
+        if not self._root.exists():
+            logger.warning("FileSystemProvider root does not exist: %s", self._root)
 
         result = discover_and_import(self._root)
 
@@ -154,73 +157,62 @@ class FileSystemProvider(LocalProvider):
         else:
             logger.debug("Ignoring unknown component type: %r", type(component))
 
-    async def _ensure_loaded(self) -> None:
-        """Ensure components are loaded, reloading if in reload mode.
+    async def _maybe_reload(self) -> None:
+        """Reload components if needed. Caller must hold ``_reload_lock``."""
+        if self._reload or not self._loaded:
+            await asyncio.to_thread(self._load_components)
 
-        Uses a lock to serialize concurrent reload operations and runs
-        filesystem I/O off the event loop using asyncio.to_thread.
+    async def _with_reload(self, coro_fn: Callable[..., Any], *args: Any) -> Any:
+        """Acquire the reload lock, reload if needed, then run *coro_fn*.
+
+        Holding the lock across both the reload and the read prevents
+        concurrent readers from seeing a partially-rebuilt ``_components``
+        dict (the ``clear()`` + re-register window).
         """
         if not self._reload and self._loaded:
-            return
+            return await coro_fn(*args)
 
         # Create lock lazily (can't create in __init__ without event loop)
         if self._reload_lock is None:
             self._reload_lock = asyncio.Lock()
 
         async with self._reload_lock:
-            # Double-check after acquiring lock
-            if self._reload or not self._loaded:
-                await asyncio.to_thread(self._load_components)
+            await self._maybe_reload()
+            return await coro_fn(*args)
 
     # Override provider methods to support reload mode
 
     async def _list_tools(self) -> Sequence[Tool]:
-        """Return all tools, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._list_tools()
+        return await self._with_reload(super()._list_tools)
 
     async def _get_tool(
         self, name: str, version: VersionSpec | None = None
     ) -> Tool | None:
-        """Get a tool by name, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._get_tool(name, version)
+        return await self._with_reload(super()._get_tool, name, version)
 
     async def _list_resources(self) -> Sequence[Resource]:
-        """Return all resources, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._list_resources()
+        return await self._with_reload(super()._list_resources)
 
     async def _get_resource(
         self, uri: str, version: VersionSpec | None = None
     ) -> Resource | None:
-        """Get a resource by URI, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._get_resource(uri, version)
+        return await self._with_reload(super()._get_resource, uri, version)
 
     async def _list_resource_templates(self) -> Sequence[ResourceTemplate]:
-        """Return all resource templates, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._list_resource_templates()
+        return await self._with_reload(super()._list_resource_templates)
 
     async def _get_resource_template(
         self, uri: str, version: VersionSpec | None = None
     ) -> ResourceTemplate | None:
-        """Get a resource template, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._get_resource_template(uri, version)
+        return await self._with_reload(super()._get_resource_template, uri, version)
 
     async def _list_prompts(self) -> Sequence[Prompt]:
-        """Return all prompts, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._list_prompts()
+        return await self._with_reload(super()._list_prompts)
 
     async def _get_prompt(
         self, name: str, version: VersionSpec | None = None
     ) -> Prompt | None:
-        """Get a prompt by name, reloading if in reload mode."""
-        await self._ensure_loaded()
-        return await super()._get_prompt(name, version)
+        return await self._with_reload(super()._get_prompt, name, version)
 
     def __repr__(self) -> str:
         return f"FileSystemProvider(root={self._root!r}, reload={self._reload})"

--- a/tests/fs/test_provider.py
+++ b/tests/fs/test_provider.py
@@ -183,7 +183,7 @@ def original() -> str:
         assert provider._loaded
         assert len(provider._components) == 1
 
-        # Add another file - should be picked up on next _ensure_loaded
+        # Add another file - should be picked up on next read
         (tmp_path / "tool2.py").write_text(
             """\
 from fastmcp.tools import tool
@@ -194,9 +194,9 @@ def added() -> str:
 """
         )
 
-        # With reload=True, _ensure_loaded re-scans
-        await provider._ensure_loaded()
-        assert len(provider._components) == 2
+        # With reload=True, reading triggers a re-scan
+        tools = await provider._list_tools()
+        assert len(tools) == 2
 
     async def test_warning_deduplication_same_file(self, tmp_path: Path, capsys):
         """Warnings for the same broken file should not repeat."""
@@ -211,7 +211,7 @@ def added() -> str:
         assert "WARNING" in captured.err and "Failed to import" in captured.err
 
         # Second load (same file, unchanged) - should NOT warn again
-        await provider._ensure_loaded()
+        await provider._list_tools()
         captured = capsys.readouterr()
         assert "Failed to import" not in captured.err
 
@@ -232,7 +232,7 @@ def added() -> str:
         bad_file.write_text("syntax error here !!!")
 
         # Next load - should warn again (file changed)
-        await provider._ensure_loaded()
+        await provider._list_tools()
         captured = capsys.readouterr()
         # Check for warning indicator (rich may truncate long paths)
         assert "WARNING" in captured.err and "Failed to import" in captured.err
@@ -262,7 +262,7 @@ def my_tool() -> str:
         )
 
         # Load again - should NOT warn, file is fixed
-        await provider._ensure_loaded()
+        await provider._list_tools()
         captured = capsys.readouterr()
         assert "Failed to import" not in captured.err
         assert len(provider._components) == 1
@@ -272,10 +272,50 @@ def my_tool() -> str:
         bad_file.write_text("1/0  # broken again")
 
         # Should warn again
-        await provider._ensure_loaded()
+        await provider._list_tools()
         captured = capsys.readouterr()
         # Check for warning indicator (rich may truncate long paths)
         assert "WARNING" in captured.err and "Failed to import" in captured.err
+
+
+class TestFileSystemProviderReloadRace:
+    """Test that concurrent readers don't see empty components during reload."""
+
+    async def test_concurrent_reader_never_sees_empty(self, tmp_path: Path):
+        """A reader during reload should see either old or new components, never empty."""
+        (tmp_path / "tool.py").write_text(
+            """\
+from fastmcp.tools import tool
+
+@tool
+def my_tool() -> str:
+    return "hello"
+"""
+        )
+
+        provider = FileSystemProvider(tmp_path, reload=True)
+        assert len(await provider._list_tools()) == 1
+
+        import asyncio
+
+        observed_empty = False
+
+        async def reader():
+            nonlocal observed_empty
+            for _ in range(20):
+                tools = await provider._list_tools()
+                if len(tools) == 0:
+                    observed_empty = True
+                await asyncio.sleep(0)
+
+        async def reloader():
+            for _ in range(5):
+                provider._loaded = False
+                await provider._list_tools()  # triggers reload
+                await asyncio.sleep(0)
+
+        await asyncio.gather(reader(), reloader())
+        assert not observed_empty, "Reader saw empty components during reload"
 
 
 class TestFileSystemProviderIntegration:

--- a/tests/fs/test_provider.py
+++ b/tests/fs/test_provider.py
@@ -1,5 +1,6 @@
 """Tests for FileSystemProvider."""
 
+import asyncio
 import time
 from pathlib import Path
 
@@ -295,8 +296,6 @@ def my_tool() -> str:
 
         provider = FileSystemProvider(tmp_path, reload=True)
         assert len(await provider._list_tools()) == 1
-
-        import asyncio
 
         observed_empty = False
 


### PR DESCRIPTION
Supersedes #3660, which had the same race condition it was trying to fix (the atomic swap exposed a partially-populated dict during the registration loop).

The fix is simpler: hold the reload lock across both the reload AND the subsequent read. Since every reader method (`_list_tools`, `_get_tool`, etc.) already called `_ensure_loaded()` before reading, we just widen the lock scope to cover both steps. No reader can observe a mid-rebuild `_components` dict because the lock serializes everything.

```python
async def _with_reload(self, coro_fn, *args):
    async with self._reload_lock:
        await self._maybe_reload()
        return await coro_fn(*args)  # read happens inside the lock
```

This only affects `reload=True` mode, which is explicitly a dev feature. The serialization cost is irrelevant for development.

Also warns when the root directory doesn't exist (previously produced zero components silently).

Closes #3625