### PR TITLE
fix: reuse OAuth proxy upstream client

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -601,6 +601,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         # against cross-process races in distributed deployments — those are
         # handled by re-reading from storage after refresh failure.
         self._refresh_locks: OrderedDict[str, anyio.Lock] = OrderedDict()
+        self._upstream_oauth_client: AsyncOAuth2Client | None = None
 
         logger.debug(
             "Initialized OAuth proxy provider with upstream server %s",
@@ -686,16 +687,18 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         override this to provide alternative authentication methods (e.g.,
         managed-identity client assertions instead of a static client secret).
         """
-        return AsyncOAuth2Client(
-            client_id=self._upstream_client_id,
-            client_secret=(
-                self._upstream_client_secret.get_secret_value()
-                if self._upstream_client_secret is not None
-                else None
-            ),
-            token_endpoint_auth_method=self._token_endpoint_auth_method,
-            timeout=HTTP_TIMEOUT_SECONDS,
-        )
+        if self._upstream_oauth_client is None:
+            self._upstream_oauth_client = AsyncOAuth2Client(
+                client_id=self._upstream_client_id,
+                client_secret=(
+                    self._upstream_client_secret.get_secret_value()
+                    if self._upstream_client_secret is not None
+                    else None
+                ),
+                token_endpoint_auth_method=self._token_endpoint_auth_method,
+                timeout=HTTP_TIMEOUT_SECONDS,
+            )
+        return self._upstream_oauth_client
 
     def _get_refresh_lock(self, token_id: str) -> anyio.Lock:
         """Get or create a per-token refresh lock, evicting LRU entries when at capacity."""

--- a/tests/server/auth/oauth_proxy/test_oauth_proxy.py
+++ b/tests/server/auth/oauth_proxy/test_oauth_proxy.py
@@ -272,6 +272,7 @@ class TestOptionalClientSecret:
         client = proxy._create_upstream_oauth_client()
         assert isinstance(client, AsyncOAuth2Client)
         assert client.client_id == "client-123"
+        assert proxy._create_upstream_oauth_client() is client
 
     def test_factory_method_with_secret(self, jwt_verifier):
         """_create_upstream_oauth_client includes the secret when configured."""
@@ -288,6 +289,7 @@ class TestOptionalClientSecret:
         client = proxy._create_upstream_oauth_client()
         assert isinstance(client, AsyncOAuth2Client)
         assert client.client_secret == "secret-456"
+        assert proxy._create_upstream_oauth_client() is client
 
     def test_consent_cookies_work_without_secret(self, jwt_verifier):
         """Cookie signing/verification works using JWT key when no secret is configured."""

--- a/tests/server/auth/oauth_proxy/test_tokens.py
+++ b/tests/server/auth/oauth_proxy/test_tokens.py
@@ -189,12 +189,13 @@ class TestOAuthProxyTokenEndpointAuth:
             await proxy.exchange_refresh_token(client, fastmcp_refresh, ["read"])
 
             # Verify auth method was passed to OAuth client
-            MockClient.assert_called_with(
+            MockClient.assert_called_once_with(
                 client_id="client-id",
                 client_secret="client-secret",
                 token_endpoint_auth_method="client_secret_post",
                 timeout=30.0,
             )
+            mock_client.refresh_token.assert_called_once()
 
 
 class TestTokenHandlerErrorTransformation:


### PR DESCRIPTION
## Summary
- cache the OAuthProxy upstream AsyncOAuth2Client instead of constructing a new httpx pool for every upstream OAuth operation
- keep the existing token endpoint auth configuration on the cached client
- cover both client-secret and public-client construction paths with reuse assertions

Fixes #4246.

## To verify
- PYTHONUTF8=1, TMP/TEMP set to repo-local .tmp/pytest, NO_PROXY=localhost,127.0.0.1,::1 uv run pytest --basetemp .tmp/pytest-run tests/server/auth/oauth_proxy -q
- uv run ruff check fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py tests/server/auth/oauth_proxy/test_oauth_proxy.py tests/server/auth/oauth_proxy/test_tokens.py
- uv run ruff format --check fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py tests/server/auth/oauth_proxy/test_oauth_proxy.py tests/server/auth/oauth_proxy/test_tokens.py
- uv run ty check fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py tests/server/auth/oauth_proxy/test_oauth_proxy.py tests/server/auth/oauth_proxy/test_tokens.py
- python -m py_compile fastmcp_slim\fastmcp\server\auth\oauth_proxy\proxy.py tests\server\auth\oauth_proxy\test_oauth_proxy.py tests\server\auth\oauth_proxy\test_tokens.py
- git diff --check