### PR TITLE
Update Prettier hook to use custom repository and upgrade to v3.8.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
     hooks:
       - id: validate-pyproject
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/JoC0de/pre-commit-prettier
+    rev: v3.8.1
     hooks:
       - id: prettier
         types_or: [yaml, json5]


### PR DESCRIPTION
## Description

This pull request updates the Prettier pre-commit hook configuration to use a different repository and a newer version. This ensures compatibility and potentially includes bug fixes and new features.

Pre-commit hook update:

* Switched the Prettier hook in `.pre-commit-config.yaml` from the official `mirrors-prettier` repository to the `JoC0de/pre-commit-prettier` fork, and upgraded the version from `v3.1.0` to `v3.8.1`.

recreated form #4271
closes #4272

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [ ] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)
