### PR TITLE
fix: respond with INVALID_REQUEST for pre-initialization requests

### DIFF
--- a/fastmcp_slim/fastmcp/server/low_level.py
+++ b/fastmcp_slim/fastmcp/server/low_level.py
@@ -151,7 +151,36 @@ class MiddlewareServerSession(ServerSession):
                     return None
 
         # Fall through to default handling (task methods now handled via registered handlers)
-        return await super()._received_request(responder)
+        try:
+            return await super()._received_request(responder)
+        except RuntimeError as exc:
+            # If a client sends a request before initialize has completed
+            # (e.g. stale/reused session after restart), respond with a
+            # protocol error instead of relying on generic SDK fallback.
+            pre_init_error_message = (
+                "Received request before initialization was complete"
+            )
+
+            if str(exc) != pre_init_error_message:
+                raise
+
+            if not responder._completed:
+                with responder:
+                    await responder.respond(
+                        mcp.types.ErrorData(
+                            code=mcp.types.INVALID_REQUEST,
+                            message=pre_init_error_message,
+                        )
+                    )
+            else:
+                logger.warning(
+                    "Pre-initialization request error occurred after "
+                    "responder completion. Unable to send MCP error "
+                    "response.",
+                    exc_info=exc,
+                )
+
+            return None
 
 
 class LowLevelServer(_Server[LifespanResultT, RequestT]):

--- a/tests/client/client/test_initialize.py
+++ b/tests/client/client/test_initialize.py
@@ -1,5 +1,9 @@
 """Client initialization tests."""
 
+import pytest
+from mcp import McpError
+from mcp.types import INVALID_REQUEST
+
 from fastmcp.client import Client
 from fastmcp.server.server import FastMCP
 
@@ -32,6 +36,27 @@ class TestInitialize:
         async with client:
             # Should not be automatically initialized
             assert client.initialize_result is None
+
+    async def test_request_before_initialize_returns_invalid_request(
+        self, fastmcp_server
+    ):
+        """Requests sent before initialize should return INVALID_REQUEST."""
+        client = Client(fastmcp_server, auto_initialize=False)
+
+        async with client:
+            with pytest.raises(McpError) as exc_info:
+                await client.call_tool("greet", {"name": "World"})
+
+            assert exc_info.value.error.code == INVALID_REQUEST
+            assert (
+                exc_info.value.error.message
+                == "Received request before initialization was complete"
+            )
+
+            # Session should still be usable after explicit initialization.
+            await client.initialize()
+            result = await client.call_tool("greet", {"name": "World"})
+            assert "Hello, World!" in str(result.content)
 
     async def test_manual_initialize(self, fastmcp_server):
         """Test manual initialization when auto_initialize=False."""


### PR DESCRIPTION
Closes #485

## Description

Catch the `RuntimeError` raised by the MCP SDK when a non-initialization request arrives before `initialize` has completed (e.g. a stale/reused SSE session after a server restart) and return a proper `INVALID_REQUEST` JSON-RPC error instead of letting the exception bubble up unhandled.

The session remains usable after the client explicitly re-initializes.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
  *(Note: `uv run` fails locally with an access-denied venv cleanup error on Windows; lint — `ruff check` — passes, and all 11 tests in `test_initialize.py` pass.)*
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)