### PR TITLE
docs: fix 5 broken internal links (auth & providers pages)

### DIFF
--- a/docs/deployment/http.mdx
+++ b/docs/deployment/http.mdx
@@ -584,7 +584,7 @@ if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)
 ```
 
-For more details on OAuth authentication, see the [Authentication guide](/servers/auth).
+For more details on OAuth authentication, see the [Authentication guide](/servers/auth/authentication).
 
 ## Production Deployment
 

--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -89,7 +89,7 @@ Okay, I rolled 3 dice and got a 5, 4, and 1.
 
 ### Remote & Authenticated Servers
 
-In the above example, we connected to our local server using `stdio` transport. Because we're using a FastMCP client, you can also connect to any local or remote MCP server, using any [transport](/clients/transports) or [auth](/clients/auth) method supported by FastMCP, simply by changing the client configuration.
+In the above example, we connected to our local server using `stdio` transport. Because we're using a FastMCP client, you can also connect to any local or remote MCP server, using any [transport](/clients/transports) or [auth](/clients/auth/oauth) method supported by FastMCP, simply by changing the client configuration.
 
 For example, to connect to a remote, authenticated server, you can use the following client:
 

--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -149,7 +149,7 @@ These parameters control what your server is built from — its components, midd
 </ParamField>
 
 <ParamField body="providers" type="list[Provider] | None">
-  [Providers](/servers/providers) that supply tools, resources, and prompts dynamically. Providers are queried at request time, so they can serve components from databases, APIs, or other external sources
+  [Providers](/servers/providers/overview) that supply tools, resources, and prompts dynamically. Providers are queried at request time, so they can serve components from databases, APIs, or other external sources
 </ParamField>
 
 <ParamField body="transforms" type="list[Transform] | None">

--- a/docs/v2/deployment/http.mdx
+++ b/docs/v2/deployment/http.mdx
@@ -574,7 +574,7 @@ if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)
 ```
 
-For more details on OAuth authentication, see the [Authentication guide](/v2/servers/auth).
+For more details on OAuth authentication, see the [Authentication guide](/v2/servers/auth/authentication).
 
 ## Production Deployment
 

--- a/docs/v2/integrations/gemini.mdx
+++ b/docs/v2/integrations/gemini.mdx
@@ -89,7 +89,7 @@ Okay, I rolled 3 dice and got a 5, 4, and 1.
 
 ### Remote & Authenticated Servers
 
-In the above example, we connected to our local server using `stdio` transport. Because we're using a FastMCP client, you can also connect to any local or remote MCP server, using any [transport](/v2/clients/transports) or [auth](/v2/clients/auth) method supported by FastMCP, simply by changing the client configuration.
+In the above example, we connected to our local server using `stdio` transport. Because we're using a FastMCP client, you can also connect to any local or remote MCP server, using any [transport](/v2/clients/transports) or [auth](/v2/clients/auth/oauth) method supported by FastMCP, simply by changing the client configuration.
 
 For example, to connect to a remote, authenticated server, you can use the following client:
 


### PR DESCRIPTION
## Problem

Five internal doc links point at pages that don't exist (no page file and no `docs.json` redirect), so they 404:

| File | Link | Should be |
|---|---|---|
| `servers/server.mdx` | `/servers/providers` | `/servers/providers/overview` |
| `deployment/http.mdx` | `/servers/auth` | `/servers/auth/authentication` |
| `integrations/gemini.mdx` | `/clients/auth` | `/clients/auth/oauth` |
| `v2/deployment/http.mdx` | `/v2/servers/auth` | `/v2/servers/auth/authentication` |
| `v2/integrations/gemini.mdx` | `/v2/clients/auth` | `/v2/clients/auth/oauth` |

## How I found it

Scanned every `docs/**/*.mdx` internal link against the set of existing pages **and** the 20 redirects in `docs.json`. These five were the only links with neither a target page nor a redirect.

## Targets chosen

- `/servers/providers` → `/servers/providers/overview` (title *Providers*, the section overview).
- `/servers/auth` → `/servers/auth/authentication` (title *Authentication* — matches the "Authentication guide" link text).
- `/clients/auth` → `/clients/auth/oauth` (the primary client auth method; the context is connecting to remote servers).

Docs-only, 5 one-line changes.