### PR TITLE
[codex] Set default OIDC discovery timeout

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
@@ -206,7 +206,7 @@ class OIDCProxy(OAuthProxy):
         client_id: str,
         client_secret: str | None = None,
         audience: str | None = None,
-        timeout_seconds: int | None = None,
+        timeout_seconds: int | None = 10,
         # Token verifier
         token_verifier: TokenVerifier | None = None,
         algorithm: str | None = None,

--- a/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
@@ -67,6 +67,7 @@ class Auth0Provider(OIDCProxy):
         base_url: AnyHttpUrl | str,
         resource_base_url: AnyHttpUrl | str | None = None,
         issuer_url: AnyHttpUrl | str | None = None,
+        timeout_seconds: int | None = 10,
         required_scopes: list[str] | None = None,
         redirect_path: str | None = None,
         allowed_client_redirect_uris: list[str] | None = None,
@@ -91,6 +92,8 @@ class Auth0Provider(OIDCProxy):
                 and token audience. Defaults to ``base_url``.
             issuer_url: Issuer URL for OAuth metadata (defaults to base_url). Use root-level URL
                 to avoid 404s during discovery when mounting under a path.
+            timeout_seconds: HTTP request timeout in seconds for fetching OIDC configuration.
+                Set to ``None`` to disable FastMCP's explicit discovery timeout.
             required_scopes: Required Auth0 scopes (defaults to ["openid"])
             redirect_path: Redirect path configured in Auth0 application
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
@@ -129,6 +132,7 @@ class Auth0Provider(OIDCProxy):
             client_id=client_id,
             client_secret=client_secret,
             audience=audience,
+            timeout_seconds=timeout_seconds,
             base_url=base_url,
             resource_base_url=resource_base_url,
             issuer_url=issuer_url,

--- a/fastmcp_slim/fastmcp/server/auth/providers/aws.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/aws.py
@@ -128,6 +128,7 @@ class AWSCognitoProvider(OIDCProxy):
         resource_base_url: AnyHttpUrl | str | None = None,
         aws_region: str = "eu-central-1",
         issuer_url: AnyHttpUrl | str | None = None,
+        timeout_seconds: int | None = 10,
         redirect_path: str = "/auth/callback",
         required_scopes: list[str] | None = None,
         allowed_client_redirect_uris: list[str] | None = None,
@@ -152,6 +153,8 @@ class AWSCognitoProvider(OIDCProxy):
             aws_region: AWS region where your User Pool is located (defaults to "eu-central-1")
             issuer_url: Issuer URL for OAuth metadata (defaults to base_url). Use root-level URL
                 to avoid 404s during discovery when mounting under a path.
+            timeout_seconds: HTTP request timeout in seconds for fetching OIDC configuration.
+                Set to ``None`` to disable FastMCP's explicit discovery timeout.
             redirect_path: Redirect path configured in Cognito app (defaults to "/auth/callback")
             required_scopes: Required Cognito scopes (defaults to ["openid"])
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
@@ -200,6 +203,7 @@ class AWSCognitoProvider(OIDCProxy):
             client_secret=client_secret,
             algorithm="RS256",
             required_scopes=required_scopes_final,
+            timeout_seconds=timeout_seconds,
             base_url=base_url,
             resource_base_url=resource_base_url,
             issuer_url=issuer_url,

--- a/fastmcp_slim/fastmcp/server/auth/providers/oci.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/oci.py
@@ -126,6 +126,7 @@ class OCIProvider(OIDCProxy):
         resource_base_url: AnyHttpUrl | str | None = None,
         audience: str | None = None,
         issuer_url: AnyHttpUrl | str | None = None,
+        timeout_seconds: int | None = 10,
         required_scopes: list[str] | None = None,
         redirect_path: str | None = None,
         allowed_client_redirect_uris: list[str] | None = None,
@@ -149,6 +150,8 @@ class OCIProvider(OIDCProxy):
                 and token audience. Defaults to ``base_url``.
             audience: OCI API audience (optional)
             issuer_url: Issuer URL for OCI IAM Domain metadata. This will override issuer URL from the discovery URL.
