### PR TITLE
Fix sampling from background tasks

### DIFF
--- a/src/fastmcp/server/sampling/run.py
+++ b/src/fastmcp/server/sampling/run.py
@@ -532,7 +532,7 @@ async def sample_step_impl(
             model_preferences=_parse_model_preferences(model_preferences),
             tools=sdk_tools,
             tool_choice=effective_tool_choice,
-            related_request_id=context.request_id,
+            related_request_id=context.origin_request_id,
         )
 
     # Check if this is a tool use response

--- a/tests/server/tasks/test_context_background_task.py
+++ b/tests/server/tasks/test_context_background_task.py
@@ -15,6 +15,7 @@ import pytest
 from mcp import ServerSession
 from mcp.server.auth.middleware.auth_context import auth_context_var
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.types import CreateMessageResult, TextContent
 from pydantic import BaseModel
 
 from fastmcp import FastMCP
@@ -282,6 +283,36 @@ class TestBackgroundTaskIntegration:
             task = await client.call_tool("check_origin_request_id", {}, task=True)
             result = await task.result()
             assert result.data == "ok"
+
+
+    async def test_sample_uses_origin_request_id_in_background_task(self):
+        """E2E: ctx.sample() works in a task without an active request context."""
+        mcp = FastMCP("sample-background-test")
+        captured: dict[str, object] = {}
+
+        @mcp.tool(task=True)
+        async def ask_client(ctx: Context) -> str:
+            assert ctx.is_background_task is True
+            assert ctx.request_context is None
+            assert ctx.origin_request_id is not None
+            result = await ctx.sample("Say hello")
+            return result.text or ""
+
+        def sampling_handler(messages, params, ctx):
+            captured["called"] = True
+            return CreateMessageResult(
+                role="assistant",
+                content=TextContent(type="text", text="hello from background"),
+                model="test-model",
+                stopReason="endTurn",
+            )
+
+        async with Client(mcp, sampling_handler=sampling_handler) as client:
+            task = await client.call_tool("ask_client", {}, task=True)
+            result = await task.result()
+
+        assert result.data == "hello from background"
+        assert captured["called"] is True
 
     async def test_elicit_accept_flow(self):
         """E2E: tool elicits input, client accepts via elicitation_handler."""


### PR DESCRIPTION
## Summary
- use the captured `origin_request_id` when server-side sampling is invoked from a background task
- keep foreground sampling behavior unchanged because `origin_request_id` resolves to the active request id there
- add an end-to-end background task regression test that calls `ctx.sample()` without an active `request_context`

## Why
`Context.request_id` raises when code runs in a background task because there is no active MCP request context in the worker. `Context.sample()` still used `context.request_id` when sending the server-initiated sampling request, so a task that called `ctx.sample()` could fail before the client sampling handler was reached.

Background task contexts already capture `origin_request_id` when the task is submitted. Passing that value to `create_message()` preserves request routing for foreground calls and lets background sampling use the stored originating request id instead of touching the unavailable request context.

Related to #2647, but this is a narrow runtime fix rather than the full client-side correlation feature.

## Testing
- `uv run pytest tests/server/tasks/test_context_background_task.py -q`
- `uv run ruff check src/fastmcp/server/sampling/run.py tests/server/tasks/test_context_background_task.py`
