### PR TITLE
fix(proxy): prevent KeyError in StatefulProxyClient._on_session_exit

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1230,7 +1230,7 @@ class StatefulProxyClient(ProxyClient[ClientTransportT]):
             self._caches[session] = proxy_client
 
             async def _on_session_exit():
-                self._caches.pop(session)
+                self._caches.pop(session, None)
                 logger.debug(f"{proxy_client} will be disconnect")
                 await proxy_client._disconnect(force=True)
 


### PR DESCRIPTION
## Summary

Fixes a `KeyError` crash in `StatefulProxyClient._on_session_exit()` when the session cache has already been cleared by `clear()`.

## Problem

When `StatefulProxyClient.clear()` disconnects all cached proxy clients, any callbacks registered via `new_stateful()` will still fire during subsequent MCP session teardown. These callbacks call `self._caches.pop(session)` on an already-emptied dict, raising:

```
KeyError: <fastmcp.server.low_level.MiddlewareServerSession object at 0x7fbcd8148ce0>
```

This cascades into further teardown errors (cancel scope mismatches, session crashes).

## Fix

One character change: `self._caches.pop(session)` → `self._caches.pop(session, None)`. The `None` default makes the pop idempotent — safe to call regardless of whether `clear()` ran first.

## Testing

- No existing tests broken
- Scenario: call `clear()` then trigger session teardown — previously crashed with KeyError, now succeeds silently

Closes #4321