### PR TITLE
Allow pre-bound HTTP sockets

### DIFF
--- a/fastmcp_slim/fastmcp/server/mixins/transport.py
+++ b/fastmcp_slim/fastmcp/server/mixins/transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket
 from collections.abc import Awaitable, Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
@@ -236,6 +237,7 @@ class TransportMixin:
         json_response: bool | None = None,
         stateless_http: bool | None = None,
         stateless: bool | None = None,
+        sockets: list[socket.socket] | None = None,
     ) -> None:
         """Run the server using HTTP transport.
 
@@ -250,6 +252,7 @@ class TransportMixin:
             json_response: Whether to use JSON response format (defaults to settings.json_response)
             stateless_http: Whether to use stateless HTTP (defaults to settings.stateless_http)
             stateless: Alias for stateless_http for CLI consistency
+            sockets: Pre-bound sockets to pass to Uvicorn
         """
         # Allow stateless as alias for stateless_http
         if stateless is not None and stateless_http is None:
@@ -302,7 +305,10 @@ class TransportMixin:
                     f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{host}:{port}/{path}"
                 )
 
-                await server.serve()
+                if sockets is not None:
+                    await server.serve(sockets=sockets)
+                else:
+                    await server.serve()
 
     def http_app(
         self: FastMCP,

--- a/tests/server/test_log_level.py
+++ b/tests/server/test_log_level.py
@@ -1,6 +1,7 @@
 """Test log_level parameter support in FastMCP server."""
 
 import asyncio
+import socket
 from unittest.mock import AsyncMock, patch
 
 from fastmcp import FastMCP
@@ -49,6 +50,26 @@ class TestLogLevelParameter:
 
             # Verify serve was called
             mock_instance.serve.assert_called_once()
+
+    async def test_run_http_passes_sockets_to_uvicorn(self):
+        """Test that run_http_async forwards pre-bound sockets to Uvicorn."""
+        server = FastMCP("TestServer")
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            with patch(
+                "fastmcp.server.mixins.transport.uvicorn.Server"
+            ) as mock_server_class:
+                mock_instance = mock_server_class.return_value
+                mock_instance.serve = AsyncMock()
+
+                await server.run_http_async(
+                    show_banner=False,
+                    host="127.0.0.1",
+                    port=8000,
+                    sockets=[sock],
+                )
+
+                mock_instance.serve.assert_called_once_with(sockets=[sock])
 
     async def test_run_async_passes_log_level(self):
         """Test that run_async passes log_level to transport methods."""


### PR DESCRIPTION
FastMCP's HTTP runner already delegates to Uvicorn, but it only let Uvicorn create its own listening socket from `host` and `port`. That blocks deployments that need to pre-bind sockets with custom options, such as IPv6 dual-stack listeners in rootless container environments.

This exposes Uvicorn's existing socket handoff through `run_http_async()` while preserving the current no-argument `serve()` call when no sockets are provided. `run()` and `run_async()` already forward transport kwargs, so the same option works through those entrypoints too.

```python
import socket

sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
sock.bind(("::", 8080))

await mcp.run_async(transport="http", sockets=[sock])
```

Closes #4201.
