### PR TITLE
fix(tests): hoist azure-identity import out of the OBO test timeout window

### DIFF
--- a/tests/server/auth/providers/test_azure_scopes.py
+++ b/tests/server/auth/providers/test_azure_scopes.py
@@ -12,6 +12,14 @@ from fastmcp.server.auth.providers.azure import (
 )
 from fastmcp.server.auth.providers.jwt import RSAKeyPair, StaticTokenVerifier
 
+# Import the optional azure-identity SDK once, at collection time. The OBO
+# tests mock it via patch("azure.identity.aio.OnBehalfOfCredential"), but the
+# provider imports it lazily — so without this the heavy SDK import lands
+# inside the first OBO test's 5s pytest-timeout window and flakes on cold
+# Windows runners (#4175). importorskip also skips cleanly if the optional
+# `azure` extra is absent, instead of hard-failing at runtime.
+pytest.importorskip("azure.identity.aio")
+
 
 @pytest.fixture
 def memory_storage() -> MemoryStore:


### PR DESCRIPTION
`TestAzureOBOIntegration` in `test_azure_scopes.py` intermittently times out on `windows-latest` with a 5s `pytest-timeout` rather than an assertion. The tests fully mock Azure, but `AzureProvider` keeps `azure-identity` optional (imported lazily in `get_obo_credential`), so the heavy SDK import (`msal`, `cryptography`, many submodules) lands inside the *first* OBO test's per-test timeout window. Under xdist on a cold Windows runner that first import can exceed 5s, so whichever test runs first flakes — order- and timing-dependent, not Windows-broken.

This adds a module-level `pytest.importorskip("azure.identity.aio")` so the SDK is imported once at collection time, outside any per-test timer; the in-test `patch(...)` then hits the module cache. It also makes the module skip cleanly if the optional `azure` extra is absent instead of hard-failing at runtime, mirroring how the provider treats azure as optional. No production code changes.

Closes #4175.