### PR TITLE
fix: VersionSpec eq matching normalizes versions and selects deterministically

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -1197,6 +1197,12 @@ class FastMCP(
         # For mounted servers, the parent's provider sets fn_key to the
         # namespaced key before delegating, ensuring correct Docket routing.
 
+        if isinstance(version, str):
+            raise TypeError(
+                f"version must be a VersionSpec (e.g., VersionSpec(eq={version!r})), "
+                f"not a string. Received: {version!r}"
+            )
+
         from fastmcp.server.providers.addressing import (
             parse_hashed_backend_name,
         )

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -1197,12 +1197,6 @@ class FastMCP(
         # For mounted servers, the parent's provider sets fn_key to the
         # namespaced key before delegating, ensuring correct Docket routing.
 
-        if isinstance(version, str):
-            raise TypeError(
-                f"version must be a VersionSpec (e.g., VersionSpec(eq={version!r})), "
-                f"not a string. Received: {version!r}"
-            )
-
         from fastmcp.server.providers.addressing import (
             parse_hashed_backend_name,
         )

--- a/fastmcp_slim/fastmcp/utilities/versions.py
+++ b/fastmcp_slim/fastmcp/utilities/versions.py
@@ -62,7 +62,7 @@ class VersionSpec:
             return match_none
 
         if self.eq is not None:
-            return version == self.eq
+            return parse_version_key(version) == parse_version_key(self.eq)
 
         key = parse_version_key(version)
 

--- a/fastmcp_slim/fastmcp/utilities/versions.py
+++ b/fastmcp_slim/fastmcp/utilities/versions.py
@@ -39,6 +39,13 @@ class VersionSpec:
         gte: If set, only versions >= this value match.
         lt: If set, only versions < this value match.
         eq: If set, only this exact version matches (gte/lt ignored).
+            Matching is PEP 440-normalized and `v`-prefix insensitive, so
+            `eq="v1.0"` matches a component versioned `"1.0"`, and `eq="1.0"`
+            matches `"1"` (PEP 440 treats `1` and `1.0` as the same version).
+            If a server registers two PEP 440-equivalent spellings of the
+            same component (e.g. both `"1"` and `"1.0"`), they are the same
+            version under this spec; selection among them is deterministic
+            (see `version_sort_key`), not registration-order dependent.
     """
 
     gte: str | None = None
@@ -199,16 +206,24 @@ def parse_version_key(version: str | None) -> VersionKey:
     return VersionKey(version)
 
 
-def version_sort_key(component: FastMCPComponent) -> VersionKey:
+def version_sort_key(component: FastMCPComponent) -> tuple[VersionKey, str]:
     """Get a sort key for a component based on its version.
 
     Use with sorted() or max() to order components by version.
+
+    The key is a `(VersionKey, raw)` tuple. The `VersionKey` orders by PEP 440
+    semantics (or lexicographically for non-PEP 440 strings); the raw version
+    string is a deterministic tie-breaker so that two components whose versions
+    are PEP 440-equivalent but spelled differently (e.g. `"1"` and `"1.0"`) are
+    ordered reproducibly instead of by registration order. The raw tie-breaker
+    only affects equivalent-version ties and never the primary version order,
+    so range/equality matching (which uses `VersionKey` directly) is unchanged.
 
     Args:
         component: The component to get a sort key for.
 
     Returns:
-        A sortable VersionKey.
+        A deterministic, sortable `(VersionKey, raw)` tuple.
 
     Example:
         ```python
@@ -216,7 +231,7 @@ def version_sort_key(component: FastMCPComponent) -> VersionKey:
         highest = max(tools, key=version_sort_key)  # Returns tool_v2
         ```
     """
-    return parse_version_key(component.version)
+    return (parse_version_key(component.version), component.version or "")
 
 
 def compare_versions(a: str | None, b: str | None) -> int:

--- a/tests/server/versioning/test_versioning.py
+++ b/tests/server/versioning/test_versioning.py
@@ -86,11 +86,9 @@ class TestVersionFunctions:
         assert not is_version_greater(None, "1.0")
 
 
-class _FakeComponent:
-    """Minimal stand-in exposing only `.version` for version_sort_key."""
-
-    def __init__(self, version: str | None) -> None:
-        self.version = version
+def _tool(version: str | None) -> Tool:
+    """Build a real Tool component (a FastMCPComponent) with a version."""
+    return Tool.from_function(lambda: None, name="t", version=version)
 
 
 class TestVersionSpecEq:
@@ -137,29 +135,56 @@ class TestVersionSelectionDeterminism:
     def test_version_sort_key_is_total_ordering_tuple(self):
         # PEP 440-equivalent but distinct spellings tie on VersionKey;
         # the raw string breaks the tie deterministically.
-        k1 = version_sort_key(_FakeComponent("1"))
-        k10 = version_sort_key(_FakeComponent("1.0"))
+        k1 = version_sort_key(_tool("1"))
+        k10 = version_sort_key(_tool("1.0"))
         assert k1[0] == k10[0]  # same VersionKey (PEP 440 equal)
         assert k1 != k10  # but distinct sort keys
         assert k10 > k1  # deterministic order ("1.0" > "1")
 
-    def test_max_is_order_independent(self):
-        forward = [_FakeComponent("1"), _FakeComponent("1.0")]
-        reverse = [_FakeComponent("1.0"), _FakeComponent("1")]
-        assert max(forward, key=version_sort_key).version == "1.0"
-        assert max(reverse, key=version_sort_key).version == "1.0"
-
     def test_unversioned_components_do_not_crash_tiebreak(self):
         # Two unversioned components: raw tie-breaker is "" for both,
-        # must not raise (None < None would).
-        items = [_FakeComponent(None), _FakeComponent(None)]
-        assert max(items, key=version_sort_key).version is None
+        # must compare equal without raising (None < None would).
+        a = version_sort_key(_tool(None))
+        b = version_sort_key(_tool(None))
+        assert a == b
 
     def test_distinct_versions_unaffected_by_tiebreak(self):
         # Primary ordering still wins; raw tie-breaker never overrides it.
         # "1.9" < "1.10" semantically even though "1.9" > "1.10" as strings.
-        items = [_FakeComponent("1.10"), _FakeComponent("1.9")]
-        assert max(items, key=version_sort_key).version == "1.10"
+        k19 = version_sort_key(_tool("1.9"))
+        k110 = version_sort_key(_tool("1.10"))
+        assert k110 > k19
+
+    async def test_selection_is_registration_order_independent(self):
+        """End-to-end: registering two PEP 440-equivalent spellings of the
+        same tool must select the same one regardless of registration order
+        (exercises the real `max(..., key=version_sort_key)` selection path)."""
+
+        forward = FastMCP()
+
+        @forward.tool(name="add", version="1")
+        def add_a(x: int) -> int:
+            return x
+
+        @forward.tool(name="add", version="1.0")
+        def add_b(x: int) -> int:
+            return x
+
+        reverse = FastMCP()
+
+        @reverse.tool(name="add", version="1.0")
+        def add_c(x: int) -> int:
+            return x
+
+        @reverse.tool(name="add", version="1")
+        def add_d(x: int) -> int:
+            return x
+
+        fwd = await forward.get_tool("add")
+        rev = await reverse.get_tool("add")
+        assert fwd is not None and rev is not None
+        # Deterministic regardless of order (previously order-dependent).
+        assert fwd.version == rev.version == "1.0"
 
 
 class TestComponentVersioning:

--- a/tests/server/versioning/test_versioning.py
+++ b/tests/server/versioning/test_versioning.py
@@ -12,8 +12,10 @@ from fastmcp import FastMCP
 from fastmcp.tools import Tool
 from fastmcp.utilities.versions import (
     VersionKey,
+    VersionSpec,
     compare_versions,
     is_version_greater,
+    version_sort_key,
 )
 
 
@@ -82,6 +84,82 @@ class TestVersionFunctions:
         assert not is_version_greater("1.0", "1.0")
         assert is_version_greater("1.0", None)
         assert not is_version_greater(None, "1.0")
+
+
+class _FakeComponent:
+    """Minimal stand-in exposing only `.version` for version_sort_key."""
+
+    def __init__(self, version: str | None) -> None:
+        self.version = version
+
+
+class TestVersionSpecEq:
+    """Tests for VersionSpec(eq=...) matching semantics."""
+
+    def test_exact_string_match(self):
+        assert VersionSpec(eq="1.0").matches("1.0")
+        assert not VersionSpec(eq="1.0").matches("2.0")
+
+    def test_v_prefix_insensitive_both_directions(self):
+        # Spec has v-prefix, component does not
+        assert VersionSpec(eq="v1.0").matches("1.0")
+        # Component has v-prefix, spec does not
+        assert VersionSpec(eq="1.0").matches("v1.0")
+        assert VersionSpec(eq="v2.3").matches("v2.3")
+
+    def test_pep440_equivalent_spellings_match(self):
+        """PEP 440 treats 1, 1.0, 1.0.0 as the same version."""
+        assert VersionSpec(eq="1.0").matches("1")
+        assert VersionSpec(eq="1").matches("1.0")
+        assert VersionSpec(eq="1.0").matches("1.0.0")
+        assert not VersionSpec(eq="1.0").matches("1.0.1")
+
+    def test_malformed_versions_use_exact_string_equality(self):
+        """Non-PEP 440 strings compare exactly (no normalization, no crash)."""
+        assert VersionSpec(eq="latest").matches("latest")
+        assert not VersionSpec(eq="latest").matches("LATEST")
+        assert VersionSpec(eq="2024-01-01").matches("2024-01-01")
+        assert not VersionSpec(eq="2024-01-01").matches("2024-01-02")
+
+    def test_eq_does_not_match_none_when_match_none_false(self):
+        assert VersionSpec(eq="1.0").matches(None, match_none=False) is False
+        assert VersionSpec(eq="1.0").matches(None, match_none=True) is True
+
+
+class TestVersionSelectionDeterminism:
+    """Selection among PEP 440-equivalent spellings must be deterministic.
+
+    Regression: previously `max(matching, key=version_sort_key)` returned the
+    first element on a tie, so registering both "1" and "1.0" made selection
+    depend on registration order. version_sort_key now has a raw tie-breaker.
+    """
+
+    def test_version_sort_key_is_total_ordering_tuple(self):
+        # PEP 440-equivalent but distinct spellings tie on VersionKey;
+        # the raw string breaks the tie deterministically.
+        k1 = version_sort_key(_FakeComponent("1"))
+        k10 = version_sort_key(_FakeComponent("1.0"))
+        assert k1[0] == k10[0]  # same VersionKey (PEP 440 equal)
+        assert k1 != k10  # but distinct sort keys
+        assert k10 > k1  # deterministic order ("1.0" > "1")
+
+    def test_max_is_order_independent(self):
+        forward = [_FakeComponent("1"), _FakeComponent("1.0")]
+        reverse = [_FakeComponent("1.0"), _FakeComponent("1")]
+        assert max(forward, key=version_sort_key).version == "1.0"
+        assert max(reverse, key=version_sort_key).version == "1.0"
+
+    def test_unversioned_components_do_not_crash_tiebreak(self):
+        # Two unversioned components: raw tie-breaker is "" for both,
+        # must not raise (None < None would).
+        items = [_FakeComponent(None), _FakeComponent(None)]
+        assert max(items, key=version_sort_key).version is None
+
+    def test_distinct_versions_unaffected_by_tiebreak(self):
+        # Primary ordering still wins; raw tie-breaker never overrides it.
+        # "1.9" < "1.10" semantically even though "1.9" > "1.10" as strings.
+        items = [_FakeComponent("1.10"), _FakeComponent("1.9")]
+        assert max(items, key=version_sort_key).version == "1.10"
 
 
 class TestComponentVersioning:


### PR DESCRIPTION
## Summary

`VersionSpec(eq=...)` compared the requested and component versions as raw strings, so `VersionSpec(eq="1.0")` would not match a component versioned `"v1.0"` — even though `VersionKey` already normalizes the `v` prefix and PEP 440 semantics for range (`gte`/`lt`) matching. `eq` was the odd one out, making exact selection inconsistent with the rest of the spec.

`eq` now normalizes both sides via `parse_version_key()`, so it is `v`-prefix insensitive and PEP 440-aware, consistent with range matching. Because PEP 440 treats `1`, `1.0`, and `1.0.0` as the same version, a server that registers two equivalent spellings of the same component could previously make `max(matching, key=version_sort_key)` order-dependent (the tie was resolved by registration order). `version_sort_key` now returns a `(VersionKey, raw)` tuple so ties among PEP 440-equivalent versions are broken deterministically by the raw string, without affecting the primary version order or range/equality matching.

```python
# All of these now match, consistently with gte/lt:
VersionSpec(eq="1.0").matches("v1.0")   # True (v-prefix insensitive)
VersionSpec(eq="1.0").matches("1")      # True (PEP 440 equivalent)
VersionSpec(eq="latest").matches("latest")  # True (exact, non-PEP 440)

# Selection is now reproducible regardless of registration order.
```

Fixes #4050.
