### PR TITLE
Restore Horizon docs banner

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,7 +12,7 @@
     "decoration": "gradient"
   },
   "banner": {
-    "content": "Deploy FastMCP servers for free on [Prefect Horizon](https://www.prefect.io/horizon)"
+    "content": "Meet [Prefect Horizon](https://prefect.io/horizon?utm_source=gofastmcp&utm_medium=docs&utm_campaign=docs_banner&utm_content=sitewide_banner), the enterprise MCP gateway built by the team behind FastMCP"
   },
   "colors": {
     "dark": "#f72585",


### PR DESCRIPTION
Update the sitewide docs banner to the Horizon copy from f5a615b8.