### PR TITLE
fix(server): wrap tool argument validation errors

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -55,6 +55,7 @@ from fastmcp.exceptions import (
     PromptError,
     ResourceError,
     ToolError,
+    ValidationError,
 )
 from fastmcp.mcp_config import MCPConfig
 from fastmcp.prompts import Prompt
@@ -1284,7 +1285,7 @@ class FastMCP(
                         name,
                         e.errors(include_url=False),
                     )
-                    raise
+                    raise ValidationError(str(e)) from e
                 except Exception as e:
                     logger.exception(f"Error calling tool {name!r}")
                     # Handle actionable errors that should reach the LLM

--- a/tests/apps/test_form.py
+++ b/tests/apps/test_form.py
@@ -11,6 +11,7 @@ from fastmcp.apps.form import (
     FormInput,
     _backfill_boolean_defaults,
 )
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.providers.addressing import hashed_backend_name
 
 
@@ -126,7 +127,7 @@ class TestFormInputProvider:
         # Should reach model validation (not crash with "missing required argument"
         # for the data parameter itself). Pydantic will still reject missing
         # required fields like title/content, but that's expected.
-        with pytest.raises(pydantic.ValidationError, match="title"):
+        with pytest.raises(FastMCPValidationError, match="title"):
             await server.call_tool(hashed_backend_name("NoteForm", "submit_form"), {})
 
     async def test_multiple_models(self):

--- a/tests/server/middleware/test_error_handling.py
+++ b/tests/server/middleware/test_error_handling.py
@@ -1,14 +1,17 @@
 """Tests for error handling middleware."""
 
 import logging
