### PR TITLE
Support output_schema=False for transformed tools

### DIFF
--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -7,6 +7,7 @@ from typing import (
     Annotated,
     Any,
     ClassVar,
+    Literal,
     TypeAlias,
     overload,
 )
@@ -417,7 +418,7 @@ class Tool(FastMCPComponent):
         description: str | NotSetT | None = NotSet,
         tags: set[str] | None = None,
         annotations: ToolAnnotations | NotSetT | None = NotSet,
-        output_schema: dict[str, Any] | NotSetT | None = NotSet,
+        output_schema: dict[str, Any] | Literal[False] | NotSetT | None = NotSet,
         serializer: ToolResultSerializerType | None = None,  # Deprecated
         meta: dict[str, Any] | NotSetT | None = NotSet,
         transform_args: dict[str, ArgTransform] | None = None,

--- a/fastmcp_slim/fastmcp/tools/tool_transform.py
+++ b/fastmcp_slim/fastmcp/tools/tool_transform.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Literal, cast
 
 import pydantic_core
 from mcp.types import ToolAnnotations
-from pydantic import ConfigDict
+from pydantic import ConfigDict, PrivateAttr
 from pydantic.fields import Field
 from pydantic.functional_validators import BeforeValidator
 from pydantic.json_schema import SkipJsonSchema
@@ -266,6 +266,7 @@ class TransformedTool(Tool):
         Callable[..., Any]
     ]  # Always present, handles arg transformation
     transform_args: dict[str, ArgTransform]
