### PR TITLE
Bug/statefulproxy clear cache

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1230,7 +1230,7 @@ class StatefulProxyClient(ProxyClient[ClientTransportT]):
             self._caches[session] = proxy_client
 
             async def _on_session_exit():
-                if session not in self._caches :
+                if session not in self._caches:
                     return
                 self._caches.pop(session)
                 logger.debug(f"{proxy_client} will be disconnect")

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1230,6 +1230,8 @@ class StatefulProxyClient(ProxyClient[ClientTransportT]):
             self._caches[session] = proxy_client
 
             async def _on_session_exit():
+                if session not in self._caches :
+                    return
                 self._caches.pop(session)
                 logger.debug(f"{proxy_client} will be disconnect")
                 await proxy_client._disconnect(force=True)

--- a/tests/server/providers/proxy/test_stateful_proxy_client.py
+++ b/tests/server/providers/proxy/test_stateful_proxy_client.py
@@ -209,6 +209,25 @@ class TestStatefulProxyClient:
                 result2 = await client.call_tool("ask_name", {})
                 assert result2.data == "Hello, Alice!"
 
+    async def test_stateful_proxy_clear_idempotent(self):
+        """Test that clearing the cache doesn't break session teardown (fixes #1234).
+           Due to fallback registered casuing idempotent for session teardown , due to race condtion causing KeyError.
+        """
+        backend = FastMCP("backend")
+
+        @backend.tool
+        async def ping() -> str:
+            return "pong"
+
+        stateful = StatefulProxyClient(backend)
+        proxy = FastMCPProxy(client_factory=stateful.new_stateful, name="proxy")
+
+        async with Client(proxy) as client:
+            await client.call_tool("ping", {})
+            await stateful.clear()
+        
+        # Test passes if no KeyError is raised during Client(proxy) exit
+
 
 class TestRestoreRequestContextCurrentServer:
     """Regression tests for `_restore_request_context` (refs #4054, Bug 4).

--- a/tests/server/providers/proxy/test_stateful_proxy_client.py
+++ b/tests/server/providers/proxy/test_stateful_proxy_client.py
@@ -211,7 +211,7 @@ class TestStatefulProxyClient:
 
     async def test_stateful_proxy_clear_idempotent(self):
         """Test that clearing the cache doesn't break session teardown (fixes #1234).
-           Due to fallback registered casuing idempotent for session teardown , due to race condtion causing KeyError.
+        Due to fallback registered causing idempotent for session teardown , due to race condition causing KeyError.
         """
         backend = FastMCP("backend")
 
@@ -225,7 +225,7 @@ class TestStatefulProxyClient:
         async with Client(proxy) as client:
             await client.call_tool("ping", {})
             await stateful.clear()
-        
+
         # Test passes if no KeyError is raised during Client(proxy) exit
 
 


### PR DESCRIPTION
## Description

#4321 
Fixes a KeyError when `StatefulProxyClient.clear()` is called before session teardown. The session cleanup callback now checks if the session exists in the cache before attempting to pop it, making the teardown idempotent.

Closes #
#4321 

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [X] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [X] This PR addresses an existing issue (or fixes a self-evident bug)
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] I have added tests that cover my changes
- [X] I have run `uv run prek run --all-files` and all checks pass
- [X] I have self-reviewed my changes
- [X] If I used an LLM, it followed the repo's contributing conventions (not generic output)
