### PR TITLE
Allow sampling handler fallback on client errors

### DIFF
--- a/docs/servers/sampling.mdx
+++ b/docs/servers/sampling.mdx
@@ -136,6 +136,7 @@ server = FastMCP(
 The `sampling_handler_behavior` parameter controls when the handler is used:
 
 - **`"fallback"`** (default): Use the handler only when the client doesn't support sampling. This lets capable clients use their own LLM while ensuring your tools still work with clients that lack sampling support.
+- **`"fallback_on_error"`**: Try client sampling first, then use the handler if the client sampling request fails. Use this when clients advertise sampling but may reject individual requests, while you still want a server-side handler as an opt-in fallback.
 - **`"always"`**: Always use the handler, bypassing the client entirely. Use this when you need guaranteed control over which LLM processes requests—for cost control, compliance requirements, or when specific model characteristics are essential.
 
 ## Structured Output

--- a/docs/v2/servers/sampling.mdx
+++ b/docs/v2/servers/sampling.mdx
@@ -478,6 +478,7 @@ server = FastMCP(
 The `sampling_handler_behavior` parameter controls when the handler is used:
 
 - **`"fallback"`** (default): Use the handler only when the client doesn't support sampling. This lets capable clients use their own LLM while ensuring your tools still work with clients that lack sampling support.
+- **`"fallback_on_error"`**: Try client sampling first, then use the handler if the client sampling request fails. Use this when clients advertise sampling but may reject individual requests, while you still want a server-side handler as an opt-in fallback.
 - **`"always"`**: Always use the handler, bypassing the client entirely. Use this when you need guaranteed control over which LLM processes requests—for cost control, compliance requirements, or when specific model characteristics are essential.
 
 <Note>

--- a/fastmcp_slim/fastmcp/server/sampling/run.py
+++ b/fastmcp_slim/fastmcp/server/sampling/run.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast
 
 import anyio
+from mcp.shared.exceptions import McpError
 from mcp.types import (
     ClientCapabilities,
     CreateMessageResult,
@@ -170,7 +171,7 @@ def determine_handler_mode(context: Context, needs_tools: bool) -> bool:
                 "sampling_handler_behavior is 'always' but no handler configured"
             )
         return True
-    elif fastmcp.sampling_handler_behavior == "fallback":
+    elif fastmcp.sampling_handler_behavior in {"fallback", "fallback_on_error"}:
         client_sufficient = has_sampling and (not needs_tools or has_tools_capability)
         if not client_sufficient:
             if fastmcp.sampling_handler is None:
@@ -184,7 +185,7 @@ def determine_handler_mode(context: Context, needs_tools: bool) -> bool:
     elif fastmcp.sampling_handler_behavior is not None:
         raise ValueError(
             f"Invalid sampling_handler_behavior: {fastmcp.sampling_handler_behavior!r}. "
-            "Must be 'always', 'fallback', or None."
+            "Must be 'always', 'fallback', 'fallback_on_error', or None."
         )
     elif not has_sampling:
         raise ValueError("Client does not support sampling")
@@ -555,16 +556,33 @@ async def sample_step_impl(
                     tool_choice=effective_tool_choice,
                 )
             else:
-                response = await context.session.create_message(
-                    messages=current_messages,
-                    system_prompt=system_prompt,
-                    temperature=temperature,
-                    max_tokens=effective_max_tokens,
-                    model_preferences=_parse_model_preferences(model_preferences),
-                    tools=sdk_tools,
-                    tool_choice=effective_tool_choice,
-                    related_request_id=context.origin_request_id,
-                )
+                try:
+                    response = await context.session.create_message(
+                        messages=current_messages,
+                        system_prompt=system_prompt,
+                        temperature=temperature,
+                        max_tokens=effective_max_tokens,
+                        model_preferences=_parse_model_preferences(model_preferences),
+                        tools=sdk_tools,
+                        tool_choice=effective_tool_choice,
+                        related_request_id=context.origin_request_id,
+                    )
+                except McpError:
+                    if (
+                        context.fastmcp.sampling_handler_behavior != "fallback_on_error"
+                        or context.fastmcp.sampling_handler is None
+                    ):
+                        raise
+                    response = await call_sampling_handler(
+                        context,
+                        current_messages,
+                        system_prompt=system_prompt,
+                        temperature=temperature,
+                        max_tokens=effective_max_tokens,
+                        model_preferences=model_preferences,
+                        sdk_tools=sdk_tools,
+                        tool_choice=effective_tool_choice,
+                    )
         except Exception as e:
             if span.is_recording():
                 span.set_attribute("error.type", type(e).__qualname__)

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -313,7 +313,7 @@ class FastMCP(
         tasks: bool | None = None,
         session_state_store: AsyncKeyValue | None = None,
         sampling_handler: SamplingHandler | None = None,
-        sampling_handler_behavior: Literal["always", "fallback"] | None = None,
+        sampling_handler_behavior: Literal["always", "fallback", "fallback_on_error"] | None = None,
         client_log_level: mcp.types.LoggingLevel | None = None,
         experimental_capabilities: dict[str, dict[str, Any]] | None = None,
         **kwargs: Any,
@@ -431,7 +431,7 @@ class FastMCP(
         self._setup_handlers()
 
         self.sampling_handler: SamplingHandler | None = sampling_handler
-        self.sampling_handler_behavior: Literal["always", "fallback"] = (
+        self.sampling_handler_behavior: Literal["always", "fallback", "fallback_on_error"] = (
             sampling_handler_behavior or "fallback"
         )
 

--- a/tests/server/sampling/test_sampling_handler_behavior.py
+++ b/tests/server/sampling/test_sampling_handler_behavior.py
@@ -1,0 +1,79 @@
+"""Tests for server sampling handler behavior modes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from mcp.shared.exceptions import McpError
+from mcp.types import INVALID_REQUEST, ErrorData
+
+from fastmcp.server.sampling.run import sample_step_impl
+
+
+class DummySession:
+    def __init__(self, *, error: Exception | None = None):
+        self.error = error
+        self.create_message_calls = 0
+
+    def check_client_capability(self, *, capability):  # noqa: ANN001
+        return True
+
+    async def create_message(self, **kwargs):  # noqa: ANN003
+        self.create_message_calls += 1
+        if self.error is not None:
+            raise self.error
+        return "client response"
+
+
+async def test_fallback_on_error_uses_handler_after_client_sampling_error():
+    calls = []
+
+    def sampling_handler(messages, params, request_context):  # noqa: ANN001, ANN202
+        calls.append((messages, params, request_context))
+        return "handler response"
+
+    session = DummySession(
+        error=McpError(
+            ErrorData(
+                code=INVALID_REQUEST,
+                message="The user has denied permission to call this method.",
+            )
+        )
+    )
+    context = SimpleNamespace(
+        fastmcp=SimpleNamespace(
+            sampling_handler=sampling_handler,
+            sampling_handler_behavior="fallback_on_error",
+        ),
+        session=session,
+        request_context=object(),
+        origin_request_id=None,
+    )
+
+    result = await sample_step_impl(context, "hello")
+
+    assert session.create_message_calls == 1
+    assert len(calls) == 1
+    assert result.text == "handler response"
+
+
+async def test_fallback_mode_preserves_client_sampling_errors():
+    error = McpError(
+        ErrorData(
+            code=INVALID_REQUEST,
+            message="The user has denied permission to call this method.",
+        )
+    )
+    context = SimpleNamespace(
+        fastmcp=SimpleNamespace(
+            sampling_handler=lambda *args: "handler response",
+            sampling_handler_behavior="fallback",
+        ),
+        session=DummySession(error=error),
+        request_context=object(),
+        origin_request_id=None,
+    )
+
+    with pytest.raises(McpError):
+        await sample_step_impl(context, "hello")


### PR DESCRIPTION
## Summary

- Adds `sampling_handler_behavior="fallback_on_error"` as an opt-in mode for server sampling handlers.
- Keeps the existing default `"fallback"` behavior unchanged: client sampling errors still propagate.
- Documents the new mode in both sampling docs pages.

Fixes #2162.

## Tests

- `uv run ruff check fastmcp_slim/fastmcp/server/sampling/run.py fastmcp_slim/fastmcp/server/server.py tests/server/sampling/test_sampling_handler_behavior.py`
- `uv run pytest -q tests/server/sampling/test_sampling_handler_behavior.py tests/server/sampling/test_prepare_tools.py`
