### PR TITLE
Switch prettier hook to rbubley/mirrors-prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
     hooks:
       - id: validate-pyproject
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.4
     hooks:
       - id: prettier
         types_or: [yaml, json5]


### PR DESCRIPTION
`pre-commit/mirrors-prettier` is archived and pinned at a stale prettier (v3.1.0). This switches to `rbubley/mirrors-prettier`, the actively-maintained community fork, at v3.8.4. No file reformatting results.

Closes #4272
