### PR TITLE
fix(resources): support list-typed optional query parameters in URI templates

### DIFF
--- a/fastmcp_slim/fastmcp/resources/template.py
+++ b/fastmcp_slim/fastmcp/resources/template.py
@@ -6,7 +6,15 @@ import functools
 import inspect
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    get_args,
+    get_origin,
+    overload,
+)
 from urllib.parse import parse_qs, quote, unquote
 
 import mcp.types
@@ -77,7 +85,51 @@ def build_regex(template: str) -> re.Pattern[str] | None:
         return None
 
 
-def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
+def _unwrap_annotation(annotation: Any) -> Any:
+    """Return the underlying type for coercion, stripping Annotated wrappers."""
+    if get_origin(annotation) is Annotated:
+        return get_args(annotation)[0]
+    return annotation
+
+
+def _coerce_query_param_value(
+    annotation: Any, value: Any, *, param_name: str | None = None
+) -> Any:
+    """Coerce a query parameter value to match the function parameter annotation."""
+    annotation = _unwrap_annotation(annotation)
+
+    if annotation is inspect.Parameter.empty or annotation is str:
+        return value
+
+    if get_origin(annotation) is list:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            return [value]
+        return value
+
+    if not isinstance(value, str):
+        return value
+
+    if annotation is int:
+        return int(value)
+    if annotation is float:
+        return float(value)
+    if annotation is bool:
+        lower = value.lower()
+        if lower in ("true", "1", "yes"):
+            return True
+        if lower in ("false", "0", "no"):
+            return False
+        label = param_name or "parameter"
+        raise ValueError(f"Invalid boolean value for {label}: {value!r}")
+
+    return value
+
+
+def match_uri_template(
+    uri: str, uri_template: str
+) -> dict[str, str | list[str]] | None:
     """Match URI against template and extract both path and query parameters.
 
     Supports RFC 6570 URI templates:
@@ -95,7 +147,9 @@ def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
     if not match:
         return None
 
-    params = {k: unquote(v) for k, v in match.groupdict().items()}
+    params: dict[str, str | list[str]] = {
+        k: unquote(v) for k, v in match.groupdict().items()
+    }
 
     # Extract query parameters if present in URI and template
     if query_string:
@@ -106,12 +160,14 @@ def match_uri_template(uri: str, uri_template: str) -> dict[str, str] | None:
 
         for name in query_param_names:
             if name in parsed_query:
-                # Take first value if multiple provided.
+                values = parsed_query[name]
+                # Preserve repeated query keys as a list (e.g. ?tags=a&tags=b).
+                # Single values stay as strings for backward compatibility.
                 # Normalize hyphens to underscores to match Python param names.
                 # Don't overwrite path params that were already extracted.
                 key = name.replace("-", "_")
                 if key not in params:
-                    params[key] = parsed_query[name][0]
+                    params[key] = values if len(values) > 1 else values[0]
 
     return params
 
@@ -460,34 +516,28 @@ class FunctionResourceTemplate(ResourceTemplate):
 
     async def read(self, arguments: dict[str, Any]) -> str | bytes | ResourceResult:
         """Read the resource content."""
-        # Type coercion for query parameters (which arrive as strings)
+        # Type coercion for query parameters (which arrive as strings or lists)
         kwargs = arguments.copy()
         sig = inspect.signature(self.fn)
         for param_name, param_value in list(kwargs.items()):
-            if param_name in sig.parameters and isinstance(param_value, str):
-                param = sig.parameters[param_name]
-                annotation = param.annotation
+            if param_name not in sig.parameters:
+                continue
 
-                if annotation is inspect.Parameter.empty or annotation is str:
-                    continue
+            param = sig.parameters[param_name]
+            annotation = param.annotation
 
-                try:
-                    if annotation is int:
-                        kwargs[param_name] = int(param_value)
-                    elif annotation is float:
-                        kwargs[param_name] = float(param_value)
-                    elif annotation is bool:
-                        lower = param_value.lower()
-                        if lower in ("true", "1", "yes"):
-                            kwargs[param_name] = True
-                        elif lower in ("false", "0", "no"):
-                            kwargs[param_name] = False
-                        else:
-                            raise ValueError(
-                                f"Invalid boolean value for {param_name}: {param_value!r}"
-                            )
-                except (ValueError, AttributeError):
-                    raise
+            if annotation is inspect.Parameter.empty or annotation is str:
+                continue
+
+            if not isinstance(param_value, (str, list)):
+                continue
+
+            try:
+                kwargs[param_name] = _coerce_query_param_value(
+                    annotation, param_value, param_name=param_name
+                )
+            except (ValueError, AttributeError):
+                raise
 
         # self.fn is wrapped by without_injected_parameters which handles
         # dependency resolution internally, so we call it directly

--- a/tests/resources/test_resource_template.py
+++ b/tests/resources/test_resource_template.py
@@ -869,6 +869,48 @@ class TestMalformedURITemplates:
         assert result is not None
         assert result == {"id": "42", "format": "", "verbose": "true"}
 
+    def test_query_param_repeated_values_return_list(self):
+        """Repeated query keys should be preserved as a list."""
+        result = match_uri_template(
+            "items://books?tags=alpha&tags=beta",
+            "items://{category}{?tags}",
+        )
+        assert result == {"category": "books", "tags": ["alpha", "beta"]}
+
+    def test_query_param_single_value_stays_string(self):
+        """Single query values remain strings for backward compatibility."""
+        result = match_uri_template(
+            "items://books?tags=alpha",
+            "items://{category}{?tags}",
+        )
+        assert result == {"category": "books", "tags": "alpha"}
+
+    async def test_list_query_param_coercion(self):
+        """list[str] query params are coerced from strings and lists."""
+        from pydantic import Field
+
+        from fastmcp.resources.template import FunctionResourceTemplate
+
+        def search(
+            category: str, tags: list[str] = Field(default_factory=list)
+        ) -> dict:
+            return {"category": category, "tags": tags}
+
+        template = FunctionResourceTemplate.from_function(
+            fn=search,
+            uri_template="items://{category}{?tags}",
+            name="search",
+        )
+
+        result = await template.read({"category": "books"})
+        assert result == {"category": "books", "tags": []}
+
+        result = await template.read({"category": "books", "tags": "alpha"})
+        assert result == {"category": "books", "tags": ["alpha"]}
+
+        result = await template.read({"category": "books", "tags": ["alpha", "beta"]})
+        assert result == {"category": "books", "tags": ["alpha", "beta"]}
+
     def test_from_function_rejects_hyphen_underscore_collision(self):
         """Two raw param names that normalize to the same key are rejected."""
 

--- a/tests/resources/test_resource_template_query_params.py
+++ b/tests/resources/test_resource_template_query_params.py
@@ -408,3 +408,38 @@ class TestResourceTemplateFieldDefaults:
         assert result2["limit"] == 50  # overridden
         assert result2["offset"] == 0  # default
         assert result2["format"] == "xml"  # overridden
+
+
+class TestListQueryParameterCoercion:
+    """Regression tests for #4378: list[str] optional query parameters."""
+
+    async def test_list_query_params_end_to_end(self):
+        import json
+
+        from pydantic import Field
+
+        from fastmcp import Client, FastMCP
+
+        mcp = FastMCP("demo")
+
+        @mcp.resource("items://{category}{?tags}")
+        def search(category: str, tags: list[str] = Field(default_factory=list)) -> dict:
+            return {"category": category, "tags": tags}
+
+        cases = [
+            ("items://books", {"category": "books", "tags": []}),
+            ("items://books?tags=alpha", {"category": "books", "tags": ["alpha"]}),
+            (
+                "items://books?tags=alpha&tags=beta",
+                {"category": "books", "tags": ["alpha", "beta"]},
+            ),
+            (
+                "items://books?tags=alpha,beta",
+                {"category": "books", "tags": ["alpha,beta"]},
+            ),
+        ]
+
+        async with Client(mcp) as client:
+            for uri, expected in cases:
+                result = await client.read_resource(uri)
+                assert json.loads(result[0].text) == expected


