### PR TITLE
fix: drop exc_info for expected tool failures, remove unreachable ValidationError

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -55,7 +55,6 @@ from fastmcp.exceptions import (
     PromptError,
     ResourceError,
     ToolError,
-    ValidationError,
 )
 from fastmcp.mcp_config import MCPConfig
 from fastmcp.prompts import Prompt
@@ -1265,12 +1264,15 @@ class FastMCP(
                 try:
                     return await tool._run(arguments or {}, task_meta=task_meta)
                 except FastMCPError as e:
-                    logger.log(
-                        e.log_level, f"Error calling tool {name!r}", exc_info=True
-                    )
+                    logger.log(e.log_level, f"Error calling tool {name!r}", exc_info=False)
                     raise
-                except (ValidationError, PydanticValidationError):
-                    logger.exception(f"Error validating tool {name!r}")
+                except PydanticValidationError as e:
+                    # fastmcp's own ValidationError is a FastMCPError, already handled above.
+                    logger.warning(
+                        "Invalid arguments for tool %r: %s",
+                        name,
+                        e.errors(include_url=False),
+                    )
                     raise
                 except Exception as e:
                     logger.exception(f"Error calling tool {name!r}")

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1264,7 +1264,9 @@ class FastMCP(
                 try:
                     return await tool._run(arguments or {}, task_meta=task_meta)
                 except FastMCPError as e:
-                    logger.log(e.log_level, f"Error calling tool {name!r}", exc_info=False)
+                    logger.log(
+                        e.log_level, f"Error calling tool {name!r}", exc_info=False
+                    )
                     raise
                 except PydanticValidationError as e:
                     # fastmcp's own ValidationError is a FastMCPError, already handled above.

--- a/tests/server/test_input_validation.py
+++ b/tests/server/test_input_validation.py
@@ -349,3 +349,71 @@ class TestEdgeCases:
             result = await client.call_tool("sum_numbers", {"numbers": ["1", "2", "3"]})
             assert isinstance(result.content[0], TextContent)
             assert result.content[0].text == "6"
+
+
+class TestExpectedToolFailureLogging:
+    async def test_validation_error_logs_warning_without_traceback(self, caplog):
+        mcp = FastMCP("TestServer", strict_input_validation=False)
+
+        @mcp.tool
+        def create_user(profile: UserProfile) -> str:
+            return profile.name
+
+        with caplog.at_level("DEBUG", logger="fastmcp.server.server"):
+            async with Client(mcp) as client:
+                with pytest.raises(ToolError):
+                    await client.call_tool(
+                        "create_user",
+                        {"profile": {"name": "x", "age": "nope", "email": "e"}},
+                    )
+
+        records = [
+            r for r in caplog.records if "Invalid arguments for tool" in r.getMessage()
+        ]
+        assert records, "expected a single 'Invalid arguments' warning"
+        assert records[0].levelname == "WARNING"
+        assert records[0].exc_info is None
+        assert "int_parsing" in records[0].getMessage()
+        assert "errors.pydantic.dev" not in records[0].getMessage()
+
+    async def test_tool_raised_tool_error_logs_without_traceback(self, caplog):
+        mcp = FastMCP("TestServer")
+
+        @mcp.tool
+        def do_thing() -> str:
+            raise ToolError("structured failure payload")
+
+        with caplog.at_level("DEBUG", logger="fastmcp.server.server"):
+            async with Client(mcp) as client:
+                with pytest.raises(ToolError):
+                    await client.call_tool("do_thing", {})
+
+        records = [
+            r
+            for r in caplog.records
+            if r.getMessage() == "Error calling tool 'do_thing'"
+        ]
+        assert records, "expected an 'Error calling tool' log without traceback"
+        assert records[0].levelname == "ERROR"
+        assert records[0].exc_info is None
+
+    async def test_unexpected_exception_still_logs_with_traceback(self, caplog):
+        mcp = FastMCP("TestServer")
+
+        @mcp.tool
+        def do_thing() -> str:
+            raise RuntimeError("actual bug")
+
+        with caplog.at_level("DEBUG", logger="fastmcp.server.server"):
+            async with Client(mcp) as client:
+                with pytest.raises(ToolError):
+                    await client.call_tool("do_thing", {})
+
+        records = [
+            r
+            for r in caplog.records
+            if r.getMessage() == "Error calling tool 'do_thing'"
+        ]
+        assert records, "expected an 'Error calling tool' exception log"
+        assert records[0].levelname == "ERROR"
+        assert records[0].exc_info is not None

--- a/tests/server/test_input_validation.py
+++ b/tests/server/test_input_validation.py
@@ -395,7 +395,7 @@ class TestExpectedToolFailureLogging:
         ]
         assert records, "expected an 'Error calling tool' log without traceback"
         assert records[0].levelname == "ERROR"
-        assert records[0].exc_info is None
+        assert not records[0].exc_info
 
     async def test_unexpected_exception_still_logs_with_traceback(self, caplog):
         mcp = FastMCP("TestServer")


### PR DESCRIPTION
## Description

Tool dispatch in `server.py` logs every failure via `logger.exception`, printing a full traceback to stderr. Three cases land in those branches, but only one is an actual bug:

- `except FastMCPError`: a tool deliberately raised `ToolError` (or similar). The traceback through fastmcp's dispatcher adds nothing — the error payload already carries the relevant context.
- `except (ValidationError, PydanticValidationError)`: the caller passed bad arguments. `err.errors()` already describes the failing field and offending value. The traceback walks Pydantic internals.
- `except Exception`: an unexpected error in tool code. This one benefits from a stack.

On stdio deployments the tracebacks from the first two cases are written to the parent process's stderr on every malformed caller request or tool-raised error.

This PR drops `exc_info` on the expected-failure branches. Log level for `FastMCPError` is unchanged — it respects `e.log_level` introduced in #4036. `fastmcp.ValidationError` is removed from the second `except` tuple; it is a `FastMCPError` subclass already caught by the branch above, making that entry unreachable.

Closes #

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)