### PR TITLE
test: import Azure identity before OBO tests

### DIFF
--- a/tests/server/auth/providers/test_azure_scopes.py
+++ b/tests/server/auth/providers/test_azure_scopes.py
@@ -3,6 +3,8 @@
 import pytest
 from key_value.aio.stores.memory import MemoryStore
 
+pytest.importorskip("azure.identity.aio")
+
 from fastmcp.server.auth.auth import MultiAuth
 from fastmcp.server.auth.providers.azure import (
     OIDC_SCOPES,


### PR DESCRIPTION
﻿## Summary
- import `azure.identity.aio` once at collection time for the Azure scope/OBO test module
- keep the Azure runtime provider lazy; this only changes the test setup path

Fixes #4175.

## To verify
- python -m py_compile tests\server\auth\providers\test_azure_scopes.py
- uv run ruff check tests\server\auth\providers\test_azure_scopes.py
- uv run ruff format --check tests\server\auth\providers\test_azure_scopes.py
- PYTHONUTF8=1 TMP=.tmp\pytest-temp TEMP=.tmp\pytest-temp uv run pytest tests\server\auth\providers\test_azure_scopes.py -q -o cache_dir=.tmp\pytest-cache
