### PR TITLE
fix(client): forward cancelled tool calls upstream

### DIFF
--- a/fastmcp_slim/fastmcp/client/mixins/tools.py
+++ b/fastmcp_slim/fastmcp/client/mixins/tools.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 import weakref
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+import anyio
 import mcp.types
 from opentelemetry.trace import Status, StatusCode
 from pydantic import RootModel
@@ -158,15 +161,25 @@ class ClientToolsMixin:
             # Inject trace context into meta for propagation to server
             propagated_meta = inject_trace_context(meta)
 
-            result = await self._await_with_session_monitoring(
-                self.session.call_tool(
-                    name=name,
-                    arguments=arguments,
-                    read_timeout_seconds=normalize_timeout_to_timedelta(timeout),
-                    progress_callback=progress_handler or self._progress_handler,
-                    meta=propagated_meta if propagated_meta else None,
+            request_id = getattr(self.session, "_request_id", None)
+            try:
+                result = await self._await_with_session_monitoring(
+                    self.session.call_tool(
+                        name=name,
+                        arguments=arguments,
+                        read_timeout_seconds=normalize_timeout_to_timedelta(timeout),
+                        progress_callback=progress_handler or self._progress_handler,
+                        meta=propagated_meta if propagated_meta else None,
+                    )
                 )
-            )
+            except asyncio.CancelledError:
+                if request_id is not None:
+                    with anyio.CancelScope(shield=True), suppress(Exception):
+                        await self.cancel(
+                            request_id,
+                            reason=f"Client cancelled tools/call request for {name}",
+                        )
+                raise
 
             # Reflect tool-level errors on the span so callers see ERROR
             # status even though the MCP protocol call itself succeeded.

--- a/tests/server/providers/proxy/test_stateful_proxy_client.py
+++ b/tests/server/providers/proxy/test_stateful_proxy_client.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 from dataclasses import dataclass
 
 import pytest
@@ -148,6 +149,36 @@ class TestStatefulProxyClient:
             result_b = await client.call_tool("b_tool_b", {})
             assert result_a.data == "a"
             assert result_b.data == "b"
+
+    async def test_stateful_proxy_forwards_tool_cancellation(self):
+        """Test proxy request cancellation is forwarded to the upstream tool."""
+        backend = FastMCP("backend")
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        @backend.tool
+        async def slow_task() -> None:
+            started.set()
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        proxy = FastMCPProxy(
+            client_factory=StatefulProxyClient(backend).new_stateful,
+            name="proxy",
+        )
+
+        async with Client(proxy) as client:
+            task = asyncio.create_task(client.call_tool("slow_task", {}))
+            await asyncio.wait_for(started.wait(), timeout=2)
+
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+            await asyncio.wait_for(cancelled.wait(), timeout=2)
 
     @pytest.mark.timeout(10)
     async def test_stateful_proxy_elicitation_over_http(self):


### PR DESCRIPTION
## Summary
- send MCP cancellation notifications when a client-side tool call await is cancelled
- preserve cancellation delivery under a shield so proxy cleanup does not swallow the upstream notification
- add a stateful proxy regression test that verifies the backend tool receives cancellation

Fixes #4124.

## Tests
- uv run pytest tests/server/providers/proxy/test_stateful_proxy_client.py -k cancellation -q
- uv run pytest tests/server/providers/proxy/test_stateful_proxy_client.py -q
- uv run ruff check fastmcp_slim/fastmcp/client/mixins/tools.py tests/server/providers/proxy/test_stateful_proxy_client.py
- git diff --check