### PR TITLE
fix(auth): silence authlib.jose DeprecationWarning at JWT import

### DIFF
--- a/src/fastmcp/server/auth/jwt_issuer.py
+++ b/src/fastmcp/server/auth/jwt_issuer.py
@@ -12,12 +12,17 @@ import time
 import warnings
 from typing import Any, overload
 
-from authlib.deprecate import AuthlibDeprecationWarning
-
 with warnings.catch_warnings():
     # authlib.jose emits AuthlibDeprecationWarning on import; suppress it so
     # importing this module does not trigger the warning under
-    # `warnings.simplefilter("error")`. See jlowin/fastmcp#4098.
+    # `warnings.simplefilter("error")`. The `authlib.deprecate` import lives
+    # inside this block too: importing it for the first time runs
+    # `warnings.simplefilter("always", AuthlibDeprecationWarning)` at module
+    # scope, which would otherwise leak past `catch_warnings()` and clobber
+    # the caller's filter for subsequent Authlib deprecations. See
+    # jlowin/fastmcp#4098.
+    from authlib.deprecate import AuthlibDeprecationWarning
+
     warnings.simplefilter("ignore", AuthlibDeprecationWarning)
     from authlib.jose import JsonWebToken
     from authlib.jose.errors import JoseError

--- a/src/fastmcp/server/auth/jwt_issuer.py
+++ b/src/fastmcp/server/auth/jwt_issuer.py
@@ -9,10 +9,18 @@ from __future__ import annotations
 
 import base64
 import time
+import warnings
 from typing import Any, overload
 
-from authlib.jose import JsonWebToken
-from authlib.jose.errors import JoseError
+from authlib.deprecate import AuthlibDeprecationWarning
+
+with warnings.catch_warnings():
+    # authlib.jose emits AuthlibDeprecationWarning on import; suppress it so
+    # importing this module does not trigger the warning under
+    # `warnings.simplefilter("error")`. See jlowin/fastmcp#4098.
+    warnings.simplefilter("ignore", AuthlibDeprecationWarning)
+    from authlib.jose import JsonWebToken
+    from authlib.jose.errors import JoseError
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC

--- a/src/fastmcp/server/auth/providers/jwt.py
+++ b/src/fastmcp/server/auth/providers/jwt.py
@@ -10,12 +10,17 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 import httpx
-from authlib.deprecate import AuthlibDeprecationWarning
-
 with warnings.catch_warnings():
     # authlib.jose emits AuthlibDeprecationWarning on import; suppress it so
-    # importing this module does not trigger the warning under
-    # `warnings.simplefilter("error")`. See jlowin/fastmcp#4098.
+    # importing this provider does not trigger the warning under
+    # `warnings.simplefilter("error")`. The `authlib.deprecate` import lives
+    # inside this block too: importing it for the first time runs
+    # `warnings.simplefilter("always", AuthlibDeprecationWarning)` at module
+    # scope, which would otherwise leak past `catch_warnings()` and clobber
+    # the caller's filter for subsequent Authlib deprecations. See
+    # jlowin/fastmcp#4098.
+    from authlib.deprecate import AuthlibDeprecationWarning
+
     warnings.simplefilter("ignore", AuthlibDeprecationWarning)
     from authlib.jose import JsonWebKey, JsonWebToken
     from authlib.jose.errors import JoseError

--- a/src/fastmcp/server/auth/providers/jwt.py
+++ b/src/fastmcp/server/auth/providers/jwt.py
@@ -5,12 +5,20 @@ from __future__ import annotations
 import contextlib
 import json
 import time
+import warnings
 from dataclasses import dataclass
 from typing import Any, cast
 
 import httpx
-from authlib.jose import JsonWebKey, JsonWebToken
-from authlib.jose.errors import JoseError
+from authlib.deprecate import AuthlibDeprecationWarning
+
+with warnings.catch_warnings():
+    # authlib.jose emits AuthlibDeprecationWarning on import; suppress it so
+    # importing this module does not trigger the warning under
+    # `warnings.simplefilter("error")`. See jlowin/fastmcp#4098.
+    warnings.simplefilter("ignore", AuthlibDeprecationWarning)
+    from authlib.jose import JsonWebKey, JsonWebToken
+    from authlib.jose.errors import JoseError
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from pydantic import AnyHttpUrl, SecretStr

--- a/src/fastmcp/server/auth/providers/jwt.py
+++ b/src/fastmcp/server/auth/providers/jwt.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 import httpx
+
 with warnings.catch_warnings():
     # authlib.jose emits AuthlibDeprecationWarning on import; suppress it so
     # importing this provider does not trigger the warning under


### PR DESCRIPTION
`authlib.jose` emits `AuthlibDeprecationWarning` at module import time, so any caller running with `warnings.simplefilter("error")` hits an exception just from touching FastMCP's JWT auth providers (`from fastmcp.server.auth.providers.jwt import StaticTokenVerifier` is enough to trigger it).

Wraps the two `from authlib.jose ...` imports in `warnings.catch_warnings()` filtering `AuthlibDeprecationWarning`. The filter snapshot is restored on context exit, so this stays scoped to the one import site and doesn't leak into user code. Migrating off `authlib.jose` to `joserfc` is a separate, larger change; this is the minimal patch for the warning.

```python
from authlib.deprecate import AuthlibDeprecationWarning

with warnings.catch_warnings():
    warnings.simplefilter("ignore", AuthlibDeprecationWarning)
    from authlib.jose import JsonWebToken
    from authlib.jose.errors import JoseError
```

Closes #4098.

- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)