### PR TITLE
fix: Trendshift link and badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [![Tests](https://github.com/PrefectHQ/fastmcp/actions/workflows/run-tests.yml/badge.svg)](https://github.com/PrefectHQ/fastmcp/actions/workflows/run-tests.yml)
 [![License](https://img.shields.io/github/license/PrefectHQ/fastmcp.svg)](https://github.com/PrefectHQ/fastmcp/blob/main/LICENSE)
 
-<a href="https://trendshift.io/repositories/13266" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13266" alt="prefecthq%2Ffastmcp | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+<a href="https://trendshift.io/repositories/21461" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21461" alt="prefecthq%2Ffastmcp | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </div>
 
 ---


### PR DESCRIPTION
## Description

<!-- What does this PR do? Link to the issue it addresses. -->

Updates the Trendshift badge in `README.md` to point to the correct repository ID.

Closes #4237

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [x] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug): 
<img width="1022" height="607" alt="image" src="https://github.com/user-attachments/assets/9e94523e-22ed-422d-9bc2-56c3387b60e4" />

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)