### PR TITLE
Reject empty env var keys

### DIFF
--- a/fastmcp_slim/fastmcp/cli/cli.py
+++ b/fastmcp_slim/fastmcp/cli/cli.py
@@ -66,6 +66,9 @@ def _parse_env_var(env_var: str) -> tuple[str, str]:
         logger.error("Invalid environment variable format. Must be KEY=VALUE")
         sys.exit(1)
     key, value = env_var.split("=", 1)
+    if not key.strip():
+        logger.error("Invalid environment variable format. KEY cannot be empty")
+        sys.exit(1)
     return key.strip(), value.strip()
 
 

--- a/fastmcp_slim/fastmcp/cli/install/shared.py
+++ b/fastmcp_slim/fastmcp/cli/install/shared.py
@@ -47,6 +47,11 @@ def parse_env_var(env_var: str) -> tuple[str, str]:
         )
         sys.exit(1)
     key, value = env_var.split("=", 1)
+    if not key.strip():
+        print(
+            f"[red]Invalid environment variable format: '[bold]{env_var}[/bold]'. KEY cannot be empty[/red]"
+        )
+        sys.exit(1)
     return key.strip(), value.strip()
 
 

--- a/tests/cli/test_shared.py
+++ b/tests/cli/test_shared.py
@@ -1,4 +1,7 @@
+import pytest
+
 from fastmcp.cli.cli import _parse_env_var
+from fastmcp.cli.install.shared import parse_env_var
 
 
 class TestEnvVarParsing:
@@ -27,3 +30,10 @@ class TestEnvVarParsing:
         key, value = _parse_env_var("EMPTY_VAR=")
         assert key == "EMPTY_VAR"
         assert value == ""
+
+    @pytest.mark.parametrize("parser", [_parse_env_var, parse_env_var])
+    def test_parse_env_var_empty_key_exits(self, parser):
+        """Environment variable names cannot be empty."""
+        with pytest.raises(SystemExit) as exc_info:
+            parser("  =value")
+        assert exc_info.value.code == 1


### PR DESCRIPTION
`fastmcp run --env` and the install helpers both accept environment variables as `KEY=VALUE`. Today a value like `=secret` or `   =secret` passes validation and produces an empty environment variable name after stripping. That can write invalid server configuration or fail later in a less direct place.

This rejects empty keys at the parse boundary while preserving the existing value parsing behavior, including empty values such as `EMPTY_VAR=` and values containing additional `=` characters.

```python
_parse_env_var("  =secret")  # exits with a clear validation error
_parse_env_var("EMPTY_VAR=")  # still accepted
```