### PR TITLE
fix(resources): coerce list[str] resource template query parameters

### DIFF
--- a/fastmcp_slim/fastmcp/resources/template.py
+++ b/fastmcp_slim/fastmcp/resources/template.py
@@ -6,7 +6,7 @@ import functools
 import inspect
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, overload
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, get_args, get_origin, overload
 from urllib.parse import parse_qs, quote, unquote
 
 import mcp.types
@@ -77,7 +77,7 @@ def build_regex(template: str) -> re.Pattern[str] | None:
         return None
 
 
-def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
+def match_uri_template(uri: str, uri_template: str) -> dict[str, Any] | None:
     """Match URI against template and extract both path and query parameters.
 
     Supports RFC 6570 URI templates:
@@ -106,14 +106,46 @@ def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
 
         for name in query_param_names:
             if name in parsed_query:
-                # Take first value if multiple provided.
+                values = parsed_query[name]
                 # Normalize hyphens to underscores to match Python param names.
                 # Don't overwrite path params that were already extracted.
                 key = name.replace("-", "_")
                 if key not in params:
-                    params[key] = parsed_query[name][0]
+                    # Preserve repeated keys as a list for list-typed parameters.
+                    params[key] = values[0] if len(values) == 1 else values
 
     return params
+
+
+def _unwrap_annotation(annotation: Any) -> Any:
+    """Return the underlying type for ``Annotated`` parameters."""
+    if get_origin(annotation) is Annotated:
+        args = get_args(annotation)
+        return args[0] if args else annotation
+    return annotation
+
+
+def _is_list_of_str_annotation(annotation: Any) -> bool:
+    """Return True when *annotation* is ``list[str]`` (or equivalent)."""
+    annotation = _unwrap_annotation(annotation)
+    if annotation is inspect.Parameter.empty:
+        return False
+    origin = get_origin(annotation)
+    if origin is list:
+        args = get_args(annotation)
+        return len(args) == 1 and args[0] is str
+    return False
+
+
+def _coerce_query_param_to_str_list(value: str | list[str]) -> list[str]:
+    """Coerce a query parameter value into ``list[str]``."""
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    if value == "":
+        return []
+    if "," in value:
+        return [part for part in value.split(",") if part != ""]
+    return [value]
 
 
 def expand_uri_template(uri_template: str, params: dict[str, Any]) -> str:
@@ -486,8 +518,16 @@ class FunctionResourceTemplate(ResourceTemplate):
                             raise ValueError(
                                 f"Invalid boolean value for {param_name}: {param_value!r}"
                             )
+                    elif _is_list_of_str_annotation(annotation):
+                        kwargs[param_name] = _coerce_query_param_to_str_list(
+                            param_value
+                        )
                 except (ValueError, AttributeError):
                     raise
+            elif param_name in sig.parameters and _is_list_of_str_annotation(
+                sig.parameters[param_name].annotation
+            ):
+                kwargs[param_name] = _coerce_query_param_to_str_list(param_value)
 
         # self.fn is wrapped by without_injected_parameters which handles
         # dependency resolution internally, so we call it directly

--- a/tests/resources/test_resource_template.py
+++ b/tests/resources/test_resource_template.py
@@ -869,6 +869,14 @@ class TestMalformedURITemplates:
         assert result is not None
         assert result == {"id": "42", "format": "", "verbose": "true"}
 
+    def test_query_param_repeated_keys_returns_list(self):
+        """Repeated query keys should be preserved as a list."""
+        result = match_uri_template(
+            "items://books?tags=alpha&tags=beta",
+            "items://{category}{?tags}",
+        )
+        assert result == {"category": "books", "tags": ["alpha", "beta"]}
+
     def test_from_function_rejects_hyphen_underscore_collision(self):
         """Two raw param names that normalize to the same key are rejected."""
 

--- a/tests/resources/test_resource_template_query_params.py
+++ b/tests/resources/test_resource_template_query_params.py
@@ -408,3 +408,87 @@ class TestResourceTemplateFieldDefaults:
         assert result2["limit"] == 50  # overridden
         assert result2["offset"] == 0  # default
         assert result2["format"] == "xml"  # overridden
+
+
+class TestListQueryParameterTypeCoercion:
+    """Test list[str] query parameters."""
+
+    async def _make_template(self):
+        from pydantic import Field
+
+        def search(
+            category: str, tags: list[str] = Field(default_factory=list)
+        ) -> dict:
+            return {"category": category, "tags": tags}
+
+        return ResourceTemplate.from_function(
+            fn=search,
+            uri_template="items://{category}{?tags}",
+            name="test",
+        )
+
+    async def test_missing_list_query_param_uses_default(self):
+        template = await self._make_template()
+
+        resource = await template.create_resource(
+            "items://books", {"category": "books"}
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": []}
+
+    async def test_single_list_query_param(self):
+        template = await self._make_template()
+
+        resource = await template.create_resource(
+            "items://books?tags=alpha",
+            {"category": "books", "tags": "alpha"},
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": ["alpha"]}
+
+    async def test_repeated_list_query_params(self):
+        template = await self._make_template()
+
+        params = template.matches("items://books?tags=alpha&tags=beta")
+        assert params == {"category": "books", "tags": ["alpha", "beta"]}
+
+        resource = await template.create_resource(
+            "items://books?tags=alpha&tags=beta",
+            params,
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": ["alpha", "beta"]}
+
+    async def test_comma_separated_list_query_param(self):
+        template = await self._make_template()
+
+        resource = await template.create_resource(
+            "items://books?tags=alpha,beta",
+            {"category": "books", "tags": "alpha,beta"},
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": ["alpha", "beta"]}
+
+    async def test_empty_list_query_param(self):
+        template = await self._make_template()
+
+        resource = await template.create_resource(
+            "items://books?tags=",
+            {"category": "books", "tags": ""},
+        )
+        result = await resource.read()
+        assert result == {"category": "books", "tags": []}
+
+    def test_list_str_annotation_helpers(self):
+        from typing import Annotated
+
+        from fastmcp.resources.template import (
+            _coerce_query_param_to_str_list,
+            _is_list_of_str_annotation,
+        )
+
+        assert _is_list_of_str_annotation(list[str])
+        assert _is_list_of_str_annotation(Annotated[list[str], "meta"])
+        assert not _is_list_of_str_annotation(str)
+        assert _coerce_query_param_to_str_list("") == []
+        assert _coerce_query_param_to_str_list(["a", "b"]) == ["a", "b"]


### PR DESCRIPTION
## Summary

Fix resource template reads for optional `list[str]` query parameters. Query values were passed through as raw strings (or only the first repeated key), causing Pydantic validation errors when the handler expected a list.

## Motivation

Fixes #4378

A resource template like `items://{category}{?tags}` with `tags: list[str] = Field(default_factory=list)` worked without query params but failed for any provided tag value:

- `?tags=alpha` → `ValidationError: Input should be a valid list`
- `?tags=alpha&tags=beta` → only `alpha` was kept
- `?tags=alpha,beta` → comma-separated value stayed a single string

## Changes

- **`match_uri_template`**: preserve repeated query keys as a list; single values remain strings for backward-compatible scalar coercion
- **`FunctionResourceTemplate.read()`**: coerce query values to `list[str]` for `list[str]` and `Annotated[list[str], ...]` parameters
  - single value → `[value]`
  - repeated keys → list passed through
  - comma-separated → split into list
  - empty value → `[]`
- **Tests**: regression coverage for missing, single, repeated, comma-separated, and empty tag values; unit test for `match_uri_template` repeated-key behavior

## Tests

```bash
PYTHONPATH=fastmcp_slim python3 -m pytest \
  tests/resources/test_resource_template_query_params.py::TestListQueryParameterTypeCoercion \
  tests/resources/test_resource_template.py::TestMalformedURITemplates::test_query_param_repeated_keys_returns_list \
  -v
```

Result: **7/7 passed**

End-to-end reproduction from the issue (Client + `read_resource`) verified for all four URI forms.

## Notes

- Comma-separated syntax cannot represent tag values that contain commas; repeated keys (`?tags=a&tags=b`) remain the safe multi-value form.
- `list[int]` / other list element types are out of scope for this fix.