### PR TITLE
feat(openapi): support per-call HTTP headers via http_headers / _meta

### DIFF
--- a/docs/integrations/openapi.mdx
+++ b/docs/integrations/openapi.mdx
@@ -68,6 +68,24 @@ mcp = FastMCP.from_openapi(
 )
 ```
 
+#### Per-call headers (multi-tenant)
+
+When one FastMCP instance is shared across callers — each with their own bearer token — auth can be injected at call time instead of being baked into the client. Pass `http_headers=` on `call_tool()` and the values are forwarded to the upstream HTTP request for that one call. Per-call values override anything set on the client.
+
+```python
+# One server, no auth on the client.
+mcp = FastMCP.from_openapi(openapi_spec=spec, client=httpx.AsyncClient(base_url=...))
+
+# Per-caller token, applied for this call only.
+result = await mcp.call_tool(
+    "search",
+    {"q": "alice"},
+    http_headers={"Authorization": f"Bearer {caller_token}"},
+)
+```
+
+The same headers can be supplied over the wire by setting `_meta.fastmcp.http_headers` on the tool call request. Per-call headers are scoped to a single call and never appear in the response sent back to the LLM.
+
 ## Route Mapping
 
 By default, FastMCP converts **every endpoint** in your OpenAPI specification into an MCP **Tool**. This provides a simple, predictable starting point that ensures all your API's functionality is immediately available to the vast majority of LLM clients which only support MCP tools.

--- a/src/fastmcp/server/dependencies.py
+++ b/src/fastmcp/server/dependencies.py
@@ -63,6 +63,7 @@ __all__ = [
     "TaskContextSnapshot",
     "TokenClaim",
     "get_access_token",
+    "get_call_http_headers",
     "get_context",
     "get_http_headers",
     "get_http_request",
@@ -98,6 +99,15 @@ _current_server: ContextVar[weakref.ref[FastMCP] | None] = ContextVar(
 
 _current_docket: ContextVar[Docket | None] = ContextVar("docket", default=None)
 _current_worker: ContextVar[Worker | None] = ContextVar("worker", default=None)
+
+# Per-call HTTP headers injected by the caller of `FastMCP.call_tool(...,
+# http_headers=...)` (or extracted from `_meta.fastmcp.http_headers` on the
+# wire). Read by upstream HTTP integrations (e.g. OpenAPI) to apply
+# request-scoped auth without rebuilding the server. The default is an
+# empty dict so readers can always treat it as a mapping.
+_current_call_http_headers: ContextVar[dict[str, str]] = ContextVar(
+    "call_http_headers", default={}
+)
 
 
 # --- Docket availability check ---
@@ -462,6 +472,29 @@ def get_http_headers(
         return headers
     except RuntimeError:
         return {}
+
+
+def get_call_http_headers() -> dict[str, str]:
+    """Return per-call HTTP headers attached to the current tool/resource call.
+
+    Headers are populated when a caller invokes :meth:`FastMCP.call_tool` (or
+    related entry points) with the ``http_headers=`` keyword argument, or when
+    an MCP request includes ``_meta.fastmcp.http_headers``. Upstream HTTP
+    integrations (notably the OpenAPI provider) read this mapping to apply
+    request-scoped headers — typically auth — without reconstructing the
+    server.
+
+    Returns an empty dict when no per-call headers are attached so callers
+    can always treat the result as a mapping. Header *names* are returned
+    as the caller supplied them; integrations that need case-insensitive
+    matching should normalize themselves.
+
+    These headers are scoped to the current request via a ContextVar; they
+    do not leak across calls. They are intentionally distinct from
+    :func:`get_http_headers`, which returns the inbound MCP transport's
+    headers (and excludes ``Authorization`` by default — see #3262).
+    """
+    return dict(_current_call_http_headers.get())
 
 
 def get_access_token() -> AccessToken | None:

--- a/src/fastmcp/server/mixins/mcp_operations.py
+++ b/src/fastmcp/server/mixins/mcp_operations.py
@@ -213,16 +213,28 @@ class MCPOperationsMixin:
         )
 
         try:
-            # Extract version and task metadata from request context.
-            # fn_key is set by call_tool() after finding the tool.
+            # Extract version, task metadata, and per-call HTTP headers from
+            # the request context. fn_key is set by call_tool() after finding
+            # the tool.
             version_str: str | None = None
             task_meta: TaskMeta | None = None
+            http_headers: dict[str, str] | None = None
             try:
                 ctx = server._mcp_server.request_context
-                # Extract version from _meta.fastmcp
+                # Extract version + per-call HTTP headers from _meta.fastmcp
                 if ctx.meta:
                     meta_dict = ctx.meta.model_dump(exclude_none=True)
-                    version_str = meta_dict.get("fastmcp", {}).get("version")
+                    fastmcp_meta = meta_dict.get("fastmcp") or {}
+                    version_str = fastmcp_meta.get("version")
+                    raw_headers = fastmcp_meta.get("http_headers")
+                    # Defensive: only forward if it parsed as a flat str->str
+                    # mapping. Anything else is silently dropped — we never
+                    # want a malformed _meta payload to crash the request.
+                    if isinstance(raw_headers, dict) and all(
+                        isinstance(k, str) and isinstance(v, str)
+                        for k, v in raw_headers.items()
+                    ):
+                        http_headers = dict(raw_headers)
                 # Extract SEP-1686 task metadata
                 if ctx.experimental.is_task:
                     mcp_task_meta = ctx.experimental.task_metadata
@@ -233,7 +245,11 @@ class MCPOperationsMixin:
 
             version = VersionSpec(eq=version_str) if version_str else None
             result = await server.call_tool(
-                key, arguments, version=version, task_meta=task_meta
+                key,
+                arguments,
+                version=version,
+                task_meta=task_meta,
+                http_headers=http_headers,
             )
 
             if isinstance(result, mcp.types.CreateTaskResult):

--- a/src/fastmcp/server/providers/openapi/components.py
+++ b/src/fastmcp/server/providers/openapi/components.py
@@ -20,7 +20,7 @@ from fastmcp.resources import (
     ResourceResult,
     ResourceTemplate,
 )
-from fastmcp.server.dependencies import get_http_headers
+from fastmcp.server.dependencies import get_call_http_headers, get_http_headers
 from fastmcp.server.tasks.config import TaskConfig
 from fastmcp.tools.base import Tool, ToolResult
 from fastmcp.utilities.logging import get_logger
@@ -195,6 +195,14 @@ class OpenAPITool(Tool):
                 for key, value in mcp_headers.items():
                     if key not in request.headers:
                         request.headers[key] = value
+
+            # Per-call HTTP headers override everything: client defaults,
+            # ambient MCP transport headers, and any auth baked into the
+            # request by the OpenAPI security scheme. The shared-instance
+            # multi-tenant case (issue #4025) demands per-caller auth wins.
+            call_headers = get_call_http_headers()
+            for key, value in call_headers.items():
+                request.headers[key] = value
         except Exception as e:
             raise ValueError(
                 f"Error building request for {self._route.method.upper()} "
@@ -308,13 +316,19 @@ class OpenAPIResource(Resource):
                     for param_name, param_value in path_params.items():
                         path = path.replace(f"{{{param_name}}}", str(param_value))
 
-            # Build headers with correct precedence
+            # Build headers with correct precedence:
+            #   client defaults < ambient MCP transport headers < per-call.
+            # Per-call (#4025) wins so per-tenant auth on a shared FastMCP
+            # instance can be injected at request time.
             headers: dict[str, str] = {}
             if self._client.headers:
                 headers.update(self._client.headers)
             mcp_headers = get_http_headers()
             if mcp_headers:
                 headers.update(mcp_headers)
+            call_headers = get_call_http_headers()
+            if call_headers:
+                headers.update(call_headers)
 
             response = await self._client.request(
                 method=self._route.method,

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1140,6 +1140,7 @@ class FastMCP(
         version: VersionSpec | None = None,
         run_middleware: bool = True,
         task_meta: None = None,
+        http_headers: dict[str, str] | None = None,
     ) -> ToolResult: ...
 
     @overload
@@ -1151,6 +1152,7 @@ class FastMCP(
         version: VersionSpec | None = None,
         run_middleware: bool = True,
         task_meta: TaskMeta,
+        http_headers: dict[str, str] | None = None,
     ) -> mcp.types.CreateTaskResult: ...
 
     async def call_tool(
@@ -1161,6 +1163,7 @@ class FastMCP(
         version: VersionSpec | None = None,
         run_middleware: bool = True,
         task_meta: TaskMeta | None = None,
+        http_headers: dict[str, str] | None = None,
     ) -> ToolResult | mcp.types.CreateTaskResult:
         """Call a tool by name.
 
@@ -1175,6 +1178,14 @@ class FastMCP(
             task_meta: If provided, execute as a background task and return
                 CreateTaskResult. If None (default), execute synchronously and
                 return ToolResult.
+            http_headers: Optional per-call HTTP headers. Forwarded to upstream
+                HTTP integrations (e.g. the OpenAPI provider) for the duration
+                of this call only. Common case: per-tenant auth on a shared
+                FastMCP instance — pass ``{"Authorization": "Bearer ..."}``
+                here instead of constructing a new server per caller. Per-call
+                headers override defaults baked into the integration's HTTP
+                client. Scoped via ContextVar; do not leak across calls and
+                are not echoed back to the LLM.
 
         Returns:
             ToolResult when task_meta is None.
@@ -1189,6 +1200,7 @@ class FastMCP(
         # For mounted servers, the parent's provider sets fn_key to the
         # namespaced key before delegating, ensuring correct Docket routing.
 
+        from fastmcp.server.dependencies import _current_call_http_headers
         from fastmcp.server.providers.addressing import (
             parse_hashed_backend_name,
         )
@@ -1201,92 +1213,108 @@ class FastMCP(
         #   2. Display-name path — everything else. Goes through normal
         #      `get_tool` aggregation/transforms. Address is determined
         #      after resolution by walking the registry.
-        async with fastmcp.server.context.Context(fastmcp=self) as ctx:
-            if run_middleware:
-                mw_context = MiddlewareContext[CallToolRequestParams](
-                    message=mcp.types.CallToolRequestParams(
-                        name=name, arguments=arguments or {}
-                    ),
-                    source="client",
-                    type="request",
-                    method="tools/call",
-                    fastmcp_context=ctx,
-                )
-                return await self._run_middleware(
-                    context=mw_context,
-                    call_next=lambda context: self.call_tool(
-                        context.message.name,
-                        context.message.arguments or {},
-                        version=version,
-                        run_middleware=False,
-                        task_meta=task_meta,
-                    ),
-                )
 
-            # Core logic: find and execute tool
-            with server_span(
-                f"tools/call {name}",
-                "tools/call",
-                self.name,
-                "tool",
-                name,
-                tool_name=name,
-            ) as span:
-                # Try normal display-name resolution first.
-                tool: Tool | None = await self.get_tool(name, version=version)
+        # Bind per-call HTTP headers to the ContextVar for the duration of
+        # this call. Set unconditionally so nested re-entries (middleware
+        # calling self.call_tool) re-bind the same value rather than
+        # silently inheriting a parent's headers; reset on the way out.
+        headers_token = _current_call_http_headers.set(dict(http_headers or {}))
+        try:
+            async with fastmcp.server.context.Context(fastmcp=self) as ctx:
+                if run_middleware:
+                    mw_context = MiddlewareContext[CallToolRequestParams](
+                        message=mcp.types.CallToolRequestParams(
+                            name=name, arguments=arguments or {}
+                        ),
+                        source="client",
+                        type="request",
+                        method="tools/call",
+                        fastmcp_context=ctx,
+                    )
+                    return await self._run_middleware(
+                        context=mw_context,
+                        call_next=lambda context: self.call_tool(
+                            context.message.name,
+                            context.message.arguments or {},
+                            version=version,
+                            run_middleware=False,
+                            task_meta=task_meta,
+                            http_headers=http_headers,
+                        ),
+                    )
 
-                # If that fails, try hashed-name dispatch. This walks
-                # the provider tree recursively (same pattern as the old
-                # get_app_tool) looking for a tool whose stored hash
-                # matches the parsed prefix.
-                if tool is None:
-                    hashed = parse_hashed_backend_name(name)
-                    if hashed is not None:
-                        digest, local_name = hashed
-                        tool = await self.get_tool_by_hash(digest, local_name)
-                        if tool is not None:
-                            # Auth still applies on the bypass path.
-                            skip_auth, token = _get_auth_context()
-                            if not skip_auth and tool.auth is not None:
-                                try:
-                                    auth_ctx = AuthContext(token=token, component=tool)
-                                    if not await run_auth_checks(tool.auth, auth_ctx):
-                                        raise NotFoundError(f"Unknown tool: {name!r}")
-                                except AuthorizationError:
-                                    raise NotFoundError(
-                                        f"Unknown tool: {name!r}"
-                                    ) from None
+                # Core logic: find and execute tool
+                with server_span(
+                    f"tools/call {name}",
+                    "tools/call",
+                    self.name,
+                    "tool",
+                    name,
+                    tool_name=name,
+                ) as span:
+                    # Try normal display-name resolution first.
+                    tool: Tool | None = await self.get_tool(name, version=version)
 
-                if tool is None:
-                    raise NotFoundError(f"Unknown tool: {name!r}")
-                span.set_attributes(tool.get_span_attributes())
-                if task_meta is not None and task_meta.fn_key is None:
-                    task_meta = replace(task_meta, fn_key=tool.key)
-                try:
-                    return await tool._run(arguments or {}, task_meta=task_meta)
-                except FastMCPError:
-                    logger.exception(f"Error calling tool {name!r}")
-                    raise
-                except (ValidationError, PydanticValidationError):
-                    logger.exception(f"Error validating tool {name!r}")
-                    raise
-                except Exception as e:
-                    logger.exception(f"Error calling tool {name!r}")
-                    # Handle actionable errors that should reach the LLM
-                    # even when masking is enabled
-                    if isinstance(e, httpx.HTTPStatusError):
-                        if e.response.status_code == 429:
+                    # If that fails, try hashed-name dispatch. This walks
+                    # the provider tree recursively (same pattern as the old
+                    # get_app_tool) looking for a tool whose stored hash
+                    # matches the parsed prefix.
+                    if tool is None:
+                        hashed = parse_hashed_backend_name(name)
+                        if hashed is not None:
+                            digest, local_name = hashed
+                            tool = await self.get_tool_by_hash(digest, local_name)
+                            if tool is not None:
+                                # Auth still applies on the bypass path.
+                                skip_auth, token = _get_auth_context()
+                                if not skip_auth and tool.auth is not None:
+                                    try:
+                                        auth_ctx = AuthContext(
+                                            token=token, component=tool
+                                        )
+                                        if not await run_auth_checks(
+                                            tool.auth, auth_ctx
+                                        ):
+                                            raise NotFoundError(
+                                                f"Unknown tool: {name!r}"
+                                            )
+                                    except AuthorizationError:
+                                        raise NotFoundError(
+                                            f"Unknown tool: {name!r}"
+                                        ) from None
+
+                    if tool is None:
+                        raise NotFoundError(f"Unknown tool: {name!r}")
+                    span.set_attributes(tool.get_span_attributes())
+                    if task_meta is not None and task_meta.fn_key is None:
+                        task_meta = replace(task_meta, fn_key=tool.key)
+                    try:
+                        return await tool._run(arguments or {}, task_meta=task_meta)
+                    except FastMCPError:
+                        logger.exception(f"Error calling tool {name!r}")
+                        raise
+                    except (ValidationError, PydanticValidationError):
+                        logger.exception(f"Error validating tool {name!r}")
+                        raise
+                    except Exception as e:
+                        logger.exception(f"Error calling tool {name!r}")
+                        # Handle actionable errors that should reach the LLM
+                        # even when masking is enabled
+                        if isinstance(e, httpx.HTTPStatusError):
+                            if e.response.status_code == 429:
+                                raise ToolError(
+                                    "Rate limited by upstream API, please retry later"
+                                ) from e
+                        if isinstance(e, httpx.TimeoutException):
                             raise ToolError(
-                                "Rate limited by upstream API, please retry later"
+                                "Upstream request timed out, please retry"
                             ) from e
-                    if isinstance(e, httpx.TimeoutException):
-                        raise ToolError(
-                            "Upstream request timed out, please retry"
-                        ) from e
-                    # Standard masking logic
-                    if self._mask_error_details:
-                        raise ToolError(f"Error calling tool {name!r}") from e
-                    raise ToolError(f"Error calling tool {name!r}: {e}") from e
+                        # Standard masking logic
+                        if self._mask_error_details:
+                            raise ToolError(f"Error calling tool {name!r}") from e
+                        raise ToolError(f"Error calling tool {name!r}: {e}") from e
+        finally:
+            _current_call_http_headers.reset(headers_token)
 
     @overload
     async def read_resource(

--- a/tests/server/providers/openapi/test_per_call_headers.py
+++ b/tests/server/providers/openapi/test_per_call_headers.py
@@ -1,0 +1,329 @@
+"""Per-call HTTP headers on OpenAPI tools (issue #4025).
+
+The shared-FastMCP-instance, multi-tenant case: one server, many callers, each
+with their own bearer token. Headers can be injected via:
+
+  - The Python-side ``http_headers=`` kwarg on ``mcp.call_tool(...)``.
+  - The wire-side ``_meta.fastmcp.http_headers`` field on a tool call request.
+
+Both paths converge on a ContextVar (`_current_call_http_headers`) that the
+OpenAPI tool reads at request-build time and applies *over* the client's
+default headers.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, Mock
+
+import httpx
+import pytest
+from httpx import Response
+
+from fastmcp import FastMCP
+from fastmcp.client import Client
+from fastmcp.server.dependencies import (
+    _current_call_http_headers,
+    get_call_http_headers,
+)
+from fastmcp.server.providers.openapi import OpenAPIProvider
+
+
+@pytest.fixture
+def simple_spec() -> dict:
+    """Single-endpoint spec — keeps tests focused on header behavior."""
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Test", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/search": {
+                "get": {
+                    "operationId": "search",
+                    "parameters": [
+                        {
+                            "name": "q",
+                            "in": "query",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object"}
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+    }
+
+
+def _build_mock_client(
+    *,
+    default_headers: dict[str, str] | None = None,
+    json_body: dict | None = None,
+) -> Mock:
+    """Mock httpx.AsyncClient that captures the request that would be sent."""
+    client = Mock(spec=httpx.AsyncClient)
+    client.base_url = "https://api.example.com"
+    client.headers = httpx.Headers(default_headers or {})
+
+    response = Mock(spec=Response)
+    response.status_code = 200
+    response.json.return_value = json_body or {"results": []}
+    response.text = json.dumps(json_body or {"results": []})
+    response.raise_for_status = Mock()
+
+    client.send = AsyncMock(return_value=response)
+    return client
+
+
+def _build_server(spec: dict, client: Mock) -> FastMCP:
+    provider = OpenAPIProvider(openapi_spec=spec, client=client)
+    mcp = FastMCP("test")
+    mcp.add_provider(provider)
+    return mcp
+
+
+def _sent_headers(client: Mock) -> dict[str, str]:
+    """Pull the headers off the captured request, lower-cased for comparison."""
+    request = client.send.call_args[0][0]
+    return {k.lower(): v for k, v in request.headers.items()}
+
+
+class TestDefaultBehaviorPreserved:
+    """No per-call headers => behavior is unchanged."""
+
+    async def test_default_client_auth_used_when_no_per_call_headers(
+        self, simple_spec
+    ):
+        client = _build_mock_client(
+            default_headers={"Authorization": "Bearer default-token"}
+        )
+        mcp = _build_server(simple_spec, client)
+
+        result = await mcp.call_tool("search", {"q": "alice"})
+
+        assert result is not None
+        sent = _sent_headers(client)
+        assert sent["authorization"] == "Bearer default-token"
+
+    async def test_no_auth_at_all_still_works(self, simple_spec):
+        client = _build_mock_client()  # no default auth
+        mcp = _build_server(simple_spec, client)
+
+        result = await mcp.call_tool("search", {"q": "alice"})
+
+        assert result is not None
+        sent = _sent_headers(client)
+        assert "authorization" not in sent
+
+
+class TestPerCallHeadersKwarg:
+    """The Python-side ``http_headers=`` kwarg path."""
+
+    async def test_per_call_headers_override_client_defaults(self, simple_spec):
+        client = _build_mock_client(
+            default_headers={"Authorization": "Bearer default-token"}
+        )
+        mcp = _build_server(simple_spec, client)
+
+        await mcp.call_tool(
+            "search",
+            {"q": "alice"},
+            http_headers={"Authorization": "Bearer caller-token"},
+        )
+
+        sent = _sent_headers(client)
+        assert sent["authorization"] == "Bearer caller-token"
+
+    async def test_per_call_headers_added_when_no_default(self, simple_spec):
+        client = _build_mock_client()
+        mcp = _build_server(simple_spec, client)
+
+        await mcp.call_tool(
+            "search",
+            {"q": "alice"},
+            http_headers={"X-Tenant-Id": "tenant-42"},
+        )
+
+        sent = _sent_headers(client)
+        assert sent["x-tenant-id"] == "tenant-42"
+
+    async def test_multiple_per_call_headers(self, simple_spec):
+        client = _build_mock_client()
+        mcp = _build_server(simple_spec, client)
+
+        await mcp.call_tool(
+            "search",
+            {"q": "alice"},
+            http_headers={
+                "Authorization": "Bearer per-call",
+                "X-Request-Id": "req-123",
+            },
+        )
+
+        sent = _sent_headers(client)
+        assert sent["authorization"] == "Bearer per-call"
+        assert sent["x-request-id"] == "req-123"
+
+    async def test_per_call_headers_do_not_leak_into_tool_result(
+        self, simple_spec
+    ):
+        """Per-call auth must not be echoed in any field of the tool result."""
+        client = _build_mock_client(json_body={"results": ["alice"]})
+        mcp = _build_server(simple_spec, client)
+
+        result = await mcp.call_tool(
+            "search",
+            {"q": "alice"},
+            http_headers={"Authorization": "Bearer secret-token"},
+        )
+
+        # Search every place the LLM could conceivably read.
+        haystacks: list[str] = []
+        if result.structured_content is not None:
+            haystacks.append(json.dumps(result.structured_content))
+        if result.content:
+            for block in result.content:
+                text = getattr(block, "text", None)
+                if text:
+                    haystacks.append(text)
+        assert haystacks, "expected some content to inspect"
+        for blob in haystacks:
+            assert "secret-token" not in blob
+            assert "Authorization" not in blob
+
+    async def test_per_call_headers_do_not_leak_across_calls(self, simple_spec):
+        """ContextVar must reset between calls so tenants stay isolated."""
+        client = _build_mock_client()
+        mcp = _build_server(simple_spec, client)
+
+        # Tenant A
+        await mcp.call_tool(
+            "search",
+            {"q": "alice"},
+            http_headers={"Authorization": "Bearer tenant-a"},
+        )
+        sent_a = _sent_headers(client)
+
+        # Tenant B — no headers passed; must NOT inherit tenant-a's token.
+        client.send.reset_mock()
+        await mcp.call_tool("search", {"q": "bob"})
+        sent_b = _sent_headers(client)
+
+        assert sent_a["authorization"] == "Bearer tenant-a"
+        assert "authorization" not in sent_b
+
+    async def test_get_call_http_headers_inside_call(self, simple_spec):
+        """The public helper sees the per-call headers from inside the call."""
+
+        seen: dict[str, dict[str, str]] = {}
+
+        async def fake_send(request):
+            # Read while the ContextVar should still be set.
+            seen["headers"] = get_call_http_headers()
+            response = Mock(spec=Response)
+            response.status_code = 200
+            response.json.return_value = {}
+            response.text = "{}"
+            response.raise_for_status = Mock()
+            return response
+
+        client = Mock(spec=httpx.AsyncClient)
+        client.base_url = "https://api.example.com"
+        client.headers = httpx.Headers()
+        client.send = AsyncMock(side_effect=fake_send)
+
+        mcp = _build_server(simple_spec, client)
+
+        await mcp.call_tool(
+            "search",
+            {"q": "alice"},
+            http_headers={"Authorization": "Bearer ctx-token"},
+        )
+
+        assert seen["headers"]["Authorization"] == "Bearer ctx-token"
+
+        # And after the call returns, the ContextVar is empty again.
+        assert get_call_http_headers() == {}
+
+
+class TestPerCallHeadersViaMetaProtocol:
+    """The wire-side ``_meta.fastmcp.http_headers`` path (in-memory client)."""
+
+    async def test_meta_field_propagates_to_upstream_request(self, simple_spec):
+        client = _build_mock_client(
+            default_headers={"Authorization": "Bearer default-token"}
+        )
+        mcp = _build_server(simple_spec, client)
+
+        async with Client(mcp) as mcp_client:
+            await mcp_client.call_tool(
+                "search",
+                {"q": "alice"},
+                meta={
+                    "fastmcp": {
+                        "http_headers": {"Authorization": "Bearer wire-token"}
+                    }
+                },
+            )
+
+        sent = _sent_headers(client)
+        assert sent["authorization"] == "Bearer wire-token"
+
+    async def test_meta_field_absent_falls_back_to_client_default(
+        self, simple_spec
+    ):
+        client = _build_mock_client(
+            default_headers={"Authorization": "Bearer default-token"}
+        )
+        mcp = _build_server(simple_spec, client)
+
+        async with Client(mcp) as mcp_client:
+            await mcp_client.call_tool("search", {"q": "alice"})
+
+        sent = _sent_headers(client)
+        assert sent["authorization"] == "Bearer default-token"
+
+    async def test_malformed_meta_headers_silently_ignored(self, simple_spec):
+        """A bad payload shouldn't break the call — it should fall through."""
+        client = _build_mock_client(
+            default_headers={"Authorization": "Bearer default-token"}
+        )
+        mcp = _build_server(simple_spec, client)
+
+        async with Client(mcp) as mcp_client:
+            await mcp_client.call_tool(
+                "search",
+                {"q": "alice"},
+                # Not a flat str->str mapping.
+                meta={"fastmcp": {"http_headers": "not-a-dict"}},
+            )
+
+        sent = _sent_headers(client)
+        assert sent["authorization"] == "Bearer default-token"
+
+
+class TestContextVarHygiene:
+    """Pure ContextVar checks, independent of OpenAPI."""
+
+    async def test_outside_call_helper_returns_empty_dict(self):
+        """No call in flight => empty mapping, never None."""
+        assert get_call_http_headers() == {}
+
+    async def test_helper_returns_a_copy(self):
+        """Mutating the result must not affect future readers."""
+        token = _current_call_http_headers.set({"Authorization": "Bearer x"})
+        try:
+            view = get_call_http_headers()
+            view["Authorization"] = "Bearer hacked"
+            assert get_call_http_headers()["Authorization"] == "Bearer x"
+        finally:
+            _current_call_http_headers.reset(token)


### PR DESCRIPTION
## Why

Closes #4025.

`FastMCP.from_openapi()` binds auth to the `httpx.AsyncClient` you pass in. In a multi-tenant proxy where one FastMCP instance is shared across callers (each with their own bearer token), there is no way to inject per-caller auth on `call_tool()` — you have to construct a new `FastMCP` per caller and tear it down after the call.

`OpenAPITool.run()` already pulls headers from the inbound MCP transport via `get_http_headers()`, but that path is empty when there is no MCP HTTP transport — e.g. when `call_tool()` is invoked directly from Python inside another service. The reporter's case has no Starlette ContextVar, so no headers reach the upstream API. (See the issue's follow-up comment for the comparison with #346 / #575.)

## What

Two ways to inject headers for one call only — both converge on a ContextVar that the OpenAPI components read at request-build time:

```python
# Python API
result = await mcp.call_tool(
    "search",
    {"q": "alice"},
    http_headers={"Authorization": f"Bearer {caller_token}"},
)

# Wire API (inside a CallToolRequest)
_meta = {"fastmcp": {"http_headers": {"Authorization": "Bearer ..."}}}
```

- New ContextVar `_current_call_http_headers` in `src/fastmcp/server/dependencies.py`, plus the public helper `get_call_http_headers()`.
- `FastMCP.call_tool()` gains an `http_headers=` kwarg that sets the ContextVar around the call and resets it on the way out (so headers do not leak across calls).
- `_call_tool_mcp` extracts `_meta.fastmcp.http_headers` (mirroring how it already extracts `_meta.fastmcp.version`) and forwards to `call_tool(http_headers=...)`. Malformed payloads are silently dropped.
- `OpenAPITool.run()` and `OpenAPIResource.read()` apply per-call headers *over* the client's defaults and ambient transport headers — per-tenant `Authorization` wins, which is the whole point of the issue.
- Per-call headers are used to build the upstream HTTP request only. They never appear in the `ToolResult` returned to the LLM. There is a regression test for that.

The default path (no `http_headers`, no `_meta.fastmcp.http_headers`) is unchanged. The security stance from #3262 (transport `Authorization` excluded from `get_http_headers()` by default) is unaffected — this PR is a separate, opt-in injection point.

Documented in `docs/integrations/openapi.mdx` under Authentication.

## Tested

New file `tests/server/providers/openapi/test_per_call_headers.py`:

- `TestDefaultBehaviorPreserved` — no per-call headers => existing behavior.
- `TestPerCallHeadersKwarg` — `http_headers=` overrides client defaults; multiple headers; helper readable from inside the call; **does not leak into the result**; **does not leak across calls**.
- `TestPerCallHeadersViaMetaProtocol` — `_meta.fastmcp.http_headers` reaches the upstream; absent meta falls back to client default; malformed payload is ignored.
- `TestContextVarHygiene` — empty mapping outside any call; helper returns a defensive copy.