### PR TITLE
fix(event_store): treat concurrent eviction as idempotent

### DIFF
--- a/fastmcp_slim/fastmcp/server/event_store.py
+++ b/fastmcp_slim/fastmcp/server/event_store.py
@@ -121,7 +121,15 @@ class EventStore(SDKEventStore):
         # Trim to max events (delete old events)
         if len(event_ids) > self._max_events_per_stream:
             for old_id in event_ids[: -self._max_events_per_stream]:
-                await self._event_store.delete(key=old_id)
+                try:
+                    await self._event_store.delete(key=old_id)
+                except FileNotFoundError:
+                    # Race with another concurrent eviction (or external
+                    # removal) — the entry is already gone, which is the
+                    # desired post-condition. Some backends (e.g. file-tree
+                    # stores) surface this as FileNotFoundError instead of
+                    # treating delete as idempotent.
+                    logger.debug("event_store: %s already evicted", old_id)
             event_ids = event_ids[-self._max_events_per_stream :]
 
         await self._stream_store.put(

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -194,6 +194,46 @@ class TestEventStore:
         assert len(replayed) == 1
 
 
+class TestEventStoreEvictionRace:
+    """Regression tests for issue #4143: concurrent eviction must not crash."""
+
+    async def test_eviction_swallows_file_not_found(self):
+        """A FileNotFoundError from the underlying delete must not propagate.
+
+        Some AsyncKeyValue backends (e.g. FileTreeStore from py-key-value-aio)
+        do an exists()-then-unlink() that races: two concurrent store_event
+        calls can both decide to evict the same key, and the loser hits
+        FileNotFoundError. The eviction is idempotent by intent, so a missing
+        key is success-by-another-name.
+        """
+        event_store = EventStore(max_events_per_stream=2, ttl=3600)
+
+        original_delete = event_store._event_store.delete
+        call_count = {"n": 0}
+
+        async def flaky_delete(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise FileNotFoundError(
+                    2, "No such file or directory", "/tmp/missing.json"
+                )
+            return await original_delete(*args, **kwargs)
+
+        event_store._event_store.delete = flaky_delete  # type: ignore[method-assign]
+
+        msg = JSONRPCMessage(root=JSONRPCRequest(jsonrpc="2.0", method="t", id=1))
+
+        # Fill past the cap so eviction triggers; first eviction call raises
+        # FileNotFoundError and must be swallowed.
+        await event_store.store_event("stream-1", msg)
+        await event_store.store_event("stream-1", msg)
+        # This third call triggers eviction of the first event and should
+        # not raise even though the backing delete reports FileNotFound.
+        third = await event_store.store_event("stream-1", msg)
+        assert third is not None
+        assert call_count["n"] >= 1
+
+
 class TestEventStoreIntegration:
     """Integration tests for EventStore with actual message types."""
 


### PR DESCRIPTION
## Description

`EventStore.store_event` keeps a per-stream ring buffer by deleting old event keys when the list exceeds `max_events_per_stream`. The caller treats `AsyncKeyValue.delete` as idempotent, but some backends (notably `py-key-value-aio`'s `FileTreeStore`) implement delete as an unguarded `exists()` + `unlink()`. When two concurrent `store_event` calls for the same session (the `sse_writer` and `message_router` tasks both run eviction) decide to evict the same `event_id`, the loser hits `FileNotFoundError` after the winner has already unlinked the file. That exception propagates out of `store_event` and produces ERROR-level tracebacks on every collision. The events that did get stored are fine, but on a busy server this is constant log noise that obscures real issues.

This wraps the per-key eviction `delete()` in `try/except FileNotFoundError` and logs at DEBUG. Eviction is idempotent by intent: a missing key is the desired post-condition, not an error. Catching `FileNotFoundError` specifically (rather than a broad `Exception`) preserves visibility for genuine backend failures like permission errors or Redis disconnects.

```python
if len(event_ids) > self._max_events_per_stream:
    for old_id in event_ids[: -self._max_events_per_stream]:
        try:
            await self._event_store.delete(key=old_id)
        except FileNotFoundError:
            logger.debug("event_store: %s already evicted", old_id)
    event_ids = event_ids[-self._max_events_per_stream :]
```

The matching `FileTreeStore.delete_entry` race in `py-key-value-aio` is tracked separately upstream. The defensive guard here is the right place regardless, since any backend with non-atomic delete semantics can surface the same race.

Closes #4143

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)