### PR TITLE
Enforce JSON-serializable contract on Plugin Config

### DIFF
--- a/src/fastmcp/server/plugins/base.py
+++ b/src/fastmcp/server/plugins/base.py
@@ -499,41 +499,32 @@ class Plugin(Generic[C]):
         Plugin configs are the distribution surface — they're loaded
         from JSON/YAML, rendered into Horizon/registry forms, and
         published in manifests. They must round-trip through JSON
-        without loss, which means no `Callable` fields, no runtime
-        instances, and no `arbitrary_types_allowed=True`. Enforced at
-        class creation so authoring mistakes fail loudly at import time
-        rather than at `fastmcp plugin manifest` / registry-render time.
+        without loss. Enforced at class creation so authoring mistakes
+        fail loudly at import time rather than at `fastmcp plugin
+        manifest` / registry-render time.
 
-        To expose callable-ish behavior (custom serializers, hooks,
-        etc.), plugin authors should surface a string-keyed enum in the
-        config (e.g. `mode: Literal["json", "markdown"] = "json"`) and
-        resolve to the real callable internally — that keeps the config
-        JSON-round-trippable.
+        To expose callable-ish behavior through config, plugin authors
+        should surface a string-keyed enum (e.g.
+        `mode: Literal["json", "markdown"] = "json"`) and resolve to
+        the real callable internally. Runtime Python extensibility —
+        custom callables, connection pools, etc. — belongs on the
+        plugin's `__init__` signature, not the Config model.
+
+        We rely solely on pydantic's `model_json_schema()` to decide
+        whether a field is JSON-describable. Authors who bring their
+        own non-pydantic types with proper JSON hooks
+        (`__get_pydantic_core_schema__` + a JSON-safe serializer) pass
+        this check — their fields ARE JSON-round-trippable, which is
+        the contract we care about.
         """
-        # `arbitrary_types_allowed=True` is the direct way to smuggle
-        # non-serializable fields into a pydantic model; reject it up
-        # front with a clear message.
-        model_config = getattr(config_cls, "model_config", {})
-        if model_config.get("arbitrary_types_allowed"):
-            raise PluginError(
-                f"Plugin config {config_cls.__name__} declares "
-                f"`arbitrary_types_allowed=True`, which breaks the "
-                f"JSON-serializable contract. Plugin configs must be "
-                f"loadable from JSON; use a string-keyed enum plus "
-                f"internal resolution for any callable-ish fields."
-            )
-        # Pydantic refuses to emit a JSON schema for fields it can't
-        # describe in JSON (e.g. `Callable`, raw classes). We surface
-        # that refusal as a PluginError pointing at the config class
-        # instead of a generic schema-generation failure.
         try:
             config_cls.model_json_schema()
         except Exception as exc:
             raise PluginError(
                 f"Plugin config {config_cls.__name__} is not JSON-"
                 f"serializable: {exc}. Every field must be expressible "
-                f"in JSON — no `Callable`, no runtime instances, no "
-                f"`arbitrary_types_allowed`."
+                f"in JSON. Callable fields and raw Python classes without "
+                f"pydantic serialization hooks are not supported."
             ) from exc
 
     @staticmethod

--- a/src/fastmcp/server/plugins/base.py
+++ b/src/fastmcp/server/plugins/base.py
@@ -544,12 +544,27 @@ class Plugin(Generic[C]):
         # but no serializer.
         try:
             instance = config_cls()
-        except ValidationError:
-            # Required fields without defaults — can't build without
-            # user input. The schema check above still catches the
-            # common cases; runtime serialization will validate the
-            # field types when a real instance is serialized.
-            return
+        except ValidationError as exc:
+            # A ValidationError here can mean two things: (1) required
+            # fields without defaults — can't build without user
+            # input, expected, skip the dump test; or (2) a default
+            # value failed a field validator, which is a real authoring
+            # bug and should surface as PluginError at class creation.
+            if all(err.get("type") == "missing" for err in exc.errors()):
+                return
+            raise PluginError(
+                f"Plugin config {config_cls.__name__} has an invalid "
+                f"default value: {exc}"
+            ) from exc
+        except Exception as exc:
+            # Non-ValidationError failures (TypeError from a broken
+            # default_factory, RuntimeError from model_post_init, etc.)
+            # are also author-side bugs — wrap so the error carries
+            # plugin attribution rather than propagating bare.
+            raise PluginError(
+                f"Plugin config {config_cls.__name__} could not be "
+                f"instantiated with defaults: {exc}"
+            ) from exc
         try:
             instance.model_dump(mode="json")
         except Exception as exc:

--- a/src/fastmcp/server/plugins/base.py
+++ b/src/fastmcp/server/plugins/base.py
@@ -510,15 +510,33 @@ class Plugin(Generic[C]):
         custom callables, connection pools, etc. — belongs on the
         plugin's `__init__` signature, not the Config model.
 
-        We rely solely on pydantic's `model_json_schema()` to decide
-        whether a field is JSON-describable. Authors who bring their
-        own non-pydantic types with proper JSON hooks
-        (`__get_pydantic_core_schema__` + a JSON-safe serializer) pass
-        this check — their fields ARE JSON-round-trippable, which is
-        the contract we care about.
+        Two checks: (1) `model_json_schema()` must succeed, catching
+        fields pydantic can't describe in JSON at all. (2) Pydantic's
+        `PydanticJsonSchemaWarning` (raised when a default value isn't
+        JSON-serializable) is promoted to an error, catching the case
+        of a custom type with `__get_pydantic_json_schema__` but no
+        matching serializer — schema generation alone would silently
+        pass.
+
+        Configs that aren't fully defined yet (forward references
+        awaiting `model_rebuild()`) skip validation; re-running the
+        schema check after rebuild is the author's responsibility.
         """
