### PR TITLE
Add setup and teardown lifecycle hooks for tools

### DIFF
--- a/docs/servers/tasks.mdx
+++ b/docs/servers/tasks.mdx
@@ -68,6 +68,8 @@ When a client requests background execution, the call returns immediately with a
 Background tasks require async functions. Attempting to use `task=True` with a sync function raises a `ValueError` at registration time.
 </Warning>
 
+Tool lifecycle hooks also run for background tasks. If a task-enabled tool defines `setup` or `teardown`, FastMCP runs those hooks in the Docket worker around the tool function. The `teardown` hook receives the raw task result or exception before the task result is stored for the client.
+
 ## Execution Modes
 
 For fine-grained control over task execution behavior, use `TaskConfig` instead of the boolean shorthand. The MCP task protocol defines three execution modes:

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -885,7 +885,7 @@ async def update_record(record_id: str, value: str) -> str:
 
 `setup` runs before every invocation. If it returns a value, FastMCP passes that value to `teardown` as `setup_result`.
 
-`teardown` runs after `setup` has been attempted, including when setup or the tool succeeds, raises an exception, times out, or is cancelled. It runs in a shielded cancellation scope so cleanup has a chance to finish even if the tool call is being cancelled. If setup or the tool failed, FastMCP preserves the original exception even if teardown also fails.
+`teardown` runs after `setup` has been attempted, including when setup or the tool succeeds, raises an exception, times out, or is cancelled. It runs in a shielded cancellation scope so cleanup has a chance to finish even if the tool call is being cancelled. If teardown raises, FastMCP logs the teardown failure and preserves the original invocation outcome: successful tool results are still returned, and setup or tool exceptions are still raised.
 
 The `teardown` hook may accept any of these keyword arguments:
 
@@ -899,6 +899,10 @@ The `teardown` hook may accept any of these keyword arguments:
 
 <ParamField body="setup_result" type="Any | None">
   The value returned by `setup`, if any.
+</ParamField>
+
+<ParamField body="timed_out" type="bool">
+  Whether the foreground invocation exceeded the tool's FastMCP `timeout`.
 </ParamField>
 
 Hooks can be sync or async. For sync tools, sync hooks follow the tool's `run_in_thread` setting: by default they run in the worker thread pool, and with `run_in_thread=False` they run inline on the event loop thread.
@@ -922,7 +926,9 @@ async def fetch_data(url: str) -> dict:
     ...
 ```
 
-Timeouts are specified in seconds as a float. When a tool exceeds its timeout, FastMCP returns an MCP error with code `-32000` and a message indicating which tool timed out and how long it ran. Both sync and async tools support timeouts—sync functions run in thread pools, so the timeout applies to the entire operation regardless of execution model.
+Timeouts are specified in seconds as a float. The timeout budget covers the foreground invocation's `setup` hook, tool execution, and result materialization. The `teardown` hook runs afterward in a shielded cancellation scope, outside the timeout budget.
+
+When a tool exceeds its timeout, FastMCP returns an MCP error with code `-32000` and a message indicating which tool timed out and how long it ran. Both sync and async tools support timeouts—sync functions run in thread pools, so the timeout applies regardless of execution model.
 
 <Note>
 Tools must explicitly opt-in to timeouts. There is no server-level default timeout setting.

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -121,6 +121,14 @@ def search_products_implementation(query: str, category: str | None = None) -> l
   Execution timeout in seconds. If the tool takes longer than this to complete, an MCP error is returned to the client. See [Timeouts](#timeouts) for details.
 </ParamField>
 
+<ParamField body="setup" type="Callable[..., Any] | None">
+  Optional hook that runs before each tool invocation. It can be sync or async. Any value it returns is passed to `teardown` as `setup_result`.
+</ParamField>
+
+<ParamField body="teardown" type="Callable[..., Any] | None">
+  Optional hook that runs after each tool invocation, including failures, timeouts, and cancellation. It can accept `result`, `exception`, and `setup_result` keyword arguments for conditional cleanup.
+</ParamField>
+
 <ParamField body="version" type="str | int | None">
   <VersionBadge version="3.0.0" />
 
@@ -843,6 +851,57 @@ def divide(a: float, b: float) -> float:
 ```
 
 When `mask_error_details=True`, only error messages from `ToolError` will include details, other exceptions will be converted to a generic message.
+
+## Lifecycle Hooks
+
+Tools can define `setup` and `teardown` hooks for per-call resource management. Use these hooks when a tool needs to acquire state before execution and reliably clean it up afterward, such as locks, temporary files, database sessions, or network clients.
+
+```python
+import asyncio
+
+from fastmcp import FastMCP
+
+mcp = FastMCP()
+resource_lock = asyncio.Lock()
+
+async def acquire_resource_lock() -> asyncio.Lock:
+    await resource_lock.acquire()
+    return resource_lock
+
+async def release_resource_lock(
+    result: str | None = None,
+    exception: BaseException | None = None,
+    setup_result: asyncio.Lock | None = None,
+) -> None:
+    if setup_result is not None and setup_result.locked():
+        setup_result.release()
+
+@mcp.tool(setup=acquire_resource_lock, teardown=release_resource_lock)
+async def update_record(record_id: str, value: str) -> str:
+    """Update a shared resource while holding a lock."""
+    ...
+    return f"Updated {record_id}"
+```
+
+`setup` runs before every invocation. If it returns a value, FastMCP passes that value to `teardown` as `setup_result`.
+
+`teardown` runs after `setup` has been attempted, including when setup or the tool succeeds, raises an exception, times out, or is cancelled. It runs in a shielded cancellation scope so cleanup has a chance to finish even if the tool call is being cancelled. If setup or the tool failed, FastMCP preserves the original exception even if teardown also fails.
+
+The `teardown` hook may accept any of these keyword arguments:
+
+<ParamField body="result" type="Any | None">
+  The raw value returned by the tool function before FastMCP converts it to a `ToolResult`. This is `None` when the tool did not produce a result.
+</ParamField>
+
+<ParamField body="exception" type="BaseException | None">
+  The exception raised during setup or tool execution, including cancellation and timeout errors. This is `None` when the invocation succeeds.
+</ParamField>
+
+<ParamField body="setup_result" type="Any | None">
+  The value returned by `setup`, if any.
+</ParamField>
+
+Hooks can be sync or async. For sync tools, sync hooks follow the tool's `run_in_thread` setting: by default they run in the worker thread pool, and with `run_in_thread=False` they run inline on the event loop thread.
 
 ## Timeouts
 

--- a/fastmcp_slim/fastmcp/apps/app.py
+++ b/fastmcp_slim/fastmcp/apps/app.py
@@ -174,6 +174,8 @@ class FastMCPApp(Provider):
         model: bool = False,
         auth: AuthCheck | list[AuthCheck] | None = None,
         timeout: float | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> F: ...
 
     @overload
