### PR TITLE
Log refresh-token misses in OAuthProxy instead of failing silently

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -1371,6 +1371,13 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         token_hash = _hash_token(refresh_token)
         metadata = await self._refresh_token_store.get(key=token_hash)
         if not metadata:
+            logger.warning(
+                "Refresh token not found for client=%s (token_hash=%s); it was "
+                "already rotated, expired, or revoked. Rejecting with invalid_grant, "
+                "which forces the client to re-authenticate.",
+                client.client_id,
+                token_hash[:8],
+            )
             return None
         # Verify token belongs to this client (prevents cross-client token usage)
         if metadata.client_id != client.client_id:

--- a/tests/server/auth/oauth_proxy/test_tokens.py
+++ b/tests/server/auth/oauth_proxy/test_tokens.py
@@ -1,5 +1,6 @@
 """Tests for OAuth proxy token endpoint and handling."""
 
+import logging
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -1883,3 +1884,30 @@ class TestTransparentUpstreamRefresh:
         assert result is not None
         assert result.token == "refreshed-upstream-access"
         mock_oauth_client.refresh_token.assert_called_once()
+
+
+class TestRefreshTokenMissLogging:
+    """A refresh-token miss forces a user-visible reconnect, so it must not be silent."""
+
+    async def test_unknown_refresh_token_logs_warning(self, oauth_proxy, caplog):
+        client = OAuthClientInformationFull(
+            client_id="test-client",
+            client_secret="test-secret",
+            redirect_uris=[AnyUrl("http://localhost:12345/callback")],
+        )
+
+        proxy_logger = logging.getLogger("fastmcp.server.auth.oauth_proxy.proxy")
+        caplog.set_level(logging.WARNING)
+        proxy_logger.addHandler(caplog.handler)
+        try:
+            result = await oauth_proxy.load_refresh_token(client, "nonexistent-token")
+        finally:
+            proxy_logger.removeHandler(caplog.handler)
+
+        assert result is None
+        assert any(
+            record.levelno == logging.WARNING
+            and "Refresh token not found" in record.getMessage()
+            and "test-client" in record.getMessage()
+            for record in caplog.records
+        )


### PR DESCRIPTION
When `OAuthProxy` rejects a refresh token it can't find, it does so silently: `load_refresh_token` returns `None` for a token that was already rotated, expired, or revoked, the SDK turns that into `invalid_grant`, and the client is forced through a full reconnect. Nothing is logged at any level, so the disconnect is invisible in server logs and impossible to triage. This came up in #4265, where two operators independently hit it and had to enable DEBUG and add custom middleware just to see that a refresh had failed.

This adds a `warning` at the point of failure, naming the likely cause and consequence so the event shows up at the default log level:

```
Refresh token not found for client=abc123 (token_hash=9f2a1c4e); it was
already rotated, expired, or revoked. Rejecting with invalid_grant, which
forces the client to re-authenticate.
```

Only a truncated token hash is logged, never the token itself. This is scoped to observability; rotation behavior is unchanged.

Refs #4265
