### PR TITLE
fix(cli): forward stateless flag in uv run path

### DIFF
--- a/fastmcp_slim/fastmcp/cli/cli.py
+++ b/fastmcp_slim/fastmcp/cli/cli.py
@@ -705,6 +705,8 @@ async def run(
             inner_cmd.extend(["--log-level", final_log_level])
         if final_no_banner:
             inner_cmd.append("--no-banner")
+        if stateless:
+            inner_cmd.append("--stateless")
         # Add skip-env flag to prevent infinite recursion
         inner_cmd.append("--skip-env")
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -977,7 +977,9 @@ class TestRunWithReloadWithServerArgs:
                 "fastmcp.cli.cli.load_and_merge_config",
                 return_value=(mock_config, "server.py"),
             ),
-            patch("fastmcp.cli.cli.subprocess.run", return_value=mock_result) as mock_run,
+            patch(
+                "fastmcp.cli.cli.subprocess.run", return_value=mock_result
+            ) as mock_run,
             pytest.raises(SystemExit) as exc_info,
         ):
             await run("server.py", stateless=True)
@@ -991,7 +993,6 @@ class TestRunWithReloadWithServerArgs:
             "server.py",
             "--stateless",
         ]
-
 
 
 class TestInspectorModuleMode:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -958,6 +958,41 @@ class TestRunWithReloadWithServerArgs:
         assert any("Detected changes" in record.message for record in caplog.records)
         assert call_count == 2, f"Restart logic was not triggered for {reload_cmd}"
 
+    async def test_run_with_needs_uv_forwards_stateless_flag(self):
+        """`--stateless` should survive the uv-wrapped subprocess path."""
+        mock_config = MagicMock()
+        mock_config.deployment.transport = None
+        mock_config.deployment.host = None
+        mock_config.deployment.port = None
+        mock_config.deployment.path = None
+        mock_config.deployment.log_level = None
+        mock_config.deployment.args = ()
+        mock_config.environment.build_command = lambda cmd: ["uv", "run", *cmd]
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with (
+            patch(
+                "fastmcp.cli.cli.load_and_merge_config",
+                return_value=(mock_config, "server.py"),
+            ),
+            patch("fastmcp.cli.cli.subprocess.run", return_value=mock_result) as mock_run,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            await run("server.py", stateless=True)
+
+        assert exc_info.value.code == 0
+        cmd = mock_run.call_args.args[0]
+        assert "--stateless" in cmd
+        assert cmd[cmd.index("--stateless") - 3 : cmd.index("--stateless") + 1] == [
+            "fastmcp",
+            "run",
+            "server.py",
+            "--stateless",
+        ]
+
+
 
 class TestInspectorModuleMode:
     """Test the inspector command's module-mode handling."""


### PR DESCRIPTION
## Summary

- forward `--stateless` into the uv-wrapped `fastmcp run` inner command
- add a regression test for the `needs_uv` path so the flag is not dropped again

## Why

The direct import path already passes `stateless=stateless`, and reload mode already adds `--stateless` to its restart command. The regular `needs_uv` subprocess path built an inner `fastmcp run ... --skip-env` command but did not include `--stateless`, so a user-provided stateless run could silently become stateful when an environment wrapper is needed.

## Validation

- `uv run pytest tests/cli/test_run.py -q`