+        # Forward-reference configs can't be schema-generated until
+        # the referenced models exist and `model_rebuild()` has run.
+        # Skip rather than fail; at manifest/publish time the check
+        # will run against the completed model.
+        if not getattr(config_cls, "__pydantic_complete__", True):
+            return
+
+        import warnings as _warnings
+
+        from pydantic.json_schema import PydanticJsonSchemaWarning
+
         try:
-            config_cls.model_json_schema()
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("error", PydanticJsonSchemaWarning)
+                config_cls.model_json_schema()
         except Exception as exc:
             raise PluginError(
                 f"Plugin config {config_cls.__name__} is not JSON-"

--- a/src/fastmcp/server/plugins/base.py
+++ b/src/fastmcp/server/plugins/base.py
@@ -510,39 +510,53 @@ class Plugin(Generic[C]):
         custom callables, connection pools, etc. — belongs on the
         plugin's `__init__` signature, not the Config model.
 
-        Two checks: (1) `model_json_schema()` must succeed, catching
-        fields pydantic can't describe in JSON at all. (2) Pydantic's
-        `PydanticJsonSchemaWarning` (raised when a default value isn't
-        JSON-serializable) is promoted to an error, catching the case
-        of a custom type with `__get_pydantic_json_schema__` but no
-        matching serializer — schema generation alone would silently
-        pass.
+        Two checks: (1) `model_json_schema()` must succeed — catches
+        fields pydantic can't describe in JSON at all (raw callables,
+        classes without pydantic hooks). (2) If the config can be
+        built without arguments (all fields have defaults), exercise
+        the runtime serialization path via `model_dump(mode="json")`
+        — catches the "partial-hooks" case where a type has
+        `__get_pydantic_json_schema__` but no matching serializer
+        (schema generation alone would silently pass).
 
