### PR TITLE
feat: add server-wide default tool timeout

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -310,6 +310,7 @@ class FastMCP(
         strict_input_validation: bool | None = None,
         list_page_size: int | None = None,
         tasks: bool | None = None,
+        default_tool_timeout: float | None = None,
         session_state_store: AsyncKeyValue | None = None,
         sampling_handler: SamplingHandler | None = None,
         sampling_handler_behavior: Literal["always", "fallback"] | None = None,
@@ -326,6 +327,7 @@ class FastMCP(
 
         # Resolve server default for background task support
         self._support_tasks_by_default: bool = tasks if tasks is not None else False
+        self._default_tool_timeout: float | None = default_tool_timeout
 
         # Docket and Worker instances (set during lifespan for cross-task access)
         self._docket = None
@@ -1777,7 +1779,7 @@ class FastMCP(
             exclude_args=exclude_args,
             meta=meta,
             task=task if task is not None else self._support_tasks_by_default,
-            timeout=timeout,
+            timeout=(timeout if timeout is not None else self._default_tool_timeout),
             auth=auth,
             run_in_thread=run_in_thread,
         )

--- a/tests/tools/test_tool_timeout.py
+++ b/tests/tools/test_tool_timeout.py
@@ -178,6 +178,34 @@ class TestToolTimeout:
         assert result2.content[0].text == "long"
         assert result3.content[0].text == "none"
 
+    async def test_default_tool_timeout_is_inherited(self):
+        """Tools inherit server default timeout when none is specified."""
+        mcp = FastMCP(default_tool_timeout=30.0)
+
+        @mcp.tool
+        async def inherited_timeout_tool() -> str:
+            return "ok"
+
+        tools = await mcp.list_tools()
+        tool = next((t for t in tools if t.name == "inherited_timeout_tool"), None)
+
+        assert tool is not None
+        assert tool.timeout == 30.0
+
+    async def test_explicit_timeout_overrides_server_default(self):
+        """Explicit tool timeout overrides server default timeout."""
+        mcp = FastMCP(default_tool_timeout=30.0)
+
+        @mcp.tool(timeout=60.0)
+        async def override_timeout_tool() -> str:
+            return "ok"
+
+        tools = await mcp.list_tools()
+        tool = next((t for t in tools if t.name == "override_timeout_tool"), None)
+
+        assert tool is not None
+        assert tool.timeout == 60.0
+
     async def test_timeout_error_converted_to_tool_error(self):
         """Timeout errors are converted to ToolError by FastMCP."""
         mcp = FastMCP()


### PR DESCRIPTION
## Description

Adds a server-wide `default_tool_timeout` option to `FastMCP`.

Currently, tool timeouts must be specified individually:

```python
mcp = FastMCP()

@mcp.tool(timeout=30)
async def a():
    ...

@mcp.tool(timeout=30)
async def b():
    ...
```

With this change:

```python
mcp = FastMCP(default_tool_timeout=30.0)

@mcp.tool()
async def a():
    ...

@mcp.tool(timeout=60.0)
async def b():
    ...
```

Tools without an explicit timeout inherit the server default, while explicit per-tool timeouts continue to override it.

Closes #4304

## Contribution type

* [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
* [ ] Documentation improvement
* [x] Enhancement (maintainers typically implement enhancements — see CONTRIBUTING.md)

## Checklist

* [x] This PR addresses an existing issue (or fixes a self-evident bug)
* [x] I have read CONTRIBUTING.md
* [x] I have added tests that cover my changes
* [x] I have run `uv run prek run --all-files` and all checks pass
* [x] I have self-reviewed my changes
* [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
