### PR TITLE
Add UTM params to Horizon docs links

### DIFF
--- a/docs/deployment/prefect-horizon.mdx
+++ b/docs/deployment/prefect-horizon.mdx
@@ -54,7 +54,7 @@ There are just three steps to deploying a server to Horizon:
 
 ### Step 1: Select a Repository
 
-Visit [horizon.prefect.io](https://horizon.prefect.io) and sign in with your GitHub account. Connect your GitHub account to grant Horizon access to your repositories, then select the repo you want to deploy.
+Visit [horizon.prefect.io](https://horizon.prefect.io?utm_source=gofastmcp&utm_medium=docs) and sign in with your GitHub account. Connect your GitHub account to grant Horizon access to your repositories, then select the repo you want to deploy.
 
 <img src="/assets/images/horizon/select-repo.png" alt="Horizon repository selection" />
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -147,7 +147,7 @@ You can preview app tools locally with `fastmcp dev apps my_server.py` — no MC
 
 ## Deploy to Prefect Horizon
 
-[Prefect Horizon](https://horizon.prefect.io) is the enterprise MCP platform built by the FastMCP team at [Prefect](https://www.prefect.io). It provides managed hosting, authentication, access control, and observability for MCP servers.
+[Prefect Horizon](https://horizon.prefect.io?utm_source=gofastmcp&utm_medium=docs) is the enterprise MCP platform built by the FastMCP team at [Prefect](https://www.prefect.io). It provides managed hosting, authentication, access control, and observability for MCP servers.
 
 <Info>
 Horizon is **free for personal projects** and offers enterprise governance for teams.
@@ -156,7 +156,7 @@ Horizon is **free for personal projects** and offers enterprise governance for t
 To deploy your server, you'll need a [GitHub account](https://github.com). Once you have one, you can deploy your server in three steps:
 
 1. Push your `my_server.py` file to a GitHub repository
-2. Sign in to [Prefect Horizon](https://horizon.prefect.io) with your GitHub account
+2. Sign in to [Prefect Horizon](https://horizon.prefect.io?utm_source=gofastmcp&utm_medium=docs) with your GitHub account
 3. Create a new project from your repository and enter `my_server.py:mcp` as the server entrypoint
 
 That's it! Horizon will build and deploy your server, making it available at a URL like `https://your-project.fastmcp.app/mcp`. You can chat with it to test its functionality, or connect to it from any LLM client that supports the MCP protocol.

--- a/docs/v2/getting-started/quickstart.mdx
+++ b/docs/v2/getting-started/quickstart.mdx
@@ -119,7 +119,7 @@ Note that:
 
 ## Deploy to Prefect Horizon
 
-[Prefect Horizon](https://horizon.prefect.io) is the enterprise MCP platform built by the FastMCP team at [Prefect](https://www.prefect.io). It provides managed hosting, authentication, access control, and observability for MCP servers.
+[Prefect Horizon](https://horizon.prefect.io?utm_source=gofastmcp&utm_medium=docs) is the enterprise MCP platform built by the FastMCP team at [Prefect](https://www.prefect.io). It provides managed hosting, authentication, access control, and observability for MCP servers.
 
 <Info>
 Horizon is **free for personal projects** and offers enterprise governance for teams.
@@ -128,7 +128,7 @@ Horizon is **free for personal projects** and offers enterprise governance for t
 To deploy your server, you'll need a [GitHub account](https://github.com). Once you have one, you can deploy your server in three steps:
 
 1. Push your `my_server.py` file to a GitHub repository
-2. Sign in to [Prefect Horizon](https://horizon.prefect.io) with your GitHub account
+2. Sign in to [Prefect Horizon](https://horizon.prefect.io?utm_source=gofastmcp&utm_medium=docs) with your GitHub account
 3. Create a new project from your repository and enter `my_server.py:mcp` as the server entrypoint
 
 That's it! Horizon will build and deploy your server, making it available at a URL like `https://your-project.fastmcp.app/mcp`. You can chat with it to test its functionality, or connect to it from any LLM client that supports the MCP protocol.

--- a/docs/v2/getting-started/welcome.mdx
+++ b/docs/v2/getting-started/welcome.mdx
@@ -73,7 +73,7 @@ FastMCP handles all the complex protocol details so you can focus on building. I
 
 🔍 **Complete**: Everything for production — enterprise auth (Google, GitHub, Azure, Auth0, WorkOS), deployment tools, testing frameworks, client libraries, and more
 
-FastMCP provides the shortest path from idea to production. Deploy locally, to the cloud with [Prefect Horizon](https://horizon.prefect.io) (free for personal projects), or to your own infrastructure.
+FastMCP provides the shortest path from idea to production. Deploy locally, to the cloud with [Prefect Horizon](https://horizon.prefect.io?utm_source=gofastmcp&utm_medium=docs) (free for personal projects), or to your own infrastructure.
 
 <Tip>
 **This documentation reflects FastMCP's `main` branch**, meaning it always reflects the latest development version. Features are generally marked with version badges (e.g. `New in version: 2.13.1`) to indicate when they were introduced. Note that this may include features that are not yet released.


### PR DESCRIPTION
Add `utm_source=gofastmcp&utm_medium=docs` to Horizon links in the docs.