### PR TITLE
fix: preserve required discriminator tags

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema.py
@@ -89,6 +89,25 @@ def _strip_discriminator(obj: Any) -> Any:
     """
     if isinstance(obj, dict):
         skip = "discriminator" in obj and ("anyOf" in obj or "oneOf" in obj)
+        if skip:
+            discriminator = obj.get("discriminator")
+            property_name = (
+                discriminator.get("propertyName")
+                if isinstance(discriminator, dict)
+                else None
+            )
+            if isinstance(property_name, str):
+                obj = obj.copy()
+                for key in ("anyOf", "oneOf"):
+                    variants = obj.get(key)
+                    if not isinstance(variants, list):
+                        continue
+                    obj[key] = [
+                        _require_property(variant, property_name)
+                        if isinstance(variant, dict)
+                        else variant
+                        for variant in variants
+                    ]
         # Keys that hold instance data, not sub-schemas — don't recurse.
         _DATA_KEYS = {"default", "const", "examples", "enum"}
         return {
@@ -99,6 +118,16 @@ def _strip_discriminator(obj: Any) -> Any:
     if isinstance(obj, list):
         return [_strip_discriminator(item) for item in obj]
     return obj
+
+
+def _require_property(schema: dict[str, Any], property_name: str) -> dict[str, Any]:
+    """Return a copy of *schema* with *property_name* in ``required``."""
+    required = schema.get("required")
+    if required is None:
+        return {**schema, "required": [property_name]}
+    if isinstance(required, list) and property_name not in required:
+        return {**schema, "required": [*required, property_name]}
+    return schema
 
 
 def dereference_refs(schema: dict[str, Any]) -> dict[str, Any]:

--- a/fastmcp_slim/fastmcp/utilities/openapi/json_schema_converter.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/json_schema_converter.py
@@ -96,17 +96,20 @@ def convert_openapi_schema_to_json_schema(
     if convert_one_of_to_any_of and "oneOf" in result:
         result["anyOf"] = result.pop("oneOf")
 
-    # Step 3: Remove OpenAPI-specific fields
+    # Step 3: Preserve discriminator tag presence before removing the keyword
+    result = _require_discriminator_property(result)
+
+    # Step 4: Remove OpenAPI-specific fields
     for field in OPENAPI_SPECIFIC_FIELDS:
         result.pop(field, None)
 
-    # Step 4: Handle readOnly/writeOnly property removal
+    # Step 5: Handle readOnly/writeOnly property removal
     if remove_read_only or remove_write_only:
         result = _filter_properties_by_access(
             result, remove_read_only, remove_write_only
         )
 
-    # Step 5: Recursively process nested schemas
+    # Step 6: Recursively process nested schemas
     for field_name, field_type in RECURSIVE_FIELDS.items():
         if field_name in result:
             if field_type is dict and isinstance(result[field_name], dict):
@@ -147,6 +150,38 @@ def convert_openapi_schema_to_json_schema(
                 ]
 
     return result
+
+
+def _require_discriminator_property(schema: dict[str, Any]) -> dict[str, Any]:
+    """Keep discriminator tags mandatory after dropping OpenAPI metadata."""
+    discriminator = schema.get("discriminator")
+    if not isinstance(discriminator, dict):
+        return schema
+    property_name = discriminator.get("propertyName")
+    if not isinstance(property_name, str):
+        return schema
+
+    result = schema.copy()
+    for key in ("anyOf", "oneOf"):
+        variants = result.get(key)
+        if not isinstance(variants, list):
+            continue
+        result[key] = [
+            _require_property(variant, property_name)
+            if isinstance(variant, dict)
+            else variant
+            for variant in variants
+        ]
+    return result
+
+
+def _require_property(schema: dict[str, Any], property_name: str) -> dict[str, Any]:
+    required = schema.get("required")
+    if required is None:
+        return {**schema, "required": [property_name]}
+    if isinstance(required, list) and property_name not in required:
+        return {**schema, "required": [*required, property_name]}
+    return schema
 
 
 def _convert_nullable_field(schema: dict[str, Any]) -> dict[str, Any]:

--- a/tests/utilities/openapi/test_discriminator.py
+++ b/tests/utilities/openapi/test_discriminator.py
@@ -1,0 +1,38 @@
+from fastmcp.utilities.openapi.json_schema_converter import (
+    convert_openapi_schema_to_json_schema,
+)
+
+
+def test_discriminator_property_remains_required_when_removed():
+    schema = {
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"const": "comprehensive", "type": "string"},
+                },
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"const": "validate", "type": "string"},
+                    "target_id": {"type": "string"},
+                },
+                "required": ["target_id"],
+            },
+        ],
+        "discriminator": {"propertyName": "kind"},
+    }
+
+    result = convert_openapi_schema_to_json_schema(schema, "3.0.0")
+
+    assert "oneOf" not in result
+    assert "discriminator" not in result
+    for variant in result["anyOf"]:
+        assert "kind" in variant["required"]
+    validate_schema = next(
+        variant
+        for variant in result["anyOf"]
+        if variant["properties"]["kind"]["const"] == "validate"
+    )
+    assert validate_schema["required"] == ["target_id", "kind"]

--- a/tests/utilities/test_json_schema.py
+++ b/tests/utilities/test_json_schema.py
@@ -292,6 +292,48 @@ class TestDereferenceRefs:
         actions = {v["properties"]["action"]["const"] for v in result["anyOf"]}
         assert actions == {"identify", "delete"}
 
+    def test_discriminator_property_remains_required_after_inlining(self):
+        schema = {
+            "$defs": {
+                "Comprehensive": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"const": "comprehensive", "type": "string"},
+                    },
+                },
+                "Validate": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"const": "validate", "type": "string"},
+                        "target_id": {"type": "string"},
+                    },
+                    "required": ["target_id"],
+                },
+            },
+            "anyOf": [
+                {"$ref": "#/$defs/Comprehensive"},
+                {"$ref": "#/$defs/Validate"},
+            ],
+            "discriminator": {
+                "mapping": {
+                    "comprehensive": "#/$defs/Comprehensive",
+                    "validate": "#/$defs/Validate",
+                },
+                "propertyName": "kind",
+            },
+        }
+        result = dereference_refs(schema)
+
+        assert "discriminator" not in result
+        for variant in result["anyOf"]:
+            assert "kind" in variant["required"]
+        validate_schema = next(
+            variant
+            for variant in result["anyOf"]
+            if variant["properties"]["kind"]["const"] == "validate"
+        )
+        assert validate_schema["required"] == ["target_id", "kind"]
+
     def test_preserves_property_named_discriminator(self):
         """A field *named* 'discriminator' inside properties must survive."""
         schema = {


### PR DESCRIPTION
## Summary

Fixes #4280.

FastMCP currently drops OpenAPI `discriminator` metadata after inlining schemas, but that loses one important semantic: the discriminator property itself must be present. If a Pydantic discriminated-union variant gives the tag a default, Pydantic does not put that tag in `required`; after `oneOf` becomes `anyOf`, an untagged payload can pass the generated tool schema and fail later in the source model with `union_tag_not_found`.

This keeps the existing behavior of removing the OpenAPI-only `discriminator` keyword, but first copies `discriminator.propertyName` into each `anyOf` / `oneOf` variant's `required` list.

## What changed

- preserve required discriminator tags in `dereference_refs()` before stripping discriminator metadata
- do the same in the OpenAPI schema converter before removing OpenAPI-specific fields
- add regression coverage for both paths:
  - `$defs` inlining + discriminator removal
  - OpenAPI `oneOf` -> JSON Schema `anyOf` conversion

## Validation

- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run pytest tests\utilities\test_json_schema.py::TestDereferenceRefs::test_strips_discriminator_mapping_after_inlining tests\utilities\test_json_schema.py::TestDereferenceRefs::test_discriminator_property_remains_required_after_inlining tests\utilities\openapi\test_discriminator.py -q`
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run pytest tests\utilities\test_json_schema.py tests\utilities\openapi -q`
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run ruff check fastmcp_slim\fastmcp\utilities\json_schema.py fastmcp_slim\fastmcp\utilities\openapi\json_schema_converter.py tests\utilities\test_json_schema.py tests\utilities\openapi\test_discriminator.py`
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run ruff format --check fastmcp_slim\fastmcp\utilities\json_schema.py fastmcp_slim\fastmcp\utilities\openapi\json_schema_converter.py tests\utilities\test_json_schema.py tests\utilities\openapi\test_discriminator.py`
- `python -m py_compile fastmcp_slim\fastmcp\utilities\json_schema.py fastmcp_slim\fastmcp\utilities\openapi\json_schema_converter.py tests\utilities\openapi\test_discriminator.py`
- `git diff --check`

Note: the first pytest run on Windows without `PYTHONUTF8=1` hit a local `pdbpp` source decode error under the default GBK codec. The same tests pass with UTF-8 enabled.
