### PR TITLE
fix(utilities): apply string constraints for str-based formats

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema_type.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema_type.py
@@ -269,12 +269,14 @@ def _create_string_type(schema: Mapping[str, Any]) -> type | Annotated[Any, ...]
     if "const" in schema:
         return Literal[schema["const"]]  # type: ignore
 
+    base_type: type = str
     if fmt := schema.get("format"):
         if fmt == "uri":
-            return AnyUrl
+            base_type = AnyUrl
         elif fmt == "uri-reference":
-            return str
-        return FORMAT_TYPES.get(fmt, str)
+            base_type = str
+        else:
+            base_type = FORMAT_TYPES.get(fmt, str)
 
     constraints = {
         k: v
@@ -286,10 +288,15 @@ def _create_string_type(schema: Mapping[str, Any]) -> type | Annotated[Any, ...]
         if v is not None
     }
 
-    if not constraints:
-        return str
+    # Length/pattern constraints only apply to plain str types. Non-str formats
+    # like date-time, email, uri, and json carry their own validation rules.
+    if base_type is not str:
+        constraints = {}
 
-    annotated: Any = Annotated[str, StringConstraints(**constraints)]
+    if not constraints:
+        return base_type
+
+    annotated: Any = Annotated[base_type, StringConstraints(**constraints)]
 
     if "pattern" in constraints:
         try:

--- a/tests/utilities/json_schema_type/test_formats.py
+++ b/tests/utilities/json_schema_type/test_formats.py
@@ -112,3 +112,55 @@ class TestFormatTypes:
         )
         assert isinstance(result.full_uri, AnyUrl)
         assert isinstance(result.ref_uri, str)
+
+    def test_unknown_format_with_max_length_enforced(self):
+        schema_type = json_schema_to_type(
+            {"type": "string", "format": "phone", "maxLength": 3}
+        )
+        validator = TypeAdapter(schema_type)
+        assert validator.validate_python("123") == "123"
+        with pytest.raises(ValidationError):
+            validator.validate_python("abcd")
+
+    def test_unknown_format_with_min_length_enforced(self):
+        schema_type = json_schema_to_type(
+            {"type": "string", "format": "phone", "minLength": 2}
+        )
+        validator = TypeAdapter(schema_type)
+        assert validator.validate_python("12") == "12"
+        with pytest.raises(ValidationError):
+            validator.validate_python("1")
+
+    def test_unknown_format_with_pattern_enforced(self):
+        schema_type = json_schema_to_type(
+            {"type": "string", "format": "phone", "pattern": "^[0-9]+$"}
+        )
+        validator = TypeAdapter(schema_type)
+        assert validator.validate_python("123") == "123"
+        with pytest.raises(ValidationError):
+            validator.validate_python("12a")
+
+    def test_uri_reference_with_max_length_enforced(self):
+        schema_type = json_schema_to_type(
+            {"type": "string", "format": "uri-reference", "maxLength": 5}
+        )
+        validator = TypeAdapter(schema_type)
+        assert validator.validate_python("/path") == "/path"
+        with pytest.raises(ValidationError):
+            validator.validate_python("/too/long/path")
+
+    def test_datetime_format_ignores_string_length_constraints(self):
+        schema_type = json_schema_to_type(
+            {"type": "string", "format": "date-time", "maxLength": 3}
+        )
+        validator = TypeAdapter(schema_type)
+        result = validator.validate_python("2024-01-17T12:34:56Z")
+        assert isinstance(result, datetime)
+
+    def test_json_format_ignores_string_length_constraints(self):
+        schema_type = json_schema_to_type(
+            {"type": "string", "format": "json", "maxLength": 3}
+        )
+        validator = TypeAdapter(schema_type)
+        result = validator.validate_python('{"key": "value"}')
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

Fix `json_schema_to_type` dropping `minLength`, `maxLength`, and `pattern` when a string schema also sets `format`.

## Motivation

`_create_string_type` returned early as soon as `format` was present, so length/pattern constraints were never applied for str-based formats like `uri-reference` or unknown formats (e.g. `phone`). This contradicts the module docstring and allows invalid values through validation.

Fixes #4404

## Changes

- Refactor `_create_string_type` to resolve the format base type first, then apply `StringConstraints` when the resolved type is plain `str`
- Leave non-str formats (`date-time`, `email`, `uri`, `json`) unchanged — they keep their own validators and ignore length/pattern constraints
- Add regression tests for `maxLength`, `minLength`, and `pattern` with str-based formats, plus guards for `date-time` and `json`

## Tests

```bash
uv run pytest tests/utilities/json_schema_type/test_formats.py -v
```

All 18 tests pass.

## Notes

I've commented on #4404 requesting assignment per CONTRIBUTING guidelines. Happy to adjust if maintainers prefer a different approach.