### PR TITLE
fix(code-mode): cancel Monty sandbox future on task cancellation

### DIFF
--- a/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
+++ b/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
@@ -133,10 +133,10 @@ class MontySandboxProvider:
 
         monty = pydantic_monty.Monty(code, inputs=list(inputs))
         future = asyncio.ensure_future(
-            monty.run_async(
+            self._run_monty(
+                monty,
                 inputs=inputs or None,
                 external_functions=async_functions or None,
-                limits=self.limits,
             )
         )
         try:
@@ -148,6 +148,24 @@ class MontySandboxProvider:
             # thread down instead of leaving it running to completion.
             future.cancel()
             raise
+
+    def _run_monty(
+        self,
+        monty: Any,
+        *,
+        inputs: dict[str, Any] | None,
+        external_functions: dict[str, Callable[..., Any]] | None,
+    ) -> Any:
+        """Launch the sandbox and return its awaitable.
+
+        Isolated so the cancellation handling in `run()` can be exercised
+        without a live `pydantic-monty` runtime.
+        """
+        return monty.run_async(
+            inputs=inputs,
+            external_functions=external_functions,
+            limits=self.limits,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
+++ b/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import json
 from collections.abc import Awaitable, Callable, Sequence
@@ -131,11 +132,22 @@ class MontySandboxProvider:
         }
 
         monty = pydantic_monty.Monty(code, inputs=list(inputs))
-        return await monty.run_async(
-            inputs=inputs or None,
-            external_functions=async_functions or None,
-            limits=self.limits,
+        future = asyncio.ensure_future(
+            monty.run_async(
+                inputs=inputs or None,
+                external_functions=async_functions or None,
+                limits=self.limits,
+            )
         )
+        try:
+            return await future
+        except asyncio.CancelledError:
+            # Awaiting alone does not stop the native sandbox thread when the
+            # surrounding task is cancelled (e.g. an HTTP client disconnects
+            # mid-execution). Explicitly cancel so the Monty runtime tears the
+            # thread down instead of leaving it running to completion.
+            future.cancel()
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/experimental/transforms/test_code_mode.py
+++ b/tests/experimental/transforms/test_code_mode.py
@@ -717,34 +717,27 @@ async def test_monty_provider_no_limits_by_default() -> None:
     assert result == 3
 
 
-async def test_monty_provider_cancels_future_when_task_cancelled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Cancelling the awaiting task must cancel the underlying Monty future.
+async def test_monty_provider_cancels_future_when_task_cancelled() -> None:
+    """Cancelling the awaiting task must cancel the underlying sandbox future.
 
-    Otherwise the native sandbox thread keeps running to completion after a
-    client disconnects or the request times out.
+    Otherwise the native Monty thread keeps running to completion after a
+    client disconnects or the request times out. A subclass overrides the
+    launch seam so the cancellation handling in `run()` is exercised against
+    a controllable future rather than a live sandbox thread.
     """
     import asyncio
-
-    import pydantic_monty
 
     loop = asyncio.get_running_loop()
     sandbox_future: asyncio.Future[Any] = loop.create_future()
 
-    class _FakeMonty:
-        def __init__(self, code: str, inputs: Any) -> None:
-            pass
-
-        def run_async(self, **kwargs: Any) -> asyncio.Future[Any]:
+    class _NeverFinishingProvider(MontySandboxProvider):
+        def _run_monty(self, monty: Any, *, inputs: Any, external_functions: Any):
             return sandbox_future
 
-    monkeypatch.setattr(pydantic_monty, "Monty", _FakeMonty)
-
-    provider = MontySandboxProvider()
+    provider = _NeverFinishingProvider()
     task = asyncio.create_task(provider.run("return 1"))
 
-    # Let the task advance to `await future` (no suspension before it).
+    # Advance the task to `await future` (no suspension point before it).
     for _ in range(3):
         await asyncio.sleep(0)
         if not task.done():

--- a/tests/experimental/transforms/test_code_mode.py
+++ b/tests/experimental/transforms/test_code_mode.py
@@ -715,3 +715,43 @@ async def test_monty_provider_no_limits_by_default() -> None:
     provider = MontySandboxProvider()
     result = await provider.run("return 1 + 2")
     assert result == 3
+
+
+async def test_monty_provider_cancels_future_when_task_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the awaiting task must cancel the underlying Monty future.
+
+    Otherwise the native sandbox thread keeps running to completion after a
+    client disconnects or the request times out.
+    """
+    import asyncio
+
+    import pydantic_monty
+
+    loop = asyncio.get_running_loop()
+    sandbox_future: asyncio.Future[Any] = loop.create_future()
+
+    class _FakeMonty:
+        def __init__(self, code: str, inputs: Any) -> None:
+            pass
+
+        def run_async(self, **kwargs: Any) -> asyncio.Future[Any]:
+            return sandbox_future
+
+    monkeypatch.setattr(pydantic_monty, "Monty", _FakeMonty)
+
+    provider = MontySandboxProvider()
+    task = asyncio.create_task(provider.run("return 1"))
+
+    # Let the task advance to `await future` (no suspension before it).
+    for _ in range(3):
+        await asyncio.sleep(0)
+        if not task.done():
+            break
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert sandbox_future.cancelled()


### PR DESCRIPTION
`MontySandboxProvider.run()` created the Monty future and awaited it in a single expression. When the awaiting task is cancelled — for example, an HTTP client disconnects or the request times out mid-`execute` — `CancelledError` propagates out of the `await`, but the future is never cancelled. Monty runs the sandbox on a native thread that releases the GIL, so the event loop stays healthy and there is no visible symptom: the thread just keeps running the LLM-generated script to completion, at full CPU, after the caller has gone. Every cancelled or timed-out execution leaks one such thread, and they accumulate silently. This only surfaces across a real transport boundary (HTTP/uvicorn); in-process the cancellation chain happens to reach the future directly.

The fix wraps the call in `asyncio.ensure_future()` and cancels it explicitly when the await is cancelled, so the Monty runtime is told to tear the thread down instead of relying on event-loop internals. `ensure_future` returns the same object when the runtime already hands back a future and wraps a coroutine in a cancellable task otherwise, so the cancellation reaches Monty in both cases.

```python
future = asyncio.ensure_future(monty.run_async(...))
try:
    return await future
except asyncio.CancelledError:
    future.cancel()
    raise
```

The regression test patches `Monty` to return a controllable future, cancels the awaiting task, and asserts the future ends up cancelled — deterministic, no timing or CPU burn.

Refs #4159.