### PR TITLE
fix: bracket IPv6 hosts in server startup log URL

### DIFF
--- a/fastmcp_slim/fastmcp/server/mixins/transport.py
+++ b/fastmcp_slim/fastmcp/server/mixins/transport.py
@@ -35,6 +35,19 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _format_host_for_url(host: str) -> str:
+    """Format a host for inclusion in a URL, bracketing IPv6 addresses.
+
+    A bare IPv6 address like ``::1`` must be wrapped in brackets when placed
+    before a ``:port`` suffix, otherwise the result (``http://::1:8000``) is an
+    invalid URL. Hostnames and IPv4 addresses are returned unchanged, as are
+    addresses that are already bracketed.
+    """
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 class TransportMixin:
     """Mixin providing transport-related methods for FastMCP.
 
@@ -301,8 +314,9 @@ class TransportMixin:
                 server = uvicorn.Server(config)
                 path = getattr(app.state, "path", "").lstrip("/")
                 mode = " (stateless)" if stateless_http else ""
+                display_host = _format_host_for_url(host)
                 logger.info(
-                    f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{host}:{port}/{path}"
+                    f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{display_host}:{port}/{path}"
                 )
 
                 if sockets is not None:

--- a/tests/server/test_transport.py
+++ b/tests/server/test_transport.py
@@ -1,0 +1,20 @@
+import pytest
+
+from fastmcp.server.mixins.transport import _format_host_for_url
+
+
+@pytest.mark.parametrize(
+    "host, expected",
+    [
+        ("127.0.0.1", "127.0.0.1"),
+        ("localhost", "localhost"),
+        ("0.0.0.0", "0.0.0.0"),
+        ("::1", "[::1]"),
+        ("::", "[::]"),
+        ("fe80::1", "[fe80::1]"),
+        ("[::1]", "[::1]"),
+    ],
+)
+def test_format_host_for_url(host: str, expected: str):
+    """IPv6 hosts are bracketed for use in a URL; everything else is unchanged."""
+    assert _format_host_for_url(host) == expected


### PR DESCRIPTION
When a server binds to an IPv6 host, the startup log line prints an unusable URL: the bare address runs straight into the port, producing `http://::1:8000/mcp`. A reader can't tell where the host ends and the port begins, and pasting it anywhere fails because an IPv6 literal must be bracketed before a `:port` suffix.

This brackets IPv6 hosts when composing the log URL, leaving hostnames and IPv4 addresses untouched (and not double-bracketing an address that already arrived bracketed).

```python
from fastmcp import FastMCP

mcp = FastMCP("Test")
mcp.run(transport="streamable-http", host="::1")
# before: Starting MCP server ... on http://::1:8000/mcp
# after:  Starting MCP server ... on http://[::1]:8000/mcp
```

Closes #4339