### PR DESCRIPTION
## Summary

Fix resource template reads for optional `list[str]` query parameters. Repeated query keys are preserved as lists, and scalar query values are coerced to single-element lists before handler invocation.

## Motivation

Fixes #4378. Resource templates like `items://{category}{?tags}` with `tags: list[str]` failed when callers passed query values such as `?tags=alpha` or `?tags=alpha&tags=beta`, raising a Pydantic `ValidationError` because `match_uri_template` only kept the first value as a string and `FunctionResourceTemplate.read()` did not coerce to `list[str]`.

## Changes

- **`match_uri_template`**: return repeated query keys as `list[str]`; keep single values as strings for backward compatibility
- **`FunctionResourceTemplate.read()`**: add `_coerce_query_param_value()` helper to wrap scalar strings in lists for `list[...]` annotations while preserving existing int/float/bool coercion and error messages
- **Tests**: unit tests for parsing/coercion plus end-to-end `Client.read_resource()` coverage for the issue reproducer URIs

## Tests

```bash
uv run pytest tests/resources/test_resource_template.py tests/resources/test_resource_template_query_params.py -q
```

Result: **169 passed, 0 failed**

```bash
uv run ty check fastmcp_slim/fastmcp/resources/template.py
```

Result: **All checks passed**

## Notes

- Comma-separated single values (e.g. `?tags=alpha,beta`) remain one list element (`["alpha,beta"]`), which matches standard query-string semantics.
- Issue assignment requested in #4378; happy to adjust if maintainers prefer a different coercion strategy.