### PR TITLE
fix: RateLimitingMiddleware supports async get_client_id callables

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py
+++ b/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py
@@ -1,6 +1,7 @@
 """Rate limiting middleware for protecting FastMCP servers from abuse."""
 
 import time
+import inspect
 from collections import defaultdict, deque
 from collections.abc import Callable
 from typing import Any
@@ -127,7 +128,11 @@ class RateLimitingMiddleware(Middleware):
         """
         self.max_requests_per_second = max_requests_per_second
         self.burst_capacity = burst_capacity or int(max_requests_per_second * 2)
-        self.get_client_id = get_client_id
+        self.get_client_id_result = get_client_id
+        if inspect.isawaitable(self.get_client_id_result):
+            self.get_client_id = await self.get_client_id_result
+        else:
+            self.get_client_id = self.get_client_id_result
         self.global_limit = global_limit
 
         # Storage for rate limiters per client


### PR DESCRIPTION
Previously `get_client_id` was typed as sync-only `Callable[[MiddlewareContext], str]`. Passing an async callable silently failed — the coroutine was never awaited, resulting in every request getting its own bucket and rate limiting being effectively disabled.

Added `inspect.isawaitable()` pattern (already used elsewhere in FastMCP, e.g. `DebugTokenVerifier.validate`) to support both sync and async callables.

Closes #4320