### PR TITLE
Fix replace_type parameter docs

### DIFF
--- a/docs/python-sdk/fastmcp-utilities-types.mdx
+++ b/docs/python-sdk/fastmcp-utilities-types.mdx
@@ -85,14 +85,13 @@ replace_type(type_, type_map: dict[type, type])
 
 
 Given a (possibly generic, nested, or otherwise complex) type, replaces all
-instances of old_type with new_type.
+instances of the keys in type_map with their corresponding values.
 
 This is useful for transforming types when creating tools.
 
 **Args:**
-- `type_`: The type to replace instances of old_type with new_type.
-- `old_type`: The type to replace.
-- `new_type`: The type to replace old_type with.
+- `type_`: The type to transform.
+- `type_map`: A mapping of source types to replacement types.
 
 Examples:
 ```python

--- a/fastmcp_slim/fastmcp/utilities/types.py
+++ b/fastmcp_slim/fastmcp/utilities/types.py
@@ -454,14 +454,13 @@ class File:
 def replace_type(type_, type_map: dict[type, type]):
     """
     Given a (possibly generic, nested, or otherwise complex) type, replaces all
-    instances of old_type with new_type.
+    instances of the keys in type_map with their corresponding values.
 
     This is useful for transforming types when creating tools.
 
     Args:
-        type_: The type to replace instances of old_type with new_type.
-        old_type: The type to replace.
-        new_type: The type to replace old_type with.
+        type_: The type to transform.
+        type_map: A mapping of source types to replacement types.
 
     Examples:
     ```python


### PR DESCRIPTION
Fixes #4376.

This updates the `replace_type()` parameter documentation to match the current signature, which accepts `type_map` rather than separate `old_type` and `new_type` parameters.

The generated Python SDK docs page is updated alongside the source docstring so the published reference stays consistent.

Validation:
- `git diff --check main...HEAD`
- `python -m py_compile fastmcp_slim\fastmcp\utilities\types.py`

I also tried `python -m pytest tests\utilities\test_types.py`, but the local environment is missing `opentelemetry`, which is imported by `tests/conftest.py` before this test module runs.
