### PR TITLE
Add missing return type annotation to __getattr__

### DIFF
--- a/src/fastmcp/server/providers/__init__.py
+++ b/src/fastmcp/server/providers/__init__.py
@@ -58,7 +58,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> object:
     """Lazy import for providers to avoid circular imports."""
     if name == "ProxyProvider":
         from fastmcp.server.providers.proxy import ProxyProvider


### PR DESCRIPTION
## Summary

Add missing `-> object` return type annotation to the module-level `__getattr__` in `src/fastmcp/server/providers/__init__.py`.

All other module-level `__getattr__` functions in the codebase have explicit return type annotations — this was the only one without it.