### PR TITLE
Add Plugin.capabilities() hook and auto-derive Plugin.meta

### DIFF
--- a/src/fastmcp/server/low_level.py
+++ b/src/fastmcp/server/low_level.py
@@ -220,6 +220,10 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
         )
         capabilities.extensions = {**existing_extensions, UI_EXTENSION_ID: {}}
 
+        # Plugin contributions apply last so plugins can override built-in
+        # defaults. See FastMCP._apply_plugin_capabilities for merge rules.
+        capabilities = self.fastmcp._apply_plugin_capabilities(capabilities)
+
         return capabilities
 
     async def run(

--- a/src/fastmcp/server/plugins/base.py
+++ b/src/fastmcp/server/plugins/base.py
@@ -11,6 +11,7 @@ See the design document for the full specification.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from email.message import Message as EmailMessage
@@ -239,14 +240,36 @@ class PluginMeta(BaseModel):
         return cls(**derived)
 
 
+_DEFAULT_PLUGIN_VERSION = "0.1.0"
+
+
+def _derive_plugin_name(cls_name: str) -> str:
+    """Kebab-case a class name, stripping a trailing ``Plugin`` suffix.
+
+    `ChannelPlugin` → `"channel"`, `CodeMode` → `"code-mode"`,
+    `PIIRedactor` → `"pii-redactor"`.
+    """
+    # Split acronym from following capitalized word: `PIIRedactor` → `PII-Redactor`
+    name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1-\2", cls_name)
+    # Split lowercase/digit from following uppercase: `CodeMode` → `Code-Mode`
+    name = re.sub(r"([a-z0-9])([A-Z])", r"\1-\2", name)
+    name = name.lower()
+    if name.endswith("-plugin") and name != "-plugin":
+        name = name[: -len("-plugin")]
+    return name
+
+
 class Plugin:
     """Base class for FastMCP plugins.
 
-    Subclass to define a plugin. A subclass must declare a class-level
-    `meta` attribute (a `PluginMeta` instance). It may optionally
-    declare a nested `Config` (subclass of `pydantic.BaseModel`)
-    describing its configuration schema, and override any of the lifecycle
-    and contribution hooks.
+    Subclass to define a plugin. A subclass may optionally declare a
+    class-level `meta` attribute (a `PluginMeta` instance); if omitted,
+    a default is derived from the class name (kebab-cased, trailing
+    `Plugin` stripped) with version `0.1.0`. Declare `meta` explicitly
+    when publishing or when Horizon/registry-facing metadata matters.
+    Subclasses may also declare a nested `Config` (subclass of
+    `pydantic.BaseModel`) describing configuration, and override any of
+    the lifecycle and contribution hooks.
 
     Example:
         ```python
@@ -273,7 +296,24 @@ class Plugin:
     """
 
     meta: ClassVar[PluginMeta]
-    """Class-level metadata. Required on every subclass."""
+    """Class-level metadata. Auto-derived from the class name and a
+    placeholder version if the subclass doesn't declare one — fine for
+    in-code use. Declare `meta = PluginMeta(...)` (or
+    `PluginMeta.from_package(...)`) explicitly when publishing or when
+    Horizon/registry-facing metadata matters.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Auto-derive meta if the subclass didn't declare its own. We
+        # check `cls.__dict__` rather than attribute lookup so inherited
+        # meta from an intermediate subclass isn't treated as a local
+        # declaration — each concrete Plugin class gets its own name.
+        if "meta" not in cls.__dict__:
+            cls.meta = PluginMeta(
+                name=_derive_plugin_name(cls.__name__),
+                version=_DEFAULT_PLUGIN_VERSION,
+            )
 
     class Config(BaseModel):
         """Default empty configuration. Subclasses override to declare fields."""
@@ -433,6 +473,28 @@ class Plugin:
     def providers(self) -> list[Provider]:
         """Return component providers."""
         return []
+
+    def capabilities(self) -> dict[str, Any]:
+        """Return a partial `ServerCapabilities` dict to merge into the server's capabilities.
+
+        The returned dict follows the MCP `ServerCapabilities` shape.
+        Contributions from all plugins are deep-merged in registration
+        order, then applied on top of the server's built-in capabilities.
+        Later plugins can add to or override earlier plugins' entries;
+        this is intentional — plugin order is a user-facing configuration
+        knob, same as middleware order.
+
+        A plugin advertising an experimental protocol extension:
+
+        ```python
+        def capabilities(self):
+            return {"experimental": {"my/ext": {}}}
+        ```
+
+        A plugin modifying a built-in capability field follows the same
+        shape, keyed by the `ServerCapabilities` field name.
+        """
+        return {}
 
     def routes(self) -> list[BaseRoute]:
         """Return custom HTTP routes to mount on the server's ASGI app.

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -84,6 +84,7 @@ from fastmcp.settings import DuplicateBehavior as DuplicateBehaviorSetting
 from fastmcp.tools.base import Tool, ToolResult
 from fastmcp.tools.function_tool import FunctionTool
 from fastmcp.tools.tool_transform import ToolTransformConfig
+from fastmcp.utilities.collections import deep_merge
 from fastmcp.utilities.components import FastMCPComponent, _coerce_version
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import FastMCPBaseModel, NotSet, NotSetT
@@ -687,6 +688,29 @@ class FastMCP(
         self.plugins = [
             p for p in self.plugins if not getattr(p, "_fastmcp_ephemeral", False)
         ]
+
+    def _apply_plugin_capabilities(
+        self, capabilities: mcp.types.ServerCapabilities
+    ) -> mcp.types.ServerCapabilities:
+        """Deep-merge plugin capability contributions into the server's capabilities.
+
+        Called by `LowLevelServer.get_capabilities` after the base SDK
+        capabilities and FastMCP post-processing have been applied.
+        Each plugin's `capabilities()` dict is folded into the running
+        capabilities in registration order, with later plugins overriding
+        earlier ones at matching leaf keys — same semantics as dict
+        update, applied recursively. Plugins that return an empty dict
+        contribute nothing.
+        """
+        contributions = [plugin.capabilities() for plugin in self.plugins]
+        if not any(contributions):
+            return capabilities
+
+        merged = capabilities.model_dump(exclude_none=True)
+        for contribution in contributions:
+            if contribution:
+                deep_merge(merged, contribution)
+        return type(capabilities).model_validate(merged)
 
     def add_provider(self, provider: Provider, *, namespace: str = "") -> None:
         """Add a provider for dynamic tools, resources, and prompts.

--- a/src/fastmcp/utilities/collections.py
+++ b/src/fastmcp/utilities/collections.py
@@ -1,0 +1,21 @@
+"""Generic helpers for collection types (dicts, lists, etc.)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge `update` into `base` in place and return it.
+
+    Dict values are merged recursively; other values (including `None`
+    and primitives) overwrite. Lists are not concatenated — `update`'s
+    list replaces `base`'s list.
+    """
+    for key, value in update.items():
+        existing = base.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            deep_merge(existing, value)
+        else:
+            base[key] = value
+    return base

--- a/src/fastmcp/utilities/collections.py
+++ b/src/fastmcp/utilities/collections.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 
@@ -11,11 +12,15 @@ def deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
     Dict values are merged recursively; other values (including `None`
     and primitives) overwrite. Lists are not concatenated — `update`'s
     list replaces `base`'s list.
+
+    Values copied from `update` are deep-copied at assignment time so
+    that subsequent merges into `base` never mutate data owned by the
+    caller (e.g. a plugin returning a class-level dict from a hook).
     """
     for key, value in update.items():
         existing = base.get(key)
         if isinstance(existing, dict) and isinstance(value, dict):
             deep_merge(existing, value)
         else:
-            base[key] = value
+            base[key] = deepcopy(value)
     return base

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -38,6 +38,12 @@ class _Recorder:
         self.events: list[tuple[str, str]] = []
 
 
+class _TestPlugin(Plugin):
+    """Base for test plugins. Relies on Plugin's auto-derived meta —
+    subclasses override `meta` only when a test asserts on a specific
+    name or version."""
+
+
 class TestPluginMeta:
     """PluginMeta is the source-of-truth metadata model."""
 
@@ -242,12 +248,36 @@ class TestFromPackage:
 class TestPluginConstruction:
     """Plugin construction validates meta and config at instantiation time."""
 
-    def test_plugin_without_meta_raises(self):
-        class NoMeta(Plugin):
+    def test_plugin_without_meta_auto_derives_from_class_name(self):
+        class ChannelPlugin(Plugin):
             pass
 
-        with pytest.raises(TypeError, match="meta"):
-            NoMeta()
+        p = ChannelPlugin()
+        # Class name is kebab-cased and the trailing "Plugin" suffix stripped.
+        assert p.meta.name == "channel"
+        assert p.meta.version == "0.1.0"
+
+    def test_plugin_meta_auto_derivation_handles_acronyms(self):
+        class PIIRedactor(Plugin):
+            pass
+
+        class CodeMode(Plugin):
+            pass
+
+        class HTTPServerPlugin(Plugin):
+            pass
+
+        assert PIIRedactor.meta.name == "pii-redactor"
+        assert CodeMode.meta.name == "code-mode"
+        # Trailing "-plugin" stripped, internal acronym preserved.
+        assert HTTPServerPlugin.meta.name == "http-server"
+
+    def test_explicit_meta_is_not_overridden(self):
+        class P(Plugin):
+            meta = PluginMeta(name="custom", version="2.0.0")
+
+        assert P.meta.name == "custom"
+        assert P.meta.version == "2.0.0"
 
     def test_plugin_with_default_config(self):
         class P(Plugin):
@@ -1246,3 +1276,127 @@ class TestManifest:
 
         with pytest.raises(PluginError, match="fastmcp"):
             FastmcpInDeps.manifest()
+
+
+class TestPluginCapabilities:
+    """Plugins contribute partial ServerCapabilities dicts via `capabilities()`."""
+
+    def test_default_returns_empty(self):
+        """Plugin with no override contributes nothing."""
+        assert _TestPlugin().capabilities() == {}
+
+    async def test_experimental_contribution_reaches_initialize_response(self):
+        """An experimental capability entry flows through to the client."""
+
+        class P(_TestPlugin):
+            def capabilities(self):
+                return {"experimental": {"my/ext": {}}}
+
+        mcp = FastMCP("t", plugins=[P()])
+
+        async with Client(mcp) as c:
+            result = c.initialize_result
+            assert result is not None
+            experimental = result.capabilities.experimental or {}
+            assert experimental.get("my/ext") == {}
+
+    async def test_multiple_plugins_merge_into_same_field(self):
+        """Contributions to the same top-level field are deep-merged."""
+
+        class A(_TestPlugin):
+            def capabilities(self):
+                return {"experimental": {"alpha": {"version": 1}}}
+
+        class B(_TestPlugin):
+            def capabilities(self):
+                return {"experimental": {"beta": {}}}
+
+        mcp = FastMCP("t", plugins=[A(), B()])
+
+        async with Client(mcp) as c:
+            result = c.initialize_result
+            assert result is not None
+            experimental = result.capabilities.experimental or {}
+            assert experimental.get("alpha") == {"version": 1}
+            assert experimental.get("beta") == {}
+
+    async def test_later_plugin_overrides_earlier_on_same_key(self):
+        """Plugins run in sequence; later contributions override earlier ones.
+
+        Plugin order is a user-facing configuration knob — same as
+        middleware order — so overriding a built-in or earlier plugin's
+        capability is intentional, not an error.
+        """
+
+        class Earlier(_TestPlugin):
+            def capabilities(self):
+                return {"experimental": {"shared": {"owner": "earlier"}}}
+
+        class Later(_TestPlugin):
+            def capabilities(self):
+                return {"experimental": {"shared": {"owner": "later"}}}
+
+        mcp = FastMCP("t", plugins=[Earlier(), Later()])
+
+        async with Client(mcp) as c:
+            result = c.initialize_result
+            assert result is not None
+            experimental = result.capabilities.experimental or {}
+            assert experimental.get("shared") == {"owner": "later"}
+
+    async def test_plugin_can_add_non_experimental_field(self):
+        """Plugins can advertise top-level capability fields the server didn't set.
+
+        `logging` is off by default on a FastMCP server; a plugin turning
+        it on must surface in the initialize response.
+        """
+
+        class P(_TestPlugin):
+            def capabilities(self):
+                return {"logging": {}}
+
+        mcp = FastMCP("t", plugins=[P()])
+
+        async with Client(mcp) as c:
+            result = c.initialize_result
+            assert result is not None
+            assert result.capabilities.logging is not None
+
+    async def test_plugin_can_override_built_in_subfield(self):
+        """Deep-merge applies to typed sub-fields of pre-populated capability objects.
+
+        FastMCP already advertises `tools.listChanged=True` by default; a
+        plugin flipping it to `False` exercises the merge path through a
+        pydantic sub-model (not just the experimental dict).
+        """
+
+        class P(_TestPlugin):
+            def capabilities(self):
+                return {"tools": {"listChanged": False}}
+
+        mcp = FastMCP("t", plugins=[P()])
+
+        async with Client(mcp) as c:
+            result = c.initialize_result
+            assert result is not None
+            assert result.capabilities.tools is not None
+            assert result.capabilities.tools.listChanged is False
+
+    async def test_loader_added_plugin_capabilities_contribute(self):
+        """Plugins added via the loader pattern still contribute capabilities."""
+
+        class Loaded(_TestPlugin):
+            def capabilities(self):
+                return {"experimental": {"loaded": {}}}
+
+        class Loader(_TestPlugin):
+            async def setup(self, server):
+                server.add_plugin(Loaded())
+
+        mcp = FastMCP("t", plugins=[Loader()])
+
+        async with Client(mcp) as c:
+            result = c.initialize_result
+            assert result is not None
+            experimental = result.capabilities.experimental or {}
+            assert experimental.get("loaded") == {}

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -1382,6 +1382,39 @@ class TestPluginCapabilities:
             assert result.capabilities.tools is not None
             assert result.capabilities.tools.listChanged is False
 
+    async def test_plugin_owned_capability_dict_is_not_mutated_across_plugins(self):
+        """Plugin-returned dicts must not be mutated by the merge.
+
+        A plugin that returns a cached/class-level dict from
+        `capabilities()` gets the same object back on subsequent calls.
+        If the merge wrote that dict into `merged` by reference, a later
+        plugin's contribution would add keys to the earlier plugin's
+        dict, leaking state across initializations.
+        """
+
+        class A(_TestPlugin):
+            _caps = {"experimental": {"alpha": {}}}
+
+            def capabilities(self):
+                return self._caps
+
+        class B(_TestPlugin):
+            def capabilities(self):
+                return {"experimental": {"beta": {}}}
+
+        a = A()
+        mcp = FastMCP("t", plugins=[a, B()])
+
+        async with Client(mcp) as c:
+            result = c.initialize_result
+            assert result is not None
+            experimental = result.capabilities.experimental or {}
+            assert "alpha" in experimental
+            assert "beta" in experimental
+
+        # A's cached dict must not have been mutated to contain B's entry.
+        assert a._caps == {"experimental": {"alpha": {}}}
+
     async def test_loader_added_plugin_capabilities_contribute(self):
         """Plugins added via the loader pattern still contribute capabilities."""
 


### PR DESCRIPTION
Plugins can now contribute to the MCP `initialize` response via a new `capabilities()` hook. Contributions from every registered plugin are deep-merged in registration order onto the server's built-in capabilities — so later plugins can add to or override earlier ones (the same ordering contract plugins already have for middleware). The hook takes an arbitrary partial `ServerCapabilities` dict, not just experimental entries, so plugins can modify any field of the capabilities response.

Declaring `Plugin.meta` is now optional. If a subclass doesn't provide one, `__init_subclass__` auto-derives `PluginMeta(name=<kebab-cased class name, trailing \"Plugin\" stripped>, version=\"0.1.0\")`. Publishing still requires an explicit `PluginMeta` (or `PluginMeta.from_package(...)`); the auto-derived default is there so in-code plugins don't pay ceremony for metadata that only matters at distribution time.

```python
from fastmcp import FastMCP
from fastmcp.server.plugins import Plugin


class Channel(Plugin):
    def capabilities(self):
        return {\"experimental\": {\"my/ext\": {}}}


mcp = FastMCP(\"my-server\", plugins=[Channel()])
# meta auto-derived as PluginMeta(name=\"channel\", version=\"0.1.0\")
# initialize response now advertises capabilities.experimental[\"my/ext\"] = {}
```

Closes FMCP-5.