### PR TITLE
fix(client): propagate tracing for list requests

### DIFF
--- a/fastmcp_slim/fastmcp/client/mixins/prompts.py
+++ b/fastmcp_slim/fastmcp/client/mixins/prompts.py
@@ -57,9 +57,24 @@ class ClientPromptsMixin:
         ):
             logger.debug(f"[{self.name}] called list_prompts")
 
-            result = await self._await_with_session_monitoring(
-                self.session.list_prompts(cursor=cursor)
-            )
+            propagated_meta = inject_trace_context()
+            if propagated_meta:
+                request = mcp.types.ListPromptsRequest(
+                    params=mcp.types.PaginatedRequestParams(
+                        cursor=cursor,
+                        _meta=propagated_meta,  # type: ignore[unknown-argument]  # pydantic alias  # ty:ignore[unknown-argument]
+                    )
+                )
+                result = await self._await_with_session_monitoring(
+                    self.session.send_request(
+                        request=request,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+                        result_type=mcp.types.ListPromptsResult,
+                    )
+                )
+            else:
+                result = await self._await_with_session_monitoring(
+                    self.session.list_prompts(cursor=cursor)
+                )
             return result
 
     async def list_prompts(

--- a/fastmcp_slim/fastmcp/client/mixins/resources.py
+++ b/fastmcp_slim/fastmcp/client/mixins/resources.py
@@ -56,9 +56,24 @@ class ClientResourcesMixin:
         ):
             logger.debug(f"[{self.name}] called list_resources")
 
-            result = await self._await_with_session_monitoring(
-                self.session.list_resources(cursor=cursor)
-            )
+            propagated_meta = inject_trace_context()
+            if propagated_meta:
+                request = mcp.types.ListResourcesRequest(
+                    params=mcp.types.PaginatedRequestParams(
+                        cursor=cursor,
+                        _meta=propagated_meta,  # type: ignore[unknown-argument]  # pydantic alias  # ty:ignore[unknown-argument]
+                    )
+                )
+                result = await self._await_with_session_monitoring(
+                    self.session.send_request(
+                        request=request,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+                        result_type=mcp.types.ListResourcesResult,
+                    )
+                )
+            else:
+                result = await self._await_with_session_monitoring(
+                    self.session.list_resources(cursor=cursor)
+                )
             return result
 
     async def list_resources(
@@ -132,9 +147,24 @@ class ClientResourcesMixin:
         ):
             logger.debug(f"[{self.name}] called list_resource_templates")
 
-            result = await self._await_with_session_monitoring(
-                self.session.list_resource_templates(cursor=cursor)
-            )
+            propagated_meta = inject_trace_context()
+            if propagated_meta:
+                request = mcp.types.ListResourceTemplatesRequest(
+                    params=mcp.types.PaginatedRequestParams(
+                        cursor=cursor,
+                        _meta=propagated_meta,  # type: ignore[unknown-argument]  # pydantic alias  # ty:ignore[unknown-argument]
+                    )
+                )
+                result = await self._await_with_session_monitoring(
+                    self.session.send_request(
+                        request=request,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+                        result_type=mcp.types.ListResourceTemplatesResult,
+                    )
+                )
+            else:
+                result = await self._await_with_session_monitoring(
+                    self.session.list_resource_templates(cursor=cursor)
+                )
             return result
 
     async def list_resource_templates(

--- a/fastmcp_slim/fastmcp/client/mixins/tools.py
+++ b/fastmcp_slim/fastmcp/client/mixins/tools.py
@@ -61,9 +61,24 @@ class ClientToolsMixin:
         ):
             logger.debug(f"[{self.name}] called list_tools")
 
