### PR TITLE
Recognize all GitHub issue-link forms in require-issue-link workflow

### DIFF
--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -277,7 +277,17 @@ jobs:
 
             // ── The actual check: an auto-close keyword + issue number ─────
             const body = pr.body || '';
-            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            // Match GitHub's auto-close keywords against any reference form
+            // that GitHub itself honors: bare `#123`, the `owner/repo#123`
+            // shorthand, and the full issue URL. Scope the qualified forms to
+            // THIS repo — GitHub only auto-closes same-repo issues, so a
+            // cross-repo reference must not be resolved against our numbering.
+            const repoRef = `${owner}/${repo}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const pattern = new RegExp(
+              '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s*:?\\s*' +
+                `(?:${repoRef}#|#|https?://github\\.com/${repoRef}/issues/)(\\d+)`,
+              'gi',
+            );
             const matches = [...body.matchAll(pattern)];
 
             if (matches.length === 0) {
@@ -425,7 +435,17 @@ jobs:
             const enforce = process.env.ENFORCE_ISSUE_LINK === 'true';
             const LABEL = 'missing-issue-link';
             const MARKER = '<!-- require-issue-link -->';
-            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            // Match GitHub's auto-close keywords against any reference form
+            // that GitHub itself honors: bare `#123`, the `owner/repo#123`
+            // shorthand, and the full issue URL. Scope the qualified forms to
+            // THIS repo — GitHub only auto-closes same-repo issues, so a
+            // cross-repo reference must not be resolved against our numbering.
+            const repoRef = `${owner}/${repo}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const pattern = new RegExp(
+              '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s*:?\\s*' +
+                `(?:${repoRef}#|#|https?://github\\.com/${repoRef}/issues/)(\\d+)`,
+              'gi',
+            );
 
             async function mutate(description, fn) {
               if (!enforce) {


### PR DESCRIPTION
The `require-issue-link` workflow only recognized the `Closes #123` hash form when scanning a PR body for its linked issue. GitHub itself also honors `Closes owner/repo#123` and the full `Closes https://github.com/owner/repo/issues/123` URL — both of which contributors use. A PR linking its issue via either of those forms was wrongly closed as "no link", and assigning the issue afterward never reopened it (the `reopen-on-assignment` job re-parsed the body with the same regex and skipped the PR). This is exactly what happened to #4319 → #4320.

The shared closing-keyword regex (used identically by both jobs) now matches all three forms GitHub recognizes, scoped to the current repo so a cross-repo reference like `Closes otherorg/repo#5` is correctly ignored rather than mis-resolved against our own issue numbering.

```js
// before — only `#123`
/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi

// after — `#123`, `owner/repo#123`, and the full issue URL, same-repo only
const repoRef = `${owner}/${repo}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
new RegExp(
  '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s*:?\\s*' +
    `(?:${repoRef}#|#|https?://github\\.com/${repoRef}/issues/)(\\d+)`,
  'gi',
);
```
