### PR TITLE
fix(http): terminate active streamable-HTTP transports before lifespan shutdown

### DIFF
--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -370,7 +370,26 @@ def create_streamable_http_app(
             server._lifespan_manager(),
             streamable_http_app.session_manager.run(),
         ):
-            yield
+            try:
+                yield
+            finally:
+                # Gracefully terminate active streamable-HTTP transports before
+                # the session manager's task group is cancelled. Without this,
+                # active SSE/streaming responses are aborted mid-flight and
+                # Uvicorn logs "ASGI callable returned without completing
+                # response." See PrefectHQ/fastmcp#3025.
+                sm = streamable_http_app.session_manager
+                # `_server_instances` is a private attribute of the upstream
+                # `StreamableHTTPSessionManager` (mcp SDK); termination is
+                # idempotent and tolerates new instances being added concurrently.
+                for transport in list(sm._server_instances.values()):
+                    try:
+                        await transport.terminate()
+                    except Exception:
+                        logger.debug(
+                            "Error terminating streamable-HTTP transport on shutdown",
+                            exc_info=True,
+                        )
 
     # Create and return the app with lifespan
     app = create_base_app(

--- a/tests/server/http/test_streamable_http_shutdown.py
+++ b/tests/server/http/test_streamable_http_shutdown.py
@@ -1,0 +1,36 @@
+"""Regression tests for graceful streamable-HTTP shutdown (issue #3025)."""
+
+from unittest.mock import AsyncMock
+
+from fastmcp.server import FastMCP
+
+
+async def test_lifespan_terminates_active_transports_before_task_group_cancel():
+    """Active streamable-HTTP transports must be terminated during lifespan
+    shutdown so streaming responses end cleanly instead of being aborted by
+    the session manager's task-group cancel.
+
+    See PrefectHQ/fastmcp#3025: without graceful termination, Uvicorn logs
+    "ASGI callable returned without completing response." on CTRL+C while a
+    client holds an SSE GET stream open.
+    """
+    server = FastMCP(name="ShutdownTest")
+    app = server.http_app(path="/mcp")
+
+    fake_transport = AsyncMock()
+    fake_transport.terminate = AsyncMock()
+
+    async with app.router.lifespan_context(app):
+        # The session manager is constructed inside the lifespan; once it has
+        # started, register a fake active transport as if a client were
+        # holding an SSE stream open.
+        sm = None
+        for route in app.router.routes:
+            endpoint = getattr(route, "endpoint", None)
+            sm = getattr(endpoint, "session_manager", None)
+            if sm is not None:
+                break
+        assert sm is not None, "streamable-http session manager not initialised"
+        sm._server_instances["fake-session"] = fake_transport
+
+    fake_transport.terminate.assert_awaited_once()


### PR DESCRIPTION

## Description

`StreamableHTTPSessionManager.run()` (upstream `mcp`) cancels its task group inside `finally` without first terminating active transports. During Uvicorn graceful shutdown the lifespan in `create_streamable_http_app` exits before the session manager, so `tg.cancel_scope.cancel()` aborts long-lived GET `/mcp/` SSE response tasks mid-flight. The streaming response never sends its final `http.response.body` and Uvicorn logs `ERROR: ASGI callable returned without completing response.`

The fix wraps the lifespan's `yield` in `try/finally` and, on exit, awaits `terminate()` on every transport currently registered in `session_manager._server_instances`. `StreamableHTTPServerTransport.terminate()` is idempotent (`_terminated` guard) and closes the per-request and read/write streams, so the SSE GET handler completes its ASGI response before the SDK's `__aexit__` cancels the task group. Termination errors are caught and logged at debug; shutdown must not raise.

Stateless servers don't populate `_server_instances`, so this is a no-op there. The issue's "Option 1" `await anyio.sleep(0.5)` isn't needed because `terminate()` already awaits stream close; the "Option 2" `@on_shutdown` hook is a larger API design and out of scope for a bug fix.

A regression test in `tests/server/http/test_streamable_http_shutdown.py` registers a fake transport on the live session manager during the lifespan and asserts `terminate()` is awaited before the lifespan completes. It fails on `main` and passes with the fix.

Closes #3025

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)