### PR TITLE
fix: validate task tool arguments

### DIFF
--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -22,7 +22,7 @@ from typing import (
 import anyio
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, Icon, ToolAnnotations
-from pydantic import Field
+from pydantic import Field, validate_call
 from pydantic.json_schema import SkipJsonSchema
 
 import fastmcp
@@ -360,13 +360,14 @@ class FunctionTool(Tool):
     def register_with_docket(self, docket: Docket) -> None:
         """Register this tool with docket for background execution.
 
-        Registers the raw function so Docket sees and resolves ALL
+        Registers a validated function so Docket sees and resolves ALL
         dependencies — both FastMCP's (CurrentContext, Progress) and
-        Docket-native ones (Retry, Timeout, ConcurrencyLimit).
+        Docket-native ones (Retry, Timeout, ConcurrencyLimit) — while matching
+        the synchronous tool path's Pydantic argument coercion.
         """
         if not self.task_config.supports_tasks():
             return
-        docket.register(self.fn, names=[self.key])
+        docket.register(validate_call(self.fn), names=[self.key])
 
     async def add_to_docket(
         self,

--- a/tests/server/tasks/test_task_tools.py
+++ b/tests/server/tasks/test_task_tools.py
@@ -8,6 +8,7 @@ and test_task_resources.py.
 import asyncio
 
 import pytest
+from pydantic import BaseModel
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
@@ -30,6 +31,41 @@ async def tool_server():
         return f"Sync: {message}"
 
     return mcp
+
+
+class Item(BaseModel):
+    name: str
+    count: int
+
+
+async def test_task_tool_coerces_model_and_list_arguments():
+    """Task tools receive the same Pydantic-coerced args as sync calls."""
+    mcp = FastMCP("tool-task-validation-server")
+
+    @mcp.tool(task=True)
+    async def inspect_items(item: Item, items: list[Item]) -> dict[str, object]:
+        return {
+            "item_is_model": isinstance(item, Item),
+            "items_are_models": [isinstance(value, Item) for value in items],
+            "total": item.count + sum(value.count for value in items),
+        }
+
+    async with Client(mcp) as client:
+        arguments = {
+            "item": {"name": "one", "count": "1"},
+            "items": [{"name": "two", "count": "2"}],
+        }
+
+        sync_result = await client.call_tool("inspect_items", arguments)
+        task = await client.call_tool("inspect_items", arguments, task=True)
+        task_result = await task.result()
+
+    assert sync_result.data == {
+        "item_is_model": True,
+        "items_are_models": [True],
+        "total": 3,
+    }
+    assert task_result.data == sync_result.data
 
 
 async def test_synchronous_tool_call_unchanged(tool_server):


### PR DESCRIPTION
## Summary
Validate task-enabled tool arguments before executing the underlying Python function.

## Motivation
For `task=True` tools, Pydantic model/list arguments currently reach the function body as raw dictionaries in the task execution path, while normal synchronous calls receive validated/coerced model instances. This makes the task path diverge from regular tool invocation and can raise errors when tool code accesses model attributes.

Fixes #4349

## Changes
- Register task-enabled function tools with `pydantic.validate_call(...)` in Docket so task execution uses the same argument coercion behavior before invoking the function body.
- Add a regression test covering both a single Pydantic model argument and `list[Model]` argument for sync and task calls.

## Testing
- `pytest tests/server/tasks/test_task_tools.py -k 'coerces_model_and_list_arguments' -q` → `1 passed, 4 deselected in 0.55s`
- `pytest tests/server/tasks/test_task_tools.py -q` → `5 passed in 0.46s`
- `ruff check fastmcp_slim/fastmcp/tools/function_tool.py tests/server/tasks/test_task_tools.py` → `All checks passed!`
- `ruff format --check fastmcp_slim/fastmcp/tools/function_tool.py tests/server/tasks/test_task_tools.py` → `2 files already formatted`
- `git diff --check`
- Strict secret scan on diff: clean