### PR TITLE
fix: preserve annotations, meta, title, icons when creating resources from templates

### DIFF
--- a/fastmcp_slim/fastmcp/resources/template.py
+++ b/fastmcp_slim/fastmcp/resources/template.py
@@ -446,6 +446,10 @@ class FunctionResourceTemplate(ResourceTemplate):
             description=self.description,
             mime_type=self.mime_type,
             tags=self.tags,
+            annotations=self.annotations,
+            meta=self.meta,
+            title=self.title,
+            icons=self.icons,
             task=self.task_config,
             auth=self.auth,
         )

--- a/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py
+++ b/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py
@@ -381,6 +381,11 @@ class FastMCPProviderResourceTemplate(ResourceTemplate):
             name=self.name,
             description=self.description,
             mime_type=self.mime_type,
+            tags=self.tags,
+            annotations=self.annotations,
+            meta=self.meta,
+            title=self.title,
+            icons=self.icons,
         )
 
     @overload

--- a/tests/resources/test_resource_template_meta.py
+++ b/tests/resources/test_resource_template_meta.py
@@ -1,4 +1,11 @@
+from mcp.types import Annotations, Icon
+
+from fastmcp import FastMCP
 from fastmcp.resources import ResourceTemplate
+from fastmcp.server.providers.fastmcp_provider import (
+    FastMCPProvider,
+    FastMCPProviderResourceTemplate,
+)
 
 
 class TestResourceTemplateMeta:
@@ -23,3 +30,86 @@ class TestResourceTemplateMeta:
         # MCP template includes fastmcp meta, so check that our meta is included
         assert mcp_template.meta is not None
         assert meta_data.items() <= mcp_template.meta.items()
+
+
+class TestResourceTemplateFieldPreservation:
+    """Regression for #4061: annotations/meta/title/icons must survive
+    materialization of a Resource from a ResourceTemplate."""
+
+    def _template(self) -> ResourceTemplate:
+        def fn(param: str) -> str:
+            return f"value-{param}"
+
+        return ResourceTemplate.from_function(
+            fn=fn,
+            uri_template="data://{param}",
+            name="t",
+            title="Human Title",
+            meta={"owner": "team-a"},
+            icons=[Icon(src="https://example.com/icon.png", mimeType="image/png")],
+            annotations=Annotations(priority=0.5, audience=["user"]),
+        )
+
+    async def test_function_template_create_resource_preserves_all_fields(self):
+        template = self._template()
+        resource = await template.create_resource("data://x", {"param": "x"})
+
+        assert resource.title == "Human Title"
+        assert resource.meta == {"owner": "team-a"}
+        assert resource.annotations is not None
+        assert resource.annotations.priority == 0.5
+        assert resource.annotations.audience == ["user"]
+        assert resource.icons is not None
+        assert len(resource.icons) == 1
+        assert str(resource.icons[0].src) == "https://example.com/icon.png"
+
+    async def test_created_resource_meta_is_not_aliased_to_template(self):
+        """Mutating the materialized resource's meta must not bleed back into
+        the template (each materialization must be independent)."""
+        template = self._template()
+        resource = await template.create_resource("data://x", {"param": "x"})
+
+        assert resource.meta is not None
+        resource.meta["mutated"] = True
+        assert "mutated" not in (template.meta or {})
+
+    async def test_fastmcp_provider_template_preserves_fields_without_double_wrap(
+        self,
+    ):
+        """The FastMCPProvider path wraps template.get_meta() (already
+        namespaced). Re-materializing must not nest fastmcp under fastmcp."""
+        sub = FastMCP("sub")
+
+        @sub.resource(
+            "data://{param}",
+            title="Sub Title",
+            meta={"owner": "team-b"},
+            icons=[Icon(src="https://example.com/s.png", mimeType="image/png")],
+            annotations=Annotations(priority=0.9),
+            tags={"alpha"},
+        )
+        def fn(param: str) -> str:
+            return f"sub-{param}"
+
+        provider = FastMCPProvider(sub)
+        templates = await provider._list_resource_templates()
+        assert len(templates) == 1
+        wrapped = templates[0]
+        assert isinstance(wrapped, FastMCPProviderResourceTemplate)
+
+        resource = await wrapped.create_resource("data://x", {"param": "x"})
+
+        assert resource.title == "Sub Title"
+        assert resource.annotations is not None
+        assert resource.annotations.priority == 0.9
+        assert resource.icons is not None and len(resource.icons) == 1
+
+        mcp_resource = resource.to_mcp_resource()
+        assert mcp_resource.meta is not None
+        # User meta survives end-to-end.
+        assert mcp_resource.meta.get("owner") == "team-b"
+        # Exactly one fastmcp namespace, and it is NOT double-wrapped.
+        fastmcp_ns = mcp_resource.meta.get("fastmcp")
+        assert isinstance(fastmcp_ns, dict)
+        assert "fastmcp" not in fastmcp_ns
+        assert "alpha" in fastmcp_ns.get("tags", [])


### PR DESCRIPTION
Materializing a `Resource` from a `ResourceTemplate` silently dropped most of the template's metadata. `FunctionResourceTemplate.create_resource()` forwarded only `name`, `description`, `mime_type`, `tags`, `task`, and `auth` to `Resource.from_function()`, and `FastMCPProviderResourceTemplate.create_resource()` forwarded only `name`, `description`, and `mime_type`. So a template that declared `annotations`, `meta`, `title`, or `icons` produced resources that had none of them — the fields existed on the template, were accepted by the resource constructor, and were just never passed through. `FastMCPProviderResource.wrap()` already forwards the full set, so the two `create_resource()` paths were the inconsistent ones.

This forwards the missing fields in both paths, matching what `wrap()` already does. The provider path passes the raw `self.meta` (not the namespaced `get_meta()`) so the `fastmcp` meta namespace is derived once at serialization rather than re-wrapped — the regression test asserts there is exactly one `fastmcp` namespace and no double nesting, and that a materialized resource's `meta` is independent of the template's.

```python
template = ResourceTemplate.from_function(
    fn=fn,
    uri_template="data://{param}",
    name="t",
    title="Human Title",
    meta={"owner": "team-a"},
    icons=[Icon(src="https://example.com/icon.png", mimeType="image/png")],
    annotations=Annotations(priority=0.5, audience=["user"]),
)
resource = await template.create_resource("data://x", {"param": "x"})
# before: title/meta/annotations/icons all None
# after:  preserved
```

Closes #4052 (Bugs 1 and 2; Bug 3 was triaged as not reproducible).
