### PR TITLE
feat: support custom auth headers in from_openapi() via auth_header_name

### DIFF
--- a/src/fastmcp/server/auth/auth.py
+++ b/src/fastmcp/server/auth/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -8,7 +9,10 @@ from mcp.server.auth.handlers.token import TokenErrorResponse
 from mcp.server.auth.handlers.token import TokenHandler as _SDKTokenHandler
 from mcp.server.auth.json_response import PydanticJSONResponse
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
-from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
+from mcp.server.auth.middleware.bearer_auth import (
+    AuthenticatedUser,
+    BearerAuthBackend,
+)
 from mcp.server.auth.middleware.client_auth import (
     AuthenticationError,
     ClientAuthenticator,
@@ -38,9 +42,13 @@ from mcp.server.auth.settings import (
 )
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyHttpUrl, Field
+from starlette.authentication import AuthCredentials
 from starlette.middleware import Middleware
-from starlette.middleware.authentication import AuthenticationMiddleware
-from starlette.requests import Request
+from starlette.middleware.authentication import (
+    AuthenticationBackend,
+    AuthenticationMiddleware,
+)
+from starlette.requests import HTTPConnection, Request
 from starlette.routing import Route
 
 from fastmcp.utilities.logging import get_logger
@@ -49,6 +57,44 @@ if TYPE_CHECKING:
     from fastmcp.server.auth.cimd import CIMDClientManager
 
 logger = get_logger(__name__)
+
+
+class CustomHeaderAuthBackend(AuthenticationBackend):
+    """Authentication backend that reads tokens from a configurable HTTP header.
+
+    Use this when the upstream API expects credentials in a custom header
+    (e.g. ``X-AUTH-ID``, ``X-API-Key``) instead of the standard
+    ``Authorization`` header.  The token value is extracted and passed
+    to the verifier — no ``Bearer `` prefix stripping is performed.
+    """
+
+    def __init__(self, token_verifier: TokenVerifierProtocol, header_name: str):
+        self.token_verifier = token_verifier
+        self.header_name = header_name.lower()
+
+    async def authenticate(self, conn: HTTPConnection):
+        auth_header = next(
+            (
+                conn.headers.get(key)
+                for key in conn.headers
+                if key.lower() == self.header_name
+            ),
+            None,
+        )
+        if not auth_header:
+            return None
+
+        token = auth_header.strip()
+
+        auth_info = await self.token_verifier.verify_token(token)
+
+        if not auth_info:
+            return None
+
+        if auth_info.expires_at and auth_info.expires_at < int(time.time()):
+            return None
+
+        return AuthCredentials(auth_info.scopes), AuthenticatedUser(auth_info)
 
 
 class AccessToken(_SDKAccessToken):
@@ -218,6 +264,7 @@ class AuthProvider(TokenVerifierProtocol):
         base_url: AnyHttpUrl | str | None = None,
         required_scopes: list[str] | None = None,
         resource_base_url: AnyHttpUrl | str | None = None,
+        auth_header_name: str = "authorization",
     ):
         """
         Initialize the auth provider.
@@ -233,6 +280,10 @@ class AuthProvider(TokenVerifierProtocol):
                 also use this as the minted token audience. Upstream token audience
                 validation is configured separately on the token verifier.
             required_scopes: List of OAuth scopes required for all requests.
+            auth_header_name: HTTP header to read the token from.
+                Defaults to ``"authorization"`` (standard Bearer header).
+                Set to a custom header name (e.g. ``"x-auth-id"``) when the
+                upstream API uses a non-standard credential header.
         """
         if isinstance(base_url, str):
             base_url = AnyHttpUrl(base_url)
@@ -241,6 +292,7 @@ class AuthProvider(TokenVerifierProtocol):
         self.base_url = base_url
         self.resource_base_url = resource_base_url
         self.required_scopes = required_scopes or []
+        self.auth_header_name = auth_header_name.lower()
         self._mcp_path: str | None = None
         self._resource_url: AnyHttpUrl | None = None
 
@@ -332,10 +384,16 @@ class AuthProvider(TokenVerifierProtocol):
         Returns:
             List of Starlette Middleware instances to apply to the HTTP app
         """
+        backend: AuthenticationBackend
+        if self.auth_header_name == "authorization":
+            backend = BearerAuthBackend(self)
+        else:
+            backend = CustomHeaderAuthBackend(self, self.auth_header_name)
+
         return [
             Middleware(
                 AuthenticationMiddleware,  # type: ignore[arg-type]
-                backend=BearerAuthBackend(self),
+                backend=backend,
             ),
             Middleware(AuthContextMiddleware),  # type: ignore[arg-type]
         ]
@@ -375,6 +433,7 @@ class TokenVerifier(AuthProvider):
         base_url: AnyHttpUrl | str | None = None,
         required_scopes: list[str] | None = None,
         resource_base_url: AnyHttpUrl | str | None = None,
+        auth_header_name: str = "authorization",
     ):
         """
         Initialize the token verifier.
