### PR TITLE
fix: avoid duplicated OAuth resource path

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/auth.py
+++ b/fastmcp_slim/fastmcp/server/auth/auth.py
@@ -357,6 +357,11 @@ class AuthProvider(TokenVerifierProtocol):
             return None
 
         if path:
+            resource_path = urlparse(str(resource_base_url)).path.rstrip("/")
+            path_suffix = "/" + path.strip("/")
+            if resource_path == path_suffix:
+                return resource_base_url
+
             prefix = str(resource_base_url).rstrip("/")
             suffix = path.lstrip("/")
             return AnyHttpUrl(f"{prefix}/{suffix}")

--- a/tests/server/auth/test_oauth_mounting.py
+++ b/tests/server/auth/test_oauth_mounting.py
@@ -16,6 +16,7 @@ from starlette.routing import Mount
 from fastmcp import FastMCP
 from fastmcp.server.auth import RemoteAuthProvider
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 
 
@@ -111,6 +112,21 @@ class TestOAuthMounting:
 
             # There will also be an extra route at /api/.well-known/oauth-protected-resource/mcp
             # (from the mounted MCP app), but we don't care about that as long as the correct one exists
+
+    async def test_well_known_does_not_duplicate_matching_mcp_path(self):
+        """base_url may already include the full externally mounted MCP path."""
+        auth_provider = InMemoryOAuthProvider(
+            base_url="https://api.example.com/api/mcp/v1"
+        )
+
+        well_known_routes = auth_provider.get_well_known_routes(mcp_path="/api/mcp/v1")
+        paths = {route.path for route in well_known_routes}
+
+        assert "/.well-known/oauth-authorization-server/api/mcp/v1" in paths
+        assert "/.well-known/oauth-protected-resource/api/mcp/v1" in paths
+        assert (
+            "/.well-known/oauth-protected-resource/api/mcp/v1/api/mcp/v1" not in paths
+        )
 
     async def test_mcp_endpoint_with_mounted_app(self, test_tokens):
         """Test that MCP endpoint works correctly when mounted.


### PR DESCRIPTION
﻿## Summary
- avoid appending `mcp_path` when the configured resource/base URL already ends at that same path
- keep the existing canonical mounted case working (`base_url=/api`, `mcp_path=/mcp`)
- add coverage for the doubled protected-resource metadata route reported in #4197

Fixes #4197

## Test Plan
- `PYTHONUTF8=1 uv run pytest tests/server/auth/test_oauth_mounting.py::TestOAuthMounting::test_well_known_does_not_duplicate_matching_mcp_path tests/server/auth/test_oauth_mounting.py::TestOAuthMounting::test_well_known_with_mounted_app tests/server/auth/test_remote_auth_provider.py::TestRemoteAuthProvider::test_get_resource_url_uses_resource_base_url_when_provided -q --basetemp .tmp/pytest-well-known-path-final`
- `uv run ruff check fastmcp_slim/fastmcp/server/auth/auth.py tests/server/auth/test_oauth_mounting.py`
- `uv run ruff format --check fastmcp_slim/fastmcp/server/auth/auth.py tests/server/auth/test_oauth_mounting.py`
- `python -m py_compile fastmcp_slim/fastmcp/server/auth/auth.py tests/server/auth/test_oauth_mounting.py`
- `git diff --check`
