### PR TITLE
Add log_level parameter to FastMCP errors

### DIFF
--- a/src/fastmcp/exceptions.py
+++ b/src/fastmcp/exceptions.py
@@ -1,5 +1,7 @@
 """Custom exceptions for FastMCP."""
 
+import logging
+
 from mcp import McpError  # noqa: F401
 
 
@@ -15,9 +17,9 @@ class FastMCPDeprecationWarning(DeprecationWarning):
 class FastMCPError(Exception):
     """Base error for FastMCP."""
 
-    def __init__(self, *args: object, suppress_log: bool = False) -> None:
+    def __init__(self, *args: object, log_level: int = logging.ERROR) -> None:
         super().__init__(*args)
-        self.suppress_log = suppress_log
+        self.log_level = log_level
 
 
 class ValidationError(FastMCPError):

--- a/src/fastmcp/exceptions.py
+++ b/src/fastmcp/exceptions.py
@@ -15,6 +15,10 @@ class FastMCPDeprecationWarning(DeprecationWarning):
 class FastMCPError(Exception):
     """Base error for FastMCP."""
 
+    def __init__(self, *args: object, suppress_log: bool = False) -> None:
+        super().__init__(*args)
+        self.suppress_log = suppress_log
+
 
 class ValidationError(FastMCPError):
     """Error in validating parameters or return values."""

--- a/src/fastmcp/prompts/function_prompt.py
+++ b/src/fastmcp/prompts/function_prompt.py
@@ -24,7 +24,7 @@ from pydantic.json_schema import SkipJsonSchema
 
 import fastmcp
 from fastmcp.decorators import resolve_task_config