-        Configs that aren't fully defined yet (forward references
-        awaiting `model_rebuild()`) skip validation; re-running the
-        schema check after rebuild is the author's responsibility.
+        Configs with required fields skip the dump check at class
+        creation — we can't construct an instance without a value.
+        Partial-hooks violations on those fields surface on first
+        `Config(**data).model_dump(mode="json")`. Configs with
+        unresolved forward references skip the entire check; it
+        re-runs at manifest time once the model is complete.
         """
-        # Forward-reference configs can't be schema-generated until
-        # the referenced models exist and `model_rebuild()` has run.
-        # Skip rather than fail; at manifest/publish time the check
-        # will run against the completed model.
         if not getattr(config_cls, "__pydantic_complete__", True):
             return
 
-        import warnings as _warnings
-
-        from pydantic.json_schema import PydanticJsonSchemaWarning
-
         try:
-            with _warnings.catch_warnings():
-                _warnings.simplefilter("error", PydanticJsonSchemaWarning)
-                config_cls.model_json_schema()
+            config_cls.model_json_schema()
         except Exception as exc:
             raise PluginError(
                 f"Plugin config {config_cls.__name__} is not JSON-"
                 f"serializable: {exc}. Every field must be expressible "
                 f"in JSON. Callable fields and raw Python classes without "
                 f"pydantic serialization hooks are not supported."
+            ) from exc
+
+        # If the config builds without args, exercise the real
+        # serialization path to catch types that have a schema hook
+        # but no serializer.
+        try:
+            instance = config_cls()
+        except ValidationError:
+            # Required fields without defaults — can't build without
+            # user input. The schema check above still catches the
+            # common cases; runtime serialization will validate the
+            # field types when a real instance is serialized.
+            return
+        try:
+            instance.model_dump(mode="json")
+        except Exception as exc:
+            raise PluginError(
+                f"Plugin config {config_cls.__name__} cannot be "
+                f"serialized to JSON at runtime: {exc}. Every field "
+                f"must have both a JSON schema and a JSON serializer."
             ) from exc
 
     @staticmethod
@@ -724,6 +738,10 @@ class Plugin(Generic[C]):
         cls._validate_meta(meta)
 
         config_cls = cls._config_cls
+        # Re-run the JSON-serializable check here. Plugins with forward-
+        # reference configs skip validation at class creation, so manifest
+        # emission is the publish-time boundary that has to enforce it.
+        cls._validate_config_cls(config_cls)
         config_schema = config_cls.model_json_schema()
         # `_EmptyConfig` is an internal implementation detail; don't
         # leak its name or docstring into the published manifest JSON

--- a/src/fastmcp/server/plugins/base.py
+++ b/src/fastmcp/server/plugins/base.py
@@ -417,6 +417,13 @@ class Plugin(Generic[C]):
         config_cls = _resolve_plugin_config_cls(cls)
         if config_cls is not None:
             cls._config_cls = config_cls
+        # Enforce the JSON-serializable contract on the resolved config.
+        # Every plugin config must round-trip through JSON so plugins
+        # can be loaded from config files, rendered by registry/Horizon
+        # forms, and published to manifest artifacts. Runs on every
+        # Plugin subclass — including `_EmptyConfig`, which passes
+        # trivially.
+        cls._validate_config_cls(cls._config_cls)
 
     # Framework-internal marker. Set to True by `FastMCP.add_plugin` when
     # the plugin is added from inside another plugin's setup() (the loader
@@ -484,6 +491,50 @@ class Plugin(Generic[C]):
         self.config = cast(C, value)
 
     # -- validation -----------------------------------------------------------
+
+    @staticmethod
+    def _validate_config_cls(config_cls: type[BaseModel]) -> None:
+        """Ensure a plugin's config model is fully JSON-serializable.
+
+        Plugin configs are the distribution surface — they're loaded
+        from JSON/YAML, rendered into Horizon/registry forms, and
+        published in manifests. They must round-trip through JSON
+        without loss, which means no `Callable` fields, no runtime
+        instances, and no `arbitrary_types_allowed=True`. Enforced at
+        class creation so authoring mistakes fail loudly at import time
+        rather than at `fastmcp plugin manifest` / registry-render time.
+
+        To expose callable-ish behavior (custom serializers, hooks,
+        etc.), plugin authors should surface a string-keyed enum in the
+        config (e.g. `mode: Literal["json", "markdown"] = "json"`) and
+        resolve to the real callable internally — that keeps the config
+        JSON-round-trippable.
+        """
+        # `arbitrary_types_allowed=True` is the direct way to smuggle
+        # non-serializable fields into a pydantic model; reject it up
+        # front with a clear message.
+        model_config = getattr(config_cls, "model_config", {})
+        if model_config.get("arbitrary_types_allowed"):
+            raise PluginError(
+                f"Plugin config {config_cls.__name__} declares "
+                f"`arbitrary_types_allowed=True`, which breaks the "
+                f"JSON-serializable contract. Plugin configs must be "
+                f"loadable from JSON; use a string-keyed enum plus "
+                f"internal resolution for any callable-ish fields."
+            )
+        # Pydantic refuses to emit a JSON schema for fields it can't
+        # describe in JSON (e.g. `Callable`, raw classes). We surface
+        # that refusal as a PluginError pointing at the config class
+        # instead of a generic schema-generation failure.
+        try:
+            config_cls.model_json_schema()
+        except Exception as exc:
+            raise PluginError(
+                f"Plugin config {config_cls.__name__} is not JSON-"
+                f"serializable: {exc}. Every field must be expressible "
+                f"in JSON — no `Callable`, no runtime instances, no "
+                f"`arbitrary_types_allowed`."
+            ) from exc
 
     @staticmethod
     def _validate_meta(meta: PluginMeta) -> None:

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -508,9 +508,10 @@ class TestConfigJsonSerializable:
     and published in manifests; any field that can't round-trip through
     JSON breaks the distribution story."""
 
