### PR TITLE
fix(proxy): shield stateful proxy disconnect during session teardown

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1232,7 +1232,13 @@ class StatefulProxyClient(ProxyClient[ClientTransportT]):
             async def _on_session_exit():
                 self._caches.pop(session)
                 logger.debug(f"{proxy_client} will be disconnect")
-                await proxy_client._disconnect(force=True)
+                # This callback runs while the server session's exit stack is
+                # unwinding, which usually happens because the owning task is
+                # being cancelled. Shield the disconnect so the forced cleanup
+                # actually runs to completion instead of aborting at the first
+                # cancellation checkpoint (e.g. acquiring the session lock).
+                with anyio.CancelScope(shield=True):
+                    await proxy_client._disconnect(force=True)
 
             session._exit_stack.push_async_callback(_on_session_exit)
 


### PR DESCRIPTION
The "lowest-direct dependencies" CI job started failing on the `StatefulProxyClient` tests with `RuntimeError: Attempted to exit a cancel scope that isn't the current task's current cancel scope`. The trigger is anyio 4.14, which now wraps every `task_group.start_soon(...)` task in a per-task cancel scope. The in-memory transport spawns the server via `start_soon`, so when a server session tears down it runs `StatefulProxyClient._on_session_exit` → `_disconnect(force=True)`, which immediately hits a cancellation checkpoint (`async with self._session_state.lock`) and raises `CancelledError`. Under anyio 4.14 that exception unwinds through the new per-task scope before the scope's own `__exit__`, so anyio sees the scopes exit out of order and raises. It was deterministic on macOS and timing-flaky on Linux, which is why only the lowest-direct job tripped it.

The forced disconnect is meant to release the proxy's backend connections when a session ends, so it shouldn't abort midway just because the owning task is being cancelled. Shielding it lets the cleanup run to completion (it already has internal `move_on_after` timeouts, so the shield can't hang):

```python
async def _on_session_exit():
    self._caches.pop(session)
    with anyio.CancelScope(shield=True):
        await proxy_client._disconnect(force=True)
```

The existing `test_stateful_proxy_client.py` tests now serve as deterministic regression coverage, since anyio 4.14 is the locked version.
