### PR TITLE
feat: add FASTMCP_TELEMETRY_OPT_OUT to disable native span creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastmcp"
-dynamic = ["version"]
+version = "3.2.4.dev0"
 description = "The fast, Pythonic way to build MCP servers and clients."
 authors = [{ name = "Jeremiah Lowin" }]
 dependencies = [
@@ -103,11 +103,11 @@ Repository = "https://github.com/PrefectHQ/fastmcp"
 Documentation = "https://gofastmcp.com"
 
 [build-system]
-requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
-source = "uv-dynamic-versioning"
+path = "pyproject.toml"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastmcp"
-version = "3.2.4.dev0"
+dynamic = ["version"]
 description = "The fast, Pythonic way to build MCP servers and clients."
 authors = [{ name = "Jeremiah Lowin" }]
 dependencies = [
@@ -103,11 +103,11 @@ Repository = "https://github.com/PrefectHQ/fastmcp"
 Documentation = "https://gofastmcp.com"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
-path = "pyproject.toml"
+source = "uv-dynamic-versioning"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/src/fastmcp/client/telemetry.py
+++ b/src/fastmcp/client/telemetry.py
@@ -3,10 +3,10 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+from opentelemetry.trace import INVALID_SPAN, Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
-from fastmcp.telemetry import INVALID_SPAN, get_tracer, is_telemetry_opted_out
+from fastmcp.telemetry import get_tracer, is_telemetry_opted_out
 
 
 @contextmanager

--- a/src/fastmcp/client/telemetry.py
+++ b/src/fastmcp/client/telemetry.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
-from fastmcp.telemetry import get_tracer
+from fastmcp.telemetry import INVALID_SPAN, get_tracer, is_telemetry_opted_out
 
 
 @contextmanager
@@ -22,7 +22,15 @@ def client_span(
     """Create a CLIENT span with standard MCP attributes.
 
     Automatically records any exception on the span and sets error status.
+
+    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields
+    ``INVALID_SPAN`` without creating a real span or modifying
+    the active OpenTelemetry context.
     """
+    if is_telemetry_opted_out():
+        yield INVALID_SPAN
+        return
+
     tracer = get_tracer()
     with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
         if span.is_recording():

--- a/src/fastmcp/client/telemetry.py
+++ b/src/fastmcp/client/telemetry.py
@@ -3,10 +3,10 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from opentelemetry.trace import INVALID_SPAN, Span, SpanKind, Status, StatusCode
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
-from fastmcp.telemetry import get_tracer, is_telemetry_opted_out
+from fastmcp.telemetry import _NOOP_SPAN, get_tracer, is_telemetry_opted_out
 
 
 @contextmanager
@@ -23,12 +23,12 @@ def client_span(
 
     Automatically records any exception on the span and sets error status.
 
-    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields
-    ``INVALID_SPAN`` without creating a real span or modifying
-    the active OpenTelemetry context.
+    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields a
+    non-recording no-op span without creating a real span or
+    modifying the active OpenTelemetry context.
     """
     if is_telemetry_opted_out():
-        yield INVALID_SPAN
+        yield _NOOP_SPAN
         return
 
     tracer = get_tracer()

--- a/src/fastmcp/server/telemetry.py
+++ b/src/fastmcp/server/telemetry.py
@@ -8,7 +8,12 @@ from opentelemetry.context import Context
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
-from fastmcp.telemetry import extract_trace_context, get_tracer
+from fastmcp.telemetry import (
+    INVALID_SPAN,
+    extract_trace_context,
+    get_tracer,
+    is_telemetry_opted_out,
+)
 
 
 def get_auth_span_attributes() -> dict[str, str]:
@@ -67,7 +72,15 @@ def server_span(
     """Create a SERVER span with standard MCP attributes and auth context.
 
     Automatically records any exception on the span and sets error status.
+
+    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields
+    ``INVALID_SPAN`` without creating a real span or modifying
+    the active OpenTelemetry context.
     """
+    if is_telemetry_opted_out():
+        yield INVALID_SPAN
+        return
+
     tracer = get_tracer()
     with tracer.start_as_current_span(
         name,
@@ -116,7 +129,15 @@ def delegate_span(
 
     Used by FastMCPProvider when delegating to mounted servers.
     Automatically records any exception on the span and sets error status.
+
+    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields
+    ``INVALID_SPAN`` without creating a real span or modifying
+    the active OpenTelemetry context.
     """
+    if is_telemetry_opted_out():
+        yield INVALID_SPAN
+        return
+
     tracer = get_tracer()
     with tracer.start_as_current_span(f"delegate {name}") as span:
         if span.is_recording():

--- a/src/fastmcp/server/telemetry.py
+++ b/src/fastmcp/server/telemetry.py
@@ -5,11 +5,10 @@ from contextlib import contextmanager
 
 from mcp.server.lowlevel.server import request_ctx
 from opentelemetry.context import Context
-from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+from opentelemetry.trace import INVALID_SPAN, Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
 from fastmcp.telemetry import (
-    INVALID_SPAN,
     extract_trace_context,
     get_tracer,
     is_telemetry_opted_out,

--- a/src/fastmcp/server/telemetry.py
+++ b/src/fastmcp/server/telemetry.py
@@ -5,10 +5,11 @@ from contextlib import contextmanager
 
 from mcp.server.lowlevel.server import request_ctx
 from opentelemetry.context import Context
-from opentelemetry.trace import INVALID_SPAN, Span, SpanKind, Status, StatusCode
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
 from fastmcp.telemetry import (
+    _NOOP_SPAN,
     extract_trace_context,
     get_tracer,
     is_telemetry_opted_out,
@@ -72,12 +73,12 @@ def server_span(
 
     Automatically records any exception on the span and sets error status.
 
-    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields
-    ``INVALID_SPAN`` without creating a real span or modifying
-    the active OpenTelemetry context.
+    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields a
+    non-recording no-op span without creating a real span or
+    modifying the active OpenTelemetry context.
     """
     if is_telemetry_opted_out():
-        yield INVALID_SPAN
+        yield _NOOP_SPAN
         return
 
     tracer = get_tracer()
@@ -129,12 +130,12 @@ def delegate_span(
     Used by FastMCPProvider when delegating to mounted servers.
     Automatically records any exception on the span and sets error status.
 
-    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields
-    ``INVALID_SPAN`` without creating a real span or modifying
-    the active OpenTelemetry context.
+    When ``FASTMCP_TELEMETRY_OPT_OUT`` is enabled, yields a
+    non-recording no-op span without creating a real span or
+    modifying the active OpenTelemetry context.
     """
     if is_telemetry_opted_out():
-        yield INVALID_SPAN
+        yield _NOOP_SPAN
         return
 
     tracer = get_tracer()

--- a/src/fastmcp/telemetry.py
+++ b/src/fastmcp/telemetry.py
@@ -4,6 +4,15 @@ This module provides native OpenTelemetry integration for FastMCP servers and cl
 It uses only the opentelemetry-api package, so telemetry is a no-op unless the user
 installs an OpenTelemetry SDK and configures exporters.
 
+Span creation can be disabled by setting the environment variable
+``FASTMCP_TELEMETRY_OPT_OUT=YES`` (case-insensitive).  When opted out,
+``client_span`` / ``server_span`` / ``delegate_span`` become no-op context
+managers that yield ``INVALID_SPAN`` **without** modifying the active
+OpenTelemetry context.  Context propagation helpers (``inject_trace_context``
+and ``extract_trace_context``) remain fully operational so that external
+instrumentations (e.g. ``opentelemetry-instrumentation-fastmcp``) can still
+propagate trace context across MCP boundaries.
+
 Example usage with SDK:
     ```python
     from opentelemetry import trace
@@ -21,18 +30,35 @@ Example usage with SDK:
     ```
 """
 
+import os
 from typing import Any
 
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 from opentelemetry.context import Context
-from opentelemetry.trace import Span, Status, StatusCode, Tracer
+from opentelemetry.trace import INVALID_SPAN, Span, Status, StatusCode, Tracer
 from opentelemetry.trace import get_tracer as otel_get_tracer
 
 INSTRUMENTATION_NAME = "fastmcp"
 
 TRACE_PARENT_KEY = "traceparent"
 TRACE_STATE_KEY = "tracestate"
+
+
+def is_telemetry_opted_out() -> bool:
+    """Check if FastMCP native telemetry span creation is disabled.
+
+    Returns True when ``FASTMCP_TELEMETRY_OPT_OUT`` is set to a truthy
+    value (``yes``, ``true``, ``1`` — case-insensitive).
+
+    When opted out, span-creating helpers become no-ops while context
+    propagation (inject/extract) continues to work normally.
+    """
+    return os.environ.get("FASTMCP_TELEMETRY_OPT_OUT", "").strip().lower() in (
+        "yes",
+        "true",
+        "1",
+    )
 
 
 def get_tracer(version: str | None = None) -> Tracer:
@@ -113,10 +139,12 @@ def extract_trace_context(meta: dict[str, Any] | None) -> Context:
 
 __all__ = [
     "INSTRUMENTATION_NAME",
+    "INVALID_SPAN",
     "TRACE_PARENT_KEY",
     "TRACE_STATE_KEY",
     "extract_trace_context",
     "get_tracer",
     "inject_trace_context",
+    "is_telemetry_opted_out",
     "record_span_error",
 ]

--- a/src/fastmcp/telemetry.py
+++ b/src/fastmcp/telemetry.py
@@ -7,7 +7,7 @@ installs an OpenTelemetry SDK and configures exporters.
 Span creation can be disabled by setting the environment variable
 ``FASTMCP_TELEMETRY_OPT_OUT=YES`` (case-insensitive).  When opted out,
 ``client_span`` / ``server_span`` / ``delegate_span`` become no-op context
-managers that yield ``INVALID_SPAN`` **without** modifying the active
+managers that yield a non-recording no-op span **without** modifying the active
 OpenTelemetry context.  Context propagation helpers (``inject_trace_context``
 and ``extract_trace_context``) remain fully operational so that external
 instrumentations (e.g. ``opentelemetry-instrumentation-fastmcp``) can still
@@ -36,10 +36,18 @@ from typing import Any
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 from opentelemetry.context import Context
-from opentelemetry.trace import Span, Status, StatusCode, Tracer
+from opentelemetry.trace import INVALID_SPAN, Span, Status, StatusCode, Tracer
 from opentelemetry.trace import get_tracer as otel_get_tracer
 
 INSTRUMENTATION_NAME = "fastmcp"
+
+_NOOP_SPAN: Span = INVALID_SPAN
+"""Non-recording span yielded when telemetry is opted out.
+
+This is the OTel API's ``INVALID_SPAN`` — a safe no-op that accepts
+all ``Span`` method calls (``is_recording()`` returns ``False``,
+``set_attribute()`` / ``record_exception()`` are no-ops, etc.).
+"""
 
 TRACE_PARENT_KEY = "traceparent"
 TRACE_STATE_KEY = "tracestate"
@@ -141,6 +149,7 @@ __all__ = [
     "INSTRUMENTATION_NAME",
     "TRACE_PARENT_KEY",
     "TRACE_STATE_KEY",
+    "_NOOP_SPAN",
     "extract_trace_context",
     "get_tracer",
     "inject_trace_context",

--- a/src/fastmcp/telemetry.py
+++ b/src/fastmcp/telemetry.py
@@ -36,7 +36,7 @@ from typing import Any
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 from opentelemetry.context import Context
-from opentelemetry.trace import INVALID_SPAN, Span, Status, StatusCode, Tracer
+from opentelemetry.trace import Span, Status, StatusCode, Tracer
 from opentelemetry.trace import get_tracer as otel_get_tracer
 
 INSTRUMENTATION_NAME = "fastmcp"
@@ -139,7 +139,6 @@ def extract_trace_context(meta: dict[str, Any] | None) -> Context:
 
 __all__ = [
     "INSTRUMENTATION_NAME",
-    "INVALID_SPAN",
     "TRACE_PARENT_KEY",
     "TRACE_STATE_KEY",
     "extract_trace_context",

--- a/tests/telemetry/test_opt_out.py
+++ b/tests/telemetry/test_opt_out.py
@@ -1,0 +1,167 @@
+"""Tests for FASTMCP_TELEMETRY_OPT_OUT flag."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import INVALID_SPAN
+
+from fastmcp import Client, FastMCP
+from fastmcp.client.telemetry import client_span
+from fastmcp.server.telemetry import delegate_span, server_span
+from fastmcp.telemetry import (
+    inject_trace_context,
+    is_telemetry_opted_out,
+)
+
+
+class TestIsTelemetryOptedOut:
+    def test_default_is_not_opted_out(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("FASTMCP_TELEMETRY_OPT_OUT", raising=False)
+        assert is_telemetry_opted_out() is False
+
+    @pytest.mark.parametrize("value", ["YES", "yes", "Yes", "true", "TRUE", "1"])
+    def test_truthy_values_opt_out(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", value)
+        assert is_telemetry_opted_out() is True
+
+    @pytest.mark.parametrize("value", ["no", "false", "0", "", "maybe"])
+    def test_non_truthy_values_do_not_opt_out(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", value)
+        assert is_telemetry_opted_out() is False
+
+    def test_whitespace_is_stripped(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "  yes  ")
+        assert is_telemetry_opted_out() is True
+
+
+class TestClientSpanOptOut:
+    def test_yields_invalid_span(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ):
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
+        with client_span(
+            "tools/call test", method="tools/call", component_key="test"
+        ) as span:
+            assert span is INVALID_SPAN
+
+        assert len(trace_exporter.get_finished_spans()) == 0
+
+    def test_does_not_modify_active_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ):
+        """Opted-out client_span must not replace the active span context."""
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
+        current_before = trace.get_current_span()
+        with client_span(
+            "tools/call test", method="tools/call", component_key="test"
+        ):
+            current_inside = trace.get_current_span()
+        assert current_inside is current_before
+
+
+class TestServerSpanOptOut:
+    def test_yields_invalid_span(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ):
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
+        with server_span(
+            "tools/call test",
+            method="tools/call",
+            server_name="test",
+            component_type="tool",
+            component_key="test",
+        ) as span:
+            assert span is INVALID_SPAN
+
+        assert len(trace_exporter.get_finished_spans()) == 0
+
+    def test_does_not_modify_active_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ):
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
+        current_before = trace.get_current_span()
+        with server_span(
+            "tools/call test",
+            method="tools/call",
+            server_name="test",
+            component_type="tool",
+            component_key="test",
+        ):
+            current_inside = trace.get_current_span()
+        assert current_inside is current_before
+
+
+class TestDelegateSpanOptOut:
+    def test_yields_invalid_span(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ):
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
+        with delegate_span(
+            "test", provider_type="linked", component_key="test"
+        ) as span:
+            assert span is INVALID_SPAN
+
+        assert len(trace_exporter.get_finished_spans()) == 0
+
+
+class TestContextPropagationStillWorks:
+    def test_inject_works_when_opted_out(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ):
+        """inject_trace_context should still work when telemetry is opted out,
+        because external instrumentations need context propagation."""
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
+
+        from fastmcp.telemetry import get_tracer
+
+        tracer = get_tracer()
+        with tracer.start_as_current_span("external-parent"):
+            meta = inject_trace_context()
+
+        assert meta is not None
+        assert "traceparent" in meta
+
+
+class TestEndToEndOptOut:
+    async def test_no_spans_when_opted_out(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ):
+        """No FastMCP spans should be created when telemetry is opted out."""
+        monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
+
+        server = FastMCP("test-server")
+
+        @server.tool()
+        def echo(message: str) -> str:
+            return message
+
+        client = Client(server)
+        async with client:
+            result = await client.call_tool("echo", {"message": "hello"})
+            assert "hello" in str(result)
+
+        spans = trace_exporter.get_finished_spans()
+        assert len(spans) == 0, (
+            f"Expected no spans when opted out, got: "
+            f"{[s.name for s in spans]}"
+        )

--- a/tests/telemetry/test_opt_out.py
+++ b/tests/telemetry/test_opt_out.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import INVALID_SPAN
 
 from fastmcp import Client, FastMCP
 from fastmcp.client.telemetry import client_span
 from fastmcp.server.telemetry import delegate_span, server_span
 from fastmcp.telemetry import (
+    _NOOP_SPAN,
     inject_trace_context,
     is_telemetry_opted_out,
 )
@@ -48,7 +48,7 @@ class TestClientSpanOptOut:
         with client_span(
             "tools/call test", method="tools/call", component_key="test"
         ) as span:
-            assert span is INVALID_SPAN
+            assert span is _NOOP_SPAN
 
         assert len(trace_exporter.get_finished_spans()) == 0
 
@@ -79,7 +79,7 @@ class TestServerSpanOptOut:
             component_type="tool",
             component_key="test",
         ) as span:
-            assert span is INVALID_SPAN
+            assert span is _NOOP_SPAN
 
         assert len(trace_exporter.get_finished_spans()) == 0
 
@@ -111,7 +111,7 @@ class TestDelegateSpanOptOut:
         with delegate_span(
             "test", provider_type="linked", component_key="test"
         ) as span:
-            assert span is INVALID_SPAN
+            assert span is _NOOP_SPAN
 
         assert len(trace_exporter.get_finished_spans()) == 0
 

--- a/tests/telemetry/test_opt_out.py
+++ b/tests/telemetry/test_opt_out.py
@@ -22,9 +22,7 @@ class TestIsTelemetryOptedOut:
         assert is_telemetry_opted_out() is False
 
     @pytest.mark.parametrize("value", ["YES", "yes", "Yes", "true", "TRUE", "1"])
-    def test_truthy_values_opt_out(
-        self, monkeypatch: pytest.MonkeyPatch, value: str
-    ):
+    def test_truthy_values_opt_out(self, monkeypatch: pytest.MonkeyPatch, value: str):
         monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", value)
         assert is_telemetry_opted_out() is True
 
@@ -62,9 +60,7 @@ class TestClientSpanOptOut:
         """Opted-out client_span must not replace the active span context."""
         monkeypatch.setenv("FASTMCP_TELEMETRY_OPT_OUT", "YES")
         current_before = trace.get_current_span()
-        with client_span(
-            "tools/call test", method="tools/call", component_key="test"
-        ):
+        with client_span("tools/call test", method="tools/call", component_key="test"):
             current_inside = trace.get_current_span()
         assert current_inside is current_before
 
@@ -162,6 +158,5 @@ class TestEndToEndOptOut:
 
         spans = trace_exporter.get_finished_spans()
         assert len(spans) == 0, (
-            f"Expected no spans when opted out, got: "
-            f"{[s.name for s in spans]}"
+            f"Expected no spans when opted out, got: {[s.name for s in spans]}"
         )


### PR DESCRIPTION
## Description

FastMCP's native telemetry uses `start_as_current_span`, which unconditionally sets FastMCP's spans as the active trace context. When a third-party instrumentation has already established a parent span, FastMCP's span replaces it — downstream `propagate.inject()` calls then propagate FastMCP's span ID instead of the instrumentation's, breaking the client → server trace link across process boundaries. There is also no way to disable native span creation when users bring their own instrumentation, leading to duplicate and conflicting span hierarchies.

This PR adds a `FASTMCP_TELEMETRY_OPT_OUT` environment variable. When set to a truthy value (`YES`, `TRUE`, `1`), `client_span`, `server_span`, and `delegate_span` become no-ops that yield `INVALID_SPAN` without touching the active context. Context propagation (`inject_trace_context`/`extract_trace_context`) remains fully operational, so external instrumentations can still propagate trace context across MCP boundaries.

```python
# External instrumentation owns the span hierarchy
FASTMCP_TELEMETRY_OPT_OUT=YES opentelemetry-instrument python my_agent.py
```

Closes #3993

## Contribution type

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

🤖 Generated with Cursor Agent