### PR TITLE
Hoist Azure identity import in OBO tests

### DIFF
--- a/tests/server/auth/providers/test_azure_scopes.py
+++ b/tests/server/auth/providers/test_azure_scopes.py
@@ -1,7 +1,6 @@
 """Tests for Azure provider scope handling, JWT verifier, and OBO integration."""
 
 import pytest
-pytest.importorskip("azure.identity.aio")
 from key_value.aio.stores.memory import MemoryStore
 
 from fastmcp.server.auth.auth import MultiAuth
@@ -599,6 +598,9 @@ class TestAzureJWTVerifier:
 
 
 class TestAzureOBOIntegration:
+    azure_identity_aio = pytest.importorskip("azure.identity.aio")
+
+    ...
     """Tests for azure.identity OBO integration (get_obo_credential, EntraOBOToken)."""
 
     async def test_get_obo_credential_returns_configured_credential(self):

--- a/tests/server/auth/providers/test_azure_scopes.py
+++ b/tests/server/auth/providers/test_azure_scopes.py
@@ -1,6 +1,7 @@
 """Tests for Azure provider scope handling, JWT verifier, and OBO integration."""
 
 import pytest
+pytest.importorskip("azure.identity.aio")
 from key_value.aio.stores.memory import MemoryStore
 
 from fastmcp.server.auth.auth import MultiAuth


### PR DESCRIPTION
## Summary

Closes #4175.

This adds a module-level `pytest.importorskip("azure.identity.aio")` in `test_azure_scopes.py`.

The OBO tests patch `azure.identity.aio.OnBehalfOfCredential`, but `azure-identity` is still imported lazily by the provider. On a cold Windows runner, that import can end up happening inside the 5s per-test timeout window.

Moving the import to collection time keeps that cost out of the timed test body, and still lets the module skip cleanly if the optional Azure dependency is not installed.

## Tests

```bash
.venv/bin/python -m pytest tests/server/auth/providers/test_azure_scopes.py::TestAzureOBOIntegration
# 10 passed

.venv/bin/python -m pytest tests/server/auth/providers/test_azure_scopes.py
# 48 passed

.venv/bin/python -m ruff check tests/server/auth/providers/test_azure_scopes.py
# All checks passed

.venv/bin/python -m ruff format --check tests/server/auth/providers/test_azure_scopes.py
# 1 file already formatted

git diff --check
# passed
```

Tested on macOS, so I couldn’t reproduce the Windows-specific timeout locally.