### PR TITLE
Update published docs after PyPI release

### DIFF
--- a/.github/workflows/publish-fastmcp.yml
+++ b/.github/workflows/publish-fastmcp.yml
@@ -85,3 +85,21 @@ jobs:
 
       - name: Publish fastmcp to PyPI
         run: uv publish -v dist/fastmcp-*.tar.gz dist/fastmcp-*.whl
+
+  update-published-docs:
+    name: Update published-docs branch
+    runs-on: ubuntu-latest
+    needs: pypi-publish
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'release'
+    timeout-minutes: 2
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Point published-docs at published release
+        run: git push --force origin "HEAD:published-docs"


### PR DESCRIPTION
FastMCP's docs branch should represent the package users can actually install, not merely the commit that triggered a GitHub release. The PyPI publish flow now has a slim package upload followed by the full `fastmcp` upload, so the `published-docs` reset belongs after the final publish succeeds.

This adds a downstream release-only job to the full package publish workflow. Interim docs hotfixes can still land on `published-docs`, and each successful release resets that branch back to the released package commit.

```yaml
needs: pypi-publish
if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'release'
```
