### PR TITLE
fix(server): avoid eager imports from server package

### DIFF
--- a/fastmcp_slim/fastmcp/server/__init__.py
+++ b/fastmcp_slim/fastmcp/server/__init__.py
@@ -2,14 +2,20 @@ import importlib
 
 from fastmcp import _install_hints
 
-try:
-    from .context import Context
-    from .server import FastMCP, create_proxy
-except ImportError as exc:
-    raise ImportError(_install_hints.SERVER_SUPPORT) from exc
-
 
 def __getattr__(name: str) -> object:
+    if name == "Context":
+        try:
+            from .context import Context
+        except ImportError as exc:
+            raise ImportError(_install_hints.SERVER_SUPPORT) from exc
+        return Context
+    if name in {"FastMCP", "create_proxy"}:
+        try:
+            from .server import FastMCP, create_proxy
+        except ImportError as exc:
+            raise ImportError(_install_hints.SERVER_SUPPORT) from exc
+        return {"FastMCP": FastMCP, "create_proxy": create_proxy}[name]
     if name == "dependencies":
         return importlib.import_module("fastmcp.server.dependencies")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/tools/test_imports.py
+++ b/tests/tools/test_imports.py
@@ -1,0 +1,8 @@
+"""Import regression tests for tools."""
+
+
+def test_fastmcp_tools_imports_without_server_cycle():
+    from fastmcp.tools import FunctionTool, tool
+
+    assert FunctionTool.__name__ == "FunctionTool"
+    assert callable(tool)


### PR DESCRIPTION
## Summary
- make `fastmcp.server` exports lazy so importing nested server modules does not eagerly load the full server stack
- fix the circular import triggered by `from fastmcp.tools import tool`
- add a regression test for importing `fastmcp.tools`

Fixes #4147

## Tests
- uv run python -c "from fastmcp.tools import tool, FunctionTool; print(tool.__name__, FunctionTool.__name__)"
- uv run python -c "from fastmcp.server import FastMCP, Context, create_proxy; print(FastMCP.__name__, Context.__name__, callable(create_proxy))"
- uv run pytest tests/tools/test_imports.py tests/deprecated/test_import_server.py tests/tools/test_standalone_decorator.py -q
- uv run pytest tests/tools tests/server/test_app_state.py tests/server/http/test_http_middleware.py tests/server/auth/test_static_token_verifier.py -q
- uv run ruff check fastmcp_slim/fastmcp/server/__init__.py tests/tools/test_imports.py
- git diff --check