### PR TITLE
fix: cli option --no-banner is NOT passed to cli but server-spec in-correctly when cli --reload option is specified.

### DIFF
--- a/src/fastmcp/cli/run.py
+++ b/src/fastmcp/cli/run.py
@@ -387,7 +387,6 @@ async def run_with_reload(
     """
     watch_paths = reload_dirs or [Path.cwd()]
     process: asyncio.subprocess.Process | None = None
-    first_run = True
 
     if is_stdio:
         logger.info("Reload mode enabled (using stateless sessions)")
@@ -413,15 +412,8 @@ async def run_with_reload(
 
     try:
         while not shutdown_event.is_set():
-            # Build command - add --no-banner on restarts to reduce noise
-            if first_run or "--no-banner" in cmd:
-                run_cmd = cmd
-            else:
-                run_cmd = [*cmd, "--no-banner"]
-            first_run = False
-
             process = await asyncio.create_subprocess_exec(
-                *run_cmd,
+                *cmd,
                 stdin=None,
                 stdout=None,
                 stderr=None,

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import json
 import subprocess
@@ -13,6 +14,7 @@ from fastmcp.cli.run import (
     create_mcp_config_server,
     is_url,
     run_module_command,
+    run_with_reload,
 )
 from fastmcp.client.client import Client
 from fastmcp.client.transports import FastMCPTransport
@@ -862,6 +864,99 @@ class TestRunModuleMode:
         assert "--module" in cmd
         assert "--no-reload" in cmd
         assert "my_module" in cmd
+
+
+class TestRunWithReloadWithServerArgs:
+    """Test the run command with reload(run_with_reload) with server args."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reload_cmd",
+        [
+            [
+                "fastmcp",
+                "run",
+                "my_module",
+                "--module",
+                "--no-reload",
+                "--no-banner",
+                "--",
+                "--debug",
+            ],
+            [
+                "fastmcp",
+                "run",
+                "my_module",
+                "--no-banner",
+                "--no-reload",
+                "--stateless",
+                "--",
+                "--debug",
+            ],
+            ["fastmcp", "run", "my_module", "--module", "--no-reload", "--", "--debug"],
+            [
+                "fastmcp",
+                "run",
+                "my_module",
+                "--no-reload",
+                "--stateless",
+                "--",
+                "--debug",
+            ],
+        ],
+    )
+    async def test_run_with_reload_does_not_mutate_command(self, reload_cmd, caplog):
+        """
+        Test for issue 4081:
+        Verify that run_with_reload does NOT mutate the command arguments.
+        The command used for restart must be identical to the original command
+        to ensure nothing is incorrectly appended or reordered.
+        """
+        reload_dirs = [Path(".")]
+        shutdown_event = asyncio.Event()
+        call_count = 0
+
+        async def mock_create_subprocess(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            proc.terminate = MagicMock()
+            proc.wait.return_value = 0
+            proc.pid = 99999
+            proc.returncode = None
+
+            if call_count >= 2:
+                actual_args = list(args)
+                try:
+                    # VALIDATION: reload_cmd remains UNCHANGED
+                    assert actual_args == reload_cmd, (
+                        f"Regression: Command was mutated during reload.\n"
+                        f"Expected: {reload_cmd}\n"
+                        f"Actual:   {actual_args}"
+                    )
+                finally:
+                    shutdown_event.set()
+
+            return proc
+
+        mock_watch = MagicMock()
+        mock_watch.__aiter__.return_value = iter([[("Change.modified", "server.py")]])
+
+        with (
+            patch(
+                "fastmcp.cli.run.asyncio.create_subprocess_exec",
+                side_effect=mock_create_subprocess,
+            ),
+            patch("fastmcp.cli.run.awatch", return_value=mock_watch),
+            patch("fastmcp.cli.run.asyncio.Event", return_value=shutdown_event),
+            caplog.at_level("INFO"),
+        ):
+            await run_with_reload(reload_cmd, reload_dirs=reload_dirs)
+
+        assert any("Detected changes" in record.message for record in caplog.records)
+        assert call_count == 2, f"Restart logic was not triggered for {reload_cmd}"
 
 
 class TestInspectorModuleMode:


### PR DESCRIPTION
## Description

<!-- What does this PR do? Link to the issue it addresses. -->

Closes #4081

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

---

- regarding `uv run prek run --all-files`, some failed, but failures is not caused by my code modification, I guess.

```bash
uv run prek run --all-files
Validate pyproject.toml..................................................Passed
prettier.................................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
ty check.................................................................Passed
loq (file size limits)...................................................Passed
- hook id: loq
- duration: 0.06s

  ✖  1_108 > 1_096  src/fastmcp/server/providers/proxy.py
  ✖  2_448 > 2_410  src/fastmcp/server/server.py
  ✖  1_453 > 1_404  src/fastmcp/server/context.py
  ✖  2_174 > 2_098  src/fastmcp/server/auth/oauth_proxy/proxy.py
  ✖  1_185 > 1_000  tests/server/auth/providers/test_azure.py
  ✖  1_271 > 1_000  tests/server/auth/oauth_proxy/test_tokens.py
  ✖  1_491 > 1_154  tests/utilities/openapi/test_director.py
  7 violations
  
  loq violations not enforced... yet!
prevent commits to main..................................................Passed
codespell................................................................Passed

```
