### PR TITLE
fix: skip stdio subprocess test on Windows CI

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -101,6 +101,11 @@ class TestFileSystemSource:
 class TestMCPConfig:
     """Test MCPConfig functionality."""
 
+    @pytest.mark.timeout(15)
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Stdio subprocess lifecycle is unreliable on Windows CI",
+    )
     async def test_run_mcp_config(self, tmp_path: Path):
         """Test creating a server from an MCPConfig file."""
         server_script = inspect.cleandoc("""


### PR DESCRIPTION
Addresses #3961 — `TestMCPConfig.test_run_mcp_config` spawns a real subprocess via `StdioMCPServer` that lingers due to `keep_alive=True`, causing intermittent timeouts on Windows CI. This applies the same skip and timeout pattern already used in `tests/test_mcp_config.py`.

🤖 Generated with [Claude Code](https://claude.ai/code)