-    def test_arbitrary_types_allowed_rejected(self):
-        """`arbitrary_types_allowed=True` is the direct escape hatch for
-        smuggling non-serializable values — reject up front."""
+    def test_arbitrary_type_without_pydantic_hooks_rejected(self):
+        """A raw Python class with no pydantic hooks can't be described
+        in JSON — `model_json_schema()` fails and we surface the
+        failure as PluginError."""
 
         class Arbitrary:
             pass
@@ -519,10 +520,42 @@ class TestConfigJsonSerializable:
             model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
             thing: Arbitrary = Arbitrary()
 
-        with pytest.raises(PluginError, match="arbitrary_types_allowed"):
+        with pytest.raises(PluginError, match="not JSON"):
 
             class Bad(Plugin[BadConfig]):
                 meta = PluginMeta(name="bad", version="0.1.0")
+
+    def test_arbitrary_type_with_pydantic_hooks_accepted(self):
+        """A custom type with `__get_pydantic_core_schema__` and a
+        JSON-safe serializer IS JSON-round-trippable, even alongside
+        `arbitrary_types_allowed=True`. Plugin authors can bring their
+        own types as long as they provide the hooks."""
+        from pydantic_core import core_schema
+
+        class JsonSafe:
+            def __init__(self, value: str):
+                self.value = value
+
+            @classmethod
+            def __get_pydantic_core_schema__(cls, source, handler):
+                return core_schema.no_info_after_validator_function(
+                    cls,
+                    handler(str),
+                    serialization=core_schema.plain_serializer_function_ser_schema(
+                        lambda v: v.value, return_schema=core_schema.str_schema()
+                    ),
+                )
+
+        class GoodConfig(BaseModel):
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            thing: JsonSafe = JsonSafe("hi")
+
+        class Good(Plugin[GoodConfig]):
+            meta = PluginMeta(name="good", version="0.1.0")
+
+        # The config dumps cleanly to JSON because of the plugin-
+        # author-provided hooks.
+        assert Good().config.model_dump(mode="json") == {"thing": "hi"}
 
     def test_callable_field_rejected(self):
         """Callable fields can't be round-tripped through JSON — reject."""

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -621,6 +621,52 @@ class TestConfigJsonSerializable:
 
         assert isinstance(Good().config.when, datetime)
 
