### PR TITLE
fix(proxy): avoid KeyError when StatefulProxyClient.clear() is called before session teardown

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1230,7 +1230,7 @@ class StatefulProxyClient(ProxyClient[ClientTransportT]):
             self._caches[session] = proxy_client
 
             async def _on_session_exit():
-                self._caches.pop(session)
+                self._caches.pop(session, None)
                 logger.debug(f"{proxy_client} will be disconnect")
                 await proxy_client._disconnect(force=True)
 


### PR DESCRIPTION
## Summary
- Fix KeyError in StatefulProxyClient session teardown when clear() is called before session exit.
- Use dict.pop(session, None) instead of dict.pop(session) to make cleanup idempotent.

## Test Plan
- [x] Existing proxy tests pass: uv run pytest tests/ -k proxy -n auto (331 passed)

## Notes
- Scope intentionally small.
- Fixes #4321