### PR TITLE
Override token endpoint auth method

### DIFF
--- a/src/fastmcp/server/auth/providers/azure.py
+++ b/src/fastmcp/server/auth/providers/azure.py
@@ -264,6 +264,7 @@ class AzureProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             valid_scopes=parsed_required_scopes,
             enable_cimd=enable_cimd,
+            token_endpoint_auth_method="client_secret_post"
         )
 
         authority_info = ""


### PR DESCRIPTION
## Description
Override token endpoint auth method on azure oauth provider. I don't think azure supports client_secret_basic
<!-- What does this PR do? Link to the issue it addresses. -->

Closes #

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [ ] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)
