### PR TITLE
fix(search): add title and description to synthetic search tools

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/search/base.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/base.py
@@ -66,6 +66,26 @@ def serialize_tools_for_output_json(tools: Sequence[Tool]) -> list[dict[str, Any
 
 SearchResultSerializer = Callable[[Sequence[Tool]], Any | Awaitable[Any]]
 
+# Titles for well-known synthetic search/call proxy tool names (with or without
+# namespace prefixes, e.g. ``ha_search_tools``).
+_SYNTHETIC_TOOL_TITLES: dict[str, str] = {
+    "search_tools": "Search Tools",
+    "call_tool": "Call Tool",
+    "call_read_tool": "Call Read Tool",
+    "call_write_tool": "Call Write Tool",
+    "call_delete_tool": "Call Delete Tool",
+}
+
+
+def synthetic_tool_title(name: str, *, default: str) -> str:
+    """Return a human-readable MCP title for a synthetic search-transform tool."""
+    if name in _SYNTHETIC_TOOL_TITLES:
+        return _SYNTHETIC_TOOL_TITLES[name]
+    for suffix, title in _SYNTHETIC_TOOL_TITLES.items():
+        if name.endswith(f"_{suffix}"):
+            return title
+    return default
+
 
 async def _invoke_serializer(
     serializer: SearchResultSerializer, tools: Sequence[Tool]
@@ -241,7 +261,15 @@ class BaseSearchTransform(CatalogTransform):
                 )
             return await ctx.fastmcp.call_tool(name, arguments)
 
-        return Tool.from_function(fn=call_tool, name=self._call_tool_name)
+        return Tool.from_function(
+            fn=call_tool,
+            name=self._call_tool_name,
+            title=synthetic_tool_title(self._call_tool_name, default="Call Tool"),
+            description=(
+                "Call a tool by name with the given arguments. "
+                "Use this to execute tools discovered via search_tools."
+            ),
+        )
 
     # ------------------------------------------------------------------
     # Serialization

--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -11,6 +11,7 @@ from fastmcp.server.transforms.search.base import (
     BaseSearchTransform,
     SearchResultSerializer,
     _extract_searchable_text,
+    synthetic_tool_title,
 )
 from fastmcp.tools.base import Tool
 
@@ -126,7 +127,16 @@ class BM25SearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, query)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=synthetic_tool_title(self._search_tool_name, default="Search Tools"),
+            description=(
+                "Search for tools using natural language. "
+                "Returns matching tool definitions ranked by relevance, "
+                "in the same format as list_tools."
+            ),
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         current_hash = _catalog_hash(tools)

--- a/fastmcp_slim/fastmcp/server/transforms/search/regex.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/regex.py
@@ -8,6 +8,7 @@ from fastmcp.server.context import Context
 from fastmcp.server.transforms.search.base import (
     BaseSearchTransform,
     _extract_searchable_text,
+    synthetic_tool_title,
 )
 from fastmcp.tools.base import Tool
 
@@ -37,7 +38,15 @@ class RegexSearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, pattern)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=synthetic_tool_title(self._search_tool_name, default="Search Tools"),
+            description=(
+                "Search for tools matching a regex pattern. "
+                "Returns matching tool definitions in the same format as list_tools."
+            ),
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         try:

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -106,6 +106,44 @@ class TestBaseTransformBehavior:
         assert call is not None
         assert call.name == "call_tool"
 
+    async def test_synthetic_tools_include_title(self):
+        mcp = _make_server_with_tools()
+        mcp.add_transform(RegexSearchTransform())
+        tools = await mcp.list_tools()
+        titles = {
+            t.name: t.to_mcp_tool().title
+            for t in tools
+            if t.name in {"search_tools", "call_tool"}
+        }
+        assert titles == {
+            "search_tools": "Search Tools",
+            "call_tool": "Call Tool",
+        }
+
+    async def test_synthetic_tools_include_title_bm25(self):
+        mcp = _make_server_with_tools()
+        mcp.add_transform(BM25SearchTransform())
+        tools = await mcp.list_tools()
+        titles = {
+            t.name: t.to_mcp_tool().title
+            for t in tools
+            if t.name in {"search_tools", "call_tool"}
+        }
+        assert titles == {
+            "search_tools": "Search Tools",
+            "call_tool": "Call Tool",
+        }
+
+    async def test_synthetic_tool_title_supports_namespaced_names(self):
+        from fastmcp.server.transforms.search.base import synthetic_tool_title
+
+        assert synthetic_tool_title("ha_search_tools", default="Search Tools") == (
+            "Search Tools"
+        )
+        assert synthetic_tool_title("ha_call_read_tool", default="Call Tool") == (
+            "Call Read Tool"
+        )
+
     async def test_get_tool_passes_through_hidden(self):
         mcp = _make_server_with_tools()
         mcp.add_transform(RegexSearchTransform())


### PR DESCRIPTION
## Summary

Add explicit MCP `title` and `description` fields to search-transform synthetic tools (`search_tools`, `call_tool`) so strict clients (e.g. ChatGPT) register them instead of silently dropping them.

## Motivation

Fixes #4418. Related to #4414.

When tool search mode is enabled, FastMCP generates synthetic discovery/proxy tools via `Tool.from_function()` without a `title`. `to_mcp_tool()` only emits `title` when one is set on the tool, so these proxies were missing the field entirely. Some MCP clients require `title` and drop tools without it, breaking search-based discovery.

## Changes

- Add `synthetic_tool_title()` helper in `BaseSearchTransform` with mappings for common proxy names, including namespaced variants (e.g. `ha_call_read_tool`).
- Pass explicit `title` and `description` when creating `call_tool` in `base.py`.
- Pass explicit `title` and `description` when creating `search_tools` in `regex.py` and `bm25.py`.
- Add regression tests asserting synthetic tools expose titles on the MCP wire format.

## Tests

- `uv run pytest tests/server/transforms/test_search.py -q` — 37 passed

## Notes

- This fixes the upstream `search_tools` / `call_tool` pair. Namespaced title mappings for `call_read_tool` / `call_write_tool` / `call_delete_tool` are included for downstream setups that use those names.
- Similar synthetic tools in other modules (e.g. code mode) may warrant a follow-up if they surface the same client behavior.