### PR TITLE
fix(config): read MCP config files as UTF-8

### DIFF
--- a/fastmcp_slim/fastmcp/mcp_config.py
+++ b/fastmcp_slim/fastmcp/mcp_config.py
@@ -332,12 +332,14 @@ class MCPConfig(BaseModel):
     def write_to_file(self, file_path: Path) -> None:
         """Write configuration to JSON file."""
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(self.model_dump_json(indent=2))
+        file_path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
 
     @classmethod
     def from_file(cls, file_path: Path) -> Self:
         """Load configuration from JSON file."""
-        if file_path.exists() and (content := file_path.read_text().strip()):
+        if file_path.exists() and (
+            content := file_path.read_text(encoding="utf-8").strip()
+        ):
             return cls.model_validate_json(content)  # ty: ignore[possibly-unresolved-reference]
 
         raise ValueError(f"No MCP servers defined in the config: {file_path}")

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1,6 +1,7 @@
 import asyncio
 import gc
 import inspect
+import json
 import logging
 import os
 import sys
@@ -128,6 +129,58 @@ def test_parse_extra_keys():
     assert (
         serialized_mcp_config["mcpServers"]["test_server"]["leaf_extra"] == "leaf_extra"
     )
+
+
+def test_mcp_config_file_io_uses_utf8(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP config files must be read and written as UTF-8.
+
+    On Windows, Path.read_text()/write_text() default to a locale encoding such
+    as cp1252. This simulates that failure mode so Unicode config values keep
+    working on every platform.
+    """
+    config_path = tmp_path / "mcp.json"
+    raw_config = {
+        "mcpServers": {
+            "emoji_server": {
+                "command": "python",
+                "args": ["serve_✅.py"],
+                "description": "Handles café data ✅",
+            }
+        }
+    }
+    config_path.write_text(json.dumps(raw_config, ensure_ascii=False), encoding="utf-8")
+
+    original_read_text = Path.read_text
+    original_write_text = Path.write_text
+
+    def strict_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+        if kwargs.get("encoding") != "utf-8":
+            raise UnicodeDecodeError(
+                "charmap", b"\x9d", 0, 1, "simulated cp1252 default"
+            )
+        return original_read_text(self, *args, **kwargs)
+
+    def strict_write_text(self: Path, data: str, *args: Any, **kwargs: Any) -> int:
+        if kwargs.get("encoding") != "utf-8":
+            raise UnicodeEncodeError("charmap", "✅", 0, 1, "simulated cp1252 default")
+        return original_write_text(self, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", strict_read_text)
+    monkeypatch.setattr(Path, "write_text", strict_write_text)
+
+    config = MCPConfig.from_file(config_path)
+    server = config.mcpServers["emoji_server"]
+    assert isinstance(server, StdioMCPServer)
+    assert server.args == ["serve_✅.py"]
+    assert server.description == "Handles café data ✅"
+
+    output_path = tmp_path / "written" / "mcp.json"
+    config.write_to_file(output_path)
+    output = original_read_text(output_path, encoding="utf-8")
+    assert "serve_✅.py" in output
+    assert "Handles café data ✅" in output
 
 
 def test_parse_mcpservers_at_root():


### PR DESCRIPTION
## Description

`MCPConfig.from_file()` and `MCPConfig.write_to_file()` now pass `encoding="utf-8"` when reading and writing JSON config files.

This fixes a self-evident file IO bug: MCP config values can contain Unicode in server names, descriptions, arguments, or paths, while `Path.read_text()` and `Path.write_text()` use the platform locale by default. On Windows that can decode or encode with cp1252 instead of UTF-8. This is the same class of issue as #4084, but in MCP config file IO rather than skill files.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

Focused checks run:

- `uv run pytest tests/test_mcp_config.py::test_mcp_config_file_io_uses_utf8 -q`
- `uv run pytest tests/cli/test_run.py::TestMCPConfig::test_run_mcp_config -q`
- `uv run ruff check fastmcp_slim/fastmcp/mcp_config.py tests/test_mcp_config.py`
- `uv run ruff format --check fastmcp_slim/fastmcp/mcp_config.py tests/test_mcp_config.py`
- `git diff --check`
