### PR TITLE
Add UTM tracking to Horizon links

### DIFF
--- a/docs/getting-started/welcome.mdx
+++ b/docs/getting-started/welcome.mdx
@@ -86,13 +86,13 @@ FastMCP is made with 💙 by [Prefect](https://www.prefect.io/).
 
 ## Run FastMCP in production with Horizon
 
-FastMCP is the standard way to build MCP servers. **[Prefect Horizon](https://www.prefect.io/horizon)** is the enterprise MCP gateway for running them safely.
+FastMCP is the standard way to build MCP servers. **[Prefect Horizon](https://www.prefect.io/horizon?utm_source=gofastmcp&utm_medium=docs&utm_campaign=docs_welcome&utm_content=welcome_body)** is the enterprise MCP gateway for running them safely.
 
 Built by the FastMCP team, Horizon packages the best practices we've learned shipping the world's most popular MCP framework.
 
 Deploy FastMCP servers from GitHub with branch previews and instant rollback. Create a private registry of every MCP your company uses. Secure access with SSO and tool-level RBAC. Get audit logs, observability, and governance across your MCP stack. Remix approved tools into purpose-built endpoints for teams and agents.
 
-Start with FastMCP. [Scale with Horizon →](https://www.prefect.io/horizon)
+Start with FastMCP. [Scale with Horizon →](https://www.prefect.io/horizon?utm_source=gofastmcp&utm_medium=docs&utm_campaign=docs_welcome&utm_content=welcome_cta)
 
 <Tip>
 **This documentation reflects FastMCP's `main` branch**, meaning it always reflects the latest development version. Features are generally marked with version badges (e.g. `New in version: 3.0.0`) to indicate when they were introduced. Note that this may include features that are not yet released.


### PR DESCRIPTION
Tracks click attribution from the Horizon promo on the docs welcome page, matching the UTM scheme used by the docs banner. `welcome_body` and `welcome_cta` distinguish the inline link from the closing CTA.