### PR TITLE
feat: add security capability definitions and integrate into tool decorators - Closes #4318

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/caching.py
+++ b/fastmcp_slim/fastmcp/server/middleware/caching.py
@@ -324,6 +324,7 @@ class ResponseCachingMiddleware(Middleware):
                 annotations=tool.annotations,
                 meta=tool.meta,
                 tags=tool.tags,
+                capabilities=tool.capabilities,
             )
             for tool in tools
         ]

--- a/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py
+++ b/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import inspect
 import types
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import partial
 from typing import (
     TYPE_CHECKING,
@@ -31,6 +31,7 @@ from fastmcp.exceptions import FastMCPDeprecationWarning
 from fastmcp.server.auth.authorization import AuthCheck
 from fastmcp.server.tasks.config import TaskConfig
 from fastmcp.tools.base import Tool
+from fastmcp.tools.capabilities import ToolCapabilityInput, normalize_tool_capabilities
 from fastmcp.tools.function_tool import FunctionTool
 from fastmcp.utilities.types import NotSet, NotSetT
 
@@ -166,6 +167,7 @@ class ToolDecoratorMixin:
                     timeout=fmeta.timeout,
                     auth=fmeta.auth,
                     run_in_thread=fmeta.run_in_thread,
+                    capabilities=fmeta.capabilities,
                 )
             else:
                 tool = Tool.from_function(tool)
@@ -196,6 +198,7 @@ class ToolDecoratorMixin:
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> F: ...
 
     @overload
@@ -219,6 +222,7 @@ class ToolDecoratorMixin:
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> Callable[[F], F]: ...
 
     # NOTE: This method mirrors fastmcp.tools.tool() but adds registration,
@@ -245,6 +249,7 @@ class ToolDecoratorMixin:
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> (
         Callable[[AnyFunction], FunctionTool]
         | FunctionTool
@@ -273,6 +278,7 @@ class ToolDecoratorMixin:
             enabled: Whether the tool is enabled (default True). If False, adds to blocklist.
             task: Optional task configuration for background execution
             serializer: Deprecated. Return ToolResult from your tools for full control over serialization.
+            capabilities: Security-sensitive capabilities exposed by this tool.
 
         Returns:
             The registered FunctionTool or a decorator function.
@@ -350,6 +356,7 @@ class ToolDecoratorMixin:
                     timeout=timeout,
                     auth=auth,
                     run_in_thread=run_in_thread,
+                    capabilities=capabilities,
                 )
                 self._add_component(tool_obj)
                 if not enabled:
@@ -376,6 +383,7 @@ class ToolDecoratorMixin:
                     auth=auth,
                     enabled=enabled,
                     run_in_thread=run_in_thread,
+                    capabilities=normalize_tool_capabilities(capabilities),
                 )
                 target = fn.__func__ if hasattr(fn, "__func__") else fn
                 target.__fastmcp__ = metadata  # type: ignore[attr-defined]  # ty:ignore[unresolved-attribute]