+            timeout_seconds: HTTP request timeout in seconds for fetching OIDC configuration.
+                Set to ``None`` to disable FastMCP's explicit discovery timeout.
             required_scopes: Required OCI scopes (defaults to ["openid"])
             redirect_path: Redirect path configured in OCI IAM Domain Integrated Application. The default is "/auth/callback".
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
@@ -174,6 +177,7 @@ class OCIProvider(OIDCProxy):
             client_id=client_id,
             client_secret=client_secret,
             audience=audience,
+            timeout_seconds=timeout_seconds,
             base_url=base_url,
             resource_base_url=resource_base_url,
             issuer_url=issuer_url,

--- a/tests/server/auth/providers/test_auth0.py
+++ b/tests/server/auth/providers/test_auth0.py
@@ -59,6 +59,7 @@ class TestAuth0Provider:
 
             call_args = mock_get.call_args
             assert str(call_args[0][0]) == TEST_CONFIG_URL
+            assert call_args[1]["timeout_seconds"] == 10
 
             assert provider._upstream_client_id == TEST_CLIENT_ID
             assert provider._upstream_client_secret is not None
@@ -97,3 +98,26 @@ class TestAuth0Provider:
             assert str(provider.base_url) == TEST_BASE_URL
             assert provider._redirect_path == "/auth/callback"
             assert provider._token_validator.required_scopes == ["openid"]
+
+    def test_init_with_custom_timeout(self, valid_oidc_configuration_dict):
+        """Test that timeout_seconds is passed to OIDC discovery."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            oidc_config = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+            mock_get.return_value = oidc_config
+
+            Auth0Provider(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                audience=TEST_AUDIENCE,
+                base_url=TEST_BASE_URL,
+                timeout_seconds=3,
+                jwt_signing_key="test-secret",
+            )
+
+            call_args = mock_get.call_args
+            assert call_args[1]["timeout_seconds"] == 3

--- a/tests/server/auth/providers/test_aws.py
+++ b/tests/server/auth/providers/test_aws.py
@@ -31,7 +31,7 @@ def mock_cognito_oidc_discovery():
         mock_response = mock_get.return_value
         mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = mock_oidc_config
-        yield
+        yield mock_get
 
 
 class TestAWSCognitoProvider:
@@ -39,7 +39,7 @@ class TestAWSCognitoProvider:
 
     def test_init_with_explicit_params(self):
         """Test initialization with explicit parameters."""
-        with mock_cognito_oidc_discovery():
+        with mock_cognito_oidc_discovery() as mock_get:
             provider = AWSCognitoProvider(
                 user_pool_id="us-east-1_XXXXXXXXX",
                 aws_region="us-east-1",
@@ -68,6 +68,7 @@ class TestAWSCognitoProvider:
                 provider._upstream_token_endpoint
                 == "https://test.auth.us-east-1.amazoncognito.com/oauth2/token"
             )
+            assert mock_get.call_args[1]["timeout"] == 10
 
     def test_init_defaults(self):
         """Test that default values are applied correctly."""
@@ -118,6 +119,20 @@ class TestAWSCognitoProvider:
 
             assert verifier._expected_client_id == "test_client"
             assert verifier.audience is None
+
+    def test_init_with_custom_timeout(self):
+        """Test that timeout_seconds is passed to OIDC discovery."""
+        with mock_cognito_oidc_discovery() as mock_get:
+            AWSCognitoProvider(
+                user_pool_id="us-east-1_XXXXXXXXX",
+                client_id="test_client",
+                client_secret="test_secret",
+                base_url="https://example.com",
+                timeout_seconds=3,
+                jwt_signing_key="test-secret",
+            )
+
+            assert mock_get.call_args[1]["timeout"] == 3
 
     def test_token_verifier_supports_audience_override(self):
         """Audience param maps to client_id validation in Cognito verifier."""

--- a/tests/server/auth/providers/test_oci.py
+++ b/tests/server/auth/providers/test_oci.py
@@ -62,6 +62,7 @@ class TestOCIProvider:
 
             call_args = mock_get.call_args
             assert str(call_args[0][0]) == TEST_CONFIG_URL
+            assert call_args[1]["timeout_seconds"] == 10
 
             assert provider._upstream_client_id == TEST_CLIENT_ID
             assert provider._upstream_client_secret is not None
@@ -85,3 +86,25 @@ class TestOCIProvider:
             assert str(provider.base_url) == TEST_BASE_URL
             assert provider._redirect_path == TEST_REDIRECT_PATH
             assert provider._token_validator.required_scopes == TEST_REQUIRED_SCOPES
+
+    def test_init_with_custom_timeout(self, valid_oidc_configuration_dict):
+        """Test that timeout_seconds is passed to OIDC discovery."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            oidc_config = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+            mock_get.return_value = oidc_config
+
+            OCIProvider(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                base_url=TEST_BASE_URL,
+                timeout_seconds=3,
+                jwt_signing_key="test-secret-key",
+            )
+
+            call_args = mock_get.call_args
+            assert call_args[1]["timeout_seconds"] == 3

