### PR TITLE
fix(ping): exit ping loop cleanly when session stream is closed

### DIFF
--- a/src/fastmcp/server/middleware/ping.py
+++ b/src/fastmcp/server/middleware/ping.py
@@ -65,6 +65,9 @@ class PingMiddleware(Middleware):
         try:
             while True:
                 await anyio.sleep(self.interval_ms / 1000)
-                await session.send_ping()
+                try:
+                    await session.send_ping()
+                except anyio.ClosedResourceError:
+                    return
         finally:
             self._active_sessions.discard(session_id)


### PR DESCRIPTION
`PingMiddleware._ping_loop` calls `session.send_ping()` in an infinite loop. When the underlying memory stream has been closed — e.g. when an MCP client disconnects — `send_ping` raises `anyio.ClosedResourceError`. The exception propagates out of the loop, is caught by the surrounding TaskGroup's `__aexit__`, and re-raised as an `ExceptionGroup`, which shows up in server logs as a noisy unhandled-exception traceback even though a closed stream is the expected end state of the loop.  Catch `ClosedResourceError` inside the loop and return — the session is going away, the ping task should just exit.

## Description

<!-- What does this PR do? Link to the issue it addresses. -->

Closes #

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [ ] This PR addresses an existing issue (or fixes a self-evident bug)
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [ ] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)
