### PR TITLE
Add per-key TTL to Context.set_state()

### DIFF
--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -238,12 +238,12 @@ async def get_counter(ctx: Context) -> int:
 Each client session has its own isolated state—two different clients calling `increment_counter` will each have their own counter.
 
 **Method signatures:**
-- **`await ctx.set_state(key, value, *, serializable=True)`**: Store a value in session state
+- **`await ctx.set_state(key, value, *, serializable=True, ttl=None)`**: Store a value in session state
 - **`await ctx.get_state(key)`**: Retrieve a value (returns None if not found)
 - **`await ctx.delete_state(key)`**: Remove a value from session state
 
 <Note>
-State methods are async and require `await`. State expires after 1 day to prevent unbounded memory growth.
+State methods are async and require `await`. State expires after 1 day by default to prevent unbounded memory growth.
 </Note>
 
 #### Non-Serializable Values
@@ -263,6 +263,22 @@ async def my_tool(ctx: Context) -> str:
 ```
 
 Values stored with `serializable=False` only live for the current MCP request (a single tool call, resource read, or prompt render). They will not be available in subsequent requests within the session.
+
+#### Per-Key TTL
+
+By default, all state expires after 1 day. Pass `ttl` (in seconds) to `set_state` to control expiration per key:
+
+```python
+@mcp.tool
+async def my_tool(ctx: Context) -> str:
+    # Cache for 5 minutes
+    await ctx.set_state("user_profile", profile, ttl=300)
+
+    # Use the default TTL (24 hours)
+    await ctx.set_state("firm_context", firm_data)
+
+    return "done"
+```
 
 #### Custom Storage Backends
 

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -1247,7 +1247,12 @@ class Context:
         return f"{self.session_id}:{key}"
 
     async def set_state(
-        self, key: str, value: Any, *, serializable: bool = True
+        self,
+        key: str,
+        value: Any,
+        *,
+        serializable: bool = True,
+        ttl: int | None = None,
     ) -> None:
         """Set a value in the state store.
 
@@ -1262,6 +1267,13 @@ class Context:
         requests.
 
         The key is automatically prefixed with the session identifier.
+
+        Args:
+            key: The state key.
+            value: The value to store.
+            serializable: If False, store in request-scoped memory only.
+            ttl: Per-key TTL in seconds. Defaults to ``_STATE_TTL_SECONDS``
+                (86400). Only applies to the session-scoped store.
         """
         prefixed_key = self._make_state_key(key)
         if not serializable:
@@ -1269,11 +1281,12 @@ class Context:
             return
         # Clear any request-scoped shadow so the session value is visible
         self._request_state.pop(prefixed_key, None)
+        effective_ttl = ttl if ttl is not None else self._STATE_TTL_SECONDS
         try:
             await self.fastmcp._state_store.put(
                 key=prefixed_key,
                 value=StateValue(value=value),
-                ttl=self._STATE_TTL_SECONDS,
+                ttl=effective_ttl,
             )
         except Exception as e:
             # Catch serialization errors from Pydantic (ValueError) or

--- a/tests/server/test_redis_state.py
+++ b/tests/server/test_redis_state.py
@@ -1,0 +1,23 @@
+"""Tests for per-key TTL on set_state."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastmcp.server import Context, FastMCP
+
+
+class TestPerKeyTTL:
+    async def test_custom_ttl_stores_value(self):
+        server = FastMCP("test")
+        session = MagicMock()
+        async with Context(server, session=session) as ctx:
+            await ctx.set_state("short_lived", "data", ttl=60)
+            assert await ctx.get_state("short_lived") == "data"
+
+    async def test_default_ttl_stores_value(self):
+        server = FastMCP("test")
+        session = MagicMock()
+        async with Context(server, session=session) as ctx:
+            await ctx.set_state("default_ttl", "data")
+            assert await ctx.get_state("default_ttl") == "data"


### PR DESCRIPTION
`set_state` already persists values with a fixed 1-day TTL. This adds an optional `ttl` keyword argument so callers can control expiration per key — useful for short-lived caches (e.g., auth tokens, rate-limit windows) alongside long-lived session data.

```python
# Cache for 5 minutes
await ctx.set_state("user_profile", profile, ttl=300)

# Default 24-hour TTL still works
await ctx.set_state("firm_context", firm_data)
```

The parameter passes through to the underlying `AsyncKeyValue.put()` call. When `ttl` is `None` (default), the existing `_STATE_TTL_SECONDS` (86400) is used — no behavioral change for existing code.

---

🤖 Generated with [Claude Code](https://claude.ai/code)