### PR TITLE
fix(versions): deep-copy meta when injecting versions in dedupe

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/versions.py
+++ b/fastmcp_slim/fastmcp/utilities/versions.py
@@ -15,6 +15,7 @@ Examples:
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 from functools import total_ordering
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -332,17 +333,8 @@ def dedupe_with_versions(
                 key=parse_version_key,
                 reverse=True,
             )
-            meta = highest.meta or {}
-            highest = highest.model_copy(
-                update={
-                    "meta": {
-                        **meta,
-                        "fastmcp": {
-                            **meta.get("fastmcp", {}),
-                            "versions": all_versions,
-                        },
-                    }
-                }
-            )
+            meta = deepcopy(highest.meta) if highest.meta else {}
+            meta["fastmcp"] = {**meta.get("fastmcp", {}), "versions": all_versions}
+            highest = highest.model_copy(update={"meta": meta})
         result.append(highest)
     return result

--- a/tests/server/versioning/test_versioning.py
+++ b/tests/server/versioning/test_versioning.py
@@ -14,6 +14,7 @@ from fastmcp.utilities.versions import (
     VersionKey,
     VersionSpec,
     compare_versions,
+    dedupe_with_versions,
     is_version_greater,
     version_sort_key,
 )
@@ -89,6 +90,22 @@ class TestVersionFunctions:
 def _tool(version: str | None) -> Tool:
     """Build a real Tool component (a FastMCPComponent) with a version."""
     return Tool.from_function(lambda: None, name="t", version=version)
+
+
+class TestDedupeWithVersions:
+    """Tests for dedupe_with_versions meta handling."""
+
+    def test_injected_meta_does_not_share_nested_state(self):
+        """Injecting versions must not alias the source component's nested meta."""
+        low = Tool.from_function(lambda: None, name="t", version="1.0")
+        high = Tool.from_function(lambda: None, name="t", version="2.0")
+        high.meta = {"nested": {"items": [1, 2]}}
+
+        (result,) = dedupe_with_versions([low, high], key_fn=lambda c: c.name)
+        assert result.meta is not None
+        result.meta["nested"]["items"].append(3)
+
+        assert high.meta["nested"]["items"] == [1, 2]
 
 
 class TestVersionSpecEq:


### PR DESCRIPTION
Fixes #4202.

### The bug

`dedupe_with_versions` injects the `fastmcp.versions` list into the selected component's `meta` using a shallow spread:

```python
meta = highest.meta or {}
highest = highest.model_copy(update={"meta": {**meta, "fastmcp": {...}}})
```

`{**meta, ...}` only copies the top level, so nested mutable values in the source component's `meta` are shared by reference with the returned component. Mutating the deduped component's meta then mutates the registered one:

```python
high.meta = {"nested": {"items": [1, 2]}}
(result,) = dedupe_with_versions([low, high], key_fn=lambda c: c.name)
result.meta["nested"]["items"].append(3)
assert high.meta["nested"]["items"] == [1, 2]  # fails: [1, 2, 3]
```

### The fix

Deep-copy `meta` before injecting the versions key, so the deduped component owns its `meta` outright.

### Testing

Added a regression test that fails on `main` and passes with the fix. `tests/server/versioning/`, the catalog transform, and provider suites stay green; `ruff` and `ty` pass.