### PR TITLE
docs: add Codex skills provider example

### DIFF
--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -102,3 +102,14 @@ mcp = FastMCP("My Skills")
 mcp.add_provider(ClaudeSkillsProvider())  # Uses ~/.claude/skills/
 mcp.run()
 ```
+
+### Codex Skills (system and user locations)
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.providers.skills import CodexSkillsProvider
+
+mcp = FastMCP("My Codex Skills")
+mcp.add_provider(CodexSkillsProvider())  # Uses /etc/codex/skills/ and ~/.codex/skills/
+mcp.run()
+```


### PR DESCRIPTION
Adds a CodexSkillsProvider usage snippet to the skills provider example README. The provider already exists in FastMCP; this documents the default Codex system and user skill locations alongside the existing Claude example.