### PR TITLE
Use configured server name in consent page tooltip

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/ui.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/ui.py
@@ -128,22 +128,29 @@ def create_consent_html(
         </form>
     """
 
-    # Build help link with tooltip (identical to current implementation)
-    help_link = """
+    # Build help link with tooltip. The tooltip refers to the server by its
+    # configured name, and the FastMCP-branded "learn more" link is only shown
+    # under default branding — servers with a custom name shouldn't direct
+    # their end users to FastMCP documentation.
+    if server_name:
+        learn_more_link = ""
+    else:
+        learn_more_link = """<br><br>
+                    <a
+                    href="https://gofastmcp.com/servers/auth/oauth-proxy#confused-deputy-attacks"
+                    target="_blank" class="tooltip-link">Learn more about
+                    FastMCP security →</a>"""
+    help_link = f"""
         <div class="help-link-container">
             <span class="help-link">
                 Why am I seeing this?
                 <span class="tooltip">
-                    This FastMCP server requires your consent to allow a new client
+                    This {server_name_escaped} server requires your consent to allow a new client
                     to connect. This protects you from <a
                     href="https://modelcontextprotocol.io/specification/2025-06-18/basic/security_best_practices#confused-deputy-problem"
                     target="_blank" class="tooltip-link">confused deputy
                     attacks</a>, where malicious clients could impersonate you
-                    and steal access.<br><br>
-                    <a
-                    href="https://gofastmcp.com/servers/auth/oauth-proxy#confused-deputy-attacks"
-                    target="_blank" class="tooltip-link">Learn more about
-                    FastMCP security →</a>
+                    and steal access.{learn_more_link}
                 </span>
             </span>
         </div>

--- a/tests/server/auth/oauth_proxy/test_ui.py
+++ b/tests/server/auth/oauth_proxy/test_ui.py
@@ -117,3 +117,51 @@ class TestConsentPageRendering:
 
         assert 'evil<img src=x onerror=alert("xss")>' not in html
         assert "evil&lt;img src=x onerror=alert(&quot;xss&quot;)&gt;" in html
+
+    def test_consent_tooltip_uses_default_branding_without_server_name(self):
+        """Without a server name, the tooltip keeps FastMCP branding."""
+
+        html = create_consent_html(
+            client_id="client-123",
+            redirect_uri="https://example.com/callback",
+            scopes=["read"],
+            txn_id="txn",
+            csrf_token="csrf",
+        )
+
+        assert "This FastMCP server requires your consent" in html
+        assert "Learn more about\n                    FastMCP security" in html
+
+    def test_consent_tooltip_uses_server_name_when_provided(self):
+        """With a server name, the tooltip refers to the server by name and
+        omits the FastMCP-branded documentation link."""
+
+        html = create_consent_html(
+            client_id="client-123",
+            redirect_uri="https://example.com/callback",
+            scopes=["read"],
+            txn_id="txn",
+            csrf_token="csrf",
+            server_name="Acme Cloud",
+            server_icon_url="https://acme.example.com/logo.png",
+        )
+
+        assert "This Acme Cloud server requires your consent" in html
+        # No residual FastMCP branding anywhere on a fully-branded page
+        assert "FastMCP" not in html
+        assert "gofastmcp.com" not in html
+
+    def test_consent_tooltip_escapes_server_name(self):
+        """Server name is HTML-escaped in the tooltip."""
+
+        html = create_consent_html(
+            client_id="client-123",
+            redirect_uri="https://example.com/callback",
+            scopes=["read"],
+            txn_id="txn",
+            csrf_token="csrf",
+            server_name="<script>alert('xss')</script>",
+        )
+
+        assert "<script>alert('xss')</script>" not in html
+        assert "This &lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt; server" in html


### PR DESCRIPTION
The consent page gained server branding in #2135 — `server_name`, icon, and website are displayed prominently — but the "Why am I seeing this?" tooltip still says *"This **FastMCP** server requires your consent…"* and links to *"Learn more about **FastMCP** security"*, with no way to override either. For white-labeled deployments this contradicts the branding shown an inch above it, and today the only workaround is monkeypatching `create_consent_html` (see #4299).

This change makes the tooltip use the same `server_name` the rest of the page already uses, and shows the FastMCP-branded documentation link only under default branding — a server presenting itself as "Acme Cloud" shouldn't send its end users to gofastmcp.com. When no `server_name` is configured, the rendered page is unchanged. The vendor-neutral MCP-spec link about confused-deputy attacks is always kept, since that's the security rationale for the page regardless of branding.

```python
mcp = FastMCP(name="Acme Cloud", icons=[Icon(src="https://acme.example.com/logo.png")])
# consent tooltip now reads "This Acme Cloud server requires your consent..."
# and the page contains no residual FastMCP branding
```

Closes #4299 (the minimal option 3 discussed there; a renderer/template hook can be a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
