### PR TITLE
Fix #4056: keep blank query values, add token bucket regression test

### DIFF
--- a/src/fastmcp/resources/template.py
+++ b/src/fastmcp/resources/template.py
@@ -104,7 +104,9 @@ def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
     # Extract query parameters if present in URI and template
     if query_string:
         query_param_names = extract_query_params(uri_template)
-        parsed_query = parse_qs(query_string)
+        # keep_blank_values=True preserves empty values (e.g. ?format=)
+        # so callers can distinguish "explicitly empty" from "missing".
+        parsed_query = parse_qs(query_string, keep_blank_values=True)
 
         for name in query_param_names:
             if name in parsed_query:

--- a/tests/resources/test_resource_template.py
+++ b/tests/resources/test_resource_template.py
@@ -850,6 +850,25 @@ class TestMalformedURITemplates:
         assert result is not None
         assert result["user_id"] == "alice"
 
+    def test_query_param_with_blank_value_is_preserved(self):
+        """Regression for #4056: blank query values (e.g. ?format=) should
+        not be silently dropped. parse_qs without keep_blank_values=True
+        elides empty values, which loses caller intent."""
+        result = match_uri_template(
+            "resource://data/42?format=", "resource://data/{id}{?format}"
+        )
+        assert result is not None
+        assert result == {"id": "42", "format": ""}
+
+    def test_query_param_with_blank_and_present_values(self):
+        """Mix of blank and non-blank query values are both surfaced."""
+        result = match_uri_template(
+            "resource://data/42?format=&verbose=true",
+            "resource://data/{id}{?format,verbose}",
+        )
+        assert result is not None
+        assert result == {"id": "42", "format": "", "verbose": "true"}
+
     def test_from_function_rejects_hyphen_underscore_collision(self):
         """Two raw param names that normalize to the same key are rejected."""
 

--- a/tests/server/middleware/test_rate_limiting.py
+++ b/tests/server/middleware/test_rate_limiting.py
@@ -74,6 +74,33 @@ class TestTokenBucketRateLimiter:
         await asyncio.sleep(0.2)
         assert await limiter.consume(2) is True
 
+    async def test_denied_consumes_do_not_freeze_clock(self):
+        """Regression for #4056: a client that retries quickly after being
+        denied must not be able to bypass the configured refill rate.
+
+        last_refill must advance on every consume() call (success or failure).
+        If it only advanced on success, the elapsed window would be re-counted
+        on each retry, letting a client refill faster than `refill_rate`.
+        """
+        limiter = TokenBucketRateLimiter(capacity=10, refill_rate=10.0)
+
+        # Drain the bucket.
+        assert await limiter.consume(10) is True
+
+        # Hammer with denied requests over ~0.2s. With the correct
+        # implementation, last_refill advances on each call, so total
+        # accumulated tokens after 0.2s is ~2 (10/s * 0.2s).
+        for _ in range(20):
+            await limiter.consume(1)
+            await asyncio.sleep(0.01)
+
+        # We should NOT be able to consume more than the configured rate
+        # would allow over the elapsed window. Allow a small slack for
+        # timing jitter, but stay well below `capacity`.
+        assert await limiter.consume(5) is False, (
+            "denied retries should not silently accrue extra tokens"
+        )
+
 
 class TestSlidingWindowRateLimiter:
     """Test sliding window rate limiter."""


### PR DESCRIPTION
## Why

Issue #4056 reports three minor bugs. After investigation, only one is a real defect that needs a code fix; the other two are addressed in the PR text below.

Closes #4056.

## What

### Bug 1 (fixed): `parse_qs` drops blank query values

`src/fastmcp/resources/template.py` calls `parse_qs(query_string)` without `keep_blank_values=True`, so URIs like `resource://data/42?format=` silently lose the `format` key. The fix adds `keep_blank_values=True` and a brief comment explaining why.

### Bug 2 (no code change needed): `env_nested_delimiter` with nested models

The issue claims `FASTMCP__DOCKET__CONCURRENCY` should work. With `env_prefix="FASTMCP_"` on the parent and `env_nested_delimiter="__"`, the correct pydantic-settings syntax is `FASTMCP_DOCKET__CONCURRENCY` (single underscore between the prefix and the nested key, double underscore for nesting). This is exactly what `docs/more/settings.mdx` already documents:

> When setting Docket values in a `.env` file, use a **double** underscore: `FASTMCP_DOCKET__URL` (not `FASTMCP_DOCKET_URL`). This is because `.env` values are resolved through the parent `Settings` class, which uses `__` as its nested delimiter.

So the documented form works; the form in the issue is not standard pydantic-settings syntax and would not work with the configured prefix. Happy to add a regression test or adjust the docs further if a maintainer wants to nail this down.

### Bug 3 (proposed fix is incorrect; defensive test added)

The issue proposes moving `self.last_refill = now` inside the `if self.tokens >= tokens:` branch in `TokenBucketRateLimiter.consume()`. That fix is wrong: it freezes the clock during denied requests. A client that retries quickly after a denial would re-count the same elapsed window on each retry, accumulating tokens far faster than the configured `refill_rate` and bypassing the rate limit. This was independently flagged by the Codex reviewer on PR #4057 and the proposer agreed (https://github.com/PrefectHQ/fastmcp/pull/4057#discussion).

The current implementation is the standard token bucket algorithm (advance the clock on every `consume()` call). To prevent regression, this PR adds `test_denied_consumes_do_not_freeze_clock` which drains the bucket, hammers it with denied calls over ~0.2s, and asserts that no extra burst capacity has accrued.

## Tested

- New: `test_query_param_with_blank_value_is_preserved` — verifies `?format=` round-trips as `{"format": ""}`.
- New: `test_query_param_with_blank_and_present_values` — mixed blank + non-blank query values.
- New: `test_denied_consumes_do_not_freeze_clock` — locks in correct token bucket semantics so the wrong fix from the issue can't be reintroduced.
- Existing tests in `tests/resources/test_resource_template.py` and `tests/server/middleware/test_rate_limiting.py` continue to apply.