### PR TITLE
fix: Invalid URL printed to log when using IPv6

### DIFF
--- a/.gate/test-run.json
+++ b/.gate/test-run.json
@@ -1,0 +1,11 @@
+{
+  "run_id": "1782137183-2735831",
+  "timestamp": "2026-06-22T14:10:02Z",
+  "command": "uv run pytest -n auto -x -q ",
+  "exit_code": 0,
+  "stdout_hash": "sha256:a25e7f6fca07836b37fa1757e7114506f3ecfceeea17bc3d4374a4db44c02358",
+  "stdout_size_bytes": 7122,
+  "stderr_size_bytes": 191,
+  "workspace_git_sha": "cf3a2d957a13424114f7e4593143043c6b721774",
+  "runner_pid": 2735831
+}

--- a/fastmcp_slim/fastmcp/server/mixins/transport.py
+++ b/fastmcp_slim/fastmcp/server/mixins/transport.py
@@ -301,8 +301,9 @@ class TransportMixin:
                 server = uvicorn.Server(config)
                 path = getattr(app.state, "path", "").lstrip("/")
                 mode = " (stateless)" if stateless_http else ""
+                formatted_host = f"[{host}]" if ":" in host else host
                 logger.info(
-                    f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{host}:{port}/{path}"
+                    f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{formatted_host}:{port}/{path}"
                 )
 
                 if sockets is not None:


### PR DESCRIPTION
Fixes #4339

## Summary
Invalid URL printed to log when using IPv6

## Changes
71ee9354 fix: Invalid URL printed to log when using IPv6

## Testing
- Reproduced bug locally
- Ran test suite via test_runner.sh
- Verified fix with tests