### PR TITLE
Guard require-issue-link check job to pull_request_target events

### DIFF
--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -57,10 +57,16 @@ jobs:
     # then the script resolves the author's real permission and exits early
     # for maintainers.
     #
-    # Gate: skip drafts, bots, and already-bypassed/trusted PRs. Allow the
-    # primary actions plus the one maintainer-override action we care about
-    # (removing the missing-issue-link label).
+    # Gate: only run on pull_request_target events. The workflow also listens
+    # to `issues.assigned` (handled by reopen-on-assignment below), and without
+    # this guard the job would also fire there — `github.event.pull_request` is
+    # null on an issues event, so `...draft == false` coerces to true and the
+    # script then dereferences a missing PR and crashes. Beyond the event type,
+    # skip drafts, bots, and already-bypassed/trusted PRs, and allow the primary
+    # actions plus the one maintainer-override action we care about (removing
+    # the missing-issue-link label).
     if: >-
+      github.event_name == 'pull_request_target' &&
       github.event.pull_request.draft == false &&
       !endsWith(github.actor, '[bot]') &&
       !contains(github.event.pull_request.labels.*.name, 'trusted-contributor') &&


### PR DESCRIPTION
The `require-issue-link` workflow listens to both `pull_request_target` and `issues.assigned`. The `reopen-on-assignment` job correctly guards itself with `github.event_name == 'issues'`, but the `check-issue-link` job had no inverse guard — and its condition opened with `github.event.pull_request.draft == false`, which on an `issues` event coerces to `null == false` → true. So every issue assignment also triggered `check-issue-link`, which immediately dereferenced the absent PR (`pr.number`) and died with `TypeError: Cannot read properties of undefined`.

The reopen path itself was unaffected, so this never broke functionality — but it left a red failed run on every single issue assignment, which is exactly the kind of noise that erodes trust in the gate. The fix adds the `github.event_name == 'pull_request_target'` guard the sibling job already has.
