### PR TITLE
feat: add icons parameter to from_openapi() and from_fastapi()

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -2266,6 +2266,7 @@ class FastMCP(
         mcp_names: dict[str, str] | None = None,
         tags: set[str] | None = None,
         validate_output: bool = True,
+        icons: list[mcp.types.Icon] | None = None,
         **settings: Any,
     ) -> Self:
         """
@@ -2303,7 +2304,7 @@ class FastMCP(
             tags=tags,
             validate_output=validate_output,
         )
-        return cls(name=name, providers=[provider], **settings)
+        return cls(name=name, providers=[provider], icons=icons, **settings)
 
     @classmethod
     def from_fastapi(
@@ -2316,6 +2317,7 @@ class FastMCP(
         mcp_names: dict[str, str] | None = None,
         httpx_client_kwargs: dict[str, Any] | None = None,
         tags: set[str] | None = None,
+        icons: list[mcp.types.Icon] | None = None,
         **settings: Any,
     ) -> Self:
         """
@@ -2358,7 +2360,7 @@ class FastMCP(
             mcp_names=mcp_names,
             tags=tags,
         )
-        return cls(name=server_name, providers=[provider], **settings)
+        return cls(name=server_name, providers=[provider], icons=icons, **settings)
 
     @classmethod
     def as_proxy(

--- a/tests/server/providers/openapi/test_openapi_features.py
+++ b/tests/server/providers/openapi/test_openapi_features.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, Mock
 
 import httpx
 import pytest
+from fastapi import FastAPI
 from httpx import Response
+from mcp.types import Icon
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
@@ -1027,3 +1029,37 @@ class TestRedactHeaders:
         headers = httpx.Headers({"Content-Type": "application/json"})
         redacted = _redact_headers(headers)
         assert redacted == {"content-type": "application/json"}
+
+
+class TestFromOpenAPIIcons:
+    """Test that icons can be passed to from_openapi() and from_fastapi()."""
+
+    @pytest.fixture
+    def minimal_spec(self):
+        return {
+            "openapi": "3.0.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "servers": [{"url": "https://api.example.com"}],
+            "paths": {},
+        }
+
+    def test_from_openapi_sets_icons(self, minimal_spec):
+        mock_client = Mock(spec=httpx.AsyncClient)
+        mock_client.base_url = "https://api.example.com"
+        mock_client.headers = None
+
+        icons = [Icon(src="https://example.com/icon.svg", mimeType="image/svg+xml")]
+        server = FastMCP.from_openapi(
+            openapi_spec=minimal_spec,
+            client=mock_client,
+            icons=icons,
+        )
+
+        assert server.icons == icons
+
+    def test_from_fastapi_sets_icons(self):
+        app = FastAPI()
+        icons = [Icon(src="https://example.com/icon.svg", mimeType="image/svg+xml")]
+        server = FastMCP.from_fastapi(app, icons=icons)
+
+        assert server.icons == icons


### PR DESCRIPTION
Closes #3007

## Description

 `FastMCP.from_openapi()` and `FastMCP.from_fastapi()` had no way to set server icons — the `icons` property is read-only after construction, and neither factory method exposed an `icons` parameter. This adds `icons` as an explicit typed
   parameter to both methods, passing it through to the `FastMCP` constructor.                                                                                                                                                                
                                                                                                                                                                                                                                              
  ```python                                                                                                                                                                                                                                 
  mcp = FastMCP.from_openapi(
      openapi_spec,
      client=client,
      icons=[Icon(src="https://example.com/icon.svg", mimeType="image/svg+xml")],                                                                                                                                                             
  ) 
```     

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
