### PR TITLE
fix(caching): skip caching tool results marked as errors

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/caching.py
+++ b/fastmcp_slim/fastmcp/server/middleware/caching.py
@@ -439,17 +439,19 @@ class ResponseCachingMiddleware(Middleware):
             return cached_value.unwrap()
 
         tool_result: ToolResult = await call_next(context)
-        cachable_tool_result: CachableToolResult = CachableToolResult.wrap(
-            value=tool_result
-        )
 
-        await self._call_tool_cache.put(
-            key=cache_key,
-            value=cachable_tool_result,
-            ttl=self._call_tool_settings.get("ttl", ONE_HOUR_IN_SECONDS),
-        )
+        if not tool_result.is_error:
+            cachable_tool_result: CachableToolResult = CachableToolResult.wrap(
+                value=tool_result
+            )
 
-        return cachable_tool_result.unwrap()
+            await self._call_tool_cache.put(
+                key=cache_key,
+                value=cachable_tool_result,
+                ttl=self._call_tool_settings.get("ttl", ONE_HOUR_IN_SECONDS),
+            )
+
+        return tool_result
 
     @override
     async def on_read_resource(

--- a/tests/server/middleware/test_caching.py
+++ b/tests/server/middleware/test_caching.py
@@ -283,6 +283,35 @@ class TestResponseCachingMiddleware:
         )
         assert middleware1._matches_tool_cache_settings(tool_name=tool_name) is result
 
+    async def test_call_tool_errors_are_not_cached(
+        self,
+        mock_context: MiddlewareContext[mcp.types.CallToolRequestParams],
+    ):
+        """Regression test for issue #4395: tool errors must not be cached."""
+        middleware = ResponseCachingMiddleware()
+        call_count = 0
+
+        async def flaky_call_next(
+            _context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        ) -> ToolResult:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ToolResult("error", is_error=True)
+            return ToolResult("ok")
+
+        first_result = await middleware.on_call_tool(mock_context, flaky_call_next)
+        second_result = await middleware.on_call_tool(mock_context, flaky_call_next)
+
+        assert first_result.is_error is True
+        assert second_result.is_error is False
+        assert second_result.content[0].text == "ok"
+        assert call_count == 2
+
+        third_result = await middleware.on_call_tool(mock_context, flaky_call_next)
+        assert third_result.content[0].text == "ok"
+        assert call_count == 2
+
 
 @pytest.mark.skipif(
     sys.platform == "win32",
@@ -370,6 +399,7 @@ class TestResponseCachingMiddlewareIntegration:
                 "add", {"a": 5, "b": 3}
             )
             assert call_tool_result_one == call_tool_result_two
+            assert tracking_calculator.add_calls == 1
 
     async def test_call_tool_very_large_value(
         self,


### PR DESCRIPTION
## Summary

Fixes #4395.

`ResponseCachingMiddleware.on_call_tool` cached every `ToolResult`, including responses with `is_error=True`. When upstream providers return error results (for example proxied MCP tools), a transient failure could be served from cache until TTL expiry instead of retrying on the next call.

## Changes

- Only write successful tool results (`not tool_result.is_error`) into the call-tool cache.
- Return the original `ToolResult` directly on cache miss.
- Add a middleware unit regression test that returns `ToolResult(is_error=True)` on the first call and verifies the second call retries.
- Tighten `test_call_tool` to assert the second identical successful call hits the cache.

## Tests

```bash
uv run pytest tests/server/middleware/test_caching.py -q
```

Result: **41 passed**

## Notes

Raised exceptions inside local `@mcp.tool()` handlers are converted to protocol errors outside this middleware hook, so the regression test targets the `ToolResult(is_error=True)` return path described in the issue (for example proxy providers).