+from typing import Annotated
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from mcp import McpError
+from pydantic import Field
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.exceptions import NotFoundError, ToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.middleware.error_handling import (
     ErrorHandlingMiddleware,
     RetryMiddleware,
@@ -565,6 +568,35 @@ class TestErrorHandlingMiddlewareIntegration:
 
         # Error should still exist (may be wrapped by FastMCP)
         assert exc_info.value is not None
+
+    async def test_tool_argument_validation_raises_fastmcp_validation_error(self):
+        """Pydantic argument errors are normalized before middleware observes them."""
+        captured_errors: list[Exception] = []
+        server = FastMCP("ValidationErrorTest")
+
+        def error_callback(error, context):
+            captured_errors.append(error)
+
+        server.add_middleware(
+            ErrorHandlingMiddleware(
+                error_callback=error_callback,
+                transform_errors=False,
+            )
+        )
+
+        @server.tool
+        def bounded(value: Annotated[int, Field(le=10)]) -> int:
+            return value
+
+        async with Client(server) as client:
+            with pytest.raises(Exception):
+                await client.call_tool("bounded", {"value": 11})
+
+        assert len(captured_errors) == 1
+        error = captured_errors[0]
+        assert isinstance(error, FastMCPValidationError)
+        assert isinstance(error.__cause__, Exception)
+        assert "less than or equal to 10" in str(error)
 
 
 class TestRetryMiddlewareIntegration:

--- a/tests/server/providers/local_provider_tools/test_parameters.py
+++ b/tests/server/providers/local_provider_tools/test_parameters.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.utilities.types import Image
 
 
@@ -109,8 +110,6 @@ class TestToolParameters:
         assert result.content[0].data == base64.b64encode(b"fake png data").decode()
 
     async def test_tool_with_invalid_input(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
@@ -118,7 +117,7 @@ class TestToolParameters:
             return x + 1
 
         with pytest.raises(
-            ValidationError,
+            FastMCPValidationError,
             match="Input should be a valid integer",
         ):
             await mcp.call_tool("my_tool", {"x": "not an int"})
@@ -149,8 +148,6 @@ class TestToolParameters:
         assert result.structured_content == {"result": True}
 
     async def test_annotated_field_validation(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
@@ -158,14 +155,12 @@ class TestToolParameters:
             pass
 
         with pytest.raises(
-            ValidationError,
+            FastMCPValidationError,
             match="Input should be greater than or equal to 1",
         ):
             await mcp.call_tool("analyze", {"x": 0})
 
     async def test_default_field_validation(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
@@ -173,26 +168,22 @@ class TestToolParameters:
             pass
 
         with pytest.raises(
-            ValidationError,
+            FastMCPValidationError,
             match="Input should be greater than or equal to 1",
         ):
             await mcp.call_tool("analyze", {"x": 0})
 
     async def test_default_field_is_still_required_if_no_default_specified(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
         def analyze(x: int = Field()) -> None:
             pass
 
-        with pytest.raises(ValidationError, match="missing"):
+        with pytest.raises(FastMCPValidationError, match="missing"):
             await mcp.call_tool("analyze", {})
 
     async def test_literal_type_validation_error(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
@@ -200,7 +191,7 @@ class TestToolParameters:
             pass
 
         with pytest.raises(
-            ValidationError,
+            FastMCPValidationError,
             match="Input should be 'a' or 'b'",
         ):
             await mcp.call_tool("analyze", {"x": "c"})
@@ -216,8 +207,6 @@ class TestToolParameters:
         assert result.structured_content == {"result": "a"}
 
     async def test_enum_type_validation_error(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         class MyEnum(Enum):
@@ -230,7 +219,7 @@ class TestToolParameters:
             return x.value
 
         with pytest.raises(
-            ValidationError,
+            FastMCPValidationError,
             match="Input should be 'red', 'green' or 'blue'",
         ):
             await mcp.call_tool("analyze", {"x": "some-color"})
@@ -251,8 +240,6 @@ class TestToolParameters:
         assert result.structured_content == {"result": "red"}
 
     async def test_union_type_validation(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
@@ -266,7 +253,7 @@ class TestToolParameters:
         assert result.structured_content == {"result": "1.0"}
 
         with pytest.raises(
-            ValidationError,
+            FastMCPValidationError,
             match="Input should be a valid",
         ):
             await mcp.call_tool("analyze", {"x": "not a number"})
@@ -285,15 +272,15 @@ class TestToolParameters:
         assert result.structured_content == {"result": str(test_path)}
 
     async def test_path_type_error(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
         def send_path(path: Path) -> str:
             return str(path)
 
-        with pytest.raises(ValidationError, match="Input is not a valid path"):
+        with pytest.raises(
+            FastMCPValidationError, match="Input is not a valid path"
+        ):
             await mcp.call_tool("send_path", {"path": 1})
 
     async def test_uuid_type(self):
@@ -310,15 +297,15 @@ class TestToolParameters:
         assert result.structured_content == {"result": str(test_uuid)}
 
     async def test_uuid_type_error(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
         def send_uuid(x: uuid.UUID) -> str:
             return str(x)
 
-        with pytest.raises(ValidationError, match="Input should be a valid UUID"):
+        with pytest.raises(
+            FastMCPValidationError, match="Input should be a valid UUID"
+        ):
             await mcp.call_tool("send_uuid", {"x": "not a uuid"})
 
     async def test_datetime_type(self):
@@ -344,15 +331,15 @@ class TestToolParameters:
         assert result.structured_content == {"result": "2021-01-01T00:00:00"}
 
     async def test_datetime_type_error(self):
-        from pydantic import ValidationError
-
         mcp = FastMCP()
 
         @mcp.tool
         def send_datetime(x: datetime.datetime) -> str:
             return x.isoformat()
 
-        with pytest.raises(ValidationError, match="Input should be a valid datetime"):
+        with pytest.raises(
+            FastMCPValidationError, match="Input should be a valid datetime"
+        ):
             await mcp.call_tool("send_datetime", {"x": "not a datetime"})
 
     async def test_date_type(self):

--- a/tests/server/providers/local_provider_tools/test_parameters.py
+++ b/tests/server/providers/local_provider_tools/test_parameters.py
@@ -278,9 +278,7 @@ class TestToolParameters:
         def send_path(path: Path) -> str:
             return str(path)
 
-        with pytest.raises(
-            FastMCPValidationError, match="Input is not a valid path"
-        ):
+        with pytest.raises(FastMCPValidationError, match="Input is not a valid path"):
             await mcp.call_tool("send_path", {"path": 1})
 
     async def test_uuid_type(self):

--- a/tests/server/test_dependencies.py
+++ b/tests/server/test_dependencies.py
@@ -9,6 +9,7 @@ from mcp.types import TextContent, TextResourceContents
 from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.dependencies import CurrentContext, Depends, Shared
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.context import Context
 
 HUZZAH = "huzzah!"
@@ -451,9 +452,7 @@ async def test_argument_validation_with_dependencies(mcp: FastMCP):
     assert result.structured_content["result"] == "age=25"
 
     # Invalid argument type should fail validation
-    import pydantic
-
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(FastMCPValidationError):
         await mcp.call_tool("validated_tool", {"age": "not a number"})
 
 
@@ -599,9 +598,7 @@ async def test_external_user_cannot_override_dependency(mcp: FastMCP):
     assert "admin=not_admin" in result.structured_content["result"]
 
     # Try to override dependency - rejected (not in schema)
-    import pydantic
-
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(FastMCPValidationError):
         await mcp.call_tool("check_permission", {"action": "read", "admin": "hacker"})
 
 


### PR DESCRIPTION
## Summary
- wrap Pydantic tool argument validation failures as FastMCP ValidationError before middleware sees them
- add middleware integration coverage for invalid tool arguments
- update direct call_tool parameter validation tests to expect FastMCP ValidationError

Fixes #4128

## Tests
- git diff --check
- uv run ruff check fastmcp_slim/fastmcp/server/server.py tests/server/middleware/test_error_handling.py tests/server/providers/local_provider_tools/test_parameters.py
- uv run pytest tests/server/middleware/test_error_handling.py tests/client/client/test_error_handling.py tests/server/providers/local_provider_tools/test_parameters.py -q