### PR TITLE
fix: RST docstrings in fastmcp.types render raw on gofastmcp.com

### DIFF
--- a/fastmcp_slim/fastmcp/types.py
+++ b/fastmcp_slim/fastmcp/types.py
@@ -1,19 +1,21 @@
 """Reusable type annotations for FastMCP tool parameters.
 
 These types can be used in tool function signatures to influence how
-parameters are presented in UIs (e.g. ``fastmcp dev apps``) and
+parameters are presented in UIs (e.g. `fastmcp dev apps`) and
 serialized in JSON Schema.
 
-Example::
+Example:
 
-    from fastmcp import FastMCP
-    from fastmcp.types import Textarea
+```python
+from fastmcp import FastMCP
+from fastmcp.types import Textarea
 
-    mcp = FastMCP("demo")
+mcp = FastMCP("demo")
 
-    @mcp.tool()
-    def run_query(sql: Textarea) -> str:
-        ...
+@mcp.tool()
+def run_query(sql: Textarea) -> str:
+    ...
+```
 """
 
 from __future__ import annotations
@@ -25,8 +27,8 @@ from pydantic import Field
 Textarea = Annotated[str, Field(json_schema_extra={"format": "textarea"})]
 """A string rendered as a multiline textarea in form-based UIs.
 
-Produces ``"format": "textarea"`` in the JSON Schema, which
-``fastmcp dev apps`` picks up automatically.
+Produces `"format": "textarea"` in the JSON Schema, which
+`fastmcp dev apps` picks up automatically.
 """
 
 __all__ = ["Textarea"]


### PR DESCRIPTION
## Description

The docstrings in `fastmcp.types` used RST syntax (Example::, double backticks), but the SDK compile to MDX, so th markup showed up raw on gofastmcp.com.

Converts to Markdon so fastmcp-types.mdx renders correctly.

Closes #4331

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [x] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
