### PR TITLE
fix: preserve resource template metadata

### DIFF
--- a/fastmcp_slim/fastmcp/resources/template.py
+++ b/fastmcp_slim/fastmcp/resources/template.py
@@ -442,6 +442,10 @@ class FunctionResourceTemplate(ResourceTemplate):
             description=self.description,
             mime_type=self.mime_type,
             tags=self.tags,
+            icons=self.icons,
+            annotations=self.annotations,
+            meta=self.meta,
+            title=self.title,
             task=self.task_config,
             auth=self.auth,
         )

--- a/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py
+++ b/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py
@@ -381,6 +381,13 @@ class FastMCPProviderResourceTemplate(ResourceTemplate):
             name=self.name,
             description=self.description,
             mime_type=self.mime_type,
+            tags=self.tags,
+            annotations=self.annotations,
+            task_config=self.task_config,
+            meta=self.get_meta(),
+            title=self.title,
+            icons=self.icons,
+            auth=self.auth,
         )
 
     @overload

--- a/tests/resources/test_resource_template.py
+++ b/tests/resources/test_resource_template.py
@@ -2,6 +2,7 @@ import functools
 from urllib.parse import quote
 
 import pytest
+from mcp.types import Annotations, Icon
 from pydantic import BaseModel
 
 from fastmcp import Context, FastMCP
@@ -194,6 +195,31 @@ class TestResourceTemplate:
         resource_result = await resource._read()
         assert len(resource_result.contents) == 1
         assert resource_result.contents[0].content == "key=foo, value=123"
+
+    async def test_create_resource_preserves_template_metadata(self):
+        def my_func(key: str) -> str:
+            return f"value={key}"
+
+        icons = [Icon(src="https://example.com/resource.png")]
+        annotations = Annotations(audience=["user"], priority=0.7)
+        template = ResourceTemplate.from_function(
+            fn=my_func,
+            uri_template="test://{key}",
+            name="test",
+            title="Test Resource",
+            tags={"alpha"},
+            icons=icons,
+            annotations=annotations,
+            meta={"custom": "value"},
+        )
+
+        resource = await template.create_resource("test://foo", {"key": "foo"})
+
+        assert resource.title == "Test Resource"
+        assert resource.tags == {"alpha"}
+        assert resource.icons == icons
+        assert resource.annotations == annotations
+        assert resource.meta == {"custom": "value"}
 
     async def test_async_text_resource(self):
         """Test creating a text resource from async function."""

--- a/tests/server/providers/test_fastmcp_provider.py
+++ b/tests/server/providers/test_fastmcp_provider.py
@@ -227,6 +227,37 @@ class TestResourceTemplateOperations:
             assert isinstance(result[0], mt.TextResourceContents)
             assert result[0].text == "data for 123"
 
+    async def test_create_resource_template_preserves_metadata(self):
+        """Template-created provider resources keep mounted template metadata."""
+        sub = FastMCP("Sub")
+
+        icons = [mt.Icon(src="https://example.com/template.png")]
+        annotations = mt.Annotations(audience=["user"], priority=0.7)
+
+        @sub.resource(
+            "resource://{id}/data",
+            title="Template Resource",
+            tags={"alpha"},
+            icons=icons,
+            annotations=annotations,
+            meta={"custom": "value"},
+        )
+        def my_template(id: str) -> str:
+            return f"data for {id}"
+
+        provider = FastMCPProvider(sub)
+        template = await provider.get_resource_template("resource://123/data")
+
+        assert template is not None
+        resource = await template.create_resource("resource://123/data", {"id": "123"})
+
+        assert resource.title == "Template Resource"
+        assert resource.tags == {"alpha"}
+        assert resource.icons == icons
+        assert resource.annotations == annotations
+        assert resource.meta is not None
+        assert resource.meta["custom"] == "value"
+
 
 class TestPromptOperations:
     """Test prompt operations through FastMCPProvider."""


### PR DESCRIPTION
﻿## Summary
- forward template metadata when `FunctionResourceTemplate.create_resource()` builds a concrete resource
- forward mounted resource-template metadata when `FastMCPProviderResourceTemplate.create_resource()` builds the provider resource
- add regression tests for both paths

Fixes #4052.

## To verify
- python -m py_compile fastmcp_slim\fastmcp\resources\template.py fastmcp_slim\fastmcp\server\providers\fastmcp_provider.py tests\resources\test_resource_template.py tests\server\providers\test_fastmcp_provider.py
- uv run ruff check fastmcp_slim\fastmcp\resources\template.py fastmcp_slim\fastmcp\server\providers\fastmcp_provider.py tests\resources\test_resource_template.py tests\server\providers\test_fastmcp_provider.py
- uv run ruff format --check fastmcp_slim\fastmcp\resources\template.py fastmcp_slim\fastmcp\server\providers\fastmcp_provider.py tests\resources\test_resource_template.py tests\server\providers\test_fastmcp_provider.py
- PYTHONUTF8=1 TMP=.tmp\pytest-temp TEMP=.tmp\pytest-temp uv run pytest tests\resources\test_resource_template.py tests\server\providers\test_fastmcp_provider.py -q -o cache_dir=.tmp\pytest-cache
