### PR TITLE
fix(server): ignore missing event during eviction

### DIFF
--- a/fastmcp_slim/fastmcp/server/event_store.py
+++ b/fastmcp_slim/fastmcp/server/event_store.py
@@ -121,7 +121,14 @@ class EventStore(SDKEventStore):
         # Trim to max events (delete old events)
         if len(event_ids) > self._max_events_per_stream:
             for old_id in event_ids[: -self._max_events_per_stream]:
-                await self._event_store.delete(key=old_id)
+                try:
+                    await self._event_store.delete(key=old_id)
+                except FileNotFoundError:
+                    logger.debug(
+                        "Event %s was already evicted from stream %s",
+                        old_id,
+                        stream_id,
+                    )
             event_ids = event_ids[-self._max_events_per_stream :]
 
         await self._stream_store.put(

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -140,6 +140,23 @@ class TestEventStore:
         result = await event_store.replay_events_after(event_ids[3], callback)
         assert result == "stream-1"
 
+    async def test_missing_evicted_event_is_ignored(self, sample_message):
+        """Concurrent eviction can delete the same old event first."""
+        event_store = EventStore(max_events_per_stream=1, ttl=3600)
+        first_event_id = await event_store.store_event("stream-1", sample_message)
+
+        async def delete_raises_for_first_event(key: str):
+            if key == first_event_id:
+                raise FileNotFoundError("already deleted")
+
+        event_store._event_store.delete = delete_raises_for_first_event
+
+        second_event_id = await event_store.store_event("stream-1", sample_message)
+
+        stream_data = await event_store._stream_store.get(key="stream-1")
+        assert stream_data is not None
+        assert stream_data.event_ids == [second_event_id]
+
     async def test_multiple_streams_are_isolated(self, event_store):
         """Events from different streams should not interfere with each other."""
         msg1 = JSONRPCMessage(


### PR DESCRIPTION
## Summary
- treat missing event entries during stream eviction as already-evicted success
- keep the stream event list trimmed after the race
- add regression coverage for FileNotFoundError during eviction

Fixes #4143.

## Tests
- uv run pytest tests/server/test_event_store.py -q
- uv run ruff check fastmcp_slim/fastmcp/server/event_store.py tests/server/test_event_store.py
- git diff --check