### PR TITLE
fix(docs): use valid FA icon on client-only package page

### DIFF
--- a/docs/clients/client-only-package.mdx
+++ b/docs/clients/client-only-package.mdx
@@ -1,7 +1,7 @@
 ---
 title: Client-Only Package
 description: Use FastMCP's client without installing the full server framework.
-icon: package
+icon: box
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'


### PR DESCRIPTION
Fixes the missing icon on the Client-Only Package sidebar entry by replacing `package` (not a valid Font Awesome icon) with `box`.