-from fastmcp.exceptions import FastMCPDeprecationWarning, PromptError
+from fastmcp.exceptions import FastMCPDeprecationWarning, FastMCPError, PromptError
 from fastmcp.prompts.base import Prompt, PromptArgument, PromptResult
 from fastmcp.server.auth.authorization import AuthCheck
 from fastmcp.server.dependencies import (
@@ -361,6 +361,8 @@ class FunctionPrompt(Prompt):
                     result = await result
 
             return self.convert_result(result)
+        except FastMCPError:
+            raise
         except Exception as e:
             logger.exception(f"Error rendering prompt {self.name}")
             raise PromptError(f"Error rendering prompt {self.name!r}: {e}") from e

--- a/src/fastmcp/server/sampling/run.py
+++ b/src/fastmcp/server/sampling/run.py
@@ -304,7 +304,8 @@ async def execute_tools(
             )
         except ToolError as e:
             # ToolError is the escape hatch - always pass message through
-            logger.exception(f"Error calling sampling tool '{tool_use.name}'")
+            if not e.suppress_log:
+                logger.exception(f"Error calling sampling tool '{tool_use.name}'")
             return ToolResultContent(
                 type="tool_result",
                 toolUseId=tool_use.id,

--- a/src/fastmcp/server/sampling/run.py
+++ b/src/fastmcp/server/sampling/run.py
@@ -304,8 +304,11 @@ async def execute_tools(
             )
         except ToolError as e:
             # ToolError is the escape hatch - always pass message through
-            if not e.suppress_log:
-                logger.exception(f"Error calling sampling tool '{tool_use.name}'")
+            logger.log(
+                e.log_level,
+                f"Error calling sampling tool '{tool_use.name}'",
+                exc_info=True,
+            )
             return ToolResultContent(
                 type="tool_result",
                 toolUseId=tool_use.id,

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1259,8 +1259,9 @@ class FastMCP(
                     task_meta = replace(task_meta, fn_key=tool.key)
                 try:
                     return await tool._run(arguments or {}, task_meta=task_meta)
-                except FastMCPError:
-                    logger.exception(f"Error calling tool {name!r}")
+                except FastMCPError as e:
+                    if not e.suppress_log:
+                        logger.exception(f"Error calling tool {name!r}")
                     raise
                 except (ValidationError, PydanticValidationError):
                     logger.exception(f"Error validating tool {name!r}")
@@ -1389,7 +1390,11 @@ class FastMCP(
                         task_meta = replace(task_meta, fn_key=resource.key)
                     try:
                         return await resource._read(task_meta=task_meta)
-                    except (FastMCPError, McpError):
+                    except FastMCPError as e:
+                        if not e.suppress_log:
+                            logger.exception(f"Error reading resource {uri!r}")
+                        raise
+                    except McpError:
                         logger.exception(f"Error reading resource {uri!r}")
                         raise
                     except Exception as e:
@@ -1428,7 +1433,11 @@ class FastMCP(
                     task_meta = replace(task_meta, fn_key=template.key)
                 try:
                     return await template._read(uri, params, task_meta=task_meta)
-                except (FastMCPError, McpError):
+                except FastMCPError as e:
+                    if not e.suppress_log:
+                        logger.exception(f"Error reading resource {uri!r}")
+                    raise
+                except McpError:
                     logger.exception(f"Error reading resource {uri!r}")
                     raise
                 except Exception as e:
@@ -1542,7 +1551,11 @@ class FastMCP(
                     task_meta = replace(task_meta, fn_key=prompt.key)
                 try:
                     return await prompt._render(arguments, task_meta=task_meta)
-                except (FastMCPError, McpError):
+                except FastMCPError as e:
+                    if not e.suppress_log:
+                        logger.exception(f"Error rendering prompt {name!r}")
+                    raise
+                except McpError:
                     logger.exception(f"Error rendering prompt {name!r}")
                     raise
                 except Exception as e:

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1260,8 +1260,9 @@ class FastMCP(
                 try:
                     return await tool._run(arguments or {}, task_meta=task_meta)
                 except FastMCPError as e:
-                    if not e.suppress_log:
-                        logger.exception(f"Error calling tool {name!r}")
+                    logger.log(
+                        e.log_level, f"Error calling tool {name!r}", exc_info=True
+                    )
                     raise
                 except (ValidationError, PydanticValidationError):
                     logger.exception(f"Error validating tool {name!r}")
@@ -1391,8 +1392,11 @@ class FastMCP(
                     try:
                         return await resource._read(task_meta=task_meta)
                     except FastMCPError as e:
-                        if not e.suppress_log:
-                            logger.exception(f"Error reading resource {uri!r}")
+                        logger.log(
+                            e.log_level,
+                            f"Error reading resource {uri!r}",
+                            exc_info=True,
+                        )
                         raise
                     except McpError:
                         logger.exception(f"Error reading resource {uri!r}")
@@ -1434,8 +1438,9 @@ class FastMCP(
                 try:
                     return await template._read(uri, params, task_meta=task_meta)
                 except FastMCPError as e:
-                    if not e.suppress_log:
-                        logger.exception(f"Error reading resource {uri!r}")
+                    logger.log(
+                        e.log_level, f"Error reading resource {uri!r}", exc_info=True
+                    )
                     raise
                 except McpError:
                     logger.exception(f"Error reading resource {uri!r}")
@@ -1552,8 +1557,9 @@ class FastMCP(
                 try:
                     return await prompt._render(arguments, task_meta=task_meta)
                 except FastMCPError as e:
-                    if not e.suppress_log:
-                        logger.exception(f"Error rendering prompt {name!r}")
+                    logger.log(
+                        e.log_level, f"Error rendering prompt {name!r}", exc_info=True
+                    )
                     raise
                 except McpError:
                     logger.exception(f"Error rendering prompt {name!r}")

--- a/tests/client/client/test_client.py
+++ b/tests/client/client/test_client.py
@@ -284,7 +284,7 @@ async def test_server_deserialization_error():
     client = Client(transport=FastMCPTransport(server))
 
     async with client:
-        with pytest.raises(McpError, match="Error rendering prompt"):
+        with pytest.raises(McpError, match="Could not convert argument"):
             await client.get_prompt(
                 "strict_typed_prompt",
                 {

--- a/tests/client/client/test_error_handling.py
+++ b/tests/client/client/test_error_handling.py
@@ -269,29 +269,33 @@ class TestParseToolResultEdgeCases:
         assert parsed.structured_content == {"key": "value"}
 
 
-class TestSuppressLog:
-    async def test_tool_error_with_suppress_log_does_not_log(self, caplog):
-        """ToolError with suppress_log=True should skip logger.exception()."""
+class TestLogLevel:
+    async def test_tool_error_with_custom_log_level(self, caplog):
+        """ToolError with custom log_level should log at specified level."""
         mcp = FastMCP("TestServer")
 
         @mcp.tool
-        def suppressed_error_tool():
-            raise ToolError("Missing required parameter", suppress_log=True)
+        def custom_level_tool():
+            raise ToolError("Missing required parameter", log_level=logging.WARNING)
 
         async with Client(transport=FastMCPTransport(mcp)) as client:
-            with caplog.at_level(logging.ERROR):
-                result = await client.call_tool_mcp("suppressed_error_tool", {})
+            with caplog.at_level(logging.WARNING):
+                result = await client.call_tool_mcp("custom_level_tool", {})
 
         assert result.isError
         assert isinstance(result.content[0], TextContent)
         assert "Missing required parameter" in result.content[0].text
+        assert any(
+            "Error calling tool" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
         assert not any(
             "Error calling tool" in record.message and record.levelname == "ERROR"
             for record in caplog.records
         )
 
-    async def test_regular_tool_error_still_logs(self, caplog):
-        """ToolError without suppress_log still triggers logger.exception()."""
+    async def test_regular_tool_error_logs_at_error(self, caplog):
+        """ToolError with default log_level logs at ERROR."""
         mcp = FastMCP("TestServer")
 
         @mcp.tool
@@ -311,29 +315,33 @@ class TestSuppressLog:
             for record in caplog.records
         )
 
-    async def test_resource_error_with_suppress_log_does_not_log(self, caplog):
-        """ResourceError with suppress_log=True should skip logger.exception()."""
+    async def test_resource_error_with_custom_log_level(self, caplog):
+        """ResourceError with custom log_level should log at specified level."""
         mcp = FastMCP("TestServer")
 
-        @mcp.resource("test://suppressed")
-        def suppressed_resource():
+        @mcp.resource("test://custom")
+        def custom_level_resource():
             raise ResourceError(
-                "Resource unavailable, try again later", suppress_log=True
+                "Resource unavailable, try again later", log_level=logging.WARNING
             )
 
         async with Client(transport=FastMCPTransport(mcp)) as client:
-            with caplog.at_level(logging.ERROR):
+            with caplog.at_level(logging.WARNING):
                 with pytest.raises(Exception) as exc_info:
-                    await client.read_resource_mcp("test://suppressed")
+                    await client.read_resource_mcp("test://custom")
 
         assert "Resource unavailable, try again later" in str(exc_info.value)
+        assert any(
+            "Error reading resource" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
         assert not any(
             "Error reading resource" in record.message and record.levelname == "ERROR"
             for record in caplog.records
         )
 
-    async def test_regular_resource_error_still_logs(self, caplog):
-        """ResourceError without suppress_log still triggers logger.exception()."""
+    async def test_regular_resource_error_logs_at_error(self, caplog):
+        """ResourceError with default log_level logs at ERROR."""
         mcp = FastMCP("TestServer")
 
         @mcp.resource("test://regular")
@@ -352,29 +360,33 @@ class TestSuppressLog:
             for record in caplog.records
         )
 
-    async def test_prompt_error_with_suppress_log_does_not_log(self, caplog):
-        """PromptError with suppress_log=True should skip logger.exception()."""
+    async def test_prompt_error_with_custom_log_level(self, caplog):
+        """PromptError with custom log_level should log at specified level."""
         mcp = FastMCP("TestServer")
 
         @mcp.prompt
-        def suppressed_prompt():
+        def custom_level_prompt():
             raise PromptError(
-                "Insufficient context, provide more details", suppress_log=True
+                "Insufficient context, provide more details", log_level=logging.WARNING
             )
 
         async with Client(transport=FastMCPTransport(mcp)) as client:
-            with caplog.at_level(logging.ERROR):
+            with caplog.at_level(logging.WARNING):
                 with pytest.raises(Exception) as exc_info:
-                    await client.get_prompt("suppressed_prompt")
+                    await client.get_prompt("custom_level_prompt")
 
         assert "Insufficient context" in str(exc_info.value)
+        assert any(
+            "Error rendering prompt" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
         assert not any(
             "Error rendering prompt" in record.message and record.levelname == "ERROR"
             for record in caplog.records
         )
 
-    async def test_regular_prompt_error_still_logs(self, caplog):
-        """PromptError without suppress_log still triggers logger.exception()."""
+    async def test_regular_prompt_error_logs_at_error(self, caplog):
+        """PromptError with default log_level logs at ERROR."""
         mcp = FastMCP("TestServer")
 
         @mcp.prompt
@@ -393,33 +405,38 @@ class TestSuppressLog:
             for record in caplog.records
         )
 
-    async def test_sampling_tool_error_with_suppress_log_does_not_log(self, caplog):
-        """ToolError with suppress_log=True in sampling should skip logging."""
+    async def test_sampling_tool_error_with_custom_log_level(self, caplog):
+        """ToolError with custom log_level in sampling should log at specified level."""
         from mcp.types import ToolUseContent
 
         from fastmcp.server.sampling.run import SamplingTool, execute_tools
 
-        async def suppressed_sampling_tool(x: int) -> int:
-            raise ToolError("Expected sampling error", suppress_log=True)
+        async def custom_level_sampling_tool(x: int) -> int:
+            raise ToolError("Expected sampling error", log_level=logging.WARNING)
 
-        tool = SamplingTool.from_function(suppressed_sampling_tool)
+        tool = SamplingTool.from_function(custom_level_sampling_tool)
         tool_use = ToolUseContent(
             type="tool_use",
             id="test-id",
-            name="suppressed_sampling_tool",
+            name="custom_level_sampling_tool",
             input={"x": 42},
         )
 
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             results = await execute_tools(
                 tool_calls=[tool_use],
-                tool_map={"suppressed_sampling_tool": tool},
+                tool_map={"custom_level_sampling_tool": tool},
                 mask_error_details=False,
             )
 
         assert len(results) == 1
         assert results[0].isError
         assert "Expected sampling error" in results[0].content[0].text  # type: ignore
+        assert any(
+            "Error calling sampling tool" in record.message
+            and record.levelname == "WARNING"
+            for record in caplog.records
+        )
         assert not any(
             "Error calling sampling tool" in record.message
             and record.levelname == "ERROR"

--- a/tests/client/client/test_error_handling.py
+++ b/tests/client/client/test_error_handling.py
@@ -1,5 +1,7 @@
 """Client error handling tests."""
 
+import logging
+
 import mcp.types
 import pytest
 from mcp.types import TextContent
@@ -8,7 +10,7 @@ from pydantic import AnyUrl
 from fastmcp.client import Client
 from fastmcp.client.mixins.tools import _parse_call_tool_result
 from fastmcp.client.transports import FastMCPTransport
-from fastmcp.exceptions import ResourceError, ToolError
+from fastmcp.exceptions import PromptError, ResourceError, ToolError
 from fastmcp.server.server import FastMCP
 
 
@@ -265,3 +267,161 @@ class TestParseToolResultEdgeCases:
         assert parsed.is_error is True
         assert parsed.data is None
         assert parsed.structured_content == {"key": "value"}
+
+
+class TestSuppressLog:
+    async def test_tool_error_with_suppress_log_does_not_log(self, caplog):
+        """ToolError with suppress_log=True should skip logger.exception()."""
+        mcp = FastMCP("TestServer")
+
+        @mcp.tool
+        def suppressed_error_tool():
+            raise ToolError("Missing required parameter", suppress_log=True)
+
+        async with Client(transport=FastMCPTransport(mcp)) as client:
+            with caplog.at_level(logging.ERROR):
+                result = await client.call_tool_mcp("suppressed_error_tool", {})
+
+        assert result.isError
+        assert isinstance(result.content[0], TextContent)
+        assert "Missing required parameter" in result.content[0].text
+        assert not any(
+            "Error calling tool" in record.message and record.levelname == "ERROR"
+            for record in caplog.records
+        )
+
+    async def test_regular_tool_error_still_logs(self, caplog):
+        """ToolError without suppress_log still triggers logger.exception()."""
+        mcp = FastMCP("TestServer")
+
+        @mcp.tool
+        def regular_error_tool():
+            raise ToolError("Something went wrong")
+
+        async with Client(transport=FastMCPTransport(mcp)) as client:
+            with caplog.at_level(logging.ERROR):
+                result = await client.call_tool_mcp("regular_error_tool", {})
+
+        assert result.isError
+        assert isinstance(result.content[0], TextContent)
+        assert "Something went wrong" in result.content[0].text
+        assert any(
+            "Error calling tool 'regular_error_tool'" in record.message
+            and record.levelname == "ERROR"
+            for record in caplog.records
+        )
+
+    async def test_resource_error_with_suppress_log_does_not_log(self, caplog):
+        """ResourceError with suppress_log=True should skip logger.exception()."""
+        mcp = FastMCP("TestServer")
+
+        @mcp.resource("test://suppressed")
+        def suppressed_resource():
+            raise ResourceError(
+                "Resource unavailable, try again later", suppress_log=True
+            )
+
+        async with Client(transport=FastMCPTransport(mcp)) as client:
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(Exception) as exc_info:
+                    await client.read_resource_mcp("test://suppressed")
+
+        assert "Resource unavailable, try again later" in str(exc_info.value)
+        assert not any(
+            "Error reading resource" in record.message and record.levelname == "ERROR"
+            for record in caplog.records
+        )
+
+    async def test_regular_resource_error_still_logs(self, caplog):
+        """ResourceError without suppress_log still triggers logger.exception()."""
+        mcp = FastMCP("TestServer")
+
+        @mcp.resource("test://regular")
+        def regular_resource():
+            raise ResourceError("Something went wrong")
+
+        async with Client(transport=FastMCPTransport(mcp)) as client:
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(Exception) as exc_info:
+                    await client.read_resource_mcp("test://regular")
+
+        assert "Something went wrong" in str(exc_info.value)
+        assert any(
+            "Error reading resource 'test://regular'" in record.message
+            and record.levelname == "ERROR"
+            for record in caplog.records
+        )
+
+    async def test_prompt_error_with_suppress_log_does_not_log(self, caplog):
+        """PromptError with suppress_log=True should skip logger.exception()."""
+        mcp = FastMCP("TestServer")
+
+        @mcp.prompt
+        def suppressed_prompt():
+            raise PromptError(
+                "Insufficient context, provide more details", suppress_log=True
+            )
+
+        async with Client(transport=FastMCPTransport(mcp)) as client:
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(Exception) as exc_info:
+                    await client.get_prompt("suppressed_prompt")
+
+        assert "Insufficient context" in str(exc_info.value)
+        assert not any(
+            "Error rendering prompt" in record.message and record.levelname == "ERROR"
+            for record in caplog.records
+        )
+
+    async def test_regular_prompt_error_still_logs(self, caplog):
+        """PromptError without suppress_log still triggers logger.exception()."""
+        mcp = FastMCP("TestServer")
+
+        @mcp.prompt
+        def regular_prompt():
+            raise PromptError("Something went wrong")
+
+        async with Client(transport=FastMCPTransport(mcp)) as client:
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(Exception) as exc_info:
+                    await client.get_prompt("regular_prompt")
+
+        assert "Something went wrong" in str(exc_info.value)
+        assert any(
+            "Error rendering prompt 'regular_prompt'" in record.message
+            and record.levelname == "ERROR"
+            for record in caplog.records
+        )
+
+    async def test_sampling_tool_error_with_suppress_log_does_not_log(self, caplog):
+        """ToolError with suppress_log=True in sampling should skip logging."""
+        from mcp.types import ToolUseContent
+
+        from fastmcp.server.sampling.run import SamplingTool, execute_tools
+
+        async def suppressed_sampling_tool(x: int) -> int:
+            raise ToolError("Expected sampling error", suppress_log=True)
+
+        tool = SamplingTool.from_function(suppressed_sampling_tool)
+        tool_use = ToolUseContent(
+            type="tool_use",
+            id="test-id",
+            name="suppressed_sampling_tool",
+            input={"x": 42},
+        )
+
+        with caplog.at_level(logging.ERROR):
+            results = await execute_tools(
+                tool_calls=[tool_use],
+                tool_map={"suppressed_sampling_tool": tool},
+                mask_error_details=False,
+            )
+
+        assert len(results) == 1
+        assert results[0].isError
+        assert "Expected sampling error" in results[0].content[0].text  # type: ignore
+        assert not any(
+            "Error calling sampling tool" in record.message
+            and record.levelname == "ERROR"
+            for record in caplog.records
+        )

--- a/tests/client/client/test_error_handling.py
+++ b/tests/client/client/test_error_handling.py
@@ -4,13 +4,14 @@ import logging
 
 import mcp.types
 import pytest
-from mcp.types import TextContent
+from mcp.types import TextContent, ToolUseContent
 from pydantic import AnyUrl
 
 from fastmcp.client import Client
 from fastmcp.client.mixins.tools import _parse_call_tool_result
 from fastmcp.client.transports import FastMCPTransport
 from fastmcp.exceptions import PromptError, ResourceError, ToolError
+from fastmcp.server.sampling.run import SamplingTool, execute_tools
 from fastmcp.server.server import FastMCP
 
 
@@ -407,9 +408,6 @@ class TestLogLevel:
 
     async def test_sampling_tool_error_with_custom_log_level(self, caplog):
         """ToolError with custom log_level in sampling should log at specified level."""
-        from mcp.types import ToolUseContent
-
-        from fastmcp.server.sampling.run import SamplingTool, execute_tools
 
         async def custom_level_sampling_tool(x: int) -> int:
             raise ToolError("Expected sampling error", log_level=logging.WARNING)

--- a/tests/prompts/test_prompt.py
+++ b/tests/prompts/test_prompt.py
@@ -273,11 +273,13 @@ class TestPromptTypeConversion:
 
         prompt = Prompt.from_function(typed_prompt)
 
-        # Test with invalid JSON - should raise PromptError due to exception handling in render()
+        # Test with invalid JSON - should raise PromptError with type conversion details
         with pytest.raises(PromptError) as exc_info:
             await prompt.render(arguments={"numbers": "not valid json"})
 
-        assert f"Error rendering prompt {prompt.name!r}" in str(exc_info.value)
+        # PromptError passes through unchanged
+        assert "Could not convert argument 'numbers'" in str(exc_info.value)
+        assert "list[int]" in str(exc_info.value)
 
     async def test_json_parsing_fallback(self):
         """Test that JSON parsing falls back to direct validation when needed."""


### PR DESCRIPTION
## Description

Closes #4035

Adds `log_level` parameter to `FastMCPError` and all subclasses (`ToolError`, `ResourceError`, `PromptError`, etc.) to control the server-side log level for expected control-flow errors.

When building multi-step LLM workflows, errors often represent normal control flow rather than bugs. For example, a tool might raise `ToolError("Model not deployed, call deploy_model first")` to guide the LLM's next action. These expected errors create noise in production error monitoring systems (Sentry, DataDog) that typically capture ERROR-level logs. Rather than suppressing logs entirely (losing all visibility), this lets server operators downgrade the log level so the error is still recorded but doesn't trigger alerts.

### Usage

```python
@mcp.tool
def check_model_status(model_id: str) -> dict:
  if not model_registry.is_deployed(model_id):
      raise ToolError(
          f"Model {model_id} not deployed. Call deploy_model first.",
          log_level=logging.WARNING  # Log at WARNING instead of ERROR
      )
  return model_registry.get_status(model_id)
```

The error still reaches the LLM client with the full message and is still logged server-side — just at the specified level instead of ERROR.

### Implementation

- Added `log_level: int = logging.ERROR` parameter to `FastMCPError.__init__`
- Updated catch blocks in `server.py` to use `logger.log(e.log_level, ..., exc_info=True)` instead of `logger.exception()`
- Updated `sampling/run.py` for sampling tool errors
- Fixed pre-existing bug where `function_prompt.py` double-wrapped `PromptError`

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
