### PR TITLE
fix(fs): isolate filesystem package imports

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py
+++ b/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py
@@ -13,6 +13,7 @@ import hashlib
 import importlib.util
 import sys
 from dataclasses import dataclass, field
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import ModuleType
 
@@ -116,6 +117,79 @@ def _compute_module_name(file_path: Path, package_root: Path) -> str:
     return ".".join(parts)
 
 
+def _module_file_matches(module: ModuleType, file_path: Path) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return False
+    return Path(module_file).resolve() == file_path.resolve()
+
+
+def _package_path_matches(module: ModuleType, package_root: Path) -> bool:
+    module_paths = getattr(module, "__path__", None)
+    if not module_paths:
+        return False
+    package_root = package_root.resolve()
+    return any(Path(p).resolve() == package_root for p in module_paths)
+
+
+def _private_package_prefix(package_root: Path) -> str:
+    digest = hashlib.sha1(str(package_root.resolve()).encode()).hexdigest()[:12]
+    return f"_fastmcp_pkg_{digest}"
+
+
+def _ensure_package_alias(name: str, package_path: Path) -> None:
+    package_path = package_path.resolve()
+    existing = sys.modules.get(name)
+    if existing is not None and _package_path_matches(existing, package_path):
+        return
+
+    init_file = package_path / "__init__.py"
+    if init_file.exists():
+        spec = importlib.util.spec_from_file_location(
+            name,
+            init_file,
+            submodule_search_locations=[str(package_path)],
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load package spec for {init_file}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return
+
+    module = ModuleType(name)
+    module.__path__ = [str(package_path)]  # type: ignore[attr-defined]
+    module.__package__ = name
+    module.__spec__ = ModuleSpec(name, loader=None, is_package=True)
+    sys.modules[name] = module
+
+
+def _import_module_from_spec(module_name: str, file_path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load spec for {file_path}")
+
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        existing.__spec__ = spec
+        existing.__loader__ = spec.loader
+        existing.__file__ = str(file_path)
+        try:
+            spec.loader.exec_module(existing)
+        except Exception as e:
+            raise ImportError(f"Failed to reload module {file_path}: {e}") from e
+        return existing
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        sys.modules.pop(module_name, None)
+        raise ImportError(f"Failed to execute module {file_path}: {e}") from e
+    return module
+
+
 def import_module_from_file(
     file_path: Path, provider_root: Path | None = None
 ) -> ModuleType:
@@ -149,6 +223,20 @@ def import_module_from_file(
     if package_root is not None:
         # Import as part of a package
         module_name = _compute_module_name(file_path, package_root)
+        existing = sys.modules.get(module_name)
+        if existing is not None and not _module_file_matches(existing, file_path):
+            prefix = _private_package_prefix(package_root)
+            private_module_name = f"{prefix}.{module_name}"
+            _ensure_package_alias(prefix, package_root.parent)
+
+            package_name = prefix
+            package_path = package_root.parent
+            for part in module_name.split(".")[:-1]:
+                package_name = f"{package_name}.{part}"
+                package_path = package_path / part
+                _ensure_package_alias(package_name, package_path)
+
+            return _import_module_from_spec(private_module_name, file_path)
 
         # Temporarily add package root's parent to sys.path for the import
         package_parent = str(package_root.parent)

--- a/tests/fs/test_provider.py
+++ b/tests/fs/test_provider.py
@@ -459,6 +459,47 @@ def charge(amount: float) -> str:
             names = {t.name for t in tools_list}
             assert names == {"greet", "charge"}
 
+    async def test_mounted_servers_with_same_package_name(self, tmp_path: Path):
+        """Same package names in different provider roots should not collide."""
+        for server_name, tool_name in [
+            ("server1", "server1_tool"),
+            ("server2", "server2_tool"),
+        ]:
+            components = tmp_path / server_name / "components"
+            components.mkdir(parents=True)
+            (components / "__init__.py").write_text("")
+            (components / "tools.py").write_text(
+                f"""\
+from fastmcp.tools import tool
+
+@tool
+def {tool_name}() -> str:
+    return "{tool_name}"
+"""
+            )
+
+        server1 = FastMCP(
+            "server1",
+            providers=[
+                FileSystemProvider(tmp_path / "server1" / "components"),
+            ],
+        )
+        server2 = FastMCP(
+            "server2",
+            providers=[
+                FileSystemProvider(tmp_path / "server2" / "components"),
+            ],
+        )
+        parent = FastMCP("parent")
+        parent.mount(server1)
+        parent.mount(server2)
+
+        tools = await parent.list_tools()
+        assert {t.name for t in tools} == {"server1_tool", "server2_tool"}
+
+        result = await parent.call_tool("server2_tool", {})
+        assert "server2_tool" in str(result)
+
 
 class TestFileSystemProviderVersioning:
     """Tests for version propagation through FileSystemProvider."""


### PR DESCRIPTION
## Summary
- avoid reusing an already-loaded package module when a FileSystemProvider root has the same package name in a different directory
- load the colliding package path under a private FastMCP alias so mounted filesystem providers can coexist
- add a regression test for two mounted servers whose providers both expose a `components/tools.py` package

Fixes #4296.

## Tests
- `python -m pytest tests\fs\test_provider.py::TestFileSystemProviderIntegration::test_mounted_servers_with_same_package_name -q`
- `python -m pytest tests\fs\test_provider.py::TestFileSystemProviderIntegration -q`
- `python -m pytest tests\fs\test_provider.py -q`
- `python -m py_compile fastmcp_slim\fastmcp\server\providers\filesystem_discovery.py tests\fs\test_provider.py`
- `python -m ruff check fastmcp_slim\fastmcp\server\providers\filesystem_discovery.py tests\fs\test_provider.py`
- `python -m ruff format --check fastmcp_slim\fastmcp\server\providers\filesystem_discovery.py tests\fs\test_provider.py`
- `git diff --check`

Notes: pytest reports the existing `Unknown config option: env` warning in this local environment. Ruff also reports a Windows permission warning while writing `.ruff_cache`, but exits successfully.
