### PR TITLE
fix: capture lifespan result in FastMCPProvider for mounted servers

### DIFF
--- a/src/fastmcp/server/providers/fastmcp_provider.py
+++ b/src/fastmcp/server/providers/fastmcp_provider.py
@@ -11,7 +11,7 @@ executed.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import TYPE_CHECKING, Any, overload
 
 import mcp.types
@@ -703,6 +703,32 @@ class FastMCPProvider(Provider):
         This starts only the wrapped server's user-defined lifespan, NOT its
         full _lifespan_manager() (which includes Docket). The parent server's
         Docket handles all background tasks.
+
+        Captures the lifespan result so that ``ctx.lifespan_context`` on the
+        mounted server returns the **child's** lifespan context, not the
+        parent's. Also starts lifespans for the child server's own providers
+        (e.g. additional providers registered on the mounted server).
         """
-        async with self.server._lifespan(self.server):
+        stack = AsyncExitStack()
+        try:
+            user_lifespan_result = await stack.enter_async_context(
+                self.server._lifespan(self.server)
+            )
+            self.server._lifespan_result = user_lifespan_result
+            self.server._lifespan_result_set = True
+
+            # Start lifespans for the child server's own providers.
+            # We skip self to avoid infinite recursion — the child's provider
+            # list includes the LocalProvider and any other providers added
+            # directly to the child server.
+            for provider in list(self.server.providers):
+                if provider is not self:
+                    await stack.enter_async_context(provider.lifespan())
+
             yield
+        finally:
+            try:
+                await stack.aclose()
+            finally:
+                self.server._lifespan_result_set = False
+                self.server._lifespan_result = None

--- a/src/fastmcp/server/providers/fastmcp_provider.py
+++ b/src/fastmcp/server/providers/fastmcp_provider.py
@@ -517,6 +517,7 @@ class FastMCPProvider(Provider):
         """
         super().__init__()
         self.server = server
+        self._lifespan_ref_count = 0
 
     # -------------------------------------------------------------------------
     # Tool methods
@@ -708,7 +709,32 @@ class FastMCPProvider(Provider):
         mounted server returns the **child's** lifespan context, not the
         parent's. Also starts lifespans for the child server's own providers
         (e.g. additional providers registered on the mounted server).
+
+        Uses ref-counting so that if the same child server's lifespan is
+        entered from multiple parent contexts (e.g. mounted on multiple
+        parents or run directly), only the last context to exit clears
+        the lifespan data.
         """
+        async with self.server._lifespan_lock:
+            if self.server._lifespan_result_set:
+                self._lifespan_ref_count += 1
+                should_enter_lifespan = False
+            else:
+                self._lifespan_ref_count = 1
+                should_enter_lifespan = True
+
+        if not should_enter_lifespan:
+            try:
+                yield
+            finally:
+                async with self.server._lifespan_lock:
+                    self._lifespan_ref_count -= 1
+                    if self._lifespan_ref_count == 0:
+                        self.server._lifespan_result_set = False
+                        self.server._lifespan_result = None
+            return
+
+        # First context: enter the child server's lifespan normally.
         stack = AsyncExitStack()
         try:
             user_lifespan_result = await stack.enter_async_context(
@@ -730,5 +756,8 @@ class FastMCPProvider(Provider):
             try:
                 await stack.aclose()
             finally:
-                self.server._lifespan_result_set = False
-                self.server._lifespan_result = None
+                async with self.server._lifespan_lock:
+                    self._lifespan_ref_count -= 1
+                    if self._lifespan_ref_count == 0:
+                        self.server._lifespan_result_set = False
+                        self.server._lifespan_result = None


### PR DESCRIPTION
## Summary

When a FastMCP server is mounted inside another via `FastMCPProvider`, its lifespan was entered via `self.server._lifespan(self.server)` but the yielded result was **discarded**. This caused two problems:

1. **`ctx.lifespan_context` returned the parent's context, not the child's** — `_lifespan_result` and `_lifespan_result_set` were never set on the child server, so `ctx.lifespan_context` in mounted tools fell through to the parent's lifespan result.

2. **Lifespan re-entered per client session** — because `_lifespan_result_set` remained `False`, the lifespan generator was re-entered on every new client connection, potentially causing resource leaks (e.g., connection pools created multiple times).

## Changes

- **`src/fastmcp/server/providers/fastmcp_provider.py`** — Updated `FastMCPProvider.lifespan()` to:
  - Capture the yielded lifespan result and store it on `self.server._lifespan_result`
  - Set `self.server._lifespan_result_set = True`
  - Start lifespans for the child server's own providers (skip self to avoid infinite recursion)
  - Clean up `_lifespan_result`/`_lifespan_result_set` on exit

This does **not** delegate to `_lifespan_manager()` — that would bundle Docket startup which should remain parent-only, as the issue's author originally noted.

## Testing

Existing tests should continue to pass. The change is minimal and follows the same pattern used in `_lifespan_manager()` for capturing lifespan results.

Fixes PrefectHQ/fastmcp#4049