### PR TITLE
fix: cancel orphaned session_task when Client._disconnect times out

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -659,16 +659,25 @@ class Client(
                 return
             session_task = self._session_state.session_task
             self._session_state.stop_event.set()
-            # wait for session to finish to ensure state has been reset
+            # Wait (bounded) for the runner to unwind gracefully. If it
+            # overruns — e.g. the transport's termination POST is blocked on
+            # a stale HTTP keep-alive connection — cancel the background
+            # task so transport resources (httpx connections, subprocess
+            # pipes) are actually released instead of leaking into the
+            # event loop. Force paths additionally shield the wait so an
+            # outer cancellation can't abandon cleanup half-done.
             try:
-                if force:
+                with anyio.CancelScope(shield=force):
+                    with anyio.move_on_after(self._disconnect_timeout):
+                        with suppress(asyncio.CancelledError):
+                            await session_task
+            finally:
+                if not session_task.done():
+                    session_task.cancel()
                     with anyio.CancelScope(shield=True):
                         with anyio.move_on_after(self._disconnect_timeout):
-                            with suppress(asyncio.CancelledError):
+                            with suppress(Exception):
                                 await session_task
-                else:
-                    await session_task
-            finally:
                 self._session_state.session_task = None
 
     async def _session_runner(self):

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -528,11 +528,7 @@ class Client(
         return await self._connect()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        # Use a timeout to prevent hanging during cleanup if the connection is in a bad
-        # state (e.g., rate-limited). The MCP SDK's transport may try to terminate the
-        # session which can hang if the server is unresponsive.
-        with anyio.move_on_after(self._disconnect_timeout):
-            await self._disconnect()
+        await self._disconnect()
 
     async def _connect(self):
         """

--- a/tests/client/client/test_client.py
+++ b/tests/client/client/test_client.py
@@ -618,6 +618,49 @@ async def test_force_close_cancelled_wait_starts_fresh_session(fastmcp_server):
     assert original_session_task.done()
 
 
+async def test_disconnect_with_hanging_transport_does_not_leak_session_task(
+    fastmcp_server, monkeypatch
+):
+    """A hung transport teardown must not leak the background session task.
+
+    Simulates the failure mode reported in
+    https://github.com/PrefectHQ/fastmcp/issues/3947: the remote HTTP server
+    has dropped the keep-alive connection, so the termination POST inside
+    the transport never returns. ``__aexit__`` must bound the wait and
+    cancel the runner so a subsequent Client can reuse the same transport
+    resources.
+    """
+    monkeypatch.setattr(fastmcp.settings, "client_disconnect_timeout", 0.2)
+
+    disconnect_started = anyio.Event()
+    never_allow_disconnect = anyio.Event()
+
+    client = Client(
+        transport=_DelayedDisconnectTransport(
+            FastMCPTransport(fastmcp_server),
+            disconnect_started=disconnect_started,
+            allow_disconnect=never_allow_disconnect,
+        )
+    )
+
+    async with client:
+        tools = await client.list_tools()
+        assert len(tools) == 3
+        session_task = client._session_state.session_task
+        assert session_task is not None
+
+    # Transport hung during teardown; the client should have bounded the
+    # wait, cancelled the runner, and cleared its own reference.
+    assert disconnect_started.is_set()
+    assert client._session_state.session_task is None
+    assert session_task.done()
+
+    # And the Client is reusable for a fresh session.
+    async with client:
+        tools = await client.list_tools()
+        assert len(tools) == 3
+
+
 async def test_concurrent_client_context_managers():
     """
     Test that concurrent client usage doesn't cause cross-task cancel scope issues.


### PR DESCRIPTION
When `Client._disconnect()`'s bounded wait expired — the practical trigger being a stale HTTP keep-alive where the server's session-termination POST never returns — `anyio.move_on_after` cancelled the awaiting coroutine but left the underlying `asyncio.Task` running. The task stayed parked in the event loop blocked on the dead connection, and the `finally` path just nulled `self._session_state.session_task` without actually stopping it. On the next `Client` in the same loop, that leaked transport state surfaced as `CancelledError` / `WouldBlock` or a stream of "Client is not connected" errors, which is what made reporters' long-running eval/test suites poison themselves after the first hung disconnect.

The fix moves the bounded wait into `_disconnect` itself and adds an explicit `session_task.cancel()` + shielded cleanup wait in the `finally`. The cancellation propagates through the runner's `AsyncExitStack.__aexit__`, which actually releases the transport's connection before we drop the reference. The outer `move_on_after` wrapper in `__aexit__` is removed since the internal bounds now cover it and duplicating the timeout just obscures the real guarantee.

Closes #3947

🤖 Generated with Claude Code