@@ -186,6 +188,8 @@ class FastMCPApp(Provider):
         model: bool = False,
         auth: AuthCheck | list[AuthCheck] | None = None,
         timeout: float | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> Callable[[F], F]: ...
 
     def tool(
@@ -197,6 +201,8 @@ class FastMCPApp(Provider):
         model: bool = False,
         auth: AuthCheck | list[AuthCheck] | None = None,
         timeout: float | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> Any:
         """Register a backend tool that the UI calls via CallTool.
 
@@ -244,6 +250,8 @@ class FastMCPApp(Provider):
                 meta=meta,
                 timeout=timeout,
                 auth=auth,
+                setup=setup,
+                teardown=teardown,
             )
             self._local._add_component(tool_obj)
             return fn
@@ -267,6 +275,8 @@ class FastMCPApp(Provider):
         annotations: ToolAnnotations | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         timeout: float | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> F: ...
 
     @overload
@@ -282,6 +292,8 @@ class FastMCPApp(Provider):
         annotations: ToolAnnotations | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         timeout: float | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> Callable[[F], F]: ...
 
     def ui(
@@ -296,6 +308,8 @@ class FastMCPApp(Provider):
         annotations: ToolAnnotations | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         timeout: float | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> Any:
         """Register a UI entry-point tool that the model calls.
 
@@ -348,6 +362,8 @@ class FastMCPApp(Provider):
                 meta=meta,
                 timeout=timeout,
                 auth=auth,
+                setup=setup,
+                teardown=teardown,
             )
             self._local._add_component(tool_obj)
 

--- a/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py
+++ b/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py
@@ -348,6 +348,8 @@ def extract_components(module: ModuleType) -> list[FastMCPComponent]:
                     timeout=meta.timeout,
                     auth=meta.auth,
                     run_in_thread=meta.run_in_thread,
+                    setup=meta.setup,
+                    teardown=meta.teardown,
                 )
                 components.append(tool)
             elif isinstance(meta, ResourceMeta):

--- a/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py
+++ b/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py
@@ -166,6 +166,8 @@ class ToolDecoratorMixin:
                     timeout=fmeta.timeout,
                     auth=fmeta.auth,
                     run_in_thread=fmeta.run_in_thread,
+                    setup=fmeta.setup,
+                    teardown=fmeta.teardown,
                 )
             else:
                 tool = Tool.from_function(tool)
@@ -196,6 +198,8 @@ class ToolDecoratorMixin:
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> F: ...
 
     @overload
@@ -219,6 +223,8 @@ class ToolDecoratorMixin:
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> Callable[[F], F]: ...
 
     # NOTE: This method mirrors fastmcp.tools.tool() but adds registration,
@@ -245,6 +251,8 @@ class ToolDecoratorMixin:
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> (
         Callable[[AnyFunction], FunctionTool]
         | FunctionTool
@@ -350,6 +358,8 @@ class ToolDecoratorMixin:
                     timeout=timeout,
                     auth=auth,
                     run_in_thread=run_in_thread,
+                    setup=setup,
+                    teardown=teardown,
                 )
                 self._add_component(tool_obj)
                 if not enabled:
@@ -376,6 +386,8 @@ class ToolDecoratorMixin:
                     auth=auth,
                     enabled=enabled,
                     run_in_thread=run_in_thread,
+                    setup=setup,
+                    teardown=teardown,
                 )
                 target = fn.__func__ if hasattr(fn, "__func__") else fn
                 target.__fastmcp__ = metadata  # type: ignore[attr-defined]  # ty:ignore[unresolved-attribute]
