### PR TITLE
fix: Don't completely hide plain mcp.tool app-only tools

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -182,30 +182,39 @@ def _get_auth_context() -> tuple[bool, Any]:
     return (False, get_access_token())
 
 
-def _is_model_visible(tool: Tool) -> bool:
-    """Check whether a tool should be visible to the model.
+def _is_backend_tool(tool: Tool) -> bool:
+    """Check whether a tool is handled specially as backend tool
 
     Tools registered via ``@app.tool()`` (without ``model=True``) have
     ``meta["ui"]["visibility"] == ["app"]`` — they are callable by app UIs
-    but should not appear in the model's tool list.
+    but should not appear in tool list the client passes to the model.
 
-    Returns True (visible) when:
-    - The tool has no ``meta.ui.visibility`` (normal tools).
-    - ``"model"`` is in the visibility list (e.g. ``["model"]`` or ``["app", "model"]``).
+    They are handled specially for in various ways - e.g. they are looked
+    up via get_app_tool(), and don't appear in the tools/list output.
+    (FIXME: the latter isn't correct behavior according to the mcp-apps spec.)
 
-    Returns False when the visibility list exists and does not contain ``"model"``
-    (e.g. ``["app"]``).
+    Returns True (a backend tool) when:
+    - The tool has ``meta.fastmcp.app``.
+    - The tool has ``meta.ui.visibility``.
+    - The visibility is precisely ``["app"]``.
+
+    Returns False otherwise.
     """
     meta = tool.meta
     if not meta:
-        return True
+        return False
+    fastmcp = meta.get("fastmcp")
+    if not isinstance(fastmcp, dict):
+        return False
+    if fastmcp.get("app") is None:
+        return False
     ui = meta.get("ui")
     if not isinstance(ui, dict):
-        return True
+        return False
     visibility = ui.get("visibility")
     if not isinstance(visibility, list):
-        return True
-    return "model" in visibility
+        return False
+    return len(visibility) == 1 and visibility[0] == "app"
 
 
 def _is_app_visible(tool: Tool) -> bool:
@@ -631,7 +640,7 @@ class FastMCP(
                 # and model-visible (app-only tools are hidden from the model).
                 tools = list(await super().list_tools())
                 tools = await apply_session_transforms(tools)
-                tools = [t for t in tools if is_enabled(t) and _is_model_visible(t)]
+                tools = [t for t in tools if is_enabled(t) and not _is_backend_tool(t)]
 
                 # Rewrite per-tool Prefab renderer URIs based on the tool's
                 # mount-point address. The walk pairs each tool with the
@@ -709,7 +718,7 @@ class FastMCP(
 
         # Apply session transforms to single item
         tools = await apply_session_transforms([tool])
-        if tools and is_enabled(tools[0]) and _is_model_visible(tools[0]):
+        if tools and is_enabled(tools[0]) and not _is_backend_tool(tools[0]):
             return tools[0]
 
         # The highest version is disabled (or app-only). If an explicit version
@@ -720,7 +729,7 @@ class FastMCP(
 
         all_tools = [t for t in await super().list_tools() if t.name == name]
         all_tools = list(await apply_session_transforms(all_tools))
-        enabled = [t for t in all_tools if is_enabled(t) and _is_model_visible(t)]
+        enabled = [t for t in all_tools if is_enabled(t) and not _is_backend_tool(t)]
 
         skip_auth, token = _get_auth_context()
         authorized: list[Tool] = []

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -225,11 +225,11 @@ class TestToolRegistrationWithApp:
         def my_tool() -> str:
             return "hello"
 
-        # App-only tools (visibility=["app"]) are hidden from list_tools
+        # app-only tools declared directly on the server are looked up normally.
+        # Filtering them out is the responsibility of the host.
         tools = list(await server.list_tools())
-        assert len(tools) == 0
+        assert len(tools) == 1
 
-        # But the tool exists on the provider
         tool = await server._get_tool("my_tool")
         assert tool is not None
         assert tool.meta is not None
@@ -256,10 +256,10 @@ class TestToolRegistrationWithApp:
         def my_tool() -> str:
             return "hello"
 
-        # App-only tools are hidden from list_tools, verify via provider
-        tool = await server._get_tool("my_tool")
-        assert tool is not None
-        mcp_tool = tool.to_mcp_tool()
+        tools = list(await server.list_tools())
+        assert len(tools) == 1
+
+        mcp_tool = tools[0].to_mcp_tool()
         assert mcp_tool.meta is not None
         assert mcp_tool.meta["ui"]["resourceUri"] == "ui://app"
         assert mcp_tool.meta["ui"]["visibility"] == ["app"]
@@ -490,6 +490,18 @@ class TestIntegration:
 
         async with Client(server) as client:
             result = await client.call_tool("greet", {"name": "Alice"})
+            assert any("Hello, Alice!" in str(c) for c in result.content)
+
+    async def test_app_backend_tool_callable(self):
+        """A tool registered with AppConfig(visibility=["app"]) is callable."""
+        server = FastMCP("test")
+
+        @server.tool(app=AppConfig(visibility=["app"]))
+        async def backend_greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        async with Client(server) as client:
+            result = await client.call_tool("backend_greet", {"name": "Alice"})
             assert any("Hello, Alice!" in str(c) for c in result.content)
 
     async def test_extension_and_tool_together(self):


### PR DESCRIPTION
## Description

If a tool was registered with visibility=["app"] on a plain mcp.tool, it was entirely unreachable - it was not listed with tools/list and not callable with tools/call.

This was a combination of a conflict with specialized routing of tool calls meant for app.tool() and a misunderstanding of the interaction of the mcp-apps specification with tools/list. (visibility=["app"] tools are excluded from the *model's* tool list, not the tool list returned to the client.)

Such tools are now listed and called like any other, and the previous handling is restricted to @app.tool defined tools. Fixing up tools/list for @app.tool declared tools is *not* handled here.

See analysis by Kerem Nalbant in #4088.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