-            result = await self._await_with_session_monitoring(
-                self.session.list_tools(cursor=cursor)
-            )
+            propagated_meta = inject_trace_context()
+            if propagated_meta:
+                request = mcp.types.ListToolsRequest(
+                    params=mcp.types.PaginatedRequestParams(
+                        cursor=cursor,
+                        _meta=propagated_meta,  # type: ignore[unknown-argument]  # pydantic alias  # ty:ignore[unknown-argument]
+                    )
+                )
+                result = await self._await_with_session_monitoring(
+                    self.session.send_request(
+                        request=request,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+                        result_type=mcp.types.ListToolsResult,
+                    )
+                )
+            else:
+                result = await self._await_with_session_monitoring(
+                    self.session.list_tools(cursor=cursor)
+                )
             return result
 
     async def list_tools(

--- a/tests/client/telemetry/test_client_list_tracing.py
+++ b/tests/client/telemetry/test_client_list_tracing.py
@@ -8,6 +8,35 @@ from opentelemetry.trace import SpanKind
 from fastmcp import Client, FastMCP
 
 
+def assert_trace_context_propagated(spans, span_name: str) -> None:
+    client_span = next(
+        (
+            s
+            for s in spans
+            if s.name == span_name
+            and s.attributes is not None
+            and "fastmcp.server.name" not in s.attributes
+        ),
+        None,
+    )
+    server_span = next(
+        (
+            s
+            for s in spans
+            if s.name == span_name
+            and s.attributes is not None
+            and "fastmcp.server.name" in s.attributes
+        ),
+        None,
+    )
+
+    assert client_span is not None, "Client span should exist"
+    assert server_span is not None, "Server span should exist"
+    assert server_span.context.trace_id == client_span.context.trace_id
+    assert server_span.parent is not None
+    assert server_span.parent.span_id == client_span.context.span_id
+
+
 class TestClientListToolsTracing:
     """Tests for client tools/list tracing."""
 
@@ -80,6 +109,23 @@ class TestClientListToolsTracing:
         assert client_span.kind == SpanKind.CLIENT
         assert server_span.kind == SpanKind.SERVER
 
+    async def test_list_tools_propagates_trace_context(
+        self, trace_exporter: InMemorySpanExporter
+    ):
+        server = FastMCP("test-server")
+
+        @server.tool()
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        client = Client(server)
+        async with client:
+            await client.list_tools()
+
+        assert_trace_context_propagated(
+            trace_exporter.get_finished_spans(), "tools/list"
+        )
+
 
 class TestClientListResourcesTracing:
     """Tests for client resources/list tracing."""
@@ -112,6 +158,23 @@ class TestClientListResourcesTracing:
         assert span.kind == SpanKind.CLIENT
         assert span.attributes is not None
         assert span.attributes["mcp.method.name"] == "resources/list"
+
+    async def test_list_resources_propagates_trace_context(
+        self, trace_exporter: InMemorySpanExporter
+    ):
+        server = FastMCP("test-server")
+
+        @server.resource("data://config")
+        def get_config() -> str:
+            return "config"
+
+        client = Client(server)
+        async with client:
+            await client.list_resources()
+
+        assert_trace_context_propagated(
+            trace_exporter.get_finished_spans(), "resources/list"
+        )
 
 
 class TestClientListResourceTemplatesTracing:
@@ -146,6 +209,23 @@ class TestClientListResourceTemplatesTracing:
         assert span.attributes is not None
         assert span.attributes["mcp.method.name"] == "resources/templates/list"
 
+    async def test_list_resource_templates_propagates_trace_context(
+        self, trace_exporter: InMemorySpanExporter
+    ):
+        server = FastMCP("test-server")
+
+        @server.resource("users://{user_id}/profile")
+        def get_profile(user_id: str) -> str:
+            return f"profile {user_id}"
+
+        client = Client(server)
+        async with client:
+            await client.list_resource_templates()
+
+        assert_trace_context_propagated(
+            trace_exporter.get_finished_spans(), "resources/templates/list"
+        )
+
 
 class TestClientListPromptsTracing:
     """Tests for client prompts/list tracing."""
@@ -178,3 +258,20 @@ class TestClientListPromptsTracing:
         assert span.kind == SpanKind.CLIENT
         assert span.attributes is not None
         assert span.attributes["mcp.method.name"] == "prompts/list"
+
+    async def test_list_prompts_propagates_trace_context(
+        self, trace_exporter: InMemorySpanExporter
+    ):
+        server = FastMCP("test-server")
+
+        @server.prompt()
+        def greeting() -> str:
+            return "Hello!"
+
+        client = Client(server)
+        async with client:
+            await client.list_prompts()
+
+        assert_trace_context_propagated(
+            trace_exporter.get_finished_spans(), "prompts/list"
+        )


### PR DESCRIPTION
## Summary
- inject OpenTelemetry trace context into MCP _meta for tools/list, resources/list, resources/templates/list, and prompts/list
- keep the existing SDK list helpers when no trace context is active
- add regression assertions that server list spans are children of the matching client spans

Fixes #3998.

Note: this intentionally does not reimplement initialize tracing; the issue discussion calls that out as broader SDK/API work.

## Tests
- uv run pytest tests/client/telemetry/test_client_list_tracing.py -q
- uv run pytest tests/client/telemetry/test_client_tracing.py tests/client/telemetry/test_client_list_tracing.py -q
- uv run ruff check fastmcp_slim/fastmcp/client/mixins/tools.py fastmcp_slim/fastmcp/client/mixins/resources.py fastmcp_slim/fastmcp/client/mixins/prompts.py tests/client/telemetry/test_client_list_tracing.py
- git diff --check