@@ -420,4 +432,6 @@ class ToolDecoratorMixin:
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            setup=setup,
+            teardown=teardown,
         )

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -1659,6 +1659,8 @@ class FastMCP(
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> F: ...
 
     @overload
@@ -1681,6 +1683,8 @@ class FastMCP(
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> Callable[[F], F]: ...
 
     def tool(
@@ -1702,6 +1706,8 @@ class FastMCP(
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool = True,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> (
         Callable[[AnyFunction], FunctionTool]
         | FunctionTool
@@ -1780,6 +1786,8 @@ class FastMCP(
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            setup=setup,
+            teardown=teardown,
         )
 
         return result

--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -247,6 +247,8 @@ class Tool(FastMCPComponent):
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> FunctionTool:
         """Create a Tool from a function."""
         from fastmcp.tools.function_tool import FunctionTool
@@ -268,6 +270,8 @@ class Tool(FastMCPComponent):
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            setup=setup,
+            teardown=teardown,
         )
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -22,7 +22,7 @@ from typing import (
 import anyio
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, Icon, ToolAnnotations
-from pydantic import Field
+from pydantic import ConfigDict, Field, create_model
 from pydantic.json_schema import SkipJsonSchema
 
 import fastmcp
@@ -308,11 +308,11 @@ class FunctionTool(Tool):
         wrapper_fn = without_injected_parameters(
             self.fn, run_in_thread=self.run_in_thread
         )
-        type_adapter = get_cached_typeadapter(wrapper_fn)
         setup_result: Any = None
         raw_result: Any = None
         has_result = False
         exception: BaseException | None = None
+        timed_out = False
         try:
             # Apply timeout if configured. Combining timeout with
             # run_in_thread=False on a sync function is rejected at
@@ -324,22 +324,12 @@ class FunctionTool(Tool):
                         if self.setup is not None:
                             setup_result = await self._call_lifecycle_hook(self.setup)
 
-                        # Thread pool execution for sync functions, direct await for async
-                        if is_coroutine_function(wrapper_fn):
-                            raw_result = await type_adapter.validate_python(arguments)
-                        else:
-                            # Sync function: run in threadpool to avoid blocking
-                            raw_result = await call_sync_fn_in_threadpool(
-                                type_adapter.validate_python, arguments
-                            )
-                            # Handle sync wrappers that return awaitables
-                            if inspect.isawaitable(raw_result):
-                                raw_result = await raw_result
-                        # Materialize generators inside timeout scope so slow
-                        # generators don't run past the configured timeout
-                        raw_result = await self._materialize_generator(raw_result)
+                        raw_result = await self._execute_with_type_adapter(
+                            wrapper_fn, arguments
+                        )
                         has_result = True
                 except TimeoutError:
+                    timed_out = True
                     logger.warning(
                         f"Tool '{self.name}' timed out after {self.timeout}s. "
                         f"Consider using task=True for long-running operations. "
@@ -355,20 +345,9 @@ class FunctionTool(Tool):
                 if self.setup is not None:
                     setup_result = await self._call_lifecycle_hook(self.setup)
 
-                # No timeout: use existing execution path
-                if is_coroutine_function(wrapper_fn):
-                    raw_result = await type_adapter.validate_python(arguments)
-                elif self.run_in_thread:
-                    raw_result = await call_sync_fn_in_threadpool(
-                        type_adapter.validate_python, arguments
-                    )
-                    if inspect.isawaitable(raw_result):
-                        raw_result = await raw_result
-                else:
-                    raw_result = type_adapter.validate_python(arguments)
-                    if inspect.isawaitable(raw_result):
-                        raw_result = await raw_result
-                raw_result = await self._materialize_generator(raw_result)
+                raw_result = await self._execute_with_type_adapter(
+                    wrapper_fn, arguments
+                )
                 has_result = True
 
             return self.convert_result(raw_result)
@@ -380,6 +359,7 @@ class FunctionTool(Tool):
                 result=raw_result if has_result else None,
                 exception=exception,
                 setup_result=setup_result,
+                timed_out=timed_out,
             )
 
     async def _run_raw_with_lifecycle(self, arguments: dict[str, Any]) -> Any:
@@ -391,16 +371,20 @@ class FunctionTool(Tool):
             if self.setup is not None:
                 setup_result = await self._call_lifecycle_hook(self.setup)
 
+            coerced_arguments = self._coerce_task_arguments(arguments)
             if is_coroutine_function(self.fn):
-                raw_result = await self.fn(**arguments)
+                raw_result = await self.fn(**coerced_arguments)
             elif self.run_in_thread:
-                raw_result = await call_sync_fn_in_threadpool(self.fn, **arguments)
+                raw_result = await call_sync_fn_in_threadpool(
+                    self.fn, **coerced_arguments
+                )
                 if inspect.isawaitable(raw_result):
                     raw_result = await raw_result
             else:
-                raw_result = self.fn(**arguments)
+                raw_result = self.fn(**coerced_arguments)
                 if inspect.isawaitable(raw_result):
                     raw_result = await raw_result
+            raw_result = await self._materialize_generator(raw_result)
             has_result = True
             return raw_result
         except BaseException as exc:
@@ -411,6 +395,7 @@ class FunctionTool(Tool):
                 result=raw_result if has_result else None,
                 exception=exception,
                 setup_result=setup_result,
+                timed_out=False,
             )
 
     async def _run_teardown(
@@ -419,6 +404,7 @@ class FunctionTool(Tool):
         result: Any,
         exception: BaseException | None,
         setup_result: Any,
+        timed_out: bool,
     ) -> None:
         if self.teardown is None:
             return
@@ -429,15 +415,74 @@ class FunctionTool(Tool):
                     result=result,
                     exception=exception,
                     setup_result=setup_result,
+                    timed_out=timed_out,
                 )
         except BaseException:
-            if exception is None:
-                raise
+            failure_context = "completed" if exception is None else "failed"
             logger.warning(
-                "Tool %r teardown failed after tool execution failed.",
+                "Tool %r teardown failed after invocation %s.",
                 self.name,
+                failure_context,
                 exc_info=True,
             )
+
+    async def _execute_with_type_adapter(
+        self, fn: Callable[..., Any], arguments: dict[str, Any]
+    ) -> Any:
+        type_adapter = get_cached_typeadapter(fn)
+        if is_coroutine_function(fn):
+            raw_result = await type_adapter.validate_python(arguments)
+        elif self.run_in_thread:
+            raw_result = await call_sync_fn_in_threadpool(
+                type_adapter.validate_python, arguments
+            )
+            if inspect.isawaitable(raw_result):
+                raw_result = await raw_result
+        else:
+            raw_result = type_adapter.validate_python(arguments)
+            if inspect.isawaitable(raw_result):
+                raw_result = await raw_result
+        return await self._materialize_generator(raw_result)
+
+    def _coerce_task_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        from fastmcp.server.dependencies import without_injected_parameters
+
+        user_fn = without_injected_parameters(self.fn, run_in_thread=self.run_in_thread)
+        signature = inspect.signature(user_fn)
+        fields: dict[str, Any] = {}
+        validation_input: dict[str, Any] = {}
+
+        for name, parameter in signature.parameters.items():
+            if parameter.kind in {
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            }:
+                continue
+
+            annotation = (
+                Any
+                if parameter.annotation is inspect.Parameter.empty
+                else parameter.annotation
+            )
+            default = (
+                ...
+                if parameter.default is inspect.Parameter.empty
+                else parameter.default
+            )
+            fields[name] = (annotation, default)
+            if name in arguments:
+                validation_input[name] = arguments[name]
+
+        if not fields:
+            return arguments
+
+        model = create_model(
+            "TaskArguments",
+            __config__=ConfigDict(arbitrary_types_allowed=True),
+            **fields,
+        )
+        validated = model.model_validate(validation_input).model_dump()
+        return {**arguments, **validated}
 
     async def _call_lifecycle_hook(
         self, hook: Callable[..., Any], **context: Any

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -87,11 +87,21 @@ class ToolMeta:
     auth: AuthCheck | list[AuthCheck] | None = None
     enabled: bool = True
     run_in_thread: bool = True
+    setup: Callable[..., Any] | None = None
+    teardown: Callable[..., Any] | None = None
 
 
 class FunctionTool(Tool):
     fn: SkipJsonSchema[Callable[..., Any]]
     return_type: Annotated[SkipJsonSchema[Any], Field(exclude=True)] = None
+    setup: Annotated[
+        SkipJsonSchema[Callable[..., Any] | None],
+        Field(default=None, exclude=True),
+    ] = None
+    teardown: Annotated[
+        SkipJsonSchema[Callable[..., Any] | None],
+        Field(default=None, exclude=True),
+    ] = None
     run_in_thread: Annotated[
         bool,
         Field(
@@ -130,6 +140,8 @@ class FunctionTool(Tool):
         timeout: float | None = None,
         auth: AuthCheck | list[AuthCheck] | None = None,
         run_in_thread: bool | None = None,
+        setup: Callable[..., Any] | None = None,
+        teardown: Callable[..., Any] | None = None,
     ) -> FunctionTool:
         """Create a FunctionTool from a function.
 
@@ -158,6 +170,8 @@ class FunctionTool(Tool):
                     timeout,
                     auth,
                     run_in_thread,
+                    setup,
+                    teardown,
                 ]
             )
             or output_schema is not NotSet
@@ -193,6 +207,8 @@ class FunctionTool(Tool):
                 timeout=timeout,
                 auth=auth,
                 run_in_thread=True if run_in_thread is None else run_in_thread,
+                setup=setup,
+                teardown=teardown,
             )
 
         if metadata.serializer is not None and fastmcp.settings.deprecation_warnings:
@@ -281,6 +297,8 @@ class FunctionTool(Tool):
             timeout=metadata.timeout,
             auth=metadata.auth,
             run_in_thread=metadata.run_in_thread,
+            setup=metadata.setup,
+            teardown=metadata.teardown,
         )
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
@@ -291,57 +309,176 @@ class FunctionTool(Tool):
             self.fn, run_in_thread=self.run_in_thread
         )
         type_adapter = get_cached_typeadapter(wrapper_fn)
+        setup_result: Any = None
+        raw_result: Any = None
+        has_result = False
+        exception: BaseException | None = None
+        try:
+            # Apply timeout if configured. Combining timeout with
+            # run_in_thread=False on a sync function is rejected at
+            # registration (see FunctionTool.from_function), so the timeout
+            # path here only needs to handle async and threadpool-sync.
+            if self.timeout is not None:
+                try:
+                    with anyio.fail_after(self.timeout):
+                        if self.setup is not None:
+                            setup_result = await self._call_lifecycle_hook(self.setup)
 
-        # Apply timeout if configured. Combining timeout with
-        # run_in_thread=False on a sync function is rejected at
-        # registration (see FunctionTool.from_function), so the timeout
-        # path here only needs to handle async and threadpool-sync.
-        if self.timeout is not None:
-            try:
-                with anyio.fail_after(self.timeout):
-                    # Thread pool execution for sync functions, direct await for async
-                    if is_coroutine_function(wrapper_fn):
-                        result = await type_adapter.validate_python(arguments)
-                    else:
-                        # Sync function: run in threadpool to avoid blocking
-                        result = await call_sync_fn_in_threadpool(
-                            type_adapter.validate_python, arguments
-                        )
-                        # Handle sync wrappers that return awaitables
-                        if inspect.isawaitable(result):
-                            result = await result
-                    # Materialize generators inside timeout scope so slow
-                    # generators don't run past the configured timeout
-                    result = await self._materialize_generator(result)
-            except TimeoutError:
-                logger.warning(
-                    f"Tool '{self.name}' timed out after {self.timeout}s. "
-                    f"Consider using task=True for long-running operations. "
-                    f"See https://gofastmcp.com/servers/tasks"
-                )
-                raise McpError(
-                    ErrorData(
-                        code=-32000,
-                        message=f"Tool '{self.name}' execution timed out after {self.timeout}s",
+                        # Thread pool execution for sync functions, direct await for async
+                        if is_coroutine_function(wrapper_fn):
+                            raw_result = await type_adapter.validate_python(arguments)
+                        else:
+                            # Sync function: run in threadpool to avoid blocking
+                            raw_result = await call_sync_fn_in_threadpool(
+                                type_adapter.validate_python, arguments
+                            )
+                            # Handle sync wrappers that return awaitables
+                            if inspect.isawaitable(raw_result):
+                                raw_result = await raw_result
+                        # Materialize generators inside timeout scope so slow
+                        # generators don't run past the configured timeout
+                        raw_result = await self._materialize_generator(raw_result)
+                        has_result = True
+                except TimeoutError:
+                    logger.warning(
+                        f"Tool '{self.name}' timed out after {self.timeout}s. "
+                        f"Consider using task=True for long-running operations. "
+                        f"See https://gofastmcp.com/servers/tasks"
                     )
-                ) from None
-        else:
-            # No timeout: use existing execution path
-            if is_coroutine_function(wrapper_fn):
-                result = await type_adapter.validate_python(arguments)
-            elif self.run_in_thread:
-                result = await call_sync_fn_in_threadpool(
-                    type_adapter.validate_python, arguments
-                )
-                if inspect.isawaitable(result):
-                    result = await result
+                    raise McpError(
+                        ErrorData(
+                            code=-32000,
+                            message=f"Tool '{self.name}' execution timed out after {self.timeout}s",
+                        )
+                    ) from None
             else:
-                result = type_adapter.validate_python(arguments)
-                if inspect.isawaitable(result):
-                    result = await result
-            result = await self._materialize_generator(result)
+                if self.setup is not None:
+                    setup_result = await self._call_lifecycle_hook(self.setup)
 
-        return self.convert_result(result)
+                # No timeout: use existing execution path
+                if is_coroutine_function(wrapper_fn):
+                    raw_result = await type_adapter.validate_python(arguments)
+                elif self.run_in_thread:
+                    raw_result = await call_sync_fn_in_threadpool(
+                        type_adapter.validate_python, arguments
+                    )
+                    if inspect.isawaitable(raw_result):
+                        raw_result = await raw_result
+                else:
+                    raw_result = type_adapter.validate_python(arguments)
+                    if inspect.isawaitable(raw_result):
+                        raw_result = await raw_result
+                raw_result = await self._materialize_generator(raw_result)
+                has_result = True
+
+            return self.convert_result(raw_result)
+        except BaseException as exc:
+            exception = exc
+            raise
+        finally:
+            await self._run_teardown(
+                result=raw_result if has_result else None,
+                exception=exception,
+                setup_result=setup_result,
+            )
+
+    async def _run_raw_with_lifecycle(self, arguments: dict[str, Any]) -> Any:
+        setup_result: Any = None
+        raw_result: Any = None
+        has_result = False
+        exception: BaseException | None = None
+        try:
+            if self.setup is not None:
+                setup_result = await self._call_lifecycle_hook(self.setup)
+
+            if is_coroutine_function(self.fn):
+                raw_result = await self.fn(**arguments)
+            elif self.run_in_thread:
+                raw_result = await call_sync_fn_in_threadpool(self.fn, **arguments)
+                if inspect.isawaitable(raw_result):
+                    raw_result = await raw_result
+            else:
+                raw_result = self.fn(**arguments)
+                if inspect.isawaitable(raw_result):
+                    raw_result = await raw_result
+            has_result = True
+            return raw_result
+        except BaseException as exc:
+            exception = exc
+            raise
+        finally:
+            await self._run_teardown(
+                result=raw_result if has_result else None,
+                exception=exception,
+                setup_result=setup_result,
+            )
+
+    async def _run_teardown(
+        self,
+        *,
+        result: Any,
+        exception: BaseException | None,
+        setup_result: Any,
+    ) -> None:
+        if self.teardown is None:
+            return
+        try:
+            with anyio.CancelScope(shield=True):
+                await self._call_lifecycle_hook(
+                    self.teardown,
+                    result=result,
+                    exception=exception,
+                    setup_result=setup_result,
+                )
+        except BaseException:
+            if exception is None:
+                raise
+            logger.warning(
+                "Tool %r teardown failed after tool execution failed.",
+                self.name,
+                exc_info=True,
+            )
+
+    async def _call_lifecycle_hook(
+        self, hook: Callable[..., Any], **context: Any
+    ) -> Any:
+        kwargs = self._lifecycle_hook_kwargs(hook, context)
+        if is_coroutine_function(hook):
+            return await hook(**kwargs)
+        if self.run_in_thread:
+            result = await call_sync_fn_in_threadpool(hook, **kwargs)
+        else:
+            result = hook(**kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    @staticmethod
+    def _lifecycle_hook_kwargs(
+        hook: Callable[..., Any], context: dict[str, Any]
+    ) -> dict[str, Any]:
+        try:
+            signature = inspect.signature(hook)
+        except (TypeError, ValueError):
+            return {}
+
+        parameters = signature.parameters
+        if any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        ):
+            return context
+
+        return {
+            name: value
+            for name, value in context.items()
+            if name in parameters
+            and parameters[name].kind
+            in {
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            }
+        }
 
     @staticmethod
     async def _materialize_generator(result: Any) -> Any:
@@ -360,13 +497,25 @@ class FunctionTool(Tool):
     def register_with_docket(self, docket: Docket) -> None:
         """Register this tool with docket for background execution.
 
-        Registers the raw function so Docket sees and resolves ALL
-        dependencies — both FastMCP's (CurrentContext, Progress) and
-        Docket-native ones (Retry, Timeout, ConcurrencyLimit).
+        Registers a lifecycle wrapper with the raw function's signature so
+        Docket can still see and resolve dependencies while setup and teardown
+        hooks run around background task execution.
         """
         if not self.task_config.supports_tasks():
             return
-        docket.register(self.fn, names=[self.key])
+        docket.register(self._docket_lifecycle_wrapper(), names=[self.key])
+
+    def _docket_lifecycle_wrapper(self) -> Callable[..., Any]:
+        async def wrapper(**arguments: Any) -> Any:
+            return await self._run_raw_with_lifecycle(arguments)
+
+        wrapper.__signature__ = inspect.signature(self.fn)  # type: ignore[attr-defined]  # ty:ignore[unresolved-attribute]
+        wrapper.__annotations__ = getattr(self.fn, "__annotations__", {}).copy()
+        wrapper.__name__ = getattr(self.fn, "__name__", "wrapper")
+        wrapper.__doc__ = getattr(self.fn, "__doc__", None)
+        wrapper.__module__ = self.fn.__module__
+        wrapper.__qualname__ = getattr(self.fn, "__qualname__", wrapper.__qualname__)
+        return wrapper
 
     async def add_to_docket(
         self,
@@ -379,7 +528,8 @@ class FunctionTool(Tool):
     ) -> Execution:
         """Schedule this tool for background execution via docket.
 
-        FunctionTool splats the arguments dict since .fn expects **kwargs.
+        FunctionTool splats the arguments dict so Docket can resolve dependencies
+        against the original function signature.
 
         Args:
             docket: The Docket instance
@@ -396,6 +546,7 @@ class FunctionTool(Tool):
 
 @overload
 def tool(fn: F) -> F: ...
+
 @overload
 def tool(
     name_or_fn: str,
@@ -414,7 +565,10 @@ def tool(
     timeout: float | None = None,
     auth: AuthCheck | list[AuthCheck] | None = None,
     run_in_thread: bool = True,
+    setup: Callable[..., Any] | None = None,
+    teardown: Callable[..., Any] | None = None,
 ) -> Callable[[F], F]: ...
+
 @overload
 def tool(
     name_or_fn: None = None,
@@ -434,6 +588,8 @@ def tool(
     timeout: float | None = None,
     auth: AuthCheck | list[AuthCheck] | None = None,
     run_in_thread: bool = True,
+    setup: Callable[..., Any] | None = None,
+    teardown: Callable[..., Any] | None = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -455,6 +611,8 @@ def tool(
     timeout: float | None = None,
     auth: AuthCheck | list[AuthCheck] | None = None,
     run_in_thread: bool = True,
+    setup: Callable[..., Any] | None = None,
+    teardown: Callable[..., Any] | None = None,
 ) -> Any:
     """Standalone decorator to mark a function as an MCP tool.
 
@@ -498,6 +656,8 @@ def tool(
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            setup=setup,
+            teardown=teardown,
         )
         return FunctionTool.from_function(fn, metadata=tool_meta)
 
@@ -518,6 +678,8 @@ def tool(
             timeout=timeout,
             auth=auth,
             run_in_thread=run_in_thread,
+            setup=setup,
+            teardown=teardown,
         )
         target = fn.__func__ if isinstance(fn, staticmethod | MethodType) else fn
         cast(Any, target).__fastmcp__ = metadata

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -22,7 +22,7 @@ from typing import (
 import anyio
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, Icon, ToolAnnotations
-from pydantic import ConfigDict, Field, create_model
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, create_model
 from pydantic.json_schema import SkipJsonSchema
 
 import fastmcp
@@ -117,6 +117,9 @@ class FunctionTool(Tool):
             )
         ),
     ] = True
+    _task_user_fn: Callable[..., Any] | None = PrivateAttr(default=None)
+    _task_argument_model: type[BaseModel] | None = PrivateAttr(default=None)
+    _task_argument_model_ready: bool = PrivateAttr(default=False)
 
     @classmethod
     def from_function(
@@ -445,12 +448,23 @@ class FunctionTool(Tool):
         return await self._materialize_generator(raw_result)
 
     def _coerce_task_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        from fastmcp.server.dependencies import without_injected_parameters
+        model = self._get_task_argument_model()
+        if model is None:
+            return arguments
 
-        user_fn = without_injected_parameters(self.fn, run_in_thread=self.run_in_thread)
+        validation_input = {
+            name: arguments[name] for name in model.model_fields if name in arguments
+        }
+        validated = model.model_validate(validation_input).model_dump()
+        return {**arguments, **validated}
+
+    def _get_task_argument_model(self) -> type[BaseModel] | None:
+        if self._task_argument_model_ready:
+            return self._task_argument_model
+
+        user_fn = self._get_task_user_fn()
         signature = inspect.signature(user_fn)
         fields: dict[str, Any] = {}
-        validation_input: dict[str, Any] = {}
 
         for name, parameter in signature.parameters.items():
             if parameter.kind in {
@@ -470,19 +484,26 @@ class FunctionTool(Tool):
                 else parameter.default
             )
             fields[name] = (annotation, default)
-            if name in arguments:
-                validation_input[name] = arguments[name]
 
-        if not fields:
-            return arguments
+        if fields:
+            self._task_argument_model = create_model(
+                "TaskArguments",
+                __config__=ConfigDict(arbitrary_types_allowed=True),
+                **fields,
+            )
+        self._task_argument_model_ready = True
+        return self._task_argument_model
 
-        model = create_model(
-            "TaskArguments",
-            __config__=ConfigDict(arbitrary_types_allowed=True),
-            **fields,
+    def _get_task_user_fn(self) -> Callable[..., Any]:
+        if self._task_user_fn is not None:
+            return self._task_user_fn
+
+        from fastmcp.server.dependencies import without_injected_parameters
+
+        self._task_user_fn = without_injected_parameters(
+            self.fn, run_in_thread=self.run_in_thread
         )
-        validated = model.model_validate(validation_input).model_dump()
-        return {**arguments, **validated}
+        return self._task_user_fn
 
     async def _call_lifecycle_hook(
         self, hook: Callable[..., Any], **context: Any

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -547,6 +547,7 @@ class FunctionTool(Tool):
 @overload
 def tool(fn: F) -> F: ...
 
+
 @overload
 def tool(
     name_or_fn: str,
@@ -568,6 +569,7 @@ def tool(
     setup: Callable[..., Any] | None = None,
     teardown: Callable[..., Any] | None = None,
 ) -> Callable[[F], F]: ...
+
 
 @overload
 def tool(

--- a/tests/server/providers/local_provider_tools/test_decorator.py
+++ b/tests/server/providers/local_provider_tools/test_decorator.py
@@ -339,3 +339,74 @@ class TestToolDecorator:
         tool = next(t for t in tools if t.name == "multiply")
 
         assert tool.meta == meta_data
+
+    async def test_mcp_tool_decorator_accepts_setup_teardown(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        @mcp.tool(setup=setup_hook, teardown=teardown_hook)
+        def hooked_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        result = await mcp.call_tool("hooked_tool")
+
+        assert result.structured_content == {"result": "ok"}
+        assert events == ["setup", "tool", "teardown"]
+
+    async def test_standalone_tool_decorator_preserves_setup_teardown_on_add_tool(self):
+        from fastmcp.tools.function_tool import tool as tool_decorator
+
+        mcp = FastMCP()
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        @tool_decorator(setup=setup_hook, teardown=teardown_hook)
+        def hooked_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        mcp.add_tool(hooked_tool)
+
+        result = await mcp.call_tool("hooked_tool")
+
+        assert result.structured_content == {"result": "ok"}
+        assert events == ["setup", "tool", "teardown"]
+
+    async def test_tool_from_function_accepts_setup_teardown(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        def hooked_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        mcp.add_tool(
+            Tool.from_function(
+                hooked_tool,
+                setup=setup_hook,
+                teardown=teardown_hook,
+            )
+        )
+
+        result = await mcp.call_tool("hooked_tool")
+
+        assert result.structured_content == {"result": "ok"}
+        assert events == ["setup", "tool", "teardown"]

--- a/tests/server/tasks/test_task_tools.py
+++ b/tests/server/tasks/test_task_tools.py
@@ -166,6 +166,38 @@ async def test_tool_task_uses_pydantic_argument_coercion(tool_server):
     assert result.data == 42
 
 
+async def test_tool_task_argument_model_is_cached(tool_server, monkeypatch):
+    """Task argument coercion reuses its generated Pydantic model."""
+    import fastmcp.tools.function_tool as function_tool
+
+    create_model_calls = 0
+    original_create_model = function_tool.create_model
+
+    def tracking_create_model(*args, **kwargs):
+        nonlocal create_model_calls
+        create_model_calls += 1
+        return original_create_model(*args, **kwargs)
+
+    monkeypatch.setattr(function_tool, "create_model", tracking_create_model)
+
+    @tool_server.tool(task=True)
+    async def increment(count: int) -> int:
+        return count + 1
+
+    async with Client(tool_server) as client:
+        first_task = await client.call_tool("increment", {"count": "1"}, task=True)
+        await first_task.wait(timeout=2.0)
+        first_result = await first_task.result()
+
+        second_task = await client.call_tool("increment", {"count": "2"}, task=True)
+        await second_task.wait(timeout=2.0)
+        second_result = await second_task.result()
+
+    assert first_result.data == 2
+    assert second_result.data == 3
+    assert create_model_calls == 1
+
+
 async def test_tool_task_hooks_preserve_current_docket_dependency(tool_server):
     """Task hooks do not break CurrentDocket dependency injection."""
     from fastmcp.server.dependencies import CurrentDocket

--- a/tests/server/tasks/test_task_tools.py
+++ b/tests/server/tasks/test_task_tools.py
@@ -101,3 +101,78 @@ async def test_forbidden_mode_tool_rejects_task_calls(tool_server):
         # New behavior: mode="forbidden" returns an error
         assert result.is_error
         assert "does not support task-augmented execution" in str(result)
+
+
+async def test_tool_task_runs_setup_and_teardown(tool_server):
+    """Task-enabled tools run setup before execution and teardown after."""
+    events: list[str] = []
+
+    def setup_hook() -> None:
+        events.append("setup")
+
+    def teardown_hook() -> None:
+        events.append("teardown")
+
+    @tool_server.tool(task=True, setup=setup_hook, teardown=teardown_hook)
+    async def hooked_task_tool() -> str:
+        events.append("tool")
+        return "ok"
+
+    async with Client(tool_server) as client:
+        task = await client.call_tool("hooked_task_tool", task=True)
+        await task.wait(timeout=2.0)
+
+        result = await task.result()
+
+    assert result.data == "ok"
+    assert events == ["setup", "tool", "teardown"]
+
+
+async def test_tool_task_teardown_receives_raw_result(tool_server):
+    """Task-enabled tool teardown receives the raw tool result."""
+    received_result = None
+
+    def teardown_hook(result: str) -> None:
+        nonlocal received_result
+        received_result = result
+
+    @tool_server.tool(task=True, teardown=teardown_hook)
+    async def hooked_task_tool() -> str:
+        return "raw-ok"
+
+    async with Client(tool_server) as client:
+        task = await client.call_tool("hooked_task_tool", task=True)
+        await task.wait(timeout=2.0)
+
+        result = await task.result()
+
+    assert result.data == "raw-ok"
+    assert received_result == "raw-ok"
+
+
+async def test_tool_task_hooks_preserve_current_docket_dependency(tool_server):
+    """Task hooks do not break CurrentDocket dependency injection."""
+    from fastmcp.server.dependencies import CurrentDocket
+
+    events: list[str] = []
+
+    def setup_hook() -> None:
+        events.append("setup")
+
+    def teardown_hook() -> None:
+        events.append("teardown")
+
+    @tool_server.tool(task=True, setup=setup_hook, teardown=teardown_hook)
+    async def docket_tool(docket=CurrentDocket()) -> str:
+        events.append("tool")
+        assert docket is not None
+        return "ok"
+
+    async with Client(tool_server) as client:
+        task = await client.call_tool("docket_tool", task=True)
+        await task.wait(timeout=2.0)
+
+        result = await task.result()
+
+    assert result.data == "ok"
+    assert events == ["setup", "tool", "teardown"]

--- a/tests/server/tasks/test_task_tools.py
+++ b/tests/server/tasks/test_task_tools.py
@@ -150,6 +150,22 @@ async def test_tool_task_teardown_receives_raw_result(tool_server):
     assert received_result == "raw-ok"
 
 
+async def test_tool_task_uses_pydantic_argument_coercion(tool_server):
+    """Task-enabled tools validate and coerce arguments like foreground calls."""
+
+    @tool_server.tool(task=True)
+    async def increment(count: int) -> int:
+        return count + 1
+
+    async with Client(tool_server) as client:
+        task = await client.call_tool("increment", {"count": "41"}, task=True)
+        await task.wait(timeout=2.0)
+
+        result = await task.result()
+
+    assert result.data == 42
+
+
 async def test_tool_task_hooks_preserve_current_docket_dependency(tool_server):
     """Task hooks do not break CurrentDocket dependency injection."""
     from fastmcp.server.dependencies import CurrentDocket

--- a/tests/test_fastmcp_app.py
+++ b/tests/test_fastmcp_app.py
@@ -165,6 +165,27 @@ class TestAppTool:
         def slow_save(name: str) -> str:
             return name
 
+    async def test_tool_with_setup_teardown(self):
+        app = FastMCPApp("test")
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        @app.tool(setup=setup_hook, teardown=teardown_hook)
+        def save(name: str) -> str:
+            events.append("tool")
+            return name
+
+        tools = await app._list_tools()
+        result = await tools[0].run({"name": "alice"})
+
+        assert result.structured_content == {"result": "alice"}
+        assert events == ["setup", "tool", "teardown"]
+
 
 # ---------------------------------------------------------------------------
 # @app.ui() decorator
@@ -279,6 +300,26 @@ class TestAppUI:
 
         tools = await app._list_tools()
         assert tools[0].tags == {"dashboard", "main"}
+
+    async def test_ui_with_setup_teardown(self):
+        app = FastMCPApp("test")
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        @app.ui(setup=setup_hook, teardown=teardown_hook)
+        def dashboard() -> str:
+            events.append("ui")
+            return "dashboard"
+
+        tools = await app._list_tools()
+        await tools[0].run({})
+
+        assert events == ["setup", "ui", "teardown"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tool_lifecycle_hooks.py
+++ b/tests/tools/test_tool_lifecycle_hooks.py
@@ -261,7 +261,6 @@ class TestToolHooks:
         assert result.content[0].text == "ok"
         assert events == ["setup", "tool", "teardown"]
 
-
     async def test_teardown_failure_preserves_original_tool_exception(self):
         mcp = FastMCP()
 

--- a/tests/tools/test_tool_lifecycle_hooks.py
+++ b/tests/tools/test_tool_lifecycle_hooks.py
@@ -85,10 +85,12 @@ class TestToolHooks:
     async def test_teardown_runs_on_timeout(self):
         mcp = FastMCP()
         teardown_called = False
+        received_timed_out: bool | None = None
 
-        def teardown_hook() -> None:
-            nonlocal teardown_called
+        def teardown_hook(timed_out: bool) -> None:
+            nonlocal teardown_called, received_timed_out
             teardown_called = True
+            received_timed_out = timed_out
 
         @mcp.tool(teardown=teardown_hook, timeout=0.1)
         async def my_tool() -> str:
@@ -99,6 +101,7 @@ class TestToolHooks:
             await mcp.call_tool("my_tool")
 
         assert teardown_called
+        assert received_timed_out is True
 
     async def test_teardown_runs_on_asyncio_cancelled_error(self):
         mcp = FastMCP()
@@ -275,6 +278,21 @@ class TestToolHooks:
             await mcp.call_tool("my_tool")
 
         assert isinstance(exc_info.value.__cause__, ValueError)
+
+    async def test_teardown_failure_after_success_preserves_tool_result(self):
+        mcp = FastMCP()
+
+        def teardown_hook() -> None:
+            raise RuntimeError("Teardown failed")
+
+        @mcp.tool(teardown=teardown_hook)
+        def my_tool() -> str:
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
 
     async def test_no_arg_teardown_works(self):
         mcp = FastMCP()

--- a/tests/tools/test_tool_lifecycle_hooks.py
+++ b/tests/tools/test_tool_lifecycle_hooks.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from mcp.types import TextContent
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+
+class TestToolHooks:
+    async def test_setup_runs_before_tool(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        @mcp.tool(setup=setup_hook)
+        def my_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert events == ["setup", "tool"]
+
+    async def test_teardown_runs_after_successful_completion(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        @mcp.tool(teardown=teardown_hook)
+        def my_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert events == ["tool", "teardown"]
+
+    async def test_teardown_receives_raw_result(self):
+        mcp = FastMCP()
+        received_result: Any = None
+
+        def teardown_hook(result: Any) -> None:
+            nonlocal received_result
+            received_result = result
+
+        @mcp.tool(teardown=teardown_hook)
+        def my_tool() -> dict[str, str]:
+            return {"status": "ok"}
+
+        result = await mcp.call_tool("my_tool")
+
+        assert result.structured_content == {"status": "ok"}
+        assert received_result == {"status": "ok"}
+
+    async def test_teardown_receives_exception_on_failure(self):
+        mcp = FastMCP()
+        received_exception: BaseException | None = None
+
+        def teardown_hook(exception: BaseException | None) -> None:
+            nonlocal received_exception
+            received_exception = exception
+
+        @mcp.tool(teardown=teardown_hook)
+        def my_tool() -> str:
+            raise ValueError("Simulated failure")
+
+        with pytest.raises(ToolError, match="Simulated failure") as exc_info:
+            await mcp.call_tool("my_tool")
+
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert isinstance(received_exception, ValueError)
+
+    async def test_teardown_runs_on_timeout(self):
+        mcp = FastMCP()
+        teardown_called = False
+
+        def teardown_hook() -> None:
+            nonlocal teardown_called
+            teardown_called = True
+
+        @mcp.tool(teardown=teardown_hook, timeout=0.1)
+        async def my_tool() -> str:
+            await asyncio.sleep(0.2)
+            return "ok"
+
+        with pytest.raises(ToolError):
+            await mcp.call_tool("my_tool")
+
+        assert teardown_called
+
+    async def test_teardown_runs_on_asyncio_cancelled_error(self):
+        mcp = FastMCP()
+        tool_started = asyncio.Event()
+        teardown_finished = asyncio.Event()
+        received_exception: BaseException | None = None
+
+        async def teardown_hook(exception: BaseException | None) -> None:
+            nonlocal received_exception
+            received_exception = exception
+            await asyncio.sleep(0)
+            teardown_finished.set()
+
+        @mcp.tool(teardown=teardown_hook)
+        async def my_tool() -> str:
+            tool_started.set()
+            await asyncio.Event().wait()
+            return "ok"
+
+        task = asyncio.create_task(mcp.call_tool("my_tool"))
+        await tool_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert teardown_finished.is_set()
+        assert isinstance(received_exception, asyncio.CancelledError)
+
+    async def test_teardown_receives_setup_result(self):
+        mcp = FastMCP()
+        received_setup_result: str | None = None
+
+        def setup_hook() -> str:
+            return "resource"
+
+        def teardown_hook(setup_result: str | None) -> None:
+            nonlocal received_setup_result
+            received_setup_result = setup_result
+
+        @mcp.tool(setup=setup_hook, teardown=teardown_hook)
+        def my_tool() -> str:
+            return "ok"
+
+        await mcp.call_tool("my_tool")
+
+        assert received_setup_result == "resource"
+
+    async def test_teardown_runs_when_setup_fails(self):
+        mcp = FastMCP()
+        events: list[str] = []
+        received_exception: BaseException | None = None
+        received_setup_result: Any = "unset"
+
+        def setup_hook() -> str:
+            events.append("setup")
+            raise RuntimeError("Setup failed")
+
+        def teardown_hook(
+            exception: BaseException | None, setup_result: Any = None
+        ) -> None:
+            nonlocal received_exception, received_setup_result
+            events.append("teardown")
+            received_exception = exception
+            received_setup_result = setup_result
+
+        @mcp.tool(setup=setup_hook, teardown=teardown_hook)
+        def my_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        with pytest.raises(ToolError, match="Setup failed") as exc_info:
+            await mcp.call_tool("my_tool")
+
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert isinstance(received_exception, RuntimeError)
+        assert received_setup_result is None
+        assert events == ["setup", "teardown"]
+
+    async def test_sync_tool_with_sync_hooks(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        @mcp.tool(setup=setup_hook, teardown=teardown_hook)
+        def my_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert events == ["setup", "tool", "teardown"]
+
+    async def test_sync_tool_with_async_hooks(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        async def setup_hook() -> None:
+            events.append("setup")
+
+        async def teardown_hook() -> None:
+            events.append("teardown")
+
+        @mcp.tool(setup=setup_hook, teardown=teardown_hook)
+        def my_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert events == ["setup", "tool", "teardown"]
+
+    async def test_async_tool_with_sync_hooks(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        def setup_hook() -> None:
+            events.append("setup")
+
+        def teardown_hook() -> None:
+            events.append("teardown")
+
+        @mcp.tool(setup=setup_hook, teardown=teardown_hook)
+        async def my_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert events == ["setup", "tool", "teardown"]
+
+    async def test_async_tool_with_async_hooks(self):
+        mcp = FastMCP()
+        events: list[str] = []
+
+        async def setup_hook() -> None:
+            events.append("setup")
+
+        async def teardown_hook() -> None:
+            events.append("teardown")
+
+        @mcp.tool(setup=setup_hook, teardown=teardown_hook)
+        async def my_tool() -> str:
+            events.append("tool")
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert events == ["setup", "tool", "teardown"]
+
+
+    async def test_teardown_failure_preserves_original_tool_exception(self):
+        mcp = FastMCP()
+
+        def teardown_hook() -> None:
+            raise RuntimeError("Teardown failed")
+
+        @mcp.tool(teardown=teardown_hook)
+        def my_tool() -> str:
+            raise ValueError("Original tool failure")
+
+        with pytest.raises(ToolError, match="Original tool failure") as exc_info:
+            await mcp.call_tool("my_tool")
+
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    async def test_no_arg_teardown_works(self):
+        mcp = FastMCP()
+        teardown_called = False
+
+        def teardown_hook() -> None:
+            nonlocal teardown_called
+            teardown_called = True
+
+        @mcp.tool(teardown=teardown_hook)
+        def my_tool() -> str:
+            return "ok"
+
+        result = await mcp.call_tool("my_tool")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert teardown_called

--- a/tests/tools/test_tool_run_in_thread.py
+++ b/tests/tools/test_tool_run_in_thread.py
@@ -266,3 +266,45 @@ class TestRunInThreadViaFileSystemProvider:
         ]
         assert len(discovered) == 1
         assert discovered[0].timeout == 5.0
+
+    async def test_filesystem_provider_forwards_setup_teardown(self, tmp_path):
+        """Filesystem discovery forwards setup/teardown from ToolMeta."""
+        from fastmcp.server.providers import FileSystemProvider
+
+        events_file = tmp_path / "events.txt"
+
+        (tmp_path / "hooked.py").write_text(
+            "from pathlib import Path\n"
+            "from fastmcp.tools import tool\n\n"
+            f"EVENTS_FILE = Path({str(events_file)!r})\n\n"
+            "def setup_hook() -> None:\n"
+            "    with EVENTS_FILE.open('a') as f:\n"
+            "        f.write('setup\\n')\n\n"
+            "def teardown_hook() -> None:\n"
+            "    with EVENTS_FILE.open('a') as f:\n"
+            "        f.write('teardown\\n')\n\n"
+            "@tool(setup=setup_hook, teardown=teardown_hook)\n"
+            "def hooked() -> str:\n"
+            "    with EVENTS_FILE.open('a') as f:\n"
+            "        f.write('tool\\n')\n"
+            "    return 'ok'\n"
+        )
+
+        provider = FileSystemProvider(tmp_path)
+
+        discovered = [
+            c
+            for c in provider._components.values()
+            if isinstance(c, Tool) and c.name == "hooked"
+        ]
+
+        assert len(discovered) == 1
+        assert discovered[0].setup is not None
+        assert discovered[0].teardown is not None
+
+        mcp = FastMCP(providers=[provider])
+        result = await mcp.call_tool("hooked")
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+        assert events_file.read_text().splitlines() == ["setup", "tool", "teardown"]

--- a/tests/tools/test_tool_run_in_thread.py
+++ b/tests/tools/test_tool_run_in_thread.py
@@ -17,6 +17,7 @@ from mcp.types import TextContent
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools.base import Tool
+from fastmcp.tools.function_tool import FunctionTool
 
 
 async def _loop_thread_id() -> int:
@@ -295,7 +296,7 @@ class TestRunInThreadViaFileSystemProvider:
         discovered = [
             c
             for c in provider._components.values()
-            if isinstance(c, Tool) and c.name == "hooked"
+            if isinstance(c, FunctionTool) and c.name == "hooked"
         ]
 
         assert len(discovered) == 1


### PR DESCRIPTION
## Description

Fixes #4340

Tools that acquire resources during execution currently have to rely on inline `try`/`finally` cleanup, which is easy to miss and does not give FastMCP a consistent lifecycle boundary for cancellation, timeout, task execution, or app-discovered tools. This PR adds `setup` and `teardown` hooks to tool registration so resource acquisition and cleanup can be declared alongside the tool itself.

`setup` runs before each invocation, and `teardown` runs in a shielded scope after setup/tool execution is attempted. The teardown hook can inspect the raw `result`, the raised `exception`, and the `setup_result`, which lets tools clean up conditionally without every implementation duplicating lifecycle boilerplate.

```python
@mcp.tool(
    setup=lambda: acquire_lock("records"),
    teardown=lambda exception=None, setup_result=None: release_lock("records"),
)
async def update_record(record_id: str, value: str) -> str:
    return await write_record(record_id, value)
```

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [x] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)