### PR TITLE
fix(event_store): tolerate lost eviction race in store_event

### DIFF
--- a/fastmcp_slim/fastmcp/server/event_store.py
+++ b/fastmcp_slim/fastmcp/server/event_store.py
@@ -121,7 +121,17 @@ class EventStore(SDKEventStore):
         # Trim to max events (delete old events)
         if len(event_ids) > self._max_events_per_stream:
             for old_id in event_ids[: -self._max_events_per_stream]:
-                await self._event_store.delete(key=old_id)
+                try:
+                    await self._event_store.delete(key=old_id)
+                except FileNotFoundError:
+                    # Eviction is idempotent by intent: a concurrent store_event
+                    # (the SSE writer and message router both store events on the
+                    # same session) or an external removal already deleted this
+                    # entry. A missing key is the desired end state, not an error.
+                    # Some backends (e.g. the file-tree store) surface the lost
+                    # race as FileNotFoundError instead of a no-op, which would
+                    # otherwise escape as an ERROR traceback out of those tasks.
+                    logger.debug("event_store: %s already evicted", old_id)
             event_ids = event_ids[-self._max_events_per_stream :]
 
         await self._stream_store.put(

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -144,6 +144,39 @@ class TestEventStore:
         result = await event_store.replay_events_after(event_ids[3], callback)
         assert result == "stream-1"
 
+    async def test_eviction_tolerates_lost_delete_race(self, event_store):
+        """Regression for #4143: a lost eviction race must not escape store_event.
+
+        The SSE writer and message router both store events on the same session,
+        so two concurrent store_event calls can evict the same event_id. The
+        loser's delete hits the entry the winner already removed; backends like
+        the file-tree store surface that as FileNotFoundError instead of a no-op.
+        store_event must treat the missing entry as success (idempotent eviction)
+        rather than letting the error escape as an ERROR traceback.
+        """
+        msg = JSONRPCMessage(root=JSONRPCRequest(jsonrpc="2.0", method="test", id=1))
+
+        # Fill exactly to the cap so the next store triggers an eviction.
+        for _ in range(event_store._max_events_per_stream):
+            await event_store.store_event("stream-1", msg)
+
+        # Simulate the lost race: the concurrent eviction already deleted the
+        # entry, so the underlying store raises FileNotFoundError on our delete.
+        async def raise_missing(*args, **kwargs):
+            raise FileNotFoundError(2, "No such file or directory")
+
+        event_store._event_store.delete = raise_missing  # type: ignore[method-assign]
+
+        # This store crosses the cap -> eviction runs -> delete raises. The error
+        # must be swallowed and the call must still return a valid event id.
+        event_id = await event_store.store_event("stream-1", msg)
+        assert isinstance(event_id, str) and event_id
+
+        # The stream list is still trimmed to the cap despite the failed delete.
+        stream_data = await event_store._stream_store.get(key="stream-1")
+        assert stream_data is not None
+        assert len(stream_data.event_ids) == event_store._max_events_per_stream
+
     async def test_multiple_streams_are_isolated(self, event_store):
         """Events from different streams should not interfere with each other."""
         msg1 = JSONRPCMessage(


### PR DESCRIPTION
## Summary

Closes #4143.

`EventStore.store_event` evicts old event ids to enforce the per-stream ring-buffer cap. The SSE writer and message router both call `store_event` on the same session, so two concurrent calls can decide to evict the **same** `event_id`. The loser's `delete()` hits the entry the winner already removed — and backends like the file-tree store (`FileTreeStore.delete_entry` does `exists()` + unguarded `unlink()`) surface that lost race as `FileNotFoundError` instead of a no-op. The exception escapes as an ERROR-level traceback out of the SSE writer / message router tasks on every collision.

## Fix

Eviction is idempotent by intent — a missing key is the desired end state, not an error. Wrap the per-id `delete()` in `try/except FileNotFoundError` and log at DEBUG (option **(a)** from the issue write-up). This defends fastmcp regardless of the underlying store; the sibling backend fix in `py-key-value` is complementary, not a prerequisite.

```python
for old_id in event_ids[: -self._max_events_per_stream]:
    try:
        await self._event_store.delete(key=old_id)
    except FileNotFoundError:
        logger.debug("event_store: %s already evicted", old_id)
```

## Test

Added `test_eviction_tolerates_lost_delete_race`, which fills the stream to the cap, monkeypatches the underlying store's `delete` to raise `FileNotFoundError` (simulating the lost race), then triggers an eviction and asserts `store_event` neither raises nor leaves the stream list over the cap.

Before/after on `main`:
- **without the fix:** the new test fails — `FileNotFoundError` propagates out of `store_event`.
- **with the fix:** passes; full `tests/server/test_event_store.py` is 15/15; `ruff check` and `ruff format --check` clean.

## Note

@justadityaraj you mentioned picking this up a few weeks back — since no PR landed I went ahead and opened one (same option (a) approach you described). Happy to defer or collaborate if you're still on it. 🙏