### PR TITLE
docs: clarify Azure OAuth proxy blockers beyond DCR

### DIFF
--- a/docs/integrations/azure.mdx
+++ b/docs/integrations/azure.mdx
@@ -9,9 +9,9 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 <VersionBadge version="2.13.0" />
 
-This guide shows you how to secure your FastMCP server using **Azure OAuth** (Microsoft Entra ID). Azure is incompatible with direct MCP client authentication in two ways: it doesn't support Dynamic Client Registration, and Azure AD v2.0 rejects the `resource` parameter that MCP clients send on authorization requests (RFC 8707). Manually creating an Azure App registration and pointing an MCP client at Azure directly is *not* a sufficient workaround — the authorization request itself will fail.
+This guide shows you how to secure your FastMCP server using **Azure OAuth** (Microsoft Entra ID). Azure is incompatible with direct MCP client authentication in two ways: it doesn't support Dynamic Client Registration, and Azure AD v2.0 rejects the optional `resource` parameter that some MCP clients include on authorization requests (RFC 8707). Manually creating an Azure App registration and pointing an MCP client at Azure directly is therefore *not* a sufficient workaround — if the client includes `resource`, the authorization request itself will fail.
 
-This integration uses the [**OAuth Proxy**](/servers/auth/oauth-proxy) pattern to bridge both gaps: it presents a DCR-compliant interface to MCP clients while using your pre-registered Azure credentials, and filters the `resource` parameter out of upstream calls so Azure accepts them. FastMCP validates Azure JWTs against your application's client_id.
+This integration uses the [**OAuth Proxy**](/servers/auth/oauth-proxy) pattern to bridge both gaps: it presents a DCR-compliant interface to MCP clients while using your pre-registered Azure credentials, and filters the `resource` parameter out of upstream calls when present so Azure accepts them. FastMCP validates Azure JWTs against your application's client_id.
 
 ## Configuration
 

--- a/docs/integrations/azure.mdx
+++ b/docs/integrations/azure.mdx
@@ -9,7 +9,9 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 <VersionBadge version="2.13.0" />
 
-This guide shows you how to secure your FastMCP server using **Azure OAuth** (Microsoft Entra ID). Since Azure doesn't support Dynamic Client Registration, this integration uses the [**OAuth Proxy**](/servers/auth/oauth-proxy) pattern to bridge Azure's traditional OAuth with MCP's authentication requirements. FastMCP validates Azure JWTs against your application's client_id.
+This guide shows you how to secure your FastMCP server using **Azure OAuth** (Microsoft Entra ID). Azure is incompatible with direct MCP client authentication in two ways: it doesn't support Dynamic Client Registration, and Azure AD v2.0 rejects the `resource` parameter that MCP clients send on authorization requests (RFC 8707). Manually creating an Azure App registration and pointing an MCP client at Azure directly is *not* a sufficient workaround — the authorization request itself will fail.
+
+This integration uses the [**OAuth Proxy**](/servers/auth/oauth-proxy) pattern to bridge both gaps: it presents a DCR-compliant interface to MCP clients while using your pre-registered Azure credentials, and filters the `resource` parameter out of upstream calls so Azure accepts them. FastMCP validates Azure JWTs against your application's client_id.
 
 ## Configuration
 

--- a/docs/v2/integrations/azure.mdx
+++ b/docs/v2/integrations/azure.mdx
@@ -10,7 +10,9 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 <VersionBadge version="2.13.0" />
 
-This guide shows you how to secure your FastMCP server using **Azure OAuth** (Microsoft Entra ID). Since Azure doesn't support Dynamic Client Registration, this integration uses the [**OAuth Proxy**](/v2/servers/auth/oauth-proxy) pattern to bridge Azure's traditional OAuth with MCP's authentication requirements. FastMCP validates Azure JWTs against your application's client_id.
+This guide shows you how to secure your FastMCP server using **Azure OAuth** (Microsoft Entra ID). Azure is incompatible with direct MCP client authentication in two ways: it doesn't support Dynamic Client Registration, and Azure AD v2.0 rejects the `resource` parameter that MCP clients send on authorization requests (RFC 8707). Manually creating an Azure App registration and pointing an MCP client at Azure directly is *not* a sufficient workaround — the authorization request itself will fail.
+
+This integration uses the [**OAuth Proxy**](/v2/servers/auth/oauth-proxy) pattern to bridge both gaps: it presents a DCR-compliant interface to MCP clients while using your pre-registered Azure credentials, and filters the `resource` parameter out of upstream calls so Azure accepts them. FastMCP validates Azure JWTs against your application's client_id.
 
 ## Configuration
 


### PR DESCRIPTION
The Azure integration docs open by attributing the need for the OAuth Proxy to Azure's lack of Dynamic Client Registration. Reading that, a user can reasonably conclude that manual App registration is a sufficient workaround  it isn't. Azure AD v2.0 also rejects the `resource` parameter that MCP clients include on authorization requests per RFC 8707, so a directly-configured MCP client fails at the `/authorize` call even with a valid, manually-registered app. The [`AzureProvider`](src/fastmcp/server/auth/providers/azure.py) already strips `resource` on upstream calls precisely for this reason, but the docs didn't mention it.

This updates the opening paragraph on both [`docs/integrations/azure.mdx`](docs/integrations/azure.mdx) and the v2 mirror to name both incompatibilities and explain what the proxy does about each — so readers don't waste time on a workaround that can't actually work.

Closes #3942