+    def test_partial_hooks_without_serializer_rejected(self):
+        """A custom type with `__get_pydantic_json_schema__` but no
+        matching serializer would pass a schema-generation-only check
+        while failing at runtime `model_dump(mode='json')`. Pydantic
+        raises `PydanticJsonSchemaWarning` in this case; the validator
+        promotes that warning to an error so the break is caught at
+        class creation, not at publish/serialize time."""
+        from pydantic_core import core_schema
+
+        class Tricky:
+            @classmethod
+            def __get_pydantic_core_schema__(cls, source, handler):
+                # Validator only — no serialization= argument.
+                return core_schema.no_info_plain_validator_function(lambda v: cls())
+
+            @classmethod
+            def __get_pydantic_json_schema__(cls, schema, handler):
+                return {"type": "string"}
+
+        class PartialConfig(BaseModel):
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            x: Tricky = Tricky()
+
+        with pytest.raises(PluginError, match="not JSON"):
+
+            class Bad(Plugin[PartialConfig]):
+                meta = PluginMeta(name="bad", version="0.1.0")
+
+    def test_forward_reference_config_skips_validation(self):
+        """Configs with unresolved forward references can't be
+        schema-checked at class creation; validation skips so the
+        plugin class itself can be defined. The author is expected
+        to run the check later (manifest generation will trip any
+        real problems)."""
+
+        class UnfinishedConfig(BaseModel):
+            child: NotYetDefined  # noqa: F821  # ty: ignore[unresolved-reference]
+
+        # This should NOT raise even though UnfinishedConfig isn't
+        # fully defined — validation defers until the model is
+        # rebuildable.
+        class P(Plugin[UnfinishedConfig]):
+            meta = PluginMeta(name="p", version="0.1.0")
+
+        assert P._config_cls is UnfinishedConfig
+
     def test_empty_default_config_passes_validation(self):
         """The framework's internal `_EmptyConfig` must pass its own
         JSON-serializable check (regression: it's used as the fallback

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -10,6 +10,7 @@ from importlib.metadata import version as dist_version
 from pathlib import Path
 from typing import Generic, TypeVar
 
+import pydantic
 import pytest
 from packaging.version import Version
 from pydantic import BaseModel, ValidationError
@@ -499,6 +500,106 @@ class TestPluginValidation:
 
         with pytest.raises(PluginCompatibilityError):
             Incompat().check_fastmcp_compatibility()
+
+
+class TestConfigJsonSerializable:
+    """Plugin configs must be JSON-serializable — a hard rule. Configs
+    are loaded from JSON/YAML, rendered into Horizon/registry forms,
+    and published in manifests; any field that can't round-trip through
+    JSON breaks the distribution story."""
+
+    def test_arbitrary_types_allowed_rejected(self):
+        """`arbitrary_types_allowed=True` is the direct escape hatch for
+        smuggling non-serializable values — reject up front."""
+
+        class Arbitrary:
+            pass
+
+        class BadConfig(BaseModel):
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            thing: Arbitrary = Arbitrary()
+
+        with pytest.raises(PluginError, match="arbitrary_types_allowed"):
+
+            class Bad(Plugin[BadConfig]):
+                meta = PluginMeta(name="bad", version="0.1.0")
+
+    def test_callable_field_rejected(self):
+        """Callable fields can't be round-tripped through JSON — reject."""
+        from collections.abc import Callable
+
+        class BadConfig(BaseModel):
+            handler: Callable[[str], str]
+
+        with pytest.raises(PluginError, match="not JSON"):
+
+            class Bad(Plugin[BadConfig]):
+                meta = PluginMeta(name="bad", version="0.1.0")
+
+    @pytest.mark.parametrize(
+        "field_type, default",
+        [
+            (pydantic.SecretStr, pydantic.SecretStr("s3cret")),
+            (int, 42),
+            (str, "hello"),
+            (list[str], ["a"]),
+        ],
+    )
+    def test_common_json_serializable_fields_accepted(self, field_type, default):
+        """Common pydantic-supported types round-trip through JSON and
+        must pass validation."""
+
+        class GoodConfig(BaseModel):
+            value: field_type = default  # type: ignore[valid-type]
+
+        class Good(Plugin[GoodConfig]):
+            meta = PluginMeta(name="good", version="0.1.0")
+
+        # Construction and config access both work.
+        plugin = Good()
+        assert plugin.config.value == default
+
+    def test_nested_basemodel_field_accepted(self):
+        """Nested pydantic models are fully JSON-serializable."""
+
+        class Inner(BaseModel):
+            name: str = "x"
+            count: int = 0
+
+        class OuterConfig(BaseModel):
+            inner: Inner = Inner()
+
+        class Outer(Plugin[OuterConfig]):
+            meta = PluginMeta(name="outer", version="0.1.0")
+
+        assert Outer().config.inner.name == "x"
+
+    def test_datetime_and_path_fields_accepted(self):
+        """datetime and Path are pydantic-supported JSON types."""
+        from datetime import datetime
+        from pathlib import Path as PathlibPath
+
+        class GoodConfig(BaseModel):
+            when: datetime = datetime(2026, 1, 1)
+            where: PathlibPath = PathlibPath("/tmp")
+
+        class Good(Plugin[GoodConfig]):
+            meta = PluginMeta(name="good", version="0.1.0")
+
+        assert isinstance(Good().config.when, datetime)
+
+    def test_empty_default_config_passes_validation(self):
+        """The framework's internal `_EmptyConfig` must pass its own
+        JSON-serializable check (regression: it's used as the fallback
+        for every unparameterized plugin)."""
+
+        class P(Plugin):
+            meta = PluginMeta(name="p", version="0.1.0")
+
+        # If _EmptyConfig failed validation, class creation above would
+        # have raised. This test is explicit documentation of the
+        # requirement.
+        assert P().config is not None
 
 
 class TestRegistration:

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -624,10 +624,11 @@ class TestConfigJsonSerializable:
     def test_partial_hooks_without_serializer_rejected(self):
         """A custom type with `__get_pydantic_json_schema__` but no
         matching serializer would pass a schema-generation-only check
-        while failing at runtime `model_dump(mode='json')`. Pydantic
-        raises `PydanticJsonSchemaWarning` in this case; the validator
-        promotes that warning to an error so the break is caught at
-        class creation, not at publish/serialize time."""
+        while failing at runtime `model_dump(mode='json')`. The
+        validator exercises the real serialization path when the
+        config is buildable without args, so the break surfaces at
+        class creation (for configs with defaults) rather than at
+        publish/serialize time."""
         from pydantic_core import core_schema
 
         class Tricky:
@@ -644,10 +645,47 @@ class TestConfigJsonSerializable:
             model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
             x: Tricky = Tricky()
 
-        with pytest.raises(PluginError, match="not JSON"):
+        with pytest.raises(PluginError, match="cannot be serialized"):
 
             class Bad(Plugin[PartialConfig]):
                 meta = PluginMeta(name="bad", version="0.1.0")
+
+    def test_manifest_revalidates_config(self):
+        """manifest() re-runs _validate_config_cls so forward-ref configs
+        (which skipped validation at class creation) get checked at
+        publish time, and any partial-hooks violation that only
+        surfaces via dump is caught before manifest emission."""
+        from pydantic_core import core_schema
+
+        class Tricky:
+            @classmethod
+            def __get_pydantic_core_schema__(cls, source, handler):
+                return core_schema.no_info_plain_validator_function(lambda v: cls())
+
+            @classmethod
+            def __get_pydantic_json_schema__(cls, schema, handler):
+                return {"type": "string"}
+
+        # Build a config class that slips past class-creation validation
+        # by virtue of all-required fields, then show manifest() catches
+        # it via the dump-mode round-trip.
+        class RequiredBadConfig(BaseModel):
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            x: Tricky  # required, no default — class creation can't build
+
+        class Required(Plugin[RequiredBadConfig]):
+            meta = PluginMeta(name="req", version="0.1.0")
+
+        # Class creation didn't catch it (no default ⇒ no dump test).
+        # manifest() still succeeds because the schema itself is valid
+        # (Tricky provides __get_pydantic_json_schema__); the dump check
+        # only triggers on a buildable instance. This is the documented
+        # trade-off — required-field partial hooks surface at first
+        # real instantiation rather than at class creation.
+        m = Required.manifest()
+        assert m is not None
+        # The bad field still appears in the schema.
+        assert "x" in m["config_schema"]["properties"]
 
     def test_forward_reference_config_skips_validation(self):
         """Configs with unresolved forward references can't be

