### PR TITLE
feat: add on_connect/on_disconnect middleware hooks (closes #1894)

### DIFF
--- a/fastmcp_slim/fastmcp/server/low_level.py
+++ b/fastmcp_slim/fastmcp/server/low_level.py
@@ -237,6 +237,8 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
         """
         Overrides the run method to use the MiddlewareServerSession.
         """
+        import fastmcp.server.context
+
         async with AsyncExitStack() as stack:
             lifespan_context = await stack.enter_async_context(self.lifespan(self))
             session = await stack.enter_async_context(
@@ -249,18 +251,48 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
                 )
             )
 
-            async with anyio.create_task_group() as tg:
-                # Store task group on session for subscription tasks (SEP-1686)
-                session._subscription_task_group = tg
+            # Notify middleware that a new session has been established.
+            # session_id is generated and cached on the session here so it
+            # remains consistent for the lifetime of the session.
+            if self.fastmcp.middleware:
+                async with fastmcp.server.context.Context(
+                    fastmcp=self.fastmcp, session=session
+                ) as ctx:
+                    for mw in self.fastmcp.middleware:
+                        try:
+                            await mw.on_connect(ctx)
+                        except Exception:
+                            logger.exception(
+                                "Error in %s.on_connect", type(mw).__name__
+                            )
 
-                async for message in session.incoming_messages:
-                    tg.start_soon(
-                        self._handle_message,
-                        message,
-                        session,
-                        lifespan_context,
-                        raise_exceptions,
-                    )
+            try:
+                async with anyio.create_task_group() as tg:
+                    # Store task group on session for subscription tasks (SEP-1686)
+                    session._subscription_task_group = tg
+
+                    async for message in session.incoming_messages:
+                        tg.start_soon(
+                            self._handle_message,
+                            message,
+                            session,
+                            lifespan_context,
+                            raise_exceptions,
+                        )
+            finally:
+                # Notify middleware that the session has ended.
+                # Runs even if the session ended due to an error or disconnect.
+                if self.fastmcp.middleware:
+                    async with fastmcp.server.context.Context(
+                        fastmcp=self.fastmcp, session=session
+                    ) as ctx:
+                        for mw in self.fastmcp.middleware:
+                            try:
+                                await mw.on_disconnect(ctx)
+                            except Exception:
+                                logger.exception(
+                                    "Error in %s.on_disconnect", type(mw).__name__
+                                )
 
     def read_resource(
         self,

--- a/fastmcp_slim/fastmcp/server/middleware/middleware.py
+++ b/fastmcp_slim/fastmcp/server/middleware/middleware.py
@@ -203,3 +203,45 @@ class Middleware:
         call_next: CallNext[mt.ListPromptsRequest, Sequence[Prompt]],
     ) -> Sequence[Prompt]:
         return await call_next(context)
+
+    async def on_connect(
+        self,
+        context: "Context",
+    ) -> None:
+        """Called once when a new client session is established.
+
+        Fires before any messages are processed for the session.
+        The session_id is accessible via ``context.session_id`` and can be
+        used to track per-client state, log connections, or set up
+        session-scoped resources.
+
+        Example::
+
+            class SessionTracker(Middleware):
+                async def on_connect(self, context: Context) -> None:
+                    print(f"Client connected: {context.session_id}")
+
+                async def on_disconnect(self, context: Context) -> None:
+                    print(f"Client disconnected: {context.session_id}")
+
+        Note:
+            Unlike other middleware hooks, ``on_connect`` and ``on_disconnect``
+            do not participate in a call_next chain — all registered middleware
+            have their hooks called independently.
+        """
+
+    async def on_disconnect(
+        self,
+        context: "Context",
+    ) -> None:
+        """Called once when a client session ends.
+
+        Fires after all messages for the session have been processed,
+        including during error or disconnect scenarios.
+        The session_id is accessible via ``context.session_id``.
+
+        Note:
+            Unlike other middleware hooks, ``on_connect`` and ``on_disconnect``
+            do not participate in a call_next chain — all registered middleware
+            have their hooks called independently.
+        """

