### PR TITLE
Fix resource templates with query params on proxied servers

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -12,6 +12,7 @@ import inspect
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, cast
+import re
 from urllib.parse import quote
 
 import anyio
@@ -64,6 +65,34 @@ logger = get_logger(__name__)
 
 # Type alias for client factory functions
 ClientFactoryT = Callable[[], Client] | Callable[[], Awaitable[Client]]
+
+
+def _expand_uri_template(template: str, params: dict[str, Any]) -> str:
+    """Expand a URI template with parameters.
+
+    Handles both {name} path placeholders and RFC 6570 {?param1,param2}
+    query parameter syntax.
+    """
+    result = template
+
+    # Replace {name} path placeholders
+    for key, value in params.items():
+        result = re.sub(rf"\{{{key}\}}", quote(str(value), safe=""), result)
+
+    # Expand {?param1,param2,...} query parameter blocks
+    def _expand_query_block(match: re.Match[str]) -> str:
+        names = [n.strip() for n in match.group(1).split(",")]
+        parts = []
+        for name in names:
+            if name in params:
+                parts.append(f"{quote(name)}={quote(str(params[name]))}")
+        if parts:
+            return "?" + "&".join(parts)
+        return ""
+
+    result = re.sub(r"\{\?([^}]+)\}", _expand_query_block, result)
+
+    return result
 
 
 def _proxy_upstream_error(error: Exception) -> McpError:
@@ -395,9 +424,7 @@ class ProxyTemplate(ResourceTemplate):
         # uri_template on the remote server.
         # quote params to ensure they are valid for the uri_template
         backend_template = self._backend_uri_template or self.uri_template
-        parameterized_uri = backend_template.format(
-            **{k: quote(v, safe="") for k, v in params.items()}
-        )
+        parameterized_uri = _expand_uri_template(backend_template, params)
         client = await self._get_client()
         async with client:
             result = await client.read_resource(parameterized_uri)

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -12,8 +12,6 @@ import inspect
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, cast
-import re
-from urllib.parse import quote
 
 import anyio
 import httpx
@@ -52,6 +50,7 @@ from fastmcp.server.providers.base import Provider
 from fastmcp.server.server import FastMCP
 from fastmcp.server.tasks.config import TaskConfig
 from fastmcp.tools.base import Tool, ToolResult
+from fastmcp.resources.template import expand_uri_template
 from fastmcp.utilities.components import FastMCPComponent, get_fastmcp_metadata
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.versions import VersionSpec, version_sort_key
@@ -65,34 +64,6 @@ logger = get_logger(__name__)
 
 # Type alias for client factory functions
 ClientFactoryT = Callable[[], Client] | Callable[[], Awaitable[Client]]
-
-
-def _expand_uri_template(template: str, params: dict[str, Any]) -> str:
-    """Expand a URI template with parameters.
-
-    Handles both {name} path placeholders and RFC 6570 {?param1,param2}
-    query parameter syntax.
-    """
-    result = template
-
-    # Replace {name} path placeholders
-    for key, value in params.items():
-        result = re.sub(rf"\{{{key}\}}", quote(str(value), safe=""), result)
-
-    # Expand {?param1,param2,...} query parameter blocks
-    def _expand_query_block(match: re.Match[str]) -> str:
-        names = [n.strip() for n in match.group(1).split(",")]
-        parts = []
-        for name in names:
-            if name in params:
-                parts.append(f"{quote(name)}={quote(str(params[name]))}")
-        if parts:
-            return "?" + "&".join(parts)
-        return ""
-
-    result = re.sub(r"\{\?([^}]+)\}", _expand_query_block, result)
-
-    return result
 
 
 def _proxy_upstream_error(error: Exception) -> McpError:
@@ -424,7 +395,7 @@ class ProxyTemplate(ResourceTemplate):
         # uri_template on the remote server.
         # quote params to ensure they are valid for the uri_template
         backend_template = self._backend_uri_template or self.uri_template
-        parameterized_uri = _expand_uri_template(backend_template, params)
+        parameterized_uri = expand_uri_template(backend_template, params)
         client = await self._get_client()
         async with client:
             result = await client.read_resource(parameterized_uri)

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -396,7 +396,8 @@ class ProxyTemplate(ResourceTemplate):
         # uri_template on the remote server.
         # quote params to ensure they are valid for the uri_template
         backend_template = self._backend_uri_template or self.uri_template