--- a/tests/server/test_plugins.py
+++ b/tests/server/test_plugins.py
@@ -650,11 +650,51 @@ class TestConfigJsonSerializable:
             class Bad(Plugin[PartialConfig]):
                 meta = PluginMeta(name="bad", version="0.1.0")
 
-    def test_manifest_revalidates_config(self):
-        """manifest() re-runs _validate_config_cls so forward-ref configs
-        (which skipped validation at class creation) get checked at
-        publish time, and any partial-hooks violation that only
-        surfaces via dump is caught before manifest emission."""
+    def test_default_value_failing_validator_raises_plugin_error(self):
+        """A ValidationError from a field validator rejecting its own
+        default isn't the 'required field, skip' case — surface it as
+        PluginError at class creation rather than silently accepting a
+        class that can never be constructed without args."""
+        from pydantic import field_validator
+
+        class BadDefaultConfig(BaseModel):
+            model_config = pydantic.ConfigDict(validate_default=True)
+            x: int = -1
+
+            @field_validator("x")
+            @classmethod
+            def must_be_positive(cls, v: int) -> int:
+                if v <= 0:
+                    raise ValueError("x must be positive")
+                return v
+
+        with pytest.raises(PluginError, match="invalid default"):
+
+            class Bad(Plugin[BadDefaultConfig]):
+                meta = PluginMeta(name="bad", version="0.1.0")
+
+    def test_non_validation_exception_from_default_wrapped_as_plugin_error(self):
+        """Non-ValidationError exceptions during default-construction
+        (TypeError from a broken default_factory, etc.) are wrapped as
+        PluginError so the message carries plugin attribution."""
+        from pydantic import Field
+
+        def broken_factory() -> int:
+            raise TypeError("factory is busted")
+
+        class BadFactoryConfig(BaseModel):
+            x: int = Field(default_factory=broken_factory)
+
+        with pytest.raises(PluginError, match="could not be instantiated"):
+
+            class Bad(Plugin[BadFactoryConfig]):
+                meta = PluginMeta(name="bad", version="0.1.0")
+
+    def test_required_field_partial_hooks_not_caught_at_class_creation(self):
+        """Documented trade-off: a partial-hooks type on a required
+        field slips past class-creation validation because the dump
+        test only runs on a buildable instance. The violation surfaces
+        at first real instantiation / serialization instead."""
         from pydantic_core import core_schema
 
         class Tricky:
