### PR TITLE
fix: narrow _token_validator with isinstance for ty in AzureProvider.from_b2c

### DIFF
--- a/src/fastmcp/server/auth/providers/azure.py
+++ b/src/fastmcp/server/auth/providers/azure.py
@@ -351,7 +351,8 @@ class AzureProvider(OAuthProxy):
             token_issuer=token_issuer,
             **kwargs,
         )
-        provider._token_validator.issuer = token_issuer  # type: ignore[union-attr]
+        if isinstance(provider._token_validator, JWTVerifier):
+            provider._token_validator.issuer = token_issuer
         provider._obo_supported = False
         return provider
 


### PR DESCRIPTION
`AzureProvider.from_b2c()` reaches in to override the JWT verifier's issuer after construction so B2C providers default to issuer-disabled validation. The original line used `# type: ignore[union-attr]` to silence mypy on `provider._token_validator.issuer = token_issuer`, but `ty` doesn't honor that pragma and reports `unresolved-attribute` on `TokenVerifier` (the abstract base, which has no `issuer`). CI's `static_analysis` job has been red since #3995 merged.

Narrow with an `isinstance(..., JWTVerifier)` check — the same pattern the test suite uses. The constructor always installs a `JWTVerifier`, so the branch is taken in practice; the guard exists purely to give `ty` enough information.

```python
if isinstance(provider._token_validator, JWTVerifier):
    provider._token_validator.issuer = token_issuer
```