### PR TITLE
fix: StatefulProxyClient.clear() no longer causes KeyError on session teardown

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1230,7 +1230,7 @@ class StatefulProxyClient(ProxyClient[ClientTransportT]):
             self._caches[session] = proxy_client
 
             async def _on_session_exit():
-                self._caches.pop(session)
+                self._caches.pop(session, None)
                 logger.debug(f"{proxy_client} will be disconnect")
                 await proxy_client._disconnect(force=True)
 


### PR DESCRIPTION
When `StatefulProxyClient.clear()` empties `self._caches`, the per-session cleanup callback registered in `new_stateful()` would crash with `KeyError` on session exit.

Fix: changed `.pop(session)` to `.pop(session, None)` so the cleanup is idempotent.

Closes #4321