### PR TITLE
fix(tools): honor Pydantic serialization config in default_serializer

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/logging.py
+++ b/fastmcp_slim/fastmcp/server/middleware/logging.py
@@ -7,14 +7,8 @@ from collections.abc import Callable
 from logging import Logger
 from typing import Any
 
-import pydantic_core
-
+from fastmcp.tools.base import default_serializer
 from .middleware import CallNext, Middleware, MiddlewareContext
-
-
-def default_serializer(data: Any) -> str:
-    """The default serializer for Payloads in the logging middleware."""
-    return pydantic_core.to_json(data, fallback=str).decode()
 
 
 class BaseLoggingMiddleware(Middleware):

--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -63,6 +63,8 @@ ToolResultSerializerType: TypeAlias = Callable[[Any], str]
 
 
 def default_serializer(data: Any) -> str:
+    if isinstance(data, BaseModel):
+        return data.model_dump_json()
     return pydantic_core.to_json(data, fallback=str).decode()
 
 

--- a/tests/tools/tool/test_tool.py
+++ b/tests/tools/tool/test_tool.py
@@ -612,3 +612,25 @@ class TestToolExecutionField:
         mcp_tool = tool.to_mcp_tool()
         assert mcp_tool.execution is not None
         assert mcp_tool.execution.taskSupport == "forbidden"
+
+
+class TestDefaultSerializer:
+    async def test_respects_serialize_by_alias_false(self):
+        """Regression for #1197: honor Pydantic serialization config in tool output."""
+        from pydantic import ConfigDict, Field
+        from mcp.types import TextContent
+
+        class BiofileResponse(BaseModel):
+            model_config = ConfigDict(serialize_by_alias=False)
+
+            id: str = Field(alias="_id")
+            filepath: str
+
+        def get_biofile() -> BiofileResponse:
+            return BiofileResponse(_id="123", filepath="/path/to/file")
+
+        tool = Tool.from_function(get_biofile)
+        result = await tool.run({})
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == '{"id":"123","filepath":"/path/to/file"}'


### PR DESCRIPTION
## Summary

`default_serializer` now uses `BaseModel.model_dump_json()` for Pydantic model instances so tool text output respects per-model serialization settings such as `serialize_by_alias=False`.

## Motivation

Fixes #1197. `pydantic_core.to_json()` defaults to `by_alias=True`, which bypasses a model's `serialize_by_alias` configuration. Tools returning Pydantic models with field aliases therefore serialized using aliases in unstructured text output even when the model explicitly disables alias serialization.

## Changes

- Route top-level `BaseModel` instances through `model_dump_json()` in `default_serializer`
- Deduplicate the logging middleware serializer by importing the shared helper from `fastmcp.tools.base`
- Add regression test for `serialize_by_alias=False` with aliased fields

## Tests

```bash
uv run --frozen pytest -x tests/tools/tool/test_tool.py::TestDefaultSerializer
uv run --frozen pytest -x tests/tools/tool/test_tool.py tests/deprecated/test_tool_serializer.py
```

All 50 tests passed locally.

## Notes

- This fix targets top-level `BaseModel` tool returns (the issue repro). List/dict wrappers containing models still use the `to_json()` path; happy to follow up if maintainers want container handling aligned.
- Assignment requested on the issue; please assign to @syf2211 so the PR can proceed per contribution guidelines.