### PR TITLE
fix: Invalid URL printed to log when using IPv6

### DIFF
--- a/fastmcp_slim/fastmcp/server/mixins/transport.py
+++ b/fastmcp_slim/fastmcp/server/mixins/transport.py
@@ -301,8 +301,9 @@ class TransportMixin:
                 server = uvicorn.Server(config)
                 path = getattr(app.state, "path", "").lstrip("/")
                 mode = " (stateless)" if stateless_http else ""
+                host_str = f"[{host}]" if ":" in host else host
                 logger.info(
-                    f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{host}:{port}/{path}"
+                    f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{host_str}:{port}/{path}"
                 )
 
                 if sockets is not None:

--- a/fastmcp_slim/fastmcp/utilities/tests.py
+++ b/fastmcp_slim/fastmcp/utilities/tests.py
@@ -127,7 +127,8 @@ def run_server_in_process(
     else:
         raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
 
-    yield f"http://{host}:{port}"
+    host_str = f"[{host}]" if ":" in host else host
+    yield f"http://{host_str}:{port}"
 
     proc.terminate()
     proc.join(timeout=5)
@@ -213,8 +214,9 @@ async def run_server_async(
     # Give uvicorn a moment to bind the port after lifespan is ready
     await asyncio.sleep(0.1)
 
+    host_str = f"[{host}]" if ":" in host else host
     try:
-        yield f"http://{host}:{port}{path}"
+        yield f"http://{host_str}:{port}{path}"
     finally:
         # Cleanup: cancel the task with timeout to avoid hanging on Windows
         server_task.cancel()


### PR DESCRIPTION
Fixes #4339

## Summary
Invalid URL printed to log when using IPv6

## Changes
f4c1bb31 fix: Invalid URL printed to log when using IPv6

## Testing
- Reproduced bug locally
- Ran test suite via test_runner.sh
- Verified fix with tests