### PR TITLE
fix: rename ctx -> context in _run_middleware closure to match CallNext protocol (#4300)

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -487,11 +487,11 @@ class FastMCP(
             next_chain: CallNext[Any, Any] = chain
 
             async def wrapped(
-                ctx: MiddlewareContext[Any],
+                context: MiddlewareContext[Any],
                 mw: Middleware = mw,
                 call_next: CallNext[Any, Any] = next_chain,
             ) -> Any:
-                return await mw(ctx, call_next)
+                return await mw(context, call_next)
 
             chain = cast(CallNext[Any, Any], wrapped)
         return await chain(context)

--- a/tests/server/middleware/test_middleware.py
+++ b/tests/server/middleware/test_middleware.py
@@ -619,3 +619,57 @@ class TestApplyMiddlewareParameter:
             "add", {"a": 5, "b": 3}, run_middleware=False
         )
         assert result_without.structured_content["result"] == 8  # type: ignore[union-attr,index]  # ty:ignore[not-subscriptable]
+
+
+class TestCallNextKeywordArgument:
+    """Regression tests for https://github.com/jlowin/fastmcp/issues/4300.
+
+    The wrapped closure in _run_middleware must use ``context`` as its
+    parameter name so that callers using ``call_next(context=context)``
+    (keyword argument) match the CallNext protocol signature.
+    """
+
+    async def test_call_next_with_keyword_context(self):
+        """Middleware using call_next(context=context) should not raise TypeError."""
+        call_order: list[str] = []
+
+        class FirstMiddleware(Middleware):
+            async def on_call_tool(
+                self,
+                context: MiddlewareContext,
+                call_next: CallNext,
+            ) -> ToolResult:
+                call_order.append("first_before")
+                # Use keyword argument — this is the pattern that triggers #4300
+                result = await call_next(context=context)
+                call_order.append("first_after")
+                return result
+
+        class SecondMiddleware(Middleware):
+            async def on_call_tool(
+                self,
+                context: MiddlewareContext,
+                call_next: CallNext,
+            ) -> ToolResult:
+                call_order.append("second_before")
+                result = await call_next(context)
+                call_order.append("second_after")
+                return result
+
+        server = FastMCP()
+
+        @server.tool
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        server.add_middleware(FirstMiddleware())
+        server.add_middleware(SecondMiddleware())
+
+        result = await server.call_tool("greet", {"name": "World"})
+        assert result.content is not None
+        assert call_order == [
+            "first_before",
+            "second_before",
+            "second_after",
+            "first_after",
+        ]


### PR DESCRIPTION
## Summary

Fixes #4300.

The `wrapped` closure in `FastMCP._run_middleware` used `ctx` as its parameter
name, but the `CallNext` protocol defines it as `context`. This causes a
`TypeError` when any middleware calls `call_next(context=context)` using a
keyword argument — including the built-in `CachingMiddleware`.

## Changes

- **`fastmcp_slim/fastmcp/server/server.py`**: Rename the `wrapped` closure
  parameter from `ctx` to `context` (2 lines changed).
- **`tests/server/middleware/test_middleware.py`**: Add
  `TestCallNextKeywordArgument` regression test class that chains two middleware
  (one using keyword, one using positional `call_next`) and verifies correct
  execution.

## Root Cause

Introduced in commit 8e66b0a4 (PR #4225), which refactored a `partial` call
into an explicit `wrapped` closure. The new closure inadvertently used `ctx`
instead of `context`.

## Testing

- New regression test: `test_call_next_with_keyword_context` — passes ✅
- Full middleware test suite: 23/23 passed ✅
- Ruff lint + format: clean ✅
