### PR TITLE
fix: ignore missing evicted events

### DIFF
--- a/fastmcp_slim/fastmcp/server/event_store.py
+++ b/fastmcp_slim/fastmcp/server/event_store.py
@@ -121,7 +121,10 @@ class EventStore(SDKEventStore):
         # Trim to max events (delete old events)
         if len(event_ids) > self._max_events_per_stream:
             for old_id in event_ids[: -self._max_events_per_stream]:
-                await self._event_store.delete(key=old_id)
+                try:
+                    await self._event_store.delete(key=old_id)
+                except FileNotFoundError:
+                    logger.debug(f"Event {old_id} was already evicted")
             event_ids = event_ids[-self._max_events_per_stream :]
 
         await self._stream_store.put(

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -140,6 +140,20 @@ class TestEventStore:
         result = await event_store.replay_events_after(event_ids[3], callback)
         assert result == "stream-1"
 
+    async def test_missing_evicted_event_is_ignored(self, sample_message, monkeypatch):
+        event_store = EventStore(max_events_per_stream=1, ttl=3600)
+        await event_store.store_event("stream-1", sample_message)
+
+        async def delete_race(*, key: str):
+            raise FileNotFoundError(key)
+
+        monkeypatch.setattr(event_store._event_store, "delete", delete_race)
+        newest_id = await event_store.store_event("stream-1", sample_message)
+
+        stream_data = await event_store._stream_store.get(key="stream-1")
+        assert stream_data is not None
+        assert stream_data.event_ids == [newest_id]
+
     async def test_multiple_streams_are_isolated(self, event_store):
         """Events from different streams should not interfere with each other."""
         msg1 = JSONRPCMessage(


### PR DESCRIPTION
## Summary
- Treat a missing event during ring-buffer eviction as an already-completed eviction.
- Keep other storage errors visible.
- Add a regression test that simulates a concurrent deleter winning the race.

Fixes #4143

## To verify
- python -m py_compile fastmcp_slim\fastmcp\server\event_store.py tests\server\test_event_store.py
- PYTHONUTF8=1 python -m pytest tests\server\test_event_store.py -q
- python -m ruff check fastmcp_slim\fastmcp\server\event_store.py tests\server\test_event_store.py
- python -m ruff format --check fastmcp_slim\fastmcp\server\event_store.py tests\server\test_event_store.py
- git diff --check