### PR TITLE
fix tests that relied on task=True returning error results

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -48,7 +48,7 @@ max_lines = 1029
 
 [[rules]]
 path = "tests/server/tasks/test_task_mount.py"
-max_lines = 1083
+max_lines = 1088
 
 [[rules]]
 path = "tests/server/test_dependencies.py"

--- a/tests/client/tasks/test_task_result_caching.py
+++ b/tests/client/tasks/test_task_result_caching.py
@@ -142,7 +142,7 @@ async def test_forbidden_mode_tool_caches_error_result():
 
     async with Client(mcp) as client:
         # Request as task, but mode="forbidden" will reject with error
-        task = await client.call_tool("non_task_tool", task=True)
+        task = await client.call_tool("non_task_tool", task=True, raise_on_error=False)
 
         # Should be immediate (error returned immediately)
         assert task.returned_immediately

--- a/tests/server/tasks/test_server_tasks_parameter.py
+++ b/tests/server/tasks/test_server_tasks_parameter.py
@@ -72,7 +72,7 @@ async def test_server_tasks_false_defaults_all_components():
 
     async with Client(mcp) as client:
         # Tool with mode="forbidden" returns error when called with task=True
-        tool_task = await client.call_tool("my_tool", task=True)
+        tool_task = await client.call_tool("my_tool", task=True, raise_on_error=False)
         assert tool_task.returned_immediately
         result = await tool_task.result()
         assert result.is_error
@@ -97,7 +97,7 @@ async def test_server_tasks_none_defaults_to_false():
 
     async with Client(mcp) as client:
         # Tool should NOT support background execution (mode="forbidden" from default)
-        tool_task = await client.call_tool("my_tool", task=True)
+        tool_task = await client.call_tool("my_tool", task=True, raise_on_error=False)
         assert tool_task.returned_immediately
         result = await tool_task.result()
         assert result.is_error
@@ -126,7 +126,9 @@ async def test_component_explicit_false_overrides_server_true():
         assert "tool:default_tool@" in docket.tasks  # Inherits tasks=True
 
         # Explicit False (mode="forbidden") returns error when called with task=True
-        no_task = await client.call_tool("no_task_tool", task=True)
+        no_task = await client.call_tool(
+            "no_task_tool", task=True, raise_on_error=False
+        )
         assert no_task.returned_immediately
         result = await no_task.result()
         assert result.is_error
@@ -161,7 +163,9 @@ async def test_component_explicit_true_overrides_server_false():
         assert not task.returned_immediately
 
         # Default (mode="forbidden") returns error when called with task=True
-        default = await client.call_tool("default_tool", task=True)
+        default = await client.call_tool(
+            "default_tool", task=True, raise_on_error=False
+        )
         assert default.returned_immediately
         result = await default.result()
         assert result.is_error
@@ -225,7 +229,9 @@ async def test_mixed_explicit_and_inherited():
         assert not explicit_true.returned_immediately
 
         # Explicit False (mode="forbidden") returns error
-        explicit_false = await client.call_tool("explicit_false_tool", task=True)
+        explicit_false = await client.call_tool(
+            "explicit_false_tool", task=True, raise_on_error=False
+        )
         assert explicit_false.returned_immediately
         result = await explicit_false.result()
         assert result.is_error
@@ -272,7 +278,9 @@ async def test_server_tasks_parameter_sets_component_defaults():
 
     async with Client(mcp2) as client:
         # Tool inherits tasks=False (mode="forbidden") - returns error
-        tool_task = await client.call_tool("tool_inherits_false", task=True)
+        tool_task = await client.call_tool(
+            "tool_inherits_false", task=True, raise_on_error=False
+        )
         assert tool_task.returned_immediately
         result = await tool_task.result()
         assert result.is_error

--- a/tests/server/tasks/test_task_config.py
+++ b/tests/server/tasks/test_task_config.py
@@ -128,7 +128,9 @@ class TestToolModeEnforcement:
         """Forbidden mode returns error when called with task metadata."""
         async with Client(server) as client:
             # Call with task=True should fail