-        query_param_names = extract_query_params(backend_template)
+        # Normalize to underscored keys to match how match_uri_template normalizes incoming params
+        query_param_names = {p.replace("-", "_") for p in extract_query_params(backend_template)}
         quoted_params = {
             k: (v if k in query_param_names else quote(str(v), safe=""))
             for k, v in params.items()

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -12,6 +12,7 @@ import inspect
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import quote
 
 import anyio
 import httpx
@@ -50,7 +51,7 @@ from fastmcp.server.providers.base import Provider
 from fastmcp.server.server import FastMCP
 from fastmcp.server.tasks.config import TaskConfig
 from fastmcp.tools.base import Tool, ToolResult
-from fastmcp.resources.template import expand_uri_template
+from fastmcp.resources.template import expand_uri_template, extract_query_params
 from fastmcp.utilities.components import FastMCPComponent, get_fastmcp_metadata
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.versions import VersionSpec, version_sort_key
@@ -395,7 +396,12 @@ class ProxyTemplate(ResourceTemplate):
         # uri_template on the remote server.
         # quote params to ensure they are valid for the uri_template
         backend_template = self._backend_uri_template or self.uri_template
-        parameterized_uri = expand_uri_template(backend_template, params)
+        query_param_names = extract_query_params(backend_template)
+        quoted_params = {
+            k: (v if k in query_param_names else quote(str(v), safe=""))
+            for k, v in params.items()
+        }
+        parameterized_uri = expand_uri_template(backend_template, quoted_params)
         client = await self._get_client()
         async with client:
             result = await client.read_resource(parameterized_uri)

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -43,6 +43,7 @@ from fastmcp.prompts import Message, Prompt, PromptResult
 from fastmcp.prompts.base import PromptArgument
 from fastmcp.resources import Resource, ResourceTemplate
 from fastmcp.resources.base import ResourceContent, ResourceResult
+from fastmcp.resources.template import expand_uri_template, extract_query_params
 from fastmcp.server.context import Context
 from fastmcp.server.dependencies import get_context
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
@@ -51,7 +52,6 @@ from fastmcp.server.providers.base import Provider
 from fastmcp.server.server import FastMCP
 from fastmcp.server.tasks.config import TaskConfig
 from fastmcp.tools.base import Tool, ToolResult
-from fastmcp.resources.template import expand_uri_template, extract_query_params
 from fastmcp.utilities.components import FastMCPComponent, get_fastmcp_metadata
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.versions import VersionSpec, version_sort_key
@@ -397,7 +397,9 @@ class ProxyTemplate(ResourceTemplate):
         # quote params to ensure they are valid for the uri_template
         backend_template = self._backend_uri_template or self.uri_template
         # Normalize to underscored keys to match how match_uri_template normalizes incoming params
-        query_param_names = {p.replace("-", "_") for p in extract_query_params(backend_template)}
+        query_param_names = {
+            p.replace("-", "_") for p in extract_query_params(backend_template)
+        }
         quoted_params = {
             k: (v if k in query_param_names else quote(str(v), safe=""))
             for k, v in params.items()

--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -779,6 +779,14 @@ class TestResourceTemplateQueryParams:
         assert isinstance(result[0], TextResourceContents)
         assert result[0].text == "id=123 api_version=v2"
 
+    def test_same_name_in_path_and_query_is_rejected(self):
+        remote = FastMCP("Remote")
+        with pytest.raises(ValueError, match="must be optional"):
+
+            @remote.resource("data://{id}{?id}")
+            def get_data(id: str) -> str:
+                return id
+
     async def test_hyphenated_query_param_not_double_encoded(self):
         remote = FastMCP("Remote")
 

--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -711,6 +711,49 @@ class TestResourceTemplates:
             assert user_template.name == "overwritten_get_user"
 
 
+class TestResourceTemplateQueryParams:
+    """Resource templates with RFC 6570 {?param} query params work through proxy."""
+
+    async def test_query_param_forwarded(self):
+        remote = FastMCP("Remote")
+
+        @remote.resource("data://{id}{?format}")
+        def get_data(id: str, format: str = "json") -> str:
+            return f"id={id} format={format}"
+
+        proxy = create_proxy(Client(remote))
+        async with Client(proxy) as client:
+            result = await client.read_resource("data://123?format=xml")
+        assert isinstance(result[0], TextResourceContents)
+        assert result[0].text == "id=123 format=xml"
+
+    async def test_query_param_default_used_when_omitted(self):
+        remote = FastMCP("Remote")
+
+        @remote.resource("data://{id}{?format}")
+        def get_data(id: str, format: str = "json") -> str:
+            return f"id={id} format={format}"
+
+        proxy = create_proxy(Client(remote))
+        async with Client(proxy) as client:
+            result = await client.read_resource("data://123")
+        assert isinstance(result[0], TextResourceContents)
+        assert result[0].text == "id=123 format=json"
+
+    async def test_multiple_query_params_forwarded(self):
+        remote = FastMCP("Remote")
+
+        @remote.resource("data://{id}{?limit,offset}")
+        def get_data(id: str, limit: int = 10, offset: int = 0) -> str:
+            return f"id={id} limit={limit} offset={offset}"
+
+        proxy = create_proxy(Client(remote))
+        async with Client(proxy) as client:
+            result = await client.read_resource("data://abc?limit=5&offset=20")
+        assert isinstance(result[0], TextResourceContents)
+        assert result[0].text == "id=abc limit=5 offset=20"
+
+
 class TestPrompts:
     async def test_get_prompts_server_method(self, proxy_server: FastMCPProxy):
         prompts = await proxy_server.list_prompts()

--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -779,6 +779,19 @@ class TestResourceTemplateQueryParams:
         assert isinstance(result[0], TextResourceContents)
         assert result[0].text == "id=123 api_version=v2"
 
+    async def test_hyphenated_query_param_not_double_encoded(self):
+        remote = FastMCP("Remote")
+
+        @remote.resource("data://{id}{?api-version}")
+        def get_data(id: str, api_version: str = "v1") -> str:
+            return f"id={id} api_version={api_version}"
+
+        proxy = create_proxy(Client(remote))
+        async with Client(proxy) as client:
+            result = await client.read_resource("data://123?api-version=a%2Fb")
+        assert isinstance(result[0], TextResourceContents)
+        assert result[0].text == "id=123 api_version=a/b"
+
 
 class TestPrompts:
     async def test_get_prompts_server_method(self, proxy_server: FastMCPProxy):

--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -753,6 +753,19 @@ class TestResourceTemplateQueryParams:
         assert isinstance(result[0], TextResourceContents)
         assert result[0].text == "id=abc limit=5 offset=20"
 
+    async def test_encoded_path_param_preserved(self):
+        remote = FastMCP("Remote")
+
+        @remote.resource("data://{id}")
+        def get_data(id: str) -> str:
+            return f"id={id}"
+
+        proxy = create_proxy(Client(remote))
+        async with Client(proxy) as client:
+            result = await client.read_resource("data://a%2Fb")
+        assert isinstance(result[0], TextResourceContents)
+        assert result[0].text == "id=a/b"
+
     async def test_hyphenated_query_param_forwarded(self):
         remote = FastMCP("Remote")
 

--- a/tests/server/providers/proxy/test_proxy_server.py
+++ b/tests/server/providers/proxy/test_proxy_server.py
@@ -753,6 +753,19 @@ class TestResourceTemplateQueryParams:
         assert isinstance(result[0], TextResourceContents)
         assert result[0].text == "id=abc limit=5 offset=20"
 
+    async def test_hyphenated_query_param_forwarded(self):
+        remote = FastMCP("Remote")
+
+        @remote.resource("data://{id}{?api-version}")
+        def get_data(id: str, api_version: str = "v1") -> str:
+            return f"id={id} api_version={api_version}"
+
+        proxy = create_proxy(Client(remote))
+        async with Client(proxy) as client:
+            result = await client.read_resource("data://123?api-version=v2")
+        assert isinstance(result[0], TextResourceContents)
+        assert result[0].text == "id=123 api_version=v2"
+
 
 class TestPrompts:
     async def test_get_prompts_server_method(self, proxy_server: FastMCPProxy):


### PR DESCRIPTION
When a resource template uses RFC 6570 query parameters (`{?param}`) and is accessed through `create_proxy`, reading the resource raises a `KeyError` whose message is the query param string (e.g., `'?format'`). This is the same bug fixed for mounted servers in #3366 / #3373, but in `ProxyTemplate.create_resource()` instead of the FastMCP provider path.

`create_resource()` was using `str.format()` to expand the backend URI template. Python's `str.format()` treats `{?format}` as a format placeholder, but `?format` is not a valid Python identifier.

The fix adds `_expand_uri_template()` to `proxy.py` — same pattern as the fix in `fastmcp_provider.py` from #3373 — and calls it instead of `str.format()`.

Closes #4250