@@ -420,4 +428,5 @@ class ToolDecoratorMixin:
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            capabilities=capabilities,
         )

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -77,6 +77,7 @@ from fastmcp.server.transforms import (
 from fastmcp.server.transforms.visibility import apply_session_transforms, is_enabled
 from fastmcp.settings import DuplicateBehavior as DuplicateBehaviorSetting
 from fastmcp.tools.base import Tool, ToolResult
+from fastmcp.tools.capabilities import ToolCapabilityInput
 from fastmcp.tools.function_tool import FunctionTool
 from fastmcp.tools.tool_transform import ToolTransformConfig
 from fastmcp.utilities.components import FastMCPComponent, _coerce_version
@@ -1659,6 +1660,7 @@ class FastMCP(
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> F: ...
 
     @overload
@@ -1681,6 +1683,7 @@ class FastMCP(
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> Callable[[F], F]: ...
 
     def tool(
@@ -1702,6 +1705,7 @@ class FastMCP(
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> (
         Callable[[AnyFunction], FunctionTool]
         | FunctionTool
@@ -1730,6 +1734,7 @@ class FastMCP(
             exclude_args: Optional list of argument names to exclude from the tool schema.
                 Deprecated: Use `Depends()` for dependency injection instead.
             meta: Optional meta information about the tool
+            capabilities: Security-sensitive capabilities exposed by this tool.
 
         Examples:
             Register a tool with a custom name:
@@ -1780,6 +1785,7 @@ class FastMCP(
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            capabilities=capabilities,
         )
 
         return result

--- a/fastmcp_slim/fastmcp/tools/__init__.py
+++ b/fastmcp_slim/fastmcp/tools/__init__.py
@@ -2,6 +2,7 @@ import sys
 
 from .function_tool import FunctionTool, tool
 from .base import Tool, ToolResult
+from .capabilities import ToolCapability, ToolRiskLevel
 from .tool_transform import forward, forward_raw
 
 # Backward compat: tool.py was renamed to base.py to stop Pyright from resolving
@@ -13,7 +14,9 @@ sys.modules[f"{__name__}.tool"] = sys.modules[f"{__name__}.base"]
 __all__ = [
     "FunctionTool",
     "Tool",
+    "ToolCapability",
     "ToolResult",
+    "ToolRiskLevel",
     "forward",
     "forward_raw",
     "tool",

--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -27,6 +27,12 @@ from pydantic import BaseModel, Field, model_validator
 from pydantic.json_schema import SkipJsonSchema
 
 from fastmcp.exceptions import FastMCPDeprecationWarning
+from fastmcp.tools.capabilities import (
+    ToolCapability,
+    ToolCapabilityInput,
+    build_security_metadata,
+    security_metadata_to_meta_dict,
+)
 from fastmcp.utilities.authorization import AuthCheck
 from fastmcp.utilities.components import FastMCPComponent
 from fastmcp.utilities.logging import get_logger
@@ -185,6 +191,13 @@ class Tool(FastMCPComponent):
             description="Execution timeout in seconds. If None, no timeout is applied."
         ),
     ] = None
+    capabilities: Annotated[
+        list[ToolCapability] | None,
+        Field(
+            default=None,
+            description="Security-sensitive capabilities declared by this tool.",
+        ),
+    ] = None
 
     @model_validator(mode="after")
     def _validate_tool_name(self) -> Tool:
@@ -227,6 +240,18 @@ class Tool(FastMCPComponent):
 
         return mcp_tool
 
+    def get_meta(self) -> dict[str, Any]:
+        """Get tool metadata, including FastMCP security capability metadata."""
+
+        meta = super().get_meta()
+        if self.capabilities:
+            fastmcp_meta = dict(meta.get("fastmcp", {}))
+            fastmcp_meta["security"] = security_metadata_to_meta_dict(
+                build_security_metadata(self.capabilities)
+            )
+            meta["fastmcp"] = fastmcp_meta
+        return meta
+
     @classmethod
     def from_function(
         cls,
@@ -247,6 +272,7 @@ class Tool(FastMCPComponent):
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool | None = None,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> FunctionTool:
         """Create a Tool from a function."""
         from fastmcp.tools.function_tool import FunctionTool
@@ -268,6 +294,7 @@ class Tool(FastMCPComponent):
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            capabilities=capabilities,
         )
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
@@ -435,6 +462,7 @@ class Tool(FastMCPComponent):
         meta: dict[str, Any] | NotSetT | None = NotSet,
         transform_args: dict[str, ArgTransform] | None = None,
         transform_fn: Callable[..., Any] | None = None,
+        capabilities: Sequence[ToolCapabilityInput] | NotSetT | None = NotSet,
     ) -> TransformedTool:
         from fastmcp.tools.tool_transform import TransformedTool
 
@@ -452,6 +480,7 @@ class Tool(FastMCPComponent):
             output_schema=output_schema,
             serializer=serializer,
             meta=meta,
+            capabilities=capabilities,
         )
 
     @classmethod

--- a/fastmcp_slim/fastmcp/tools/capabilities.py
+++ b/fastmcp_slim/fastmcp/tools/capabilities.py
@@ -1,0 +1,274 @@
+"""
+Security capability definitions for FastMCP tools.
+
+This module provides a centralized location for declaring tool
+capabilities and determining their associated security risk levels.
+
+The goal is to make potentially sensitive tool actions visible to:
+
+- MCP server developers
+- MCP clients
+- Future permission and confirmation systems
+
+Examples
+--------
+A tool that can execute shell commands:
+
+    @mcp.tool(
+        capabilities=[ToolCapability.SHELL_EXECUTE]
+    )
+    def run_command(command: str) -> str:
+        ...
+
+A tool that can delete files:
+
+    @mcp.tool(
+        capabilities=[
+            ToolCapability.FILESYSTEM_READ,
+            ToolCapability.FILESYSTEM_DELETE,
+        ]
+    )
+    def delete_directory(path: str) -> None:
+        ...
+
+The effective risk level of a tool is calculated from the highest-risk
+capability assigned to it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, TypeAlias
+
+
+class ToolCapability(str, Enum):
+    """
+    Security-sensitive capabilities that a tool may possess.
+
+    Capabilities describe WHAT a tool is allowed to do rather than
+    HOW it performs the action.
+
+    These values may later be surfaced through MCP metadata,
+    permission systems, approval workflows, or security dashboards.
+    """
+
+    FILESYSTEM_READ = "filesystem:read"
+    FILESYSTEM_WRITE = "filesystem:write"
+    FILESYSTEM_DELETE = "filesystem:delete"
+
+    ENVIRONMENT_READ = "environment:read"
+
+    NETWORK_READ = "network:read"
+    NETWORK_WRITE = "network:write"
+
+    DATABASE_READ = "database:read"
+    DATABASE_WRITE = "database:write"
+
+    SHELL_EXECUTE = "shell:execute"
+
+
+class ToolRiskLevel(str, Enum):
+    """
+    Security risk classification for a tool.
+
+    Risk levels are ordered from least dangerous to most dangerous.
+
+    The highest-risk capability assigned to a tool determines the
+    overall tool risk classification.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+ToolCapabilityInput: TypeAlias = ToolCapability | str
+
+
+#
+# Numeric severity ranking used for comparisons.
+#
+# Example:
+#     HIGH > MEDIUM
+#     CRITICAL > HIGH
+#
+_RISK_PRIORITY = {
+    ToolRiskLevel.LOW: 1,
+    ToolRiskLevel.MEDIUM: 2,
+    ToolRiskLevel.HIGH: 3,
+    ToolRiskLevel.CRITICAL: 4,
+}
+
+
+#
+# Maps a capability to its default security risk.
+#
+# These values can be refined later as the capability model evolves.
+#
+CAPABILITY_RISK_MAPPING = {
+    ToolCapability.FILESYSTEM_READ: ToolRiskLevel.LOW,
+    ToolCapability.NETWORK_READ: ToolRiskLevel.LOW,
+    ToolCapability.DATABASE_READ: ToolRiskLevel.LOW,
+
+    ToolCapability.FILESYSTEM_WRITE: ToolRiskLevel.MEDIUM,
+    ToolCapability.NETWORK_WRITE: ToolRiskLevel.MEDIUM,
+
+    ToolCapability.ENVIRONMENT_READ: ToolRiskLevel.HIGH,
+    ToolCapability.DATABASE_WRITE: ToolRiskLevel.HIGH,
+
+    ToolCapability.FILESYSTEM_DELETE: ToolRiskLevel.CRITICAL,
+    ToolCapability.SHELL_EXECUTE: ToolRiskLevel.CRITICAL,
+}
+
+
+@dataclass(frozen=True)
+class ToolSecurityMetadata:
+    """
+    Security metadata associated with a registered tool.
+
+    Attributes
+    ----------
+    capabilities:
+        Declared capabilities exposed by the tool.
+
+    risk_level:
+        Computed overall risk classification.
+    """
+
+    capabilities: tuple[ToolCapability, ...]
+    risk_level: ToolRiskLevel
+
+
+def normalize_tool_capabilities(
+    capabilities: Sequence[ToolCapabilityInput] | None,
+) -> list[ToolCapability] | None:
+    """
+    Normalize user-provided capability values.
+
+    The public decorator accepts either ``ToolCapability`` members or their
+    string values. Normalizing early gives users a clear error for invalid
+    capability strings and keeps the stored tool model consistent.
+    """
+
+    if capabilities is None:
+        return None
+
+    normalized: list[ToolCapability] = []
+    seen: set[ToolCapability] = set()
+
+    for capability in capabilities:
+        parsed = (
+            capability
+            if isinstance(capability, ToolCapability)
+            else ToolCapability(capability)
+        )
+        if parsed not in seen:
+            normalized.append(parsed)
+            seen.add(parsed)
+
+    return normalized
+
+
+def get_capability_risk(
+    capability: ToolCapability,
+) -> ToolRiskLevel:
+    """
+    Return the risk level associated with a capability.
+
+    Parameters
+    ----------
+    capability:
+        Capability whose risk should be evaluated.
+
+    Returns
+    -------
+    ToolRiskLevel
+        Risk classification for the capability.
+    """
+
+    return CAPABILITY_RISK_MAPPING.get(
+        capability,
+        ToolRiskLevel.LOW,
+    )
+
+
+def calculate_tool_risk(
+    capabilities: Sequence[ToolCapabilityInput] | None,
+) -> ToolRiskLevel:
+    """
+    Calculate the effective risk level for a tool.
+
+    The overall tool risk is determined by the highest-risk
+    capability declared by the tool.
+
+    Examples
+    --------
+    [FILESYSTEM_READ]
+        -> LOW
+
+    [FILESYSTEM_READ, FILESYSTEM_WRITE]
+        -> MEDIUM
+
+    [FILESYSTEM_DELETE]
+        -> CRITICAL
+    """
+
+    normalized = normalize_tool_capabilities(capabilities)
+
+    if not normalized:
+        return ToolRiskLevel.LOW
+
+    highest_risk = ToolRiskLevel.LOW
+
+    for capability in normalized:
+        capability_risk = get_capability_risk(capability)
+
+        if (
+            _RISK_PRIORITY[capability_risk]
+            > _RISK_PRIORITY[highest_risk]
+        ):
+            highest_risk = capability_risk
+
+    return highest_risk
+
+
+def build_security_metadata(
+    capabilities: Sequence[ToolCapabilityInput],
+) -> ToolSecurityMetadata:
+    """
+    Construct tool security metadata.
+
+    Parameters
+    ----------
+    capabilities:
+        Declared capabilities for a tool.
+
+    Returns
+    -------
+    ToolSecurityMetadata
+        Immutable metadata object containing capabilities
+        and the computed risk level.
+    """
+
+    normalized = normalize_tool_capabilities(capabilities) or []
+
+    return ToolSecurityMetadata(
+        capabilities=tuple(normalized),
+        risk_level=calculate_tool_risk(normalized),
+    )
+
+
+def security_metadata_to_meta_dict(
+    security_metadata: ToolSecurityMetadata,
+) -> dict[str, Any]:
+    """Convert security metadata to the public FastMCP ``_meta`` shape."""
+
+    return {
+        "capabilities": [
+            capability.value for capability in security_metadata.capabilities
+        ],
+        "riskLevel": security_metadata.risk_level.value,
+    }

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from types import MethodType
 from typing import (
@@ -32,6 +32,11 @@ from fastmcp.tools.base import (
     Tool,
     ToolResult,
     ToolResultSerializerType,
+)
+from fastmcp.tools.capabilities import (
+    ToolCapability,
+    ToolCapabilityInput,
+    normalize_tool_capabilities,
 )
 from fastmcp.tools.function_parsing import ParsedFunction, _is_object_schema
 from fastmcp.utilities.async_utils import (
@@ -87,6 +92,7 @@ class ToolMeta:
     auth: AuthCheck | list[AuthCheck] | None = None
     enabled: bool = True
     run_in_thread: bool = True
+    capabilities: list[ToolCapability] | None = None
 
 
 class FunctionTool(Tool):
@@ -130,6 +136,7 @@ class FunctionTool(Tool):
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool | None = None,
+        capabilities: Sequence[ToolCapabilityInput] | None = None,
     ) -> FunctionTool:
         """Create a FunctionTool from a function.
 
@@ -153,6 +160,7 @@ class FunctionTool(Tool):
                     tags,
                     annotations,
                     meta,
+                    capabilities,
                     task,
                     serializer,
                     timeout,
@@ -193,6 +201,7 @@ class FunctionTool(Tool):
                 timeout=timeout,
                 auth=auth,
                 run_in_thread=True if run_in_thread is None else run_in_thread,
+                capabilities=normalize_tool_capabilities(capabilities),
             )
 
         if metadata.serializer is not None and fastmcp.settings.deprecation_warnings:
@@ -281,6 +290,7 @@ class FunctionTool(Tool):
             timeout=metadata.timeout,
             auth=metadata.auth,
             run_in_thread=metadata.run_in_thread,
+            capabilities=normalize_tool_capabilities(metadata.capabilities),
         )
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
@@ -414,6 +424,7 @@ def tool(
     timeout: float | None = None,
     auth: AuthCheck | list[AuthCheck] | None = None,
     run_in_thread: bool = True,
+    capabilities: Sequence[ToolCapabilityInput] | None = None,
 ) -> Callable[[F], F]: ...
 @overload
 def tool(
@@ -434,6 +445,7 @@ def tool(
     timeout: float | None = None,
     auth: AuthCheck | list[AuthCheck] | None = None,
     run_in_thread: bool = True,
+    capabilities: Sequence[ToolCapabilityInput] | None = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -455,6 +467,7 @@ def tool(
     timeout: float | None = None,
     auth: AuthCheck | list[AuthCheck] | None = None,
     run_in_thread: bool = True,
+    capabilities: Sequence[ToolCapabilityInput] | None = None,
 ) -> Any:
     """Standalone decorator to mark a function as an MCP tool.
 
@@ -498,6 +511,7 @@ def tool(
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            capabilities=normalize_tool_capabilities(capabilities),
         )
         return FunctionTool.from_function(fn, metadata=tool_meta)
 
@@ -518,6 +532,7 @@ def tool(
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            capabilities=normalize_tool_capabilities(capabilities),
         )
         target = fn.__func__ if isinstance(fn, staticmethod | MethodType) else fn
         cast(Any, target).__fastmcp__ = metadata

--- a/fastmcp_slim/fastmcp/tools/tool_transform.py
+++ b/fastmcp_slim/fastmcp/tools/tool_transform.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextvars import ContextVar
 from copy import deepcopy
 from dataclasses import dataclass
@@ -18,6 +18,7 @@ from pydantic.json_schema import SkipJsonSchema
 import fastmcp
 from fastmcp.exceptions import FastMCPDeprecationWarning
 from fastmcp.tools.base import Tool, ToolResult, _convert_to_content
+from fastmcp.tools.capabilities import ToolCapability, ToolCapabilityInput
 from fastmcp.tools.function_parsing import ParsedFunction
 from fastmcp.utilities.async_utils import (
     call_sync_fn_in_threadpool,
@@ -382,6 +383,7 @@ class TransformedTool(Tool):
         output_schema: dict[str, Any] | NotSetT | None = NotSet,
         serializer: Callable[[Any], str] | NotSetT | None = NotSet,  # Deprecated
         meta: dict[str, Any] | NotSetT | None = NotSet,
+        capabilities: Sequence[ToolCapabilityInput] | NotSetT | None = NotSet,
     ) -> TransformedTool:
         """Create a transformed tool from a parent tool.
 
@@ -407,6 +409,7 @@ class TransformedTool(Tool):
                 - NotSet (default): Inherit from parent tool
                 - dict: Use custom meta information
                 - None: Remove meta information
+            capabilities: Security capabilities. Defaults to parent's capabilities.
 
         Returns:
             TransformedTool with the specified transformations.
@@ -591,6 +594,9 @@ class TransformedTool(Tool):
         final_serializer = (
             serializer if not isinstance(serializer, NotSetT) else tool.serializer
         )
+        final_capabilities = (
+            capabilities if not isinstance(capabilities, NotSetT) else tool.capabilities
+        )
 
         transformed_tool = cls(
             fn=final_fn,
@@ -606,6 +612,7 @@ class TransformedTool(Tool):
             annotations=final_annotations,
             serializer=final_serializer,
             meta=final_meta,
+            capabilities=final_capabilities,
             transform_args=transform_args,
             auth=tool.auth,
         )
@@ -971,6 +978,10 @@ class ToolTransformConfig(FastMCPBaseModel):
     meta: dict[str, Any] | None = Field(
         default=None,
         description="The new meta information for the tool.",
+    )
+    capabilities: list[ToolCapability] | None = Field(
+        default=None,
+        description="The new security-sensitive capabilities for the tool.",
     )
     enabled: bool = Field(
         default=True,

--- a/tests/server/middleware/test_caching.py
+++ b/tests/server/middleware/test_caching.py
@@ -42,6 +42,7 @@ from fastmcp.server.middleware.caching import (
 )
 from fastmcp.server.middleware.middleware import CallNext, MiddlewareContext
 from fastmcp.tools.base import Tool, ToolResult
+from fastmcp.tools.capabilities import ToolCapability
 
 TEST_URI = AnyUrl("https://test_uri")
 
@@ -351,6 +352,38 @@ class TestResponseCachingMiddlewareIntegration:
             assert len(post_tool_list) == 5
 
             assert pre_tool_list == post_tool_list
+
+    async def test_list_tools_preserves_capabilities_and_security_meta(
+        self, caching_server: FastMCP
+    ):
+        """Test that cached list-tools preserves capability metadata."""
+
+        tool = Tool.from_function(
+            fn=lambda: 42,
+            name="shell_tool",
+            capabilities=[ToolCapability.SHELL_EXECUTE],
+        )
+        caching_server.add_tool(tool=tool)
+
+        async with Client(caching_server) as client:
+            pre_tool_list: list[mcp.types.Tool] = await client.list_tools()
+            cached_tool = next(
+                t for t in pre_tool_list if t.name == "shell_tool"
+            )
+            assert cached_tool.meta is not None
+            assert cached_tool.meta["fastmcp"]["security"]["capabilities"] == [
+                "shell:execute"
+            ]
+
+            post_tool_list: list[mcp.types.Tool] = await client.list_tools()
+            cached_tool = next(
+                t for t in post_tool_list if t.name == "shell_tool"
+            )
+            assert cached_tool.meta is not None
+            assert cached_tool.meta["fastmcp"]["security"]["capabilities"] == [
+                "shell:execute"
+            ]
+            assert cached_tool.meta["fastmcp"]["security"]["riskLevel"] == "critical"
 
     async def test_call_tool(
         self,

--- a/tests/server/providers/local_provider_tools/test_decorator.py
+++ b/tests/server/providers/local_provider_tools/test_decorator.py
@@ -10,6 +10,7 @@ from typing_extensions import TypedDict
 from fastmcp import FastMCP
 from fastmcp.exceptions import NotFoundError
 from fastmcp.tools.base import Tool
+from fastmcp.tools.capabilities import ToolCapability
 
 
 def _normalize_anyof_order(schema):
@@ -339,3 +340,24 @@ class TestToolDecorator:
         tool = next(t for t in tools if t.name == "multiply")
 
         assert tool.meta == meta_data
+
+    async def test_tool_decorator_with_capabilities(self):
+        """Test that capabilities are passed through the tool decorator."""
+        mcp = FastMCP()
+
+        @mcp.tool(capabilities=[ToolCapability.SHELL_EXECUTE, "filesystem:delete"])
+        def run_command(command: str) -> str:
+            """Run a command."""
+            return command
+
+        tools = await mcp.list_tools()
+        tool = next(t for t in tools if t.name == "run_command")
+
+        assert tool.capabilities == [
+            ToolCapability.SHELL_EXECUTE,
+            ToolCapability.FILESYSTEM_DELETE,
+        ]
+        assert tool.to_mcp_tool().meta["fastmcp"]["security"] == {
+            "capabilities": ["shell:execute", "filesystem:delete"],
+            "riskLevel": "critical",
+        }

--- a/tests/tools/test_standalone_decorator.py
+++ b/tests/tools/test_standalone_decorator.py
@@ -15,6 +15,7 @@ from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.tools import tool
 from fastmcp.tools.base import Tool
+from fastmcp.tools.capabilities import ToolCapability
 from fastmcp.tools.function_tool import DecoratedTool, FunctionTool, ToolMeta
 
 
@@ -112,6 +113,25 @@ class TestToolDecorator:
         assert decorated.__fastmcp__.description == "Greets people"
         assert decorated.__fastmcp__.tags == {"greeting", "demo"}
         assert decorated.__fastmcp__.meta == {"custom": "value"}
+
+    def test_tool_with_capabilities(self):
+        """@tool should attach declared capabilities."""
+
+        @tool(capabilities=[ToolCapability.ENVIRONMENT_READ, "shell:execute"])
+        def read_secret() -> str:
+            return "secret"
+
+        decorated = cast(DecoratedTool, read_secret)
+        assert decorated.__fastmcp__.capabilities == [
+            ToolCapability.ENVIRONMENT_READ,
+            ToolCapability.SHELL_EXECUTE,
+        ]
+
+        created_tool = Tool.from_function(read_secret)
+        assert created_tool.capabilities == [
+            ToolCapability.ENVIRONMENT_READ,
+            ToolCapability.SHELL_EXECUTE,
+        ]
 
     @pytest.mark.parametrize(
         "factory", [Tool.from_function, FunctionTool.from_function]

--- a/tests/tools/tool/test_tool.py
+++ b/tests/tools/tool/test_tool.py
@@ -11,6 +11,7 @@ from mcp.types import (
 from pydantic import BaseModel
 
 from fastmcp.tools.base import Tool, ToolResult
+from fastmcp.tools.capabilities import ToolCapability, ToolRiskLevel
 from fastmcp.utilities.types import Audio, File, Image
 
 
@@ -69,6 +70,43 @@ class TestToolFromFunction:
         # MCP tool includes fastmcp meta, so check that our meta is included
         assert mcp_tool.meta is not None
         assert meta_data.items() <= mcp_tool.meta.items()
+
+    def test_capabilities_parameter(self):
+        """Test that capabilities are stored and surfaced in MCP metadata."""
+
+        def delete_file(path: str) -> str:
+            """Delete a file."""
+            return path
+
+        tool = Tool.from_function(
+            delete_file,
+            capabilities=[
+                ToolCapability.FILESYSTEM_READ,
+                "filesystem:delete",
+                ToolCapability.FILESYSTEM_DELETE,
+            ],
+        )
+
+        assert tool.capabilities == [
+            ToolCapability.FILESYSTEM_READ,
+            ToolCapability.FILESYSTEM_DELETE,
+        ]
+
+        mcp_tool = tool.to_mcp_tool()
+        assert mcp_tool.meta is not None
+        assert mcp_tool.meta["fastmcp"]["security"] == {
+            "capabilities": ["filesystem:read", "filesystem:delete"],
+            "riskLevel": ToolRiskLevel.CRITICAL.value,
+        }
+
+    def test_invalid_capability_raises(self):
+        """Test that invalid capability strings fail during registration."""
+
+        def tool_fn() -> str:
+            return "ok"
+
+        with pytest.raises(ValueError):
+            Tool.from_function(tool_fn, capabilities=["invalid:capability"])
 
     async def test_async_function(self):
         """Test registering and running an async function."""

--- a/tests/tools/tool_transform/test_metadata.py
+++ b/tests/tools/tool_transform/test_metadata.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import Field
 
 from fastmcp.tools import Tool
+from fastmcp.tools.capabilities import ToolCapability
 from fastmcp.tools.function_tool import FunctionTool
 from fastmcp.tools.tool_transform import (
     ToolTransformConfig,
@@ -144,6 +145,31 @@ def test_transform_adds_meta_to_none(sample_tool_no_title):
     sample_tool_no_title.meta = None
     transformed = Tool.from_tool(sample_tool_no_title, meta={"added": True})
     assert transformed.meta == {"added": True}
+
+
+def test_transform_inherits_capabilities(sample_tool):
+    """Test that transformed tools inherit security capabilities by default."""
+    sample_tool.capabilities = [ToolCapability.SHELL_EXECUTE]
+
+    transformed = Tool.from_tool(sample_tool, name="wrapped_tool")
+
+    assert transformed.capabilities == [ToolCapability.SHELL_EXECUTE]
+    assert transformed.to_mcp_tool().meta["fastmcp"]["security"] == {
+        "capabilities": ["shell:execute"],
+        "riskLevel": "critical",
+    }
+
+
+def test_transform_overrides_capabilities(sample_tool):
+    """Test that transformed tools can override inherited capabilities."""
+    sample_tool.capabilities = [ToolCapability.SHELL_EXECUTE]
+
+    transformed = Tool.from_tool(
+        sample_tool,
+        capabilities=[ToolCapability.FILESYSTEM_READ],
+    )
+
+    assert transformed.capabilities == [ToolCapability.FILESYSTEM_READ]
 
 
 def test_tool_transform_config_inherits_meta(sample_tool):


### PR DESCRIPTION
## Problem

FastMCP tools can perform security-sensitive actions such as shell execution, filesystem writes/deletes, or environment access, but there is currently no structured way for a tool to declare those capabilities.

## Concrete use case

A server operator wants to inspect registered tools and understand whether a tool may execute shell commands, modify files, delete files, or read environment variables before exposing it to clients.

## Expected behavior

Tool authors can declare security-relevant capabilities when registering a tool, and FastMCP preserves that metadata when tools are listed.

## Actual behavior

Tool registration/listing does not expose structured security capability metadata, so clients/operators cannot distinguish ordinary tools from tools with higher-risk behavior.

Closes #4318

## Contribution type

* [x] Enhancement

## Checklist

* [x] This PR addresses an existing issue
* [x] I have read CONTRIBUTING.md
* [x] I have added tests that cover my changes
* [x] I have run `uv run prek run --all-files` and all checks pass
* [x] I have self-reviewed my changes
* [x] If I used an LLM, it followed the repo's contributing conventions