### PR TITLE
feat(settings): accept FASTMCP__FIELD env vars as aliases of FASTMCP_FIELD

### DIFF
--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -10,8 +10,10 @@ from platformdirs import user_data_dir
 from pydantic import Field, field_validator
 from pydantic_settings import (
     BaseSettings,
+    PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
+from pydantic_settings.sources.providers.env import EnvSettingsSource
 
 from fastmcp.utilities.logging import get_logger
 
@@ -114,6 +116,36 @@ class DocketSettings(BaseSettings):
     ] = timedelta(seconds=5)
 
 
+def _inject_prefix_aliases(source: PydanticBaseSettingsSource) -> None:
+    """Add ``<PREFIX>_<FIELD>`` aliases for env vars written as ``<PREFIX>__<FIELD>``.
+
+    Many projects separate a namespace prefix from a field name with a
+    double underscore (``DATABASE__PASSWORD``, ``COGNITO__CLIENT_SECRET``).
+    With ``env_prefix="FASTMCP_"`` + ``env_nested_delimiter="__"``,
+    pydantic-settings parses ``FASTMCP__HOME`` as field ``_home`` (which
+    doesn't exist) and silently drops it — only ``FASTMCP_HOME`` is seen.
+
+    For each ``FASTMCP__<FIELD>`` entry in the source's already-loaded
+    ``env_vars``, write the canonical ``FASTMCP_<FIELD>`` key (via
+    ``setdefault``, so an explicit canonical value wins). Nested fields
+    are unaffected because this only translates the namespace boundary:
+    ``FASTMCP__DOCKET__NAME`` becomes ``FASTMCP_DOCKET__NAME`` which
+    pydantic then splits on ``__`` as usual.
+    """
+    if not isinstance(source, EnvSettingsSource):
+        return  # Not an env-backed source — nothing to translate.
+    prefix = source.env_prefix if source.case_sensitive else source.env_prefix.lower()
+    alias = prefix + "_"
+    # Upgrade to a mutable dict — some sources expose a read-only Mapping
+    # and `get_field_value` just reads from this attribute either way.
+    env_vars: dict[str, str | None] = dict(source.env_vars)
+    for key in list(env_vars):
+        if key.startswith(alias):
+            canonical = prefix + key[len(alias) :]
+            env_vars.setdefault(canonical, env_vars[key])
+    source.env_vars = env_vars
+
+
 class Settings(BaseSettings):
     """FastMCP settings."""
 
@@ -125,6 +157,26 @@ class Settings(BaseSettings):
         nested_model_default_partial_update=True,
         validate_assignment=True,
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Accept ``FASTMCP__<FIELD>`` aliases on the env + dotenv sources.
+
+        Mutating the sources in place is cleaner than substituting
+        subclasses — it preserves any init-time overrides (e.g.
+        ``Settings(_env_file=...)``) that pydantic-settings has already
+        baked into the default source instances.
+        """
+        _inject_prefix_aliases(env_settings)
+        _inject_prefix_aliases(dotenv_settings)
+        return init_settings, env_settings, dotenv_settings, file_secret_settings
 
     def get_setting(self, attr: str) -> Any:
         """