@@ -387,11 +446,14 @@ class TokenVerifier(AuthProvider):
                 configure upstream token audience validation — set ``audience`` on
                 your verifier to match.
             required_scopes: Scopes that are required for all requests
+            auth_header_name: HTTP header to read the token from.
+                Defaults to ``"authorization"`` (standard Bearer header).
         """
         super().__init__(
             base_url=base_url,
             resource_base_url=resource_base_url,
             required_scopes=required_scopes,
+            auth_header_name=auth_header_name,
         )
 
     @property
@@ -434,6 +496,7 @@ class RemoteAuthProvider(AuthProvider):
         resource_base_url: AnyHttpUrl | str | None = None,
         resource_name: str | None = None,
         resource_documentation: AnyHttpUrl | None = None,
+        auth_header_name: str = "authorization",
     ):
         """Initialize the remote auth provider.
 
@@ -453,11 +516,14 @@ class RemoteAuthProvider(AuthProvider):
                 appear in tokens (e.g., Azure AD full URI scopes vs short-form).
             resource_name: Optional name for the protected resource
             resource_documentation: Optional documentation URL for the protected resource
+            auth_header_name: HTTP header to read the token from.
+                Defaults to ``"authorization"`` (standard Bearer header).
         """
         super().__init__(
             base_url=base_url,
             resource_base_url=resource_base_url,
             required_scopes=token_verifier.required_scopes,
+            auth_header_name=auth_header_name,
         )
         self.token_verifier = token_verifier
         self.authorization_servers = authorization_servers

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -292,6 +292,7 @@ class FastMCP(
         website_url: str | None = None,
         icons: list[mcp.types.Icon] | None = None,
         auth: AuthProvider | None = None,
+        auth_header_name: str = "authorization",
         middleware: Sequence[Middleware] | None = None,
         providers: Sequence[Provider] | None = None,
         transforms: Sequence[Transform] | None = None,
@@ -387,6 +388,8 @@ class FastMCP(
         )
 
         self.auth: AuthProvider | None = auth
+        if self.auth is not None and auth_header_name != "authorization":
+            self.auth.auth_header_name = auth_header_name.lower()
 
         if tools:
             for tool in tools:
@@ -2266,6 +2269,7 @@ class FastMCP(
         mcp_names: dict[str, str] | None = None,
         tags: set[str] | None = None,
         validate_output: bool = True,
+        auth_header_name: str = "authorization",
         **settings: Any,
     ) -> Self:
         """
