### PR TITLE
Wrap tool argument validation errors

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -35,7 +35,6 @@ from mcp.types import (
     ToolAnnotations,
 )
 from pydantic import AnyUrl
-from pydantic import ValidationError as PydanticValidationError
 from starlette.routing import BaseRoute
 from typing_extensions import Self
 
@@ -54,6 +53,7 @@ from fastmcp.exceptions import (
     PromptError,
     ResourceError,
     ToolError,
+    ValidationError,
 )
 from fastmcp.mcp_config import MCPConfig
 from fastmcp.prompts import Prompt
@@ -1280,17 +1280,14 @@ class FastMCP(
                     task_meta = replace(task_meta, fn_key=tool.key)
                 try:
                     return await tool._run(arguments or {}, task_meta=task_meta)
+                except ValidationError as e:
+                    logger.log(
+                        e.log_level, f"Invalid arguments for tool {name!r}: {e}"
+                    )
+                    raise
                 except FastMCPError as e:
                     logger.log(
                         e.log_level, f"Error calling tool {name!r}", exc_info=False
-                    )
-                    raise
-                except PydanticValidationError as e:
-                    # fastmcp's own ValidationError is a FastMCPError, already handled above.
-                    logger.warning(
-                        "Invalid arguments for tool %r: %s",
-                        name,
-                        e.errors(include_url=False),
                     )
                     raise
                 except Exception as e:

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -1281,9 +1281,7 @@ class FastMCP(
                 try:
                     return await tool._run(arguments or {}, task_meta=task_meta)
                 except ValidationError as e:
-                    logger.log(
-                        e.log_level, f"Invalid arguments for tool {name!r}: {e}"
-                    )
+                    logger.log(e.log_level, f"Invalid arguments for tool {name!r}: {e}")
                     raise
                 except FastMCPError as e:
                     logger.log(

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -23,11 +24,12 @@ import anyio
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, Icon, ToolAnnotations
 from pydantic import Field
+from pydantic import ValidationError as PydanticValidationError
 from pydantic.json_schema import SkipJsonSchema
 
 import fastmcp
 from fastmcp.decorators import get_fastmcp_meta, resolve_task_config
-from fastmcp.exceptions import FastMCPDeprecationWarning
+from fastmcp.exceptions import FastMCPDeprecationWarning, ValidationError
 from fastmcp.tools.base import (
     Tool,
     ToolResult,
@@ -54,6 +56,23 @@ if TYPE_CHECKING:
     from docket.execution import Execution
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _exception_traceback_contains_callable(
+    exc: BaseException, fn: Callable[..., Any]
+) -> bool:
+    target = fn.__func__ if inspect.ismethod(fn) else fn
+    code = getattr(target, "__code__", None)
+    if code is None:
+        return False
+
+    traceback = exc.__traceback__
+    while traceback is not None:
+        if traceback.tb_frame.f_code is code:
+            return True
+        traceback = traceback.tb_next
+
+    return False
 
 
 @runtime_checkable
@@ -292,54 +311,62 @@ class FunctionTool(Tool):
         )
         type_adapter = get_cached_typeadapter(wrapper_fn)
 
-        # Apply timeout if configured. Combining timeout with
-        # run_in_thread=False on a sync function is rejected at
-        # registration (see FunctionTool.from_function), so the timeout
-        # path here only needs to handle async and threadpool-sync.
-        if self.timeout is not None:
-            try:
-                with anyio.fail_after(self.timeout):
-                    # Thread pool execution for sync functions, direct await for async
-                    if is_coroutine_function(wrapper_fn):
-                        result = await type_adapter.validate_python(arguments)
-                    else:
-                        # Sync function: run in threadpool to avoid blocking
-                        result = await call_sync_fn_in_threadpool(
-                            type_adapter.validate_python, arguments
-                        )
-                        # Handle sync wrappers that return awaitables
-                        if inspect.isawaitable(result):
-                            result = await result
-                    # Materialize generators inside timeout scope so slow
-                    # generators don't run past the configured timeout
-                    result = await self._materialize_generator(result)
-            except TimeoutError:
-                logger.warning(
-                    f"Tool '{self.name}' timed out after {self.timeout}s. "
-                    f"Consider using task=True for long-running operations. "
-                    f"See https://gofastmcp.com/servers/tasks"
-                )
-                raise McpError(
-                    ErrorData(
-                        code=-32000,
-                        message=f"Tool '{self.name}' execution timed out after {self.timeout}s",
+        try:
+            # Apply timeout if configured. Combining timeout with
+            # run_in_thread=False on a sync function is rejected at
+            # registration (see FunctionTool.from_function), so the timeout
+            # path here only needs to handle async and threadpool-sync.
+            if self.timeout is not None:
+                try:
+                    with anyio.fail_after(self.timeout):
+                        # Thread pool execution for sync functions, direct await for async
+                        if is_coroutine_function(wrapper_fn):
+                            result = await type_adapter.validate_python(arguments)
+                        else:
+                            # Sync function: run in threadpool to avoid blocking
+                            result = await call_sync_fn_in_threadpool(
+                                type_adapter.validate_python, arguments
+                            )
+                            # Handle sync wrappers that return awaitables
+                            if inspect.isawaitable(result):
+                                result = await result
+                        # Materialize generators inside timeout scope so slow
+                        # generators don't run past the configured timeout
+                        result = await self._materialize_generator(result)
+                except TimeoutError:
+                    logger.warning(
+                        f"Tool '{self.name}' timed out after {self.timeout}s. "
+                        f"Consider using task=True for long-running operations. "
+                        f"See https://gofastmcp.com/servers/tasks"
                     )
-                ) from None
-        else:
-            # No timeout: use existing execution path
-            if is_coroutine_function(wrapper_fn):
-                result = await type_adapter.validate_python(arguments)
-            elif self.run_in_thread:
-                result = await call_sync_fn_in_threadpool(
-                    type_adapter.validate_python, arguments
-                )
-                if inspect.isawaitable(result):
-                    result = await result
+                    raise McpError(
+                        ErrorData(
+                            code=-32000,
+                            message=f"Tool '{self.name}' execution timed out after {self.timeout}s",
+                        )
+                    ) from None
             else:
-                result = type_adapter.validate_python(arguments)
-                if inspect.isawaitable(result):
-                    result = await result
-            result = await self._materialize_generator(result)
+                # No timeout: use existing execution path
+                if is_coroutine_function(wrapper_fn):
+                    result = await type_adapter.validate_python(arguments)
+                elif self.run_in_thread:
+                    result = await call_sync_fn_in_threadpool(
+                        type_adapter.validate_python, arguments
+                    )
+                    if inspect.isawaitable(result):
+                        result = await result
+                else:
+                    result = type_adapter.validate_python(arguments)
+                    if inspect.isawaitable(result):
+                        result = await result
+                result = await self._materialize_generator(result)
+        except PydanticValidationError as e:
+            if _exception_traceback_contains_callable(e, self.fn):
+                raise
+            raise ValidationError(
+                f"Invalid arguments for tool {self.name!r}: {e.errors(include_url=False)}",
+                log_level=logging.WARNING,
+            ) from e
 
         return self.convert_result(result)
 

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -364,7 +364,8 @@ class FunctionTool(Tool):
             if _exception_traceback_contains_callable(e, self.fn):
                 raise
             raise ValidationError(
-                f"Invalid arguments for tool {self.name!r}: {e.errors(include_url=False)}",
+                f"Invalid arguments for tool {self.name!r}: validation failed: "
+                f"{e.errors(include_url=False)}",
                 log_level=logging.WARNING,
             ) from e
 

--- a/tests/server/test_input_validation.py
+++ b/tests/server/test_input_validation.py
@@ -8,12 +8,16 @@ strict_input_validation=False, the default).
 
 import json
 
+import mcp.types
 import pytest
 from mcp.types import TextContent
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 
 from fastmcp import Client, FastMCP
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError, ValidationError as FastMCPValidationError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import ToolResult
 
 
 class UserProfile(BaseModel):
@@ -352,6 +356,58 @@ class TestEdgeCases:
 
 
 class TestExpectedToolFailureLogging:
+    async def test_invalid_tool_arguments_raise_fastmcp_validation_error(self):
+        server = FastMCP("TestServer", strict_input_validation=False)
+
+        @server.tool
+        def square(n: int) -> int:
+            return n * n
+
+        with pytest.raises(FastMCPValidationError) as exc_info:
+            await server.call_tool("square", {"n": "not-a-number"})
+
+        assert isinstance(exc_info.value.__cause__, PydanticValidationError)
+        assert "Invalid arguments for tool 'square'" in str(exc_info.value)
+
+    async def test_middleware_can_catch_invalid_tool_argument_validation_error(self):
+        server = FastMCP("TestServer", strict_input_validation=False)
+        observed: list[FastMCPValidationError] = []
+
+        @server.tool
+        def square(n: int) -> int:
+            return n * n
+
+        class ObservingMiddleware(Middleware):
+            async def on_call_tool(
+                self,
+                context: MiddlewareContext[mcp.types.CallToolRequestParams],
+                call_next: CallNext[mcp.types.CallToolRequestParams, ToolResult],
+            ) -> ToolResult:
+                try:
+                    return await call_next(context)
+                except FastMCPValidationError as exc:
+                    observed.append(exc)
+                    raise
+
+        server.add_middleware(ObservingMiddleware())
+
+        with pytest.raises(FastMCPValidationError):
+            await server.call_tool("square", {"n": "not-a-number"})
+
+        assert len(observed) == 1
+
+    async def test_tool_body_pydantic_validation_error_is_tool_error(self):
+        server = FastMCP("TestServer", strict_input_validation=False)
+
+        @server.tool
+        def validate_inside() -> None:
+            UserProfile.model_validate({"name": "x", "age": "nope", "email": "e"})
+
+        with pytest.raises(ToolError) as exc_info:
+            await server.call_tool("validate_inside", {})
+
+        assert isinstance(exc_info.value.__cause__, PydanticValidationError)
+
     async def test_validation_error_logs_warning_without_traceback(self, caplog):
         mcp = FastMCP("TestServer", strict_input_validation=False)
 

--- a/tests/server/test_input_validation.py
+++ b/tests/server/test_input_validation.py
@@ -15,7 +15,8 @@ from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
 from fastmcp import Client, FastMCP
-from fastmcp.exceptions import ToolError, ValidationError as FastMCPValidationError
+from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 


### PR DESCRIPTION
Fixes #4128.

## Summary
- wrap Pydantic argument validation failures from tool entry-point parsing as FastMCP ValidationError
- keep tool-body Pydantic failures on the existing ToolError path
- cover client and middleware behavior around argument validation

## Verification
- .venv/bin/python -m pytest tests/server/test_input_validation.py -q
- uv run prek run --files fastmcp_slim/fastmcp/tools/function_tool.py fastmcp_slim/fastmcp/server/server.py tests/server/test_input_validation.py