### PR TITLE
fix: propagate asyncio task cancellation to Monty sandbox thread

### DIFF
--- a/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
+++ b/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import json
 from collections.abc import Awaitable, Callable, Sequence
@@ -131,11 +132,16 @@ class MontySandboxProvider:
         }
 
         monty = pydantic_monty.Monty(code, inputs=list(inputs))
-        return await monty.run_async(
+        fut = monty.run_async(
             inputs=inputs or None,
             external_functions=async_functions or None,
             limits=self.limits,
         )
+        try:
+            return await fut
+        except asyncio.CancelledError:
+            fut.cancel()
+            raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When an asyncio task awaiting `MontySandboxProvider.run()` is cancelled, the underlying Monty future is not cancelled. The sandbox's native thread keeps running until the process exits.

## Root cause

`monty.run_async()` returns a `Future` backed by a native thread. When the awaiting asyncio task is cancelled, Python raises `CancelledError` at the `await` — but `fut.cancel()` is never called, so the native thread continues running.

## Fix

Wrap the `monty.run_async()` future in a `try/except CancelledError` block that calls `fut.cancel()` before re-raising.

## Reproduction

Connect a FastMCP `Client` over HTTP to a server with `CodeMode`, call `execute` with a long-running script, then cancel the asyncio task. OS thread count and CPU remain elevated after cancel.

Note: this does **not** reproduce with in-process transport, where the asyncio cancellation chain is direct and `fut.cancel()` happens to be called. It only surfaces when there's a real async task boundary (HTTP transport, uvicorn).

## Impact

Each cancelled or timed-out `execute` request leaks a native thread running at full CPU.

Fixes #4159