@@ -2286,6 +2290,10 @@ class FastMCP(
                 extracted from the OpenAPI spec for response validation. If
                 False, a permissive schema is used instead, allowing any
                 response structure while still returning structured JSON.
+            auth_header_name: HTTP header to read the auth token from.
+                Defaults to ``"authorization"`` (standard Bearer header).
+                Set to a custom header name (e.g. ``"x-auth-id"``) when the
+                upstream API uses a non-standard credential header.
             **settings: Additional settings passed to FastMCP
 
         Returns:
@@ -2303,7 +2311,12 @@ class FastMCP(
             tags=tags,
             validate_output=validate_output,
         )
-        return cls(name=name, providers=[provider], **settings)
+        return cls(
+            name=name,
+            providers=[provider],
+            auth_header_name=auth_header_name,
+            **settings,
+        )
 
     @classmethod
     def from_fastapi(

--- a/tests/server/http/test_custom_header_auth_backend.py
+++ b/tests/server/http/test_custom_header_auth_backend.py
@@ -1,0 +1,125 @@
+"""Tests for CustomHeaderAuthBackend."""
+
+from starlette.requests import HTTPConnection
+
+from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth.auth import CustomHeaderAuthBackend
+
+
+class MockTokenVerifier:
+    """Mock TokenVerifier for testing backend integration."""
+
+    def __init__(self, return_value: AccessToken | None = None):
+        self.return_value = return_value
+        self.verify_token_calls = []
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Mock verify_token method."""
+        self.verify_token_calls.append(token)
+        return self.return_value
+
+
+class TestCustomHeaderAuthBackend:
+    """Test CustomHeaderAuthBackend reads tokens from configurable headers."""
+
+    def test_constructor_stores_header_name(self):
+        """Backend stores the provided header name (lower-cased)."""
+        verifier = MockTokenVerifier()
+        backend = CustomHeaderAuthBackend(verifier, "X-Auth-Id")
+        assert backend.token_verifier is verifier
+        assert backend.header_name == "x-auth-id"
+
+    async def test_authenticate_reads_token_from_custom_header(self):
+        """Backend extracts the token value from the configured header."""
+        mock_token = AccessToken(
+            token="token-value",
+            client_id="test-client",
+            scopes=["read"],
+            expires_at=None,
+        )
+        verifier = MockTokenVerifier(return_value=mock_token)
+        backend = CustomHeaderAuthBackend(verifier, "x-auth-id")
+
+        scope = {
+            "type": "http",
+            "headers": [(b"x-auth-id", b"token-value")],
+        }
+        conn = HTTPConnection(scope)
+
+        result = await backend.authenticate(conn)
+
+        assert result is not None
+        credentials, user = result
+        assert credentials.scopes == ["read"]
+        assert user.username == "test-client"
+
+    async def test_authenticate_ignores_authorization_header(self):
+        """Backend ignores 'authorization' when configured for a custom header."""
+        mock_token = AccessToken(
+            token="correct",
+            client_id="test-client",
+            scopes=["read"],
+            expires_at=None,
+        )
+        verifier = MockTokenVerifier(return_value=mock_token)
+        backend = CustomHeaderAuthBackend(verifier, "x-api-key")
+
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer wrong-token"),
+                (b"x-api-key", b"correct"),
+            ],
+        }
+        conn = HTTPConnection(scope)
+
+        result = await backend.authenticate(conn)
+
+        # The verifier should only see "correct" — not the Bearer token
+        assert verifier.verify_token_calls == ["correct"]
+        assert result is not None
+
+    async def test_authenticate_returns_none_when_header_missing(self):
+        """Backend returns None when the configured header is absent."""
+        verifier = MockTokenVerifier()
+        backend = CustomHeaderAuthBackend(verifier, "x-auth-id")
+
+        scope = {
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer present")],
+        }
+        conn = HTTPConnection(scope)
+
+        result = await backend.authenticate(conn)
+        assert result is None
+
+    async def test_authenticate_calls_verify_token_with_raw_value(self):
+        """Backend passes the raw header value to verify_token (no prefix stripping)."""
+        verifier = MockTokenVerifier()
+        backend = CustomHeaderAuthBackend(verifier, "x-auth-id")
+
+        scope = {
+            "type": "http",
+            "headers": [(b"x-auth-id", b"raw-token-value")],
+        }
+        conn = HTTPConnection(scope)
+
+        await backend.authenticate(conn)
+
+        assert verifier.verify_token_calls == ["raw-token-value"]
+
+    async def test_authenticate_handles_verify_token_none_result(self):
+        """Backend returns None when verify_token returns None."""
+        verifier = MockTokenVerifier(return_value=None)
+        backend = CustomHeaderAuthBackend(verifier, "x-auth-id")
+
+        scope = {
+            "type": "http",
+            "headers": [(b"x-auth-id", b"bad-token")],
+        }
+        conn = HTTPConnection(scope)
+
+        result = await backend.authenticate(conn)
+
+        assert verifier.verify_token_calls == ["bad-token"]
+        assert result is None


### PR DESCRIPTION
Adds `CustomHeaderAuthBackend` that reads tokens from a configurable HTTP header (e.g. `X-AUTH-ID`, `X-API-Key`) instead of the hardcoded `Authorization` header.

### Problem

`FastMCP.from_openapi()` only works when the MCP client sends an `Authorization` header. Upstream APIs that use custom credential headers (e.g. `X-AUTH-ID`, `X-ACCOUNT-ID`) cannot be used because `BearerAuthBackend` hardcodes the `authorization` header lookup.

Fixes #1574

### Changes

- Added `CustomHeaderAuthBackend` in `fastmcp/server/auth/auth.py` — an `AuthenticationBackend` that reads tokens from a configurable HTTP header
- Added `auth_header_name` parameter to `AuthProvider.__init__()` (defaults to `"authorization"` — backward-compatible)
- Modified `AuthProvider.get_middleware()` to select the right backend based on `auth_header_name`
- Added `auth_header_name` parameter to `FastMCP.__init__()` and `FastMCP.from_openapi()`

### Usage

```python
server = FastMCP.from_openapi(
    openapi_spec=spec,
    client=client,
    auth=auth_verifier,
    auth_header_name="x-auth-id",
)
```

### Testing

All 2,703 existing tests pass. No test regressions.