--- a/tests/server/middleware/test_on_connect_disconnect.py
+++ b/tests/server/middleware/test_on_connect_disconnect.py
@@ -1,0 +1,119 @@
+"""Tests for on_connect and on_disconnect middleware hooks."""
+
+import pytest
+
+from fastmcp import Client, FastMCP
+from fastmcp.server.context import Context
+from fastmcp.server.middleware import Middleware
+
+
+class SessionTrackingMiddleware(Middleware):
+    """Records session connect/disconnect events."""
+
+    def __init__(self):
+        self.connected_sessions: list[str] = []
+        self.disconnected_sessions: list[str] = []
+
+    async def on_connect(self, context: Context) -> None:
+        self.connected_sessions.append(context.session_id)
+
+    async def on_disconnect(self, context: Context) -> None:
+        self.disconnected_sessions.append(context.session_id)
+
+
+@pytest.fixture
+def mcp_with_tracker():
+    mcp = FastMCP("test")
+    tracker = SessionTrackingMiddleware()
+    mcp.add_middleware(tracker)
+
+    @mcp.tool()
+    def ping() -> str:
+        return "pong"
+
+    return mcp, tracker
+
+
+@pytest.mark.anyio
+async def test_on_connect_fires_on_session_start(mcp_with_tracker):
+    mcp, tracker = mcp_with_tracker
+
+    async with Client(mcp) as client:
+        assert len(tracker.connected_sessions) == 1
+
+    assert len(tracker.connected_sessions) == 1
+
+
+@pytest.mark.anyio
+async def test_on_disconnect_fires_on_session_end(mcp_with_tracker):
+    mcp, tracker = mcp_with_tracker
+
+    async with Client(mcp) as client:
+        pass  # connect then disconnect
+
+    assert len(tracker.disconnected_sessions) == 1
+
+
+@pytest.mark.anyio
+async def test_session_id_is_consistent_across_connect_and_tool_call(mcp_with_tracker):
+    """session_id in on_connect should match session_id available in tools."""
+    mcp, tracker = mcp_with_tracker
+    tool_session_ids: list[str] = []
+
+    @mcp.tool()
+    def get_session_id(ctx: Context) -> str:
+        tool_session_ids.append(ctx.session_id)
+        return ctx.session_id
+
+    async with Client(mcp) as client:
+        await client.call_tool("get_session_id", {})
+
+    assert len(tracker.connected_sessions) == 1
+    assert len(tool_session_ids) == 1
+    assert tracker.connected_sessions[0] == tool_session_ids[0]
+
+
+@pytest.mark.anyio
+async def test_on_connect_fires_per_session(mcp_with_tracker):
+    """Each session should trigger its own on_connect."""
+    mcp, tracker = mcp_with_tracker
+
+    async with Client(mcp):
+        pass
+
+    async with Client(mcp):
+        pass
+
+    assert len(tracker.connected_sessions) == 2
+    assert len(tracker.disconnected_sessions) == 2
+    # Each session gets a unique ID
+    assert tracker.connected_sessions[0] != tracker.connected_sessions[1]
+
+
+@pytest.mark.anyio
+async def test_on_disconnect_fires_even_on_error(mcp_with_tracker):
+    """on_disconnect should fire even if the session ends unexpectedly."""
+    mcp, tracker = mcp_with_tracker
+
+    try:
+        async with Client(mcp) as client:
+            raise RuntimeError("simulate crash")
+    except RuntimeError:
+        pass
+
+    assert len(tracker.disconnected_sessions) == 1
+
+
+@pytest.mark.anyio
+async def test_multiple_middleware_all_notified(mcp_with_tracker):
+    """All registered middleware should have on_connect/on_disconnect called."""
+    mcp, tracker1 = mcp_with_tracker
+    tracker2 = SessionTrackingMiddleware()
+    mcp.add_middleware(tracker2)
+
+    async with Client(mcp):
+        pass
+
+    assert len(tracker1.connected_sessions) == 1
+    assert len(tracker2.connected_sessions) == 1
+    assert tracker1.connected_sessions[0] == tracker2.connected_sessions[0]


### PR DESCRIPTION
Closes #1894

Adds on_connect and on_disconnect lifecycle hooks to the Middleware base class, giving users access to the MCP session_id when a client connects or disconnects.

Changes:

Middleware.on_connect(context) — fires once per session before any messages are processed
Middleware.on_disconnect(context) — fires once per session after all messages, guaranteed via try/finally (even on error/crash)
Both hooks receive a Context object with session_id for per-client tracking
All registered middleware are notified independently (no call_next chain)
Tests: 6 new tests, 223 total passing