--- a/tests/test_settings_double_underscore_alias.py
+++ b/tests/test_settings_double_underscore_alias.py
@@ -1,0 +1,71 @@
+"""Tests for the ``FASTMCP__<FIELD>`` alias accepted alongside the canonical
+``FASTMCP_<FIELD>`` env var form.
+
+See ``_inject_prefix_aliases`` in ``fastmcp.settings``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fastmcp.settings import Settings
+
+
+class TestDoubleUnderscoreEnvAlias:
+    """``FASTMCP__<FIELD>`` should be accepted as an alias for ``FASTMCP_<FIELD>``."""
+
+    def test_canonical_form_still_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FASTMCP_HOME", "/tmp/canonical")
+        assert Settings().home == Path("/tmp/canonical")
+
+    def test_double_underscore_alias_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FASTMCP__HOME", "/tmp/alias")
+        assert Settings().home == Path("/tmp/alias")
+
+    def test_canonical_wins_over_alias_when_both_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FASTMCP_HOME", "/tmp/canonical-wins")
+        monkeypatch.setenv("FASTMCP__HOME", "/tmp/alias-loses")
+        assert Settings().home == Path("/tmp/canonical-wins")
+
+    def test_nested_canonical_form_still_works(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Nested-delimiter semantics (FASTMCP_<SUBMODEL>__<FIELD>) must not break.
+        monkeypatch.setenv("FASTMCP_DOCKET__NAME", "nested-canonical")
+        assert Settings().docket.name == "nested-canonical"
+
+    def test_nested_via_double_underscore_prefix_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The alias only translates the namespace boundary; the nested `__`
+        # delimiter between submodel and field is preserved verbatim.
+        monkeypatch.setenv("FASTMCP__DOCKET__NAME", "nested-via-alias")
+        assert Settings().docket.name == "nested-via-alias"
+
+    def test_alias_does_not_affect_non_fastmcp_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Sanity check: nothing outside the FASTMCP_ namespace is translated.
+        monkeypatch.setenv("SOMETHING__ELSE", "untouched")
+        monkeypatch.setenv("FASTMCP__HOME", "/tmp/fastmcp-only")
+        settings = Settings()
+        assert settings.home == Path("/tmp/fastmcp-only")
+
+    def test_dotenv_file_alias_is_accepted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # Clear any inherited vars so only the .env file value matters.
+        monkeypatch.delenv("FASTMCP__HOME", raising=False)
+        monkeypatch.delenv("FASTMCP_HOME", raising=False)
+        env_file = tmp_path / ".env"
+        env_file.write_text("FASTMCP__HOME=/tmp/from-dotenv\n")
+        # pydantic-settings supports overriding env_file at construction time.
+        assert Settings(_env_file=str(env_file)).home == Path("/tmp/from-dotenv")  # type: ignore[call-arg]


### PR DESCRIPTION
## Problem

Many projects separate namespace prefix from field name with a **double** underscore in their env vars (`DATABASE__PASSWORD`, `COGNITO__CLIENT_SECRET`) — it makes namespaces visually distinct from `WORD_WORD` field names.

FastMCP doesn't follow that convention. With `env_prefix=\"FASTMCP_\"` + `env_nested_delimiter=\"__\"`, pydantic-settings parses `FASTMCP__HOME` as field `_home` (doesn't exist) and silently drops it. Only `FASTMCP_HOME` (single underscore between prefix and field) is visible to `Settings`.

For projects that want to keep a single convention across their whole stack, this means writing a bootstrap shim that mutates `os.environ` before fastmcp is imported:

```python
# Every project wiring fastmcp ends up with this somewhere
for k, v in list(os.environ.items()):
    if k.startswith(\"FASTMCP__\"):
        os.environ.setdefault(\"FASTMCP_\" + k[len(\"FASTMCP__\"):], v)
```

This PR makes that shim unnecessary.

## Change

Override `settings_customise_sources` to inject `FASTMCP_<FIELD>` aliases for any `FASTMCP__<FIELD>` entries already loaded by the env and dotenv sources. The helper mutates the existing source instances in place — substituting subclasses instead would lose init-time overrides like `Settings(_env_file=...)` that pydantic-settings bakes into the default source instances.

Backward-compatible:

- Every existing `FASTMCP_<FIELD>` env var still resolves exactly as before.
- `FASTMCP_<SUBMODEL>__<FIELD>` nested vars (e.g. `FASTMCP_DOCKET__NAME`) still resolve exactly as before — the alias only translates the namespace boundary, not the nested delimiter.
- When both `FASTMCP_HOME` and `FASTMCP__HOME` are set, the canonical single-underscore form wins (via \`setdefault\`).
- Only previously-ignored `FASTMCP__<FIELD>` env vars gain new meaning.

## Design alternatives considered

- **\`AliasChoices\` / \`validation_alias\` per field** — would duplicate the alias declaration across ~30 fields and wouldn't help future fields added to \`Settings\` or \`DocketSettings\`.
- **Subclass \`EnvSettingsSource\` and \`DotEnvSettingsSource\`** — initially tried, but substituting new source instances in \`settings_customise_sources\` loses the init-time \`_env_file\` override that pydantic-settings bakes into the default \`dotenv_settings\` it passes in. Mutating in place avoids that gotcha.
- **Runtime rename (\`home\` → nested submodel)** — breaking for every current user.

## Tests

New \`tests/test_settings_double_underscore_alias.py\`:

- \`FASTMCP_HOME\` canonical (regression)
- \`FASTMCP__HOME\` alias resolves equivalently
- Canonical wins over alias when both set
- Nested \`FASTMCP_DOCKET__NAME\` (regression)
- Nested via alias prefix \`FASTMCP__DOCKET__NAME\` resolves equivalently
- Non-FASTMCP env vars are not touched
- \`.env\` file values are covered too (via \`_env_file\` override)

All 7 pass. Existing \`tests/cli/\` + \`tests/deprecated/test_settings.py\` (482 tests) and any test matching \`-k \"settings or env\"\` (143 tests) still pass with no changes. \`uv run --frozen ty check src/fastmcp/settings.py\` is clean.

## Context

We use this shim in two downstream projects today and would rather delete it once a fastmcp release carries this fix. Happy to iterate on the approach if you'd prefer a different hook point.