### PR TITLE
fix(server): make fastmcp.server top-level imports lazy (#4147)

### DIFF
--- a/fastmcp_slim/fastmcp/server/__init__.py
+++ b/fastmcp_slim/fastmcp/server/__init__.py
@@ -1,15 +1,39 @@
 import importlib
+from typing import TYPE_CHECKING
 
 from fastmcp import _install_hints
 
-try:
-    from .context import Context
-    from .server import FastMCP, create_proxy
-except ImportError as exc:
-    raise ImportError(_install_hints.SERVER_SUPPORT) from exc
+if TYPE_CHECKING:
+    from .context import Context as Context
+    from .server import FastMCP as FastMCP
+    from .server import create_proxy as create_proxy
 
 
+# --- Lazy imports to avoid circular imports (see #4147) ---
+# Eagerly importing Context/FastMCP at package init time pulls in the full
+# server import chain, which can re-enter partially-initialized modules
+# (e.g. fastmcp.tools.function_tool) and raise a misleading ImportError.
+# Defer these to __getattr__ so submodule imports like
+# `fastmcp.server.tasks.config` don't trigger the heavy import chain.
 def __getattr__(name: str) -> object:
+    if name == "Context":
+        try:
+            from .context import Context
+        except ImportError as exc:
+            raise ImportError(_install_hints.SERVER_SUPPORT) from exc
+        return Context
+    if name == "FastMCP":
+        try:
+            from .server import FastMCP
+        except ImportError as exc:
+            raise ImportError(_install_hints.SERVER_SUPPORT) from exc
+        return FastMCP
+    if name == "create_proxy":
+        try:
+            from .server import create_proxy
+        except ImportError as exc:
+            raise ImportError(_install_hints.SERVER_SUPPORT) from exc
+        return create_proxy
     if name == "dependencies":
         return importlib.import_module("fastmcp.server.dependencies")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/tools/test_import_no_circular.py
+++ b/tests/tools/test_import_no_circular.py
@@ -1,0 +1,59 @@
+"""Regression test for #4147: circular import in fastmcp.tools.
+
+Importing :mod:`fastmcp.tools` (or its submodules) must not trigger the
+heavy ``fastmcp.server`` import chain. The chain previously re-entered
+partially-initialized ``fastmcp.tools.function_tool`` and raised a
+misleading ``ImportError`` claiming server support wasn't installed, on
+fresh installs of fastmcp 3.3.0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_import(stmt: str) -> subprocess.CompletedProcess[str]:
+    """Run ``stmt`` in a fresh interpreter and return the completed process.
+
+    A fresh subprocess is required because Python caches modules in
+    ``sys.modules`` once an import succeeds; the regression only
+    reproduces from a clean module cache.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", stmt],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_fastmcp_tools_does_not_circular() -> None:
+    """``from fastmcp.tools import tool`` must not raise."""
+    result = _run_import("from fastmcp.tools import tool")
+    assert result.returncode == 0, (
+        f"Import failed (#4147 regression):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_import_function_tool_does_not_circular() -> None:
+    """``from fastmcp.tools.function_tool import FunctionTool`` must not raise."""
+    result = _run_import("from fastmcp.tools.function_tool import FunctionTool")
+    assert result.returncode == 0, (
+        f"Import failed (#4147 regression):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_import_server_submodule_does_not_circular() -> None:
+    """Importing a server submodule must not trigger the full server chain.
+
+    ``from fastmcp.server.tasks.config import TaskConfig`` previously
+    triggered ``fastmcp.server.__init__`` which eagerly imported the
+    heavy ``Context``/``FastMCP`` chain.
+    """
+    result = _run_import("from fastmcp.server.tasks.config import TaskConfig")
+    assert result.returncode == 0, (
+        f"Import failed (#4147 regression):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
Fixes #4147

## Problem

A fresh `pip install fastmcp==3.3.0` raises `ImportError` on any import that touches `fastmcp.tools`:

```
$ python -c "from fastmcp.tools import tool"
ImportError: cannot import name 'FunctionTool' from partially initialized module
'fastmcp.tools.function_tool' (most likely due to a circular import)
ImportError: FastMCP server support is not installed.
Install `fastmcp` or `fastmcp-slim[server]`.
```

## Root cause

`fastmcp/server/__init__.py` eagerly imports `Context` and `FastMCP` at package init time. When unrelated code does `from fastmcp.server.auth.authorization import AuthCheck` (or any other `fastmcp.server.*` submodule), Python first runs the `__init__.py`, which transitively pulls in:

```
fastmcp.server.__init__
  -> fastmcp.server.context
    -> fastmcp.server.low_level
      -> fastmcp.apps.config
        -> fastmcp.apps.app
          -> fastmcp.server.providers.filesystem
            -> fastmcp.server.providers.local_provider
              -> ...decorators.tools
                -> fastmcp.tools.function_tool   # ← still being initialized
```

The re-entry into the partially-initialized `fastmcp.tools.function_tool` raises `ImportError`, which the eager `try/except` in `server/__init__.py` then re-wraps as a misleading "server support not installed" message.

## Fix

Mirror the lazy `__getattr__` pattern that `fastmcp/__init__.py` itself already uses (see #3292). `Context`, `FastMCP`, and `create_proxy` are now resolved on attribute access instead of at package init time, so submodule imports like `fastmcp.server.tasks.config` no longer trigger the heavy import chain.

`__all__`, the `dependencies` shortcut, and the `ImportError(_install_hints.SERVER_SUPPORT)` wrapping are all preserved. The `TYPE_CHECKING` block keeps the names visible to static analyzers.

## Tests

Added `tests/tools/test_import_no_circular.py` with three subprocess-based regression tests (subprocess is required because `sys.modules` caching hides the regression after first successful import in the same interpreter):

- `test_import_fastmcp_tools_does_not_circular` — `from fastmcp.tools import tool`
- `test_import_function_tool_does_not_circular` — `from fastmcp.tools.function_tool import FunctionTool`
- `test_import_server_submodule_does_not_circular` — `from fastmcp.server.tasks.config import TaskConfig`

All three fail on `main` and pass with this fix.

## Verification

- Reproduced the bug in a fresh venv with `fastmcp==3.3.0` ✅
- Verified the fix resolves `from fastmcp.tools import tool` ✅
- All existing `tests/tools/` tests pass (314 passed, 1 skipped) ✅
- All public exports (`Context`, `FastMCP`, `create_proxy`) work via direct attribute access, `from` imports, and one-statement imports ✅
- All submodule imports (`tasks.config`, `auth.authorization`, `dependencies`, `context`, `server`) work ✅
- End-to-end functional test (FastMCP server + `@server.tool` + tool invocation) passes ✅
- `ty check` passes on the modified file ✅