-            task = await client.call_tool("forbidden_tool", {}, task=True)
+            task = await client.call_tool(
+                "forbidden_tool", {}, task=True, raise_on_error=False
+            )
             assert task is not None
             # The task should have returned immediately with an error
             assert task.returned_immediately

--- a/tests/server/tasks/test_task_mount.py
+++ b/tests/server/tasks/test_task_mount.py
@@ -176,7 +176,10 @@ class TestMountedToolTasks:
         """Sync-only mounted tool returns error with task=True."""
         async with Client(parent_server) as client:
             task = await client.call_tool(
-                "child_sync_child_tool", {"message": "hello"}, task=True
+                "child_sync_child_tool",
+                {"message": "hello"},
+                task=True,
+                raise_on_error=False,
             )
 
             # Should return immediately with an error
@@ -663,7 +666,9 @@ class TestMountedTaskConfigModes:
     async def test_forbidden_mode_with_task_through_mount(self, parent_with_modes):
         """Forbidden mode tool degrades gracefully with task through mount."""
         async with Client(parent_with_modes) as client:
-            task = await client.call_tool("child_forbidden_tool", {}, task=True)
+            task = await client.call_tool(
+                "child_forbidden_tool", {}, task=True, raise_on_error=False
+            )
 
             # Should return immediately (graceful degradation)
             assert task.returned_immediately

--- a/tests/server/tasks/test_task_proxy.py
+++ b/tests/server/tasks/test_task_proxy.py
@@ -85,7 +85,9 @@ class TestProxyToolsTaskForbidden:
     async def test_tool_task_returns_error_immediately(self, proxy_server: FastMCP):
         """Tool called with task=True through proxy returns error immediately."""
         async with Client(proxy_server) as client:
-            task = await client.call_tool("add_numbers", {"a": 5, "b": 3}, task=True)
+            task = await client.call_tool(
+                "add_numbers", {"a": 5, "b": 3}, task=True, raise_on_error=False
+            )
 
             # Should return immediately (forbidden behavior)
             assert task.returned_immediately
@@ -100,7 +102,10 @@ class TestProxyToolsTaskForbidden:
         """Sync-only tool with task=True also returns error immediately."""
         async with Client(proxy_server) as client:
             task = await client.call_tool(
-                "sync_only_tool", {"message": "test"}, task=True
+                "sync_only_tool",
+                {"message": "test"},
+                task=True,
+                raise_on_error=False,
             )
 
             assert task.returned_immediately

--- a/tests/server/tasks/test_task_tools.py
+++ b/tests/server/tasks/test_task_tools.py
@@ -91,7 +91,9 @@ async def test_forbidden_mode_tool_rejects_task_calls(tool_server):
     """Tools with task=False (mode=forbidden) reject task-augmented calls."""
     async with Client(tool_server) as client:
         # Calling with task=True when task=False should return error
-        task = await client.call_tool("sync_only_tool", {"message": "test"}, task=True)
+        task = await client.call_tool(
+            "sync_only_tool", {"message": "test"}, task=True, raise_on_error=False
+        )
         assert task
         assert task.returned_immediately
 


### PR DESCRIPTION
PR #3946 made `ToolTask.result()` raise `ToolError` on error results by default, aligning `task=True` behavior with the existing non-task `call_tool` path. Thirteen tests exercising forbidden-mode rejection were relying on the prior inconsistency — they called `client.call_tool(..., task=True)` with the default `raise_on_error=True` and then asserted on `result.is_error`, which is now unreachable.

The fix is scoped to the tests: each affected call site now passes `raise_on_error=False` when the test's intent is to inspect the error result directly. Logic in #3946 is correct and stays as-is.

```python
task = await client.call_tool(
    "forbidden_tool", task=True, raise_on_error=False
)
assert task.returned_immediately
result = await task.result()
assert result.is_error
```