### PR TITLE
fix(server): wrap pydantic ValidationError from tool arg validation as fastmcp ValidationError

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -55,6 +55,7 @@ from fastmcp.exceptions import (
     PromptError,
     ResourceError,
     ToolError,
+    ValidationError,
 )
 from fastmcp.mcp_config import MCPConfig
 from fastmcp.prompts import Prompt
@@ -1284,7 +1285,7 @@ class FastMCP(
                         name,
                         e.errors(include_url=False),
                     )
-                    raise
+                    raise ValidationError(str(e)) from e
                 except Exception as e:
                     logger.exception(f"Error calling tool {name!r}")
                     # Handle actionable errors that should reach the LLM

--- a/tests/server/providers/local_provider_tools/test_parameters.py
+++ b/tests/server/providers/local_provider_tools/test_parameters.py
@@ -109,7 +109,7 @@ class TestToolParameters:
         assert result.content[0].data == base64.b64encode(b"fake png data").decode()
 
     async def test_tool_with_invalid_input(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -149,7 +149,7 @@ class TestToolParameters:
         assert result.structured_content == {"result": True}
 
     async def test_annotated_field_validation(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -164,7 +164,7 @@ class TestToolParameters:
             await mcp.call_tool("analyze", {"x": 0})
 
     async def test_default_field_validation(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -179,7 +179,7 @@ class TestToolParameters:
             await mcp.call_tool("analyze", {"x": 0})
 
     async def test_default_field_is_still_required_if_no_default_specified(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -191,7 +191,7 @@ class TestToolParameters:
             await mcp.call_tool("analyze", {})
 
     async def test_literal_type_validation_error(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -216,7 +216,7 @@ class TestToolParameters:
         assert result.structured_content == {"result": "a"}
 
     async def test_enum_type_validation_error(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -251,7 +251,7 @@ class TestToolParameters:
         assert result.structured_content == {"result": "red"}
 
     async def test_union_type_validation(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -285,7 +285,7 @@ class TestToolParameters:
         assert result.structured_content == {"result": str(test_path)}
 
     async def test_path_type_error(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -310,7 +310,7 @@ class TestToolParameters:
         assert result.structured_content == {"result": str(test_uuid)}
 
     async def test_uuid_type_error(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 
@@ -344,7 +344,7 @@ class TestToolParameters:
         assert result.structured_content == {"result": "2021-01-01T00:00:00"}
 
     async def test_datetime_type_error(self):
-        from pydantic import ValidationError
+        from fastmcp.exceptions import ValidationError
 
         mcp = FastMCP()
 

--- a/tests/server/test_input_validation.py
+++ b/tests/server/test_input_validation.py
@@ -12,8 +12,10 @@ import pytest
 from mcp.types import TextContent
 from pydantic import BaseModel
 
+from pydantic import ValidationError as PydanticValidationError
+
 from fastmcp import Client, FastMCP
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError, ValidationError
 
 
 class UserProfile(BaseModel):
@@ -417,3 +419,46 @@ class TestExpectedToolFailureLogging:
         assert records, "expected an 'Error calling tool' exception log"
         assert records[0].levelname == "ERROR"
         assert records[0].exc_info is not None
+
+
+class TestArgumentValidationErrorWrapping:
+    """Argument validation must surface fastmcp's ValidationError, not the raw
+    pydantic one, so middleware and downstream consumers (e.g. Sentry filters
+    configured with ``ignore_errors=[fastmcp.exceptions.ValidationError]``) can
+    match on the framework's error type. See issue #4128."""
+
+    async def test_call_tool_wraps_pydantic_validation_error(self):
+        mcp = FastMCP("TestServer", strict_input_validation=False)
+
+        @mcp.tool
+        def create_user(profile: UserProfile) -> str:
+            return profile.name
+
+        with pytest.raises(ValidationError) as exc_info:
+            await mcp.call_tool(
+                "create_user",
+                {"profile": {"name": "x", "age": "nope", "email": "e"}},
+            )
+
+        assert not isinstance(exc_info.value, PydanticValidationError)
+        assert isinstance(exc_info.value.__cause__, PydanticValidationError)
+        assert "int_parsing" in str(exc_info.value)
+
+    async def test_wrapped_validation_error_reaches_client_as_tool_error(self):
+        """End-to-end: an invalid-argument call still surfaces as a ToolError on
+        the client side (preserving the wire-level contract) while the server
+        raises fastmcp.exceptions.ValidationError on the inside."""
+        mcp = FastMCP("TestServer", strict_input_validation=False)
+
+        @mcp.tool
+        def create_user(profile: UserProfile) -> str:
+            return profile.name
+
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError) as exc_info:
+                await client.call_tool(
+                    "create_user",
+                    {"profile": {"name": "x", "age": "nope", "email": "e"}},
+                )
+
+        assert "int_parsing" in str(exc_info.value)


### PR DESCRIPTION
## Description

When invalid arguments are passed to a tool, `pydantic-core`'s call validator raises a raw `pydantic.ValidationError` which `FastMCP.call_tool` re-raises unchanged. The error then propagates through the middleware chain as a non-fastmcp type, so consumers filtering on the framework's own error taxonomy (e.g. a Sentry `ignore_errors=[fastmcp.exceptions.ValidationError]` filter) can't match it. The `call_tool` docstring already advertises `ValidationError: If arguments fail validation`, so the implementation had drifted from the contract.

This wraps the caught `PydanticValidationError` in `fastmcp.exceptions.ValidationError` with `from e`, preserving the structured pydantic error as `__cause__` so consumers that still want `.errors()` can walk the chain. The warning log just above the re-raise is unchanged, and the client-side wire contract (a `ToolError` reaches the client) is preserved.

The 10 existing `pytest.raises(ValidationError)` blocks in `tests/server/providers/local_provider_tools/test_parameters.py` that target `mcp.call_tool(...)` are migrated from `pydantic.ValidationError` to `fastmcp.exceptions.ValidationError` in the same PR, since they assert against the new error type. No `TypeAdapter`-direct tests exist in that file, so no `pydantic.ValidationError` raises are left intact.

The reporter notes in the issue thread that tool _bodies_ can also raise `pydantic.ValidationError` from their own bugs, and those should arguably stay distinguishable from bad-call errors. Distinguishing the two requires splitting argument validation from invocation inside `FunctionTool.run` (today `type_adapter.validate_python(arguments)` does both), which is a deeper refactor than this bug warrants.

Closes #4128.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)