### PR TITLE
Fix GitHub MCP resource integration test

### DIFF
--- a/tests/integration_tests/test_github_mcp_remote.py
+++ b/tests/integration_tests/test_github_mcp_remote.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 from mcp import McpError
-from mcp.types import TextContent, Tool
+from mcp.types import Resource, TextContent, Tool
 
 from fastmcp import Client
 from fastmcp.client import StreamableHttpTransport
@@ -75,7 +75,10 @@ class TestGithubMCPRemote:
             assert streamable_http_client.is_connected()
             resources = await streamable_http_client.list_resources()
             assert isinstance(resources, list)
-            assert len(resources) == 0
+            for resource in resources:
+                assert isinstance(resource, Resource)
+                assert resource.name
+                assert str(resource.uri)
 
     async def test_list_prompts(
         self, streamable_http_client: Client[StreamableHttpTransport]


### PR DESCRIPTION
GitHub's remote MCP server now advertises UI resources, so the integration test should exercise FastMCP's ability to list resources without freezing GitHub's current resource count into our suite. This keeps the test focused on the client contract: list_resources returns a list, and every returned item is a valid MCP Resource with a name and URI.

Before, a harmless upstream addition made CI fail:

```python
assert len(resources) == 0
```

Now the test accepts GitHub's live resource catalog while still validating the shape FastMCP exposes:

```python
resources = await streamable_http_client.list_resources()
assert isinstance(resources, list)
for resource in resources:
    assert isinstance(resource, Resource)
    assert resource.name
    assert str(resource.uri)
```
