### PR TITLE
Add uv dependency cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ members = ["fastmcp_slim"]
 
 [tool.uv]
 default-groups = ["dev"]
+exclude-newer = "1 week"
+exclude-newer-package = { prefab-ui = false }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-05-15T22:43:18.553853Z"
+exclude-newer-span = "P1W"
+
+[options.exclude-newer-package]
+prefab-ui = false
+
 [manifest]
 members = [
     "fastmcp",


### PR DESCRIPTION
FastMCP resolves a large dependency graph, and fresh package uploads are the highest-risk window for many PyPI supply-chain incidents. This adds uv's dependency cooldown so normal repo resolution ignores registry artifacts uploaded in the last week, giving compromised releases time to be discovered before they enter the lockfile.

`prefab-ui` stays exempt because FastMCP needs to consume internal UI releases immediately while still applying the cooldown to the rest of the registry graph.

```toml
[tool.uv]
exclude-newer = "1 week"
exclude-newer-package = { prefab-ui = false }
```