--- a/tests/server/auth/test_oidc_proxy.py
+++ b/tests/server/auth/test_oidc_proxy.py
@@ -391,8 +391,10 @@ class TestGetOIDCConfiguration:
         )
         assert call_args[1]["timeout"] == 10
 
-    def test_get_oidc_configuration_no_timeout(self, valid_oidc_configuration_dict):
-        """Test with valid response and no timeout."""
+    def test_get_oidc_configuration_explicit_no_timeout(
+        self, valid_oidc_configuration_dict
+    ):
+        """Test with valid response and explicit no timeout."""
         call_args = validate_get_oidc_configuration(
             valid_oidc_configuration_dict, True, None
         )
@@ -488,6 +490,29 @@ class TestOIDCProxyInitialization:
 
             call_args = mock_get.call_args
             assert call_args[1]["timeout_seconds"] == 12
+
+    def test_default_timeout_seconds_initialization(
+        self, valid_oidc_configuration_dict
+    ):
+        """Test that OIDC discovery uses a bounded default timeout."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            oidc_config = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+            mock_get.return_value = oidc_config
+
+            OIDCProxy(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                base_url=TEST_BASE_URL,
+                jwt_signing_key="test-secret",
+            )
+
+            call_args = mock_get.call_args
+            assert call_args[1]["timeout_seconds"] == 10
 
     def test_token_verifier_initialization(self, valid_oidc_configuration_dict):
         """Test token verifier initialization."""


### PR DESCRIPTION
## Summary
- set OIDCProxy discovery to use the documented 10-second default timeout
- expose the same timeout_seconds parameter on Auth0, AWS Cognito, and OCI OIDC provider wrappers
- keep timeout_seconds=None as an explicit escape hatch for callers that do not want FastMCP to set a timeout

## Why
OIDC provider construction currently calls httpx.get without a timeout on the default path, even though the docs describe timeout_seconds as defaulting to 10. A slow or unreachable IdP can therefore hang server startup indefinitely. This fixes the no-timeout part of #4353 while preserving the existing eager discovery behavior.

Fixes #4353

## Validation
- uv run pytest tests/server/auth/test_oidc_proxy.py tests/server/auth/providers/test_auth0.py tests/server/auth/providers/test_aws.py tests/server/auth/providers/test_oci.py -q
- uv run ruff check fastmcp_slim/fastmcp/server/auth/oidc_proxy.py fastmcp_slim/fastmcp/server/auth/providers/auth0.py fastmcp_slim/fastmcp/server/auth/providers/aws.py fastmcp_slim/fastmcp/server/auth/providers/oci.py tests/server/auth/test_oidc_proxy.py tests/server/auth/providers/test_auth0.py tests/server/auth/providers/test_aws.py tests/server/auth/providers/test_oci.py
- uv run ruff format --check fastmcp_slim/fastmcp/server/auth/oidc_proxy.py fastmcp_slim/fastmcp/server/auth/providers/auth0.py fastmcp_slim/fastmcp/server/auth/providers/aws.py fastmcp_slim/fastmcp/server/auth/providers/oci.py tests/server/auth/test_oidc_proxy.py tests/server/auth/providers/test_auth0.py tests/server/auth/providers/test_aws.py tests/server/auth/providers/test_oci.py
- git diff --check
