### PR TITLE
chore(examples): use namespace in mount example

### DIFF
--- a/examples/mount_example.py
+++ b/examples/mount_example.py
@@ -63,9 +63,9 @@ def check_app_status() -> dict[str, str]:
 
 
 # Mount sub-applications
-app.mount(server=weather_app, prefix="weather")
+app.mount(server=weather_app, namespace="weather")
 
-app.mount(server=news_app, prefix="news")
+app.mount(server=news_app, namespace="news")
 
 
 async def get_server_details():


### PR DESCRIPTION
## Summary

- replace deprecated `prefix=` usage in `examples/mount_example.py` with `namespace=`
- keep the example behavior and namespaces unchanged

## Why

Other examples have already moved to `namespace=`, and `prefix=` now emits a deprecation warning. Updating this example keeps the user-facing sample aligned with the current mount API.

## Validation

- `uv run python -m py_compile examples/mount_example.py`
