### PR TITLE
fix(tools): preserve isError flag and deep-copy meta in dedupe (refs #4055)

### DIFF
--- a/src/fastmcp/tools/base.py
+++ b/src/fastmcp/tools/base.py
@@ -76,12 +76,20 @@ class ToolResult(BaseModel):
     meta: dict[str, Any] | None = Field(
         default=None, description="Runtime metadata about the tool execution"
     )
+    is_error: bool = Field(
+        default=False,
+        description=(
+            "Whether the tool call ended in an error. Maps to "
+            "CallToolResult.isError on the wire."
+        ),
+    )
 
     def __init__(
         self,
         content: list[ContentBlock] | Any | None = None,
         structured_content: dict[str, Any] | Any | None = None,
         meta: dict[str, Any] | None = None,
+        is_error: bool = False,
     ):
         if content is None and structured_content is None:
             raise ValueError("Either content or structured_content must be provided")
@@ -118,7 +126,10 @@ class ToolResult(BaseModel):
                 )
 
         super().__init__(
-            content=converted_content, structured_content=structured_content, meta=meta
+            content=converted_content,
+            structured_content=structured_content,
+            meta=meta,
+            is_error=is_error,
         )
 
     def to_mcp_result(
@@ -126,10 +137,15 @@ class ToolResult(BaseModel):
     ) -> (
         list[ContentBlock] | tuple[list[ContentBlock], dict[str, Any]] | CallToolResult
     ):
-        if self.meta is not None:
+        # When meta is present we must always return a CallToolResult so
+        # _meta survives the trip. When is_error is set we also need a
+        # CallToolResult so the isError flag is preserved on the wire —
+        # otherwise the tuple/list shortcut drops it.
+        if self.meta is not None or self.is_error:
             return CallToolResult(
                 structuredContent=self.structured_content,
                 content=self.content,
+                isError=self.is_error,
                 _meta=self.meta,  # type: ignore[call-arg]  # _meta is Pydantic alias for meta field  # ty:ignore[unknown-argument]
             )
         if self.structured_content is None:

--- a/src/fastmcp/utilities/versions.py
+++ b/src/fastmcp/utilities/versions.py
@@ -318,6 +318,11 @@ def dedupe_with_versions(
                 reverse=True,
             )
             meta = highest.meta or {}
+            # deep=True so nested mutables in `meta` (dicts, lists) are
+            # not shared between the deduplicated copy and the original
+            # component. Without this a caller mutating a dict inside
+            # `meta` on the deduped result would leak into the original
+            # (and vice versa) because model_copy does a shallow copy.
             highest = highest.model_copy(
                 update={
                     "meta": {
@@ -327,7 +332,8 @@ def dedupe_with_versions(
                             "versions": all_versions,
                         },
                     }
-                }
+                },
+                deep=True,
             )
         result.append(highest)
     return result

--- a/tests/tools/tool/test_tool.py
+++ b/tests/tools/tool/test_tool.py
@@ -612,3 +612,47 @@ class TestToolExecutionField:
         mcp_tool = tool.to_mcp_tool()
         assert mcp_tool.execution is not None
         assert mcp_tool.execution.taskSupport == "forbidden"
+
+
+class TestToolResultIsError:
+    """Regression tests for is_error preservation through to_mcp_result.
+
+    Refs https://github.com/PrefectHQ/fastmcp/issues/4055 (bug 1).
+    """
+
+    def test_is_error_true_is_preserved(self):
+        from mcp.types import CallToolResult, TextContent
+
+        result = ToolResult(
+            content=[TextContent(type="text", text="boom")],
+            is_error=True,
+        )
+        mcp_result = result.to_mcp_result()
+        assert isinstance(mcp_result, CallToolResult)
+        assert mcp_result.isError is True
+
+    def test_is_error_false_default_is_preserved(self):
+        from mcp.types import CallToolResult, TextContent
+
+        # Forcing meta makes to_mcp_result return CallToolResult so we
+        # can assert isError is explicitly False (not None).
+        result = ToolResult(
+            content=[TextContent(type="text", text="ok")],
+            meta={"k": "v"},
+        )
+        mcp_result = result.to_mcp_result()
+        assert isinstance(mcp_result, CallToolResult)
+        assert mcp_result.isError is False
+
+    def test_is_error_with_structured_content(self):
+        from mcp.types import CallToolResult, TextContent
+
+        result = ToolResult(
+            content=[TextContent(type="text", text="boom")],
+            structured_content={"error": "details"},
+            is_error=True,
+        )
+        mcp_result = result.to_mcp_result()
+        assert isinstance(mcp_result, CallToolResult)
+        assert mcp_result.isError is True
+        assert mcp_result.structuredContent == {"error": "details"}

