### PR TITLE
fix: preserve @tool metadata in from_function

### DIFF
--- a/src/fastmcp/tools/function_tool.py
+++ b/src/fastmcp/tools/function_tool.py
@@ -24,7 +24,7 @@ from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
 
 import fastmcp
-from fastmcp.decorators import resolve_task_config
+from fastmcp.decorators import get_fastmcp_meta, resolve_task_config
 from fastmcp.exceptions import FastMCPDeprecationWarning
 from fastmcp.server.auth.authorization import AuthCheck
 from fastmcp.server.dependencies import without_injected_parameters
@@ -168,6 +168,11 @@ class FunctionTool(Tool):
                 "Cannot pass both 'metadata' and individual parameters to from_function(). "
                 "Use metadata alone or individual parameters alone."
             )
+
+        if metadata is None and not individual_params_provided:
+            fmeta = get_fastmcp_meta(fn)
+            if isinstance(fmeta, ToolMeta):
+                metadata = fmeta
 
         # Build metadata from kwargs if not provided
         if metadata is None:

--- a/tests/tools/test_standalone_decorator.py
+++ b/tests/tools/test_standalone_decorator.py
@@ -12,7 +12,8 @@ import pytest
 from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.tools import tool
-from fastmcp.tools.function_tool import DecoratedTool, ToolMeta
+from fastmcp.tools.base import Tool
+from fastmcp.tools.function_tool import DecoratedTool, FunctionTool, ToolMeta
 
 
 class TestToolDecorator:
@@ -88,6 +89,33 @@ class TestToolDecorator:
         assert decorated.__fastmcp__.description == "Greets people"
         assert decorated.__fastmcp__.tags == {"greeting", "demo"}
         assert decorated.__fastmcp__.meta == {"custom": "value"}
+
+    @pytest.mark.parametrize(
+        "factory", [Tool.from_function, FunctionTool.from_function]
+    )
+    def test_from_function_preserves_decorator_metadata(self, factory):
+        """Direct from_function calls should respect @tool metadata."""
+
+        @tool(
+            name="custom-greet",
+            version="v1",
+            title="Greeting Tool",
+            description="Greets people",
+            tags={"greeting", "demo"},
+            meta={"custom": "value"},
+        )
+        def greet(name: str) -> str:
+            """Fallback description."""
+            return f"Hello, {name}!"
+
+        created_tool = factory(greet)
+
+        assert created_tool.name == "custom-greet"
+        assert created_tool.version == "v1"
+        assert created_tool.title == "Greeting Tool"
+        assert created_tool.description == "Greets people"
+        assert created_tool.tags == {"greeting", "demo"}
+        assert created_tool.meta == {"custom": "value"}
 
     async def test_tool_function_still_callable(self):
         """Decorated function should still be directly callable."""


### PR DESCRIPTION
Direct `Tool.from_function()` and `FunctionTool.from_function()` calls currently rebuild tool metadata from defaults even when the function was decorated with standalone `@tool(...)`. That drops the decorator-provided name, version, title, description, tags, and meta for direct factory users, even though the server registration path already respects the same metadata.

This restores the existing decorator metadata lookup in the direct factory path, but only when no explicit `from_function()` parameters were supplied, so explicit factory arguments keep their current behavior.

```python
@tool(name="custom-greet", version="v1")
def greet(name: str) -> str:
    return f"Hello, {name}!"

Tool.from_function(greet).name
# "custom-greet"
```

Refs #4055 (decorator metadata bug).

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

Generated with Codex.