### PR TITLE
fix: RST docstrings in fastmcp.types render raw on gofastmcp.com

### DIFF
--- a/fastmcp_slim/fastmcp/types.py
+++ b/fastmcp_slim/fastmcp/types.py
@@ -1,19 +1,21 @@
 """Reusable type annotations for FastMCP tool parameters.
 
 These types can be used in tool function signatures to influence how
-parameters are presented in UIs (e.g. ``fastmcp dev apps``) and
+parameters are presented in UIs (e.g. `fastmcp dev apps`) and
 serialized in JSON Schema.
 
-Example::
+Example:
 
-    from fastmcp import FastMCP
-    from fastmcp.types import Textarea
+```python
+from fastmcp import FastMCP
+from fastmcp.types import Textarea
 
-    mcp = FastMCP("demo")
+mcp = FastMCP("demo")
 
-    @mcp.tool()
-    def run_query(sql: Textarea) -> str:
-        ...
+@mcp.tool()
+def run_query(sql: Textarea) -> str:
+    ...
+```
 """
 
 from __future__ import annotations
@@ -25,8 +27,8 @@ from pydantic import Field
 Textarea = Annotated[str, Field(json_schema_extra={"format": "textarea"})]
 """A string rendered as a multiline textarea in form-based UIs.
 
-Produces ``"format": "textarea"`` in the JSON Schema, which
-``fastmcp dev apps`` picks up automatically.
+Produces `"format": "textarea"` in the JSON Schema, which
+`fastmcp dev apps` picks up automatically.
 """
 
 __all__ = ["Textarea"]


### PR DESCRIPTION
The docstrings in `fastmcp.types` used RST syntax (`Example::`, double backticks), but FastMCP compiles docstrings to MDX for gofastmcp.com — so the markup rendered raw on the published docs. This converts the module and `Textarea` docstrings to Markdown (fenced code block, single backticks) so `fastmcp-types.mdx` renders correctly.

This re-lands the fix from #4347 by @justinvzyl, which was auto-closed by the issue-link bot because the external contributor wasn't assigned to the referenced issue. Full credit to Justin — preserved as co-author on the commit.

Closes #4331
