### PR TITLE
Allow custom timeout error factories for tools

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -77,7 +77,7 @@ from fastmcp.server.transforms import (
 from fastmcp.server.transforms.visibility import apply_session_transforms, is_enabled
 from fastmcp.settings import DuplicateBehavior as DuplicateBehaviorSetting
 from fastmcp.tools.base import Tool, ToolResult
-from fastmcp.tools.function_tool import FunctionTool
+from fastmcp.tools.function_tool import FunctionTool, ToolTimeoutErrorFactory
 from fastmcp.tools.tool_transform import ToolTransformConfig
 from fastmcp.utilities.components import FastMCPComponent, _coerce_version
 from fastmcp.utilities.logging import get_logger
@@ -315,6 +315,7 @@ class FastMCP(
         sampling_handler_behavior: Literal["always", "fallback"] | None = None,
         client_log_level: mcp.types.LoggingLevel | None = None,
         experimental_capabilities: dict[str, dict[str, Any]] | None = None,
+        tool_timeout_error_factory: ToolTimeoutErrorFactory | None = None,
         **kwargs: Any,
     ):
         _check_removed_kwargs(kwargs)
@@ -432,6 +433,10 @@ class FastMCP(
         self.sampling_handler: SamplingHandler | None = sampling_handler
         self.sampling_handler_behavior: Literal["always", "fallback"] = (
             sampling_handler_behavior or "fallback"
+        )
+
+        self._tool_timeout_error_factory: ToolTimeoutErrorFactory | None = (
+            tool_timeout_error_factory
         )
 
     def __repr__(self) -> str:
@@ -1168,6 +1173,12 @@ class FastMCP(
         run_middleware: bool = True,
         task_meta: TaskMeta,
     ) -> mcp.types.CreateTaskResult: ...
+
+    def on_tool_timeout(
+        self, factory: ToolTimeoutErrorFactory
+    ) -> ToolTimeoutErrorFactory:
+        self._tool_timeout_error_factory = factory
+        return factory
 
     async def call_tool(
         self,

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -13,6 +13,7 @@ from typing import (
     Any,
     Literal,
     Protocol,
+    TypeAlias,
     TypeVar,
     cast,
     overload,
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+ToolTimeoutErrorFactory: TypeAlias = Callable[[str, float], Exception]
 
 @runtime_checkable
 class DecoratedTool(Protocol):
@@ -314,6 +316,21 @@ class FunctionTool(Tool):
                     # generators don't run past the configured timeout
                     result = await self._materialize_generator(result)
             except TimeoutError:
+                from fastmcp.server.dependencies import get_server
+
+                try:
+                    timeout_error_factory = get_server()._tool_timeout_error_factory
+                except RuntimeError:
+                    timeout_error_factory = None
+
+                if timeout_error_factory is not None:
+                    error = timeout_error_factory(self.name, self.timeout)
+                    if not isinstance(error, Exception):
+                        raise TypeError(
+                            "tool_timeout_error_factory must return an Exception"
+                        ) from None
+                    raise error from None
+
                 logger.warning(
                     f"Tool '{self.name}' timed out after {self.timeout}s. "
                     f"Consider using task=True for long-running operations. "

--- a/tests/tools/test_tool_timeout.py
+++ b/tests/tools/test_tool_timeout.py
@@ -104,6 +104,38 @@ class TestToolTimeout:
         with pytest.raises(ToolError):
             await mcp.call_tool("slow_tool")
 
+    async def test_custom_tool_timeout_error_factory(self):
+        """Custom tool timeout error factory is used to create timeout exceptions."""
+        mcp = FastMCP(
+            tool_timeout_error_factory=lambda name, timeout: ToolError(
+                f"custom timeout: {name} after {timeout}"
+            )
+        )
+
+        @mcp.tool(timeout=0.01)
+        async def slow_tool() -> str:
+            await anyio.sleep(1)
+            return "never"
+
+        with pytest.raises(ToolError, match="custom timeout: slow_tool after 0.01"):
+            await mcp.call_tool("slow_tool")
+
+    async def test_on_tool_timeout_handler(self):
+        """on_tool_timeout handler is called when a tool times out."""
+        mcp = FastMCP()
+
+        @mcp.on_tool_timeout
+        def timeout_error(name: str, timeout: float) -> Exception:
+            return ToolError(f"hook timeout: {name}")
+
+        @mcp.tool(timeout=0.01)
+        async def slow_tool() -> str:
+            await anyio.sleep(1)
+            return "never"
+
+        with pytest.raises(ToolError, match="hook timeout: slow_tool"):
+            await mcp.call_tool("slow_tool")
+
     async def test_timeout_from_tool_from_function(self):
         """Timeout works when using Tool.from_function()."""
         from fastmcp.tools import Tool


### PR DESCRIPTION
## Description

Tool timeouts currently always use FastMCP's built-in timeout error path. This change adds a server-level timeout error factory and an `@mcp.on_tool_timeout` registration hook so applications can control the exception raised when a tool exceeds its configured timeout.

Default behavior is unchanged when no handler is registered.

Example:

```python
from fastmcp import FastMCP
from fastmcp.exceptions import ToolError

mcp = FastMCP()

@mcp.on_tool_timeout
def timeout_error(name: str, timeout: float) -> Exception:
    return ToolError(f"{name} timed out after {timeout}s")
```

Closes #4305

## Contribution type

* [ ] Bug fix
* [ ] Documentation improvement
* [x] Enhancement

## Checklist

* [x] This PR addresses an existing issue (or fixes a self-evident bug)
* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] I have added tests that cover my changes
* [x] I have run `uv run prek run --all-files` and all checks pass
* [x] I have self-reviewed my changes
* [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)