### PR TITLE
chore: use SHA-256 for dynamic provider module name suffix

### DIFF
--- a/src/fastmcp/server/providers/filesystem_discovery.py
+++ b/src/fastmcp/server/providers/filesystem_discovery.py
@@ -183,7 +183,7 @@ def import_module_from_file(
         if existing is not None and getattr(existing, "__file__", None) != str(
             file_path
         ):
-            module_name = f"_fastmcp_{stem}_{hashlib.sha1(str(file_path).encode()).hexdigest()[:12]}"
+            module_name = f"_fastmcp_{stem}_{hashlib.sha256(str(file_path).encode()).hexdigest()[:12]}"
         else:
             module_name = stem
 


### PR DESCRIPTION
When avoiding `sys.modules` collisions for filesystem-discovered providers, derive the private module suffix with SHA-256 instead of SHA-1 (weaker per crypto hygiene / static scanners).
