### PR TITLE
fix: prevent caching of tool errors in ResponseCachingMiddleware

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/caching.py
+++ b/fastmcp_slim/fastmcp/server/middleware/caching.py
@@ -439,17 +439,19 @@ class ResponseCachingMiddleware(Middleware):
             return cached_value.unwrap()
 
         tool_result: ToolResult = await call_next(context)
-        cachable_tool_result: CachableToolResult = CachableToolResult.wrap(
-            value=tool_result
-        )
 
-        await self._call_tool_cache.put(
-            key=cache_key,
-            value=cachable_tool_result,
-            ttl=self._call_tool_settings.get("ttl", ONE_HOUR_IN_SECONDS),
-        )
+        if not tool_result.is_error:
+            cachable_tool_result: CachableToolResult = CachableToolResult.wrap(
+                value=tool_result
+            )
 
-        return cachable_tool_result.unwrap()
+            await self._call_tool_cache.put(
+                key=cache_key,
+                value=cachable_tool_result,
+                ttl=self._call_tool_settings.get("ttl", ONE_HOUR_IN_SECONDS),
+            )
+
+        return tool_result
 
     @override
     async def on_read_resource(

--- a/tests/server/middleware/test_caching.py
+++ b/tests/server/middleware/test_caching.py
@@ -283,6 +283,35 @@ class TestResponseCachingMiddleware:
         )
         assert middleware1._matches_tool_cache_settings(tool_name=tool_name) is result
 
+    async def test_call_tool_errors_are_not_cached(
+        self,
+        mock_context: MiddlewareContext[mcp.types.CallToolRequestParams],
+    ):
+        """Regression test for issue #4395: tool errors must not be cached."""
+        middleware = ResponseCachingMiddleware()
+        call_count = 0
+
+        async def flaky_call_next(
+            _context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        ) -> ToolResult:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ToolResult("error", is_error=True)
+            return ToolResult("ok")
+
+        first_result = await middleware.on_call_tool(mock_context, flaky_call_next)
+        second_result = await middleware.on_call_tool(mock_context, flaky_call_next)
+
+        assert first_result.is_error is True
+        assert second_result.is_error is False
+        assert second_result.content[0].text == "ok"
+        assert call_count == 2
+
+        third_result = await middleware.on_call_tool(mock_context, flaky_call_next)
+        assert third_result.content[0].text == "ok"
+        assert call_count == 2
+
 
 @pytest.mark.skipif(
     sys.platform == "win32",


### PR DESCRIPTION
## Description

This PR fixes a bug in `ResponseCachingMiddleware.on_call_tool` where tool execution errors were being cached unconditionally. 

Previously, if a tool failed due to a transient issue (like a network timeout), the error would be cached for the full TTL (default 1 hour), causing all subsequent identical calls to fail without actually re-running the tool.

This adds a check `if not tool_result.is_error:` to ensure we only cache successful tool executions. A unit test `test_call_tool_errors_are_not_cached` has been added to `test_caching.py` to prevent future regressions.

Closes #4395

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
