### PR TITLE
fix: Unable to raise unhandled exceptions as McpError (Protocol Errors) (#4126)

### DIFF
--- a/fastmcp_slim/fastmcp/server/mixins/mcp_operations.py
+++ b/fastmcp_slim/fastmcp/server/mixins/mcp_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import mcp.types
@@ -22,6 +23,17 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 PaginateT = TypeVar("PaginateT")
+
+# Side channel used to surface McpError raised during tools/call as a
+# JSON-RPC protocol error. The MCP SDK's call_tool wrapper catches every
+# exception (except UrlElicitationRequiredError) and converts it into a
+# CallToolResult with isError=True. That swallows McpError raised by
+# middleware that intentionally wants the JSON-RPC error path (e.g.
+# ErrorHandlingMiddleware(transform_errors=True)). We stash the McpError
+# here so the outer wrapper can re-raise it after the SDK returns.
+_pending_call_tool_mcp_error: ContextVar[McpError | None] = ContextVar(
+    "_pending_call_tool_mcp_error", default=None
+)
 
 
 def _apply_pagination(
@@ -76,6 +88,30 @@ class MCPOperationsMixin:
 
         self._mcp_server.call_tool(validate_input=self.strict_input_validation)(
             self._call_tool_mcp
+        )
+        # Wrap the SDK-registered call_tool handler so McpError raised by
+        # _call_tool_mcp (e.g. by ErrorHandlingMiddleware) propagates as a
+        # JSON-RPC protocol error rather than being swallowed by the SDK
+        # wrapper and converted to a CallToolResult with isError=True.
+        sdk_call_tool_handler = self._mcp_server.request_handlers[
+            mcp.types.CallToolRequest
+        ]
+
+        async def _call_tool_handler_with_mcp_error_propagation(
+            req: mcp.types.CallToolRequest,
+        ) -> mcp.types.ServerResult:
+            token = _pending_call_tool_mcp_error.set(None)
+            try:
+                result = await sdk_call_tool_handler(req)
+                pending = _pending_call_tool_mcp_error.get()
+                if pending is not None:
+                    raise pending
+                return result
+            finally:
+                _pending_call_tool_mcp_error.reset(token)
+
+        self._mcp_server.request_handlers[mcp.types.CallToolRequest] = (
+            _call_tool_handler_with_mcp_error_propagation
         )
         self._mcp_server.read_resource()(self._read_resource_mcp)
         self._mcp_server.get_prompt()(self._get_prompt_mcp)
@@ -244,6 +280,13 @@ class MCPOperationsMixin:
             raise NotFoundError(f"Unknown tool: {key!r}") from e
         except NotFoundError as e:
             raise NotFoundError(f"Unknown tool: {key!r}") from e
+        except McpError as e:
+            # Stash so the outer handler wrapper can re-raise this as a
+            # JSON-RPC protocol error. The SDK's call_tool wrapper would
+            # otherwise catch it via `except Exception` and turn it into a
+            # CallToolResult with isError=True.
+            _pending_call_tool_mcp_error.set(e)
+            raise
 
     async def _read_resource_mcp(
         self, uri: AnyUrl | str

--- a/tests/server/middleware/test_error_handling.py
+++ b/tests/server/middleware/test_error_handling.py
@@ -566,6 +566,32 @@ class TestErrorHandlingMiddlewareIntegration:
         # Error should still exist (may be wrapped by FastMCP)
         assert exc_info.value is not None
 
+    async def test_transform_errors_surfaces_mcp_error_as_protocol_error(self):
+        """McpError raised by the middleware must surface as a JSON-RPC
+        protocol error on the client, not a tool-execution error.
+
+        Regression for https://github.com/PrefectHQ/fastmcp/issues/4126:
+        ``ErrorHandlingMiddleware(transform_errors=True)`` transforms an
+        unhandled exception into ``McpError(code=-32603, "Internal
+        error: ...")``. The MCP SDK's call_tool wrapper otherwise catches
+        every exception and converts it into ``CallToolResult(isError=True)``,
+        which is then surfaced to the client as a ``ToolError``.
+        """
+        mcp = FastMCP("test-exception-handling")
+        mcp.add_middleware(ErrorHandlingMiddleware(transform_errors=True))
+
+        @mcp.tool
+        def tool_that_raises_runtime_error() -> str:
+            raise RuntimeError("This is an unhandled exception")
+
+        async with Client(mcp) as client:
+            with pytest.raises(McpError) as exc_info:
+                await client.call_tool("tool_that_raises_runtime_error", {})
+
+        error = exc_info.value.error
+        assert error.code == -32603
+        assert "Internal error" in error.message
+
 
 class TestRetryMiddlewareIntegration:
     """Integration tests for retry middleware with real FastMCP server."""

--- a/tests/server/middleware/test_rate_limiting.py
+++ b/tests/server/middleware/test_rate_limiting.py
@@ -4,10 +4,10 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from mcp import McpError
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
-from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware.middleware import MiddlewareContext
 from fastmcp.server.middleware.rate_limiting import (
     RateLimitError,
@@ -349,7 +349,7 @@ class TestRateLimitingMiddlewareIntegration:
             for i in range(30):
                 try:
                     await client.call_tool("quick_action", {"message": str(i)})
-                except ToolError as exc:
+                except McpError as exc:
                     assert "Rate limit exceeded" in str(exc)
                     hit_limit = True
                     break
@@ -402,7 +402,7 @@ class TestRateLimitingMiddlewareIntegration:
             await client.call_tool("quick_action", {"message": "3"})
 
             # Fourth should be blocked
-            with pytest.raises(ToolError, match="Rate limit exceeded"):
+            with pytest.raises(McpError, match="Rate limit exceeded"):
                 await client.call_tool("quick_action", {"message": "4"})
 
     async def test_rate_limiting_with_different_operations(self, rate_limit_server):
@@ -417,7 +417,7 @@ class TestRateLimitingMiddlewareIntegration:
             await client.call_tool("heavy_computation")
 
             # Should be rate limited regardless of operation type
-            with pytest.raises(ToolError, match="Rate limit exceeded"):
+            with pytest.raises(McpError, match="Rate limit exceeded"):
                 await client.call_tool("batch_process", {"items": ["a", "b", "c"]})
 
     async def test_custom_client_identification(self, rate_limit_server):
@@ -440,7 +440,7 @@ class TestRateLimitingMiddlewareIntegration:
             await client.call_tool("quick_action", {"message": "first"})
 
             # Second should be rate limited for this specific client
-            with pytest.raises(ToolError) as exc_info:
+            with pytest.raises(McpError) as exc_info:
                 await client.call_tool("quick_action", {"message": "second"})
             assert "Rate limit exceeded for client: test_client_123" in str(
                 exc_info.value
@@ -460,7 +460,7 @@ class TestRateLimitingMiddlewareIntegration:
 
             middleware.global_limiter.tokens = 0
 
-            with pytest.raises(ToolError, match="Global rate limit exceeded"):
+            with pytest.raises(McpError, match="Global rate limit exceeded"):
                 await client.call_tool("quick_action", {"message": "blocked"})
 
     async def test_rate_limiting_recovery_over_time(self, rate_limit_server):
@@ -477,7 +477,7 @@ class TestRateLimitingMiddlewareIntegration:
             await client.call_tool("quick_action", {"message": "first"})
 
             # Should be rate limited immediately
-            with pytest.raises(ToolError):
+            with pytest.raises(McpError):
                 await client.call_tool("quick_action", {"message": "second"})
 
             # Wait for token bucket to refill (150ms should be enough for ~1.5 tokens)


### PR DESCRIPTION
## Description

Root cause: The MCP SDK's `call_tool` wrapper (in `mcp/server/lowlevel/server.py`) catches every exception except `UrlElicitationRequiredError` and converts it into a `CallToolResult(isError=True)` (a tool-execution error). FastMCP registers `_call_tool_mcp` via that wrapper, so an `McpError` raised by middleware - e.g., `ErrorHandlingMiddleware(transform_errors=True)` mapping a `RuntimeError` to `McpError(-32603 "Internal error")` - is swallowed by the SDK and emitted as `isError=True`.

Change: In `fastmcp_slim/fastmcp/server/mixins/mcp_operations.py`, added a ContextVar (`_pending_call_tool_mcp_error`) used as a side channel. `_call_tool_mcp` now catches `McpError`, stashes it into the ContextVar, and re-raises so the SDK still produces its expected `isError=True` result.

Closes #4126

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->
- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist
- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)