### PR TITLE
fix(resources): coerce list[str] resource template query parameters

### DIFF
--- a/fastmcp_slim/fastmcp/resources/template.py
+++ b/fastmcp_slim/fastmcp/resources/template.py
@@ -6,7 +6,7 @@ import functools
 import inspect
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, overload
+from typing import TYPE_CHECKING, Any, ClassVar, get_args, get_origin, overload
 from urllib.parse import parse_qs, quote, unquote
 
 import mcp.types
@@ -106,14 +106,35 @@ def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
 
         for name in query_param_names:
             if name in parsed_query:
-                # Take first value if multiple provided.
+                values = parsed_query[name]
                 # Normalize hyphens to underscores to match Python param names.
                 # Don't overwrite path params that were already extracted.
                 key = name.replace("-", "_")
                 if key not in params:
-                    params[key] = parsed_query[name][0]
+                    # Preserve repeated keys as a list for list-typed parameters.
+                    params[key] = values[0] if len(values) == 1 else values
 
     return params
+
+
+def _is_list_of_str_annotation(annotation: Any) -> bool:
+    """Return True when *annotation* is ``list[str]`` (or equivalent)."""
+    if annotation is inspect.Parameter.empty:
+        return False
+    origin = get_origin(annotation)
+    if origin is list:
+        args = get_args(annotation)
+        return len(args) == 1 and args[0] is str
+    return False
+
+
+def _coerce_query_param_to_str_list(value: str | list[str]) -> list[str]:
+    """Coerce a query parameter value into ``list[str]``."""
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    if "," in value:
+        return [part for part in value.split(",") if part != ""]
+    return [value]
 
 
 def expand_uri_template(uri_template: str, params: dict[str, Any]) -> str:
@@ -486,8 +507,17 @@ class FunctionResourceTemplate(ResourceTemplate):
                             raise ValueError(
                                 f"Invalid boolean value for {param_name}: {param_value!r}"
                             )
+                    elif _is_list_of_str_annotation(annotation):
+                        kwargs[param_name] = _coerce_query_param_to_str_list(
+                            param_value
+                        )
                 except (ValueError, AttributeError):
                     raise
+            elif param_name in sig.parameters and _is_list_of_str_annotation(
+                sig.parameters[param_name].annotation
+            ):
+                if isinstance(param_value, list):
+                    kwargs[param_name] = [str(v) for v in param_value]
 
         # self.fn is wrapped by without_injected_parameters which handles
         # dependency resolution internally, so we call it directly

--- a/tests/resources/test_resource_template_query_params.py
+++ b/tests/resources/test_resource_template_query_params.py
@@ -408,3 +408,59 @@ class TestResourceTemplateFieldDefaults:
         assert result2["limit"] == 50  # overridden
         assert result2["offset"] == 0  # default
         assert result2["format"] == "xml"  # overridden
+
+
+class TestListQueryParameterTypeCoercion:
+    """Test list[str] query parameters."""
+
+    async def _make_template(self):
+        from pydantic import Field
+
+        def search(category: str, tags: list[str] = Field(default_factory=list)) -> dict:
+            return {"category": category, "tags": tags}
+
+        return ResourceTemplate.from_function(
+            fn=search,
+            uri_template="items://{category}{?tags}",
+            name="test",
+        )
+
+    async def test_missing_list_query_param_uses_default(self):
+        template = await self._make_template()
+
+        resource = await template.create_resource("items://books", {"category": "books"})
+        result = await resource.read()
+        assert result == {"category": "books", "tags": []}
+
+    async def test_single_list_query_param(self):
+        template = await self._make_template()
+
+        resource = await template.create_resource(
+            "items://books?tags=alpha",
+            {"category": "books", "tags": "alpha"},
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": ["alpha"]}
+
+    async def test_repeated_list_query_params(self):
+        template = await self._make_template()
+
+        params = template.matches("items://books?tags=alpha&tags=beta")
+        assert params == {"category": "books", "tags": ["alpha", "beta"]}
+
+        resource = await template.create_resource(
+            "items://books?tags=alpha&tags=beta",
+            params,
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": ["alpha", "beta"]}
+
+    async def test_comma_separated_list_query_param(self):
+        template = await self._make_template()
+
+        resource = await template.create_resource(
+            "items://books?tags=alpha,beta",
+            {"category": "books", "tags": "alpha,beta"},
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": ["alpha", "beta"]}


### PR DESCRIPTION
## Summary

Resource templates with optional `list[str]` query parameters (e.g. `{?tags}`) failed at read time because query values were passed through as plain strings.

## Motivation

Fixes #4378. Filters such as `items://books?tags=alpha` raised Pydantic validation errors instead of invoking the handler with `["alpha"]`.

## Changes

- `match_uri_template`: preserve repeated query keys as a list instead of keeping only the first value
- `FunctionResourceTemplate.read()`: coerce string or list query values into `list[str]` when the parameter is annotated `list[str]` (including comma-separated single values)
- Add regression tests in `test_resource_template_query_params.py`

## Tests

```bash
uv run pytest tests/resources/test_resource_template_query_params.py -v
```

36 passed.

## Notes

- Only `list[str]` is handled in this change; other list element types are unchanged.
- I commented on the issue requesting assignment per CONTRIBUTING guidelines.