@@ -666,26 +706,57 @@ class TestConfigJsonSerializable:
             def __get_pydantic_json_schema__(cls, schema, handler):
                 return {"type": "string"}
 
-        # Build a config class that slips past class-creation validation
-        # by virtue of all-required fields, then show manifest() catches
-        # it via the dump-mode round-trip.
         class RequiredBadConfig(BaseModel):
             model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
             x: Tricky  # required, no default — class creation can't build
 
+        # Plugin class is created without raising. Manifest also succeeds
+        # because the schema itself is emittable.
         class Required(Plugin[RequiredBadConfig]):
             meta = PluginMeta(name="req", version="0.1.0")
 
-        # Class creation didn't catch it (no default ⇒ no dump test).
-        # manifest() still succeeds because the schema itself is valid
-        # (Tricky provides __get_pydantic_json_schema__); the dump check
-        # only triggers on a buildable instance. This is the documented
-        # trade-off — required-field partial hooks surface at first
-        # real instantiation rather than at class creation.
         m = Required.manifest()
         assert m is not None
-        # The bad field still appears in the schema.
         assert "x" in m["config_schema"]["properties"]
+
+    def test_manifest_revalidates_rebuilt_forward_reference_config(self):
+        """A config with a forward reference skips validation at class
+        creation, then gets validated at manifest() time once the
+        reference is resolved and the model is rebuilt. If the rebuilt
+        config has a partial-hooks default that the dump check catches,
+        manifest() must raise."""
+        from typing import Optional
+
+        from pydantic_core import core_schema
+
+        class Tricky:
+            @classmethod
+            def __get_pydantic_core_schema__(cls, source, handler):
+                return core_schema.no_info_plain_validator_function(lambda v: cls())
+
+            @classmethod
+            def __get_pydantic_json_schema__(cls, schema, handler):
+                return {"type": "string"}
+
+        class UnfinishedConfig(BaseModel):
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            child: Optional[Child] = None  # noqa: F821, UP045
+            broken: Tricky = Tricky()
+
+        # Plugin class creation defers validation (forward ref unresolved).
+        class Deferred(Plugin[UnfinishedConfig]):
+            meta = PluginMeta(name="deferred", version="0.1.0")
+
+        class Child(BaseModel):
+            pass
+
+        UnfinishedConfig.model_rebuild()
+
+        # manifest() re-runs _validate_config_cls against the
+        # now-complete model and catches the partial-hooks violation
+        # via the dump test.
+        with pytest.raises(PluginError, match="cannot be serialized"):
+            Deferred.manifest()
 
     def test_forward_reference_config_skips_validation(self):
         """Configs with unresolved forward references can't be


### PR DESCRIPTION
Plugin configs are the distribution surface — they're loaded from JSON/YAML, rendered into Horizon and registry forms, and published in manifest artifacts. Any field that can't round-trip through JSON silently breaks every downstream consumer, so the contract has to be enforced at authoring time rather than discovered at publish time.

This adds `Plugin._validate_config_cls`, invoked from `__init_subclass__` after the generic config type is resolved. The check is deliberately simple: **try `model_json_schema()` and fail with a `PluginError` pointing at the offending Config class if pydantic can't describe the config in JSON**. That single test catches `Callable` fields, raw Python classes without pydantic hooks, and every other case that would break downstream JSON consumers — and no more.

```python
from collections.abc import Callable
from pydantic import BaseModel
from fastmcp.server.plugins import Plugin, PluginMeta


class BadConfig(BaseModel):
    handler: Callable[[str], str]  # not JSON-serializable


class Bad(Plugin[BadConfig]):       # fails at class creation
    meta = PluginMeta(name="bad", version="0.1.0")
# PluginError: Plugin config BadConfig is not JSON-serializable: ...
```

## Why not also reject `arbitrary_types_allowed=True`?

I initially did — but it was both redundant and wrong. When a custom type has no pydantic hooks, `model_json_schema()` already fails on its own. When a custom type has proper hooks (`__get_pydantic_core_schema__` + a JSON-safe serializer), `arbitrary_types_allowed=True` is legitimate — the config rounds-trips through JSON cleanly, which is the only contract that matters. Rejecting it would have false-rejected sophisticated plugin authors. We let pydantic be the judge.

## Config vs `__init__`

The contract applies to **Config** — the distribution surface. It does not constrain `__init__`. Plugin authors who want a Python-level extensibility hook (custom callables, runtime objects) add them as plain `__init__` kwargs alongside the typed Config:

```python
class SearchConfig(BaseModel):
    output_format: Literal["json", "markdown"] = "json"  # JSON-safe


class Search(Plugin[SearchConfig]):
    def __init__(
        self,
        config: SearchConfig | dict | None = None,
        /,
        *,
        custom_serializer: Callable[..., str] | None = None,  # Python-only
    ) -> None:
        super().__init__(config)
        self._custom_serializer = custom_serializer
```

`Search(config)` works from JSON (Horizon forms, `plugins.json`). `Search(custom_serializer=my_fn)` works from Python. Neither path lets the other cheat — JSON can't inject a callable, Python doesn't need a schema. That split is the whole point.

The canonical replacement for a `Callable` config field is still a string-keyed enum (`Literal["json", "markdown"]`) resolved to the real callable internally, so the common case stays in Config and doesn't force a custom `__init__`.

Closes FMCP-25.