--- a/tests/utilities/test_versions.py
+++ b/tests/utilities/test_versions.py
@@ -1,0 +1,63 @@
+"""Tests for fastmcp.utilities.versions.
+
+Regression tests for the dedupe_with_versions deep-copy fix.
+Refs https://github.com/PrefectHQ/fastmcp/issues/4055 (bug 2).
+"""
+
+from fastmcp.tools.base import Tool
+from fastmcp.utilities.versions import dedupe_with_versions
+
+
+def _make_tool(name: str, version: str | None, meta: dict | None = None) -> Tool:
+    return Tool(
+        name=name,
+        description=f"Tool {name} v{version}",
+        parameters={"type": "object", "properties": {}},
+        version=version,
+        meta=meta,
+    )
+
+
+class TestDedupeWithVersionsMetaIsolation:
+    """The deduped component must not share nested mutable state with the
+    original component (or with sibling versions).
+
+    Without `model_copy(deep=True)` the inner dicts/lists in `meta` are
+    aliased between the deduped result and the input components — a
+    mutation on one leaks into the others.
+    """
+
+    def test_mutating_dedupe_meta_does_not_leak_to_original(self):
+        # Two versions of the same tool, both with nested mutable meta.
+        original_meta = {"shared": {"counter": 0}, "tags_list": ["a"]}
+        v1 = _make_tool("hello", "1.0", meta={**original_meta})
+        v2 = _make_tool("hello", "2.0", meta={**original_meta})
+
+        result = dedupe_with_versions([v1, v2], lambda t: t.name)
+        assert len(result) == 1
+        deduped = result[0]
+        assert deduped.version == "2.0"
+
+        # Mutate a nested dict and a nested list on the deduped copy.
+        assert deduped.meta is not None
+        deduped.meta["shared"]["counter"] = 999
+        deduped.meta["tags_list"].append("MUTATED")
+
+        # The original components must be untouched.
+        assert v1.meta is not None and v2.meta is not None
+        assert v1.meta["shared"]["counter"] == 0
+        assert v2.meta["shared"]["counter"] == 0
+        assert v1.meta["tags_list"] == ["a"]
+        assert v2.meta["tags_list"] == ["a"]
+
+    def test_dedupe_injects_versions_metadata(self):
+        # Sanity check: the existing behavior of recording all versions
+        # under meta["fastmcp"]["versions"] still works after deep-copying.
+        v1 = _make_tool("hello", "1.0")
+        v2 = _make_tool("hello", "2.0")
+
+        result = dedupe_with_versions([v1, v2], lambda t: t.name)
+        assert len(result) == 1
+        deduped = result[0]
+        assert deduped.meta is not None
+        assert deduped.meta["fastmcp"]["versions"] == ["2.0", "1.0"]


### PR DESCRIPTION
## Description

Two bugs from #4055 in tool result handling and component deduplication.

`ToolResult.to_mcp_result()` built a `CallToolResult` with `content`, `structuredContent`, and `_meta` but never set `isError`, so a tool returning an error result had the flag silently dropped before it reached the wire — clients could no longer tell an error apart from a success. `ToolResult` now carries an `is_error` field that maps to `CallToolResult.isError`. The shape returned for the no-meta, no-error case is unchanged.

`dedupe_with_versions()` used `model_copy()` without `deep=True`, so the deduplicated component shared nested mutables (dicts and lists inside `meta`) with the original input components. A caller that touched the result's `meta` would silently mutate the originals (and vice versa). Switched to `model_copy(deep=True)`.

```python
from fastmcp.tools.base import ToolResult
from mcp.types import TextContent

result = ToolResult(content=[TextContent(type="text", text="boom")], is_error=True)
mcp_result = result.to_mcp_result()
mcp_result.isError  # True   (was: dropped)
```

Bug 3 from the same issue (decorator metadata in `from_function`) is being addressed separately in #4072 and is not touched here.

Closes #4055

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