+    _disable_structured_output: bool = PrivateAttr(default=False)
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
         """Run the tool with context set for forward() functions.
@@ -320,6 +321,19 @@ class TransformedTool(Tool):
                 result = await call_sync_fn_in_threadpool(self.fn, **arguments)
                 if inspect.isawaitable(result):
                     result = await result
+
+            if self._disable_structured_output:
+                if isinstance(result, ToolResult):
+                    return ToolResult(
+                        content=result.content,
+                        structured_content=None,
+                        meta=result.meta,
+                    )
+
+                return ToolResult(
+                    content=_convert_to_content(result, serializer=self.serializer),
+                    structured_content=None,
+                )
 
             # If transform function returns ToolResult, respect our output_schema setting
             if isinstance(result, ToolResult):
@@ -379,7 +393,7 @@ class TransformedTool(Tool):
         transform_fn: Callable[..., Any] | None = None,
         transform_args: dict[str, ArgTransform] | None = None,
         annotations: ToolAnnotations | NotSetT | None = NotSet,
-        output_schema: dict[str, Any] | NotSetT | None = NotSet,
+        output_schema: dict[str, Any] | Literal[False] | NotSetT | None = NotSet,
         serializer: Callable[[Any], str] | NotSetT | None = NotSet,  # Deprecated
         meta: dict[str, Any] | NotSetT | None = NotSet,
     ) -> TransformedTool:
@@ -400,8 +414,10 @@ class TransformedTool(Tool):
             tags: New tags. Defaults to parent's tags.
             annotations: New annotations. Defaults to parent's annotations.
             output_schema: Control output schema for structured outputs:
-                - None (default): Inherit from transform_fn if available, then parent tool
+                - NotSet (default): Inherit from transform_fn if available, then parent tool
                 - dict: Use custom output schema
+                - None: Remove output schema but still auto-detect structured content
+                - False: Disable output schema and strip structured content from results
             serializer: Deprecated. Return ToolResult from your tools for full control over serialization.
             meta: Control meta information:
                 - NotSet (default): Inherit from parent tool
@@ -443,8 +459,11 @@ class TransformedTool(Tool):
                 "properties": {"status": {"type": "string"}}
             })
 
-            # Disable structured outputs
+            # Remove output schema but keep automatic dict structured content
             Tool.from_tool(parent, output_schema=None)
+
+            # Disable structured outputs entirely
+            Tool.from_tool(parent, output_schema=False)
 
             # Return ToolResult for full control
             async def custom_output(**kwargs) -> ToolResult:
@@ -489,6 +508,7 @@ class TransformedTool(Tool):
         schema, forwarding_fn = cls._create_forwarding_transform(tool, transform_args)
 
         # Handle output schema
+        disable_structured_output = False
         if output_schema is NotSet:
             # Use smart fallback: try custom function, then parent
             if transform_fn is not None:
@@ -505,6 +525,9 @@ class TransformedTool(Tool):
                         final_output_schema = tool.output_schema
             else:
                 final_output_schema = tool.output_schema
+        elif output_schema is False:
+            final_output_schema = None
+            disable_structured_output = True
         else:
             final_output_schema = cast(dict | None, output_schema)
 
@@ -609,6 +632,7 @@ class TransformedTool(Tool):
             transform_args=transform_args,
             auth=tool.auth,
         )
+        transformed_tool._disable_structured_output = disable_structured_output
 
         return transformed_tool
 

--- a/tests/tools/tool_transform/test_schemas.py
+++ b/tests/tools/tool_transform/test_schemas.py
@@ -86,6 +86,62 @@ class TestTransformToolOutputSchema:
         assert isinstance(result.content[0], TextContent)
         assert result.content[0].text == "Result: 5"
 
+    async def test_transform_output_schema_false_disables_structured_content(
+        self, base_dict_tool
+    ):
+        """Test output_schema=False disables structured content for raw dict results."""
+        new_tool = Tool.from_tool(base_dict_tool, output_schema=False)
+
+        assert new_tool.output_schema is None
+
+        result = await new_tool.run({"x": 5})
+
+        assert result.structured_content is None
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == '{"value":5}'
+
+    async def test_transform_output_schema_false_strips_tool_result_structured_content(
+        self, base_string_tool
+    ):
+        """Test output_schema=False strips structured content from ToolResult returns."""
+
+        async def custom_fn(x: int) -> ToolResult:
+            return ToolResult(
+                content=[TextContent(type="text", text=f"Direct: {x}")],
+                structured_content={"direct_value": x},
+                meta={"trace": "kept"},
+            )
+
+        new_tool = Tool.from_tool(
+            base_string_tool, transform_fn=custom_fn, output_schema=False
+        )
+
+        assert new_tool.output_schema is None
+
+        result = await new_tool.run({"x": 5})
+
+        assert result.structured_content is None
+        assert result.meta == {"trace": "kept"}
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "Direct: 5"
+
+    async def test_transform_output_schema_false_vs_none(self, base_dict_tool):
+        """Test None keeps dict fallback structured content while False disables it."""
+        tool_explicit_none = Tool.from_tool(base_dict_tool, output_schema=None)
+        tool_explicit_false = Tool.from_tool(base_dict_tool, output_schema=False)
+
+        result_none = await tool_explicit_none.run({"x": 5})
+        result_false = await tool_explicit_false.run({"x": 5})
+
+        assert result_none.structured_content == {"value": 5}
+        assert result_false.structured_content is None
+
+    def test_transform_output_schema_false_mcp_tool(self, base_dict_tool):
+        """Test output_schema=False removes the MCP output schema."""
+        new_tool = Tool.from_tool(base_dict_tool, output_schema=False)
+
+        assert new_tool.to_mcp_tool().outputSchema is None
+
     def test_transform_with_explicit_output_schema_dict(self, base_string_tool):
         """Test that explicit output schema overrides parent."""
         custom_schema = {


### PR DESCRIPTION
## Summary
- allow `Tool.from_tool(..., output_schema=False)` for transformed tools
- keep `None` semantics as schema-less but still auto-detecting structured content
- add an internal flag that strips structured content when `False` is explicitly requested
- cover dict returns, `ToolResult` returns, `None` vs `False`, and MCP tool schema output

Fixes #3834

## Testing
- `uv run ruff check fastmcp_slim/fastmcp/tools/base.py fastmcp_slim/fastmcp/tools/tool_transform.py tests/tools/tool_transform/test_schemas.py`
- `git diff --check`

Could not run `uv run pytest tests/tools/tool_transform/test_schemas.py` locally because collection fails before tests execute with `ImportError: FastMCP server support is not installed. Install fastmcp or fastmcp-slim[server]`, caused by a circular import while loading `fastmcp.server.providers.local_provider.decorators.tools`. I also tried installing `fastmcp_slim[server]` locally, but collection still failed at the same import path.