### PR TITLE
Fix MDX syntax error in changelog

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -279,7 +279,7 @@ A grab bag of fixes, hardening, and polish. The headline behavior change: backgr
 A stopgap pin: fakeredis 2.35.0 shipped an undocumented rename that broke pydocket's `memory://` backend, causing `fastmcp[tasks]` installs to fail at startup with an `ImportError`. This pins `fakeredis<2.35.0` in the `tasks` extra until a fixed pydocket ships.
 
 ### Fixes 🐞
-* Pin fakeredis<2.35.0 in tasks extra by [@jlowin](https://github.com/jlowin) in [#3804](https://github.com/PrefectHQ/fastmcp/pull/3804)
+* Pin `fakeredis<2.35.0` in tasks extra by [@jlowin](https://github.com/jlowin) in [#3804](https://github.com/PrefectHQ/fastmcp/pull/3804)
 ### Docs 📚
 * Document session state isolation across mount boundaries by [@jlowin](https://github.com/jlowin) in [#3801](https://github.com/PrefectHQ/fastmcp/pull/3801)
 
@@ -1309,7 +1309,7 @@ Breaking changes are minimal: for most servers, updating the import statement is
 A 2.x backport of the fakeredis pin: fakeredis 2.35.0 renamed a connection class that pydocket's `memory://` backend depended on, crashing `fastmcp[tasks]` installs at startup. This caps `fakeredis<2.35.0` on the 2.x line.
 
 ### Fixes 🐞
-* fix(deps): cap fakeredis to <2.35.0 to prevent startup crash on 2.x by [@vincent067](https://github.com/vincent067) in [#3883](https://github.com/PrefectHQ/fastmcp/pull/3883)
+* fix(deps): cap fakeredis to `<2.35.0` to prevent startup crash on 2.x by [@vincent067](https://github.com/vincent067) in [#3883](https://github.com/PrefectHQ/fastmcp/pull/3883)
 
 **Full Changelog**: [v2.14.6...v2.14.7](https://github.com/PrefectHQ/fastmcp/compare/v2.14.6...v2.14.7)
 

--- a/docs/v2/changelog.mdx
+++ b/docs/v2/changelog.mdx
@@ -4,6 +4,20 @@ icon: "list-check"
 rss: true
 ---
 
+<Update label="v2.14.7" description="2026-04-13">
+
+**[v2.14.7: Fake It Till You Break It](https://github.com/PrefectHQ/fastmcp/releases/tag/v2.14.7)**
+
+A 2.x backport of the fakeredis pin: fakeredis 2.35.0 renamed a connection class that pydocket's `memory://` backend depended on, crashing `fastmcp[tasks]` installs at startup. This caps `fakeredis<2.35.0` on the 2.x line.
+
+## What's Changed
+### Fixes 🐞
+* fix(deps): cap fakeredis to `<2.35.0` to prevent startup crash on 2.x by [@vincent067](https://github.com/vincent067) in [#3883](https://github.com/PrefectHQ/fastmcp/pull/3883)
+
+**Full Changelog**: [v2.14.6...v2.14.7](https://github.com/PrefectHQ/fastmcp/compare/v2.14.6...v2.14.7)
+
+</Update>
+
 <Update label="v2.14.6" description="2026-03-27">
 
 **[v2.14.6: $Ref Dead Redemption](https://github.com/PrefectHQ/fastmcp/releases/tag/v2.14.6)**

--- a/docs/v2/updates.mdx
+++ b/docs/v2/updates.mdx
@@ -5,6 +5,16 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 2.14.7" description="April 13, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP 2.14.7: Fake It Till You Break It"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v2.14.7"
+cta="Read the release notes"
+>
+A 2.x backport of the fakeredis pin: fakeredis 2.35.0 renamed a connection class that pydocket's `memory://` backend relied on, crashing `fastmcp[tasks]` installs at startup. Caps `fakeredis<2.35.0` on the 2.x line.
+</Card>
+</Update>
+
 <Update label="FastMCP 2.14.6" description="March 27, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP 2.14.6: $Ref Dead Redemption"


### PR DESCRIPTION
The changelog backfill (#4269) broke the Mintlify deployment: two PR-title bullets carried a raw `fakeredis<2.35.0` version spec, and MDX parses `<2...` as a JSX tag and errors. Backticking the spec (matching how every other version constraint in the file is written) renders it as inline code and fixes the deploy.
