### PR TITLE
Add metadata to search proxy tools

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/search/base.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/base.py
@@ -151,6 +151,10 @@ def serialize_tools_for_output_markdown(tools: Sequence[Tool]) -> str:
     return "\n\n".join(blocks)
 
 
+def _title_from_tool_name(name: str) -> str:
+    return name.replace("_", " ").title()
+
+
 class BaseSearchTransform(CatalogTransform):
     """Replace the tool listing with a search interface.
 
@@ -241,7 +245,15 @@ class BaseSearchTransform(CatalogTransform):
                 )
             return await ctx.fastmcp.call_tool(name, arguments)
 
-        return Tool.from_function(fn=call_tool, name=self._call_tool_name)
+        return Tool.from_function(
+            fn=call_tool,
+            name=self._call_tool_name,
+            title=_title_from_tool_name(self._call_tool_name),
+            description=(
+                "Call a tool by name with the given arguments. "
+                f"Use this to execute tools discovered via {self._search_tool_name}."
+            ),
+        )
 
     # ------------------------------------------------------------------
     # Serialization

--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -11,6 +11,7 @@ from fastmcp.server.transforms.search.base import (
     BaseSearchTransform,
     SearchResultSerializer,
     _extract_searchable_text,
+    _title_from_tool_name,
 )
 from fastmcp.tools.base import Tool
 
@@ -126,7 +127,12 @@ class BM25SearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, query)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=_title_from_tool_name(self._search_tool_name),
+            description="Search for tools using natural language.",
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         current_hash = _catalog_hash(tools)

--- a/fastmcp_slim/fastmcp/server/transforms/search/regex.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/regex.py
@@ -8,6 +8,7 @@ from fastmcp.server.context import Context
 from fastmcp.server.transforms.search.base import (
     BaseSearchTransform,
     _extract_searchable_text,
+    _title_from_tool_name,
 )
 from fastmcp.tools.base import Tool
 
@@ -37,7 +38,12 @@ class RegexSearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, pattern)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=_title_from_tool_name(self._search_tool_name),
+            description="Search for tools matching a regex pattern.",
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         try:

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -137,6 +137,55 @@ class TestBaseTransformBehavior:
         assert await mcp.get_tool("find_tools") is not None
         assert await mcp.get_tool("run_tool") is not None
 
+    @pytest.mark.parametrize(
+        ("transform", "search_description"),
+        [
+            (
+                RegexSearchTransform(
+                    search_tool_name="find_tools",
+                    call_tool_name="call_read_tool",
+                ),
+                "Search for tools matching a regex pattern.",
+            ),
+            (
+                BM25SearchTransform(
+                    search_tool_name="find_tools",
+                    call_tool_name="call_read_tool",
+                ),
+                "Search for tools using natural language.",
+            ),
+        ],
+    )
+    async def test_synthetic_tools_have_titles_and_descriptions(
+        self,
+        transform: RegexSearchTransform | BM25SearchTransform,
+        search_description: str,
+    ):
+        mcp = _make_server_with_tools()
+        mcp.add_transform(transform)
+
+        tools = {tool.name: tool for tool in await mcp.list_tools()}
+        assert tools["find_tools"].title == "Find Tools"
+        assert tools["find_tools"].description == search_description
+        assert tools["call_read_tool"].title == "Call Read Tool"
+        assert tools["call_read_tool"].description == (
+            "Call a tool by name with the given arguments. "
+            "Use this to execute tools discovered via find_tools."
+        )
+
+        wire_tools = {
+            name: tool.to_mcp_tool()
+            for name, tool in tools.items()
+            if name in {"find_tools", "call_read_tool"}
+        }
+        assert wire_tools["find_tools"].title == "Find Tools"
+        assert wire_tools["find_tools"].description == search_description
+        assert wire_tools["call_read_tool"].title == "Call Read Tool"
+        assert wire_tools["call_read_tool"].description == (
+            "Call a tool by name with the given arguments. "
+            "Use this to execute tools discovered via find_tools."
+        )
+
     async def test_search_respects_visibility_filtering(self):
         """Tools disabled via Visibility transform should not appear in search."""
         mcp = _make_server_with_tools()


### PR DESCRIPTION
Fixes #4418

## Summary

Adds explicit `title` and `description` metadata to the synthetic tools generated by search transforms:

- `search_tools` / custom search tool names now get a title derived from the configured tool name and a stable description for the search strategy.
- `call_tool` / custom call proxy names now get a title derived from the configured tool name and a description that points users to the configured search tool.

This makes generated proxy tools such as `call_read_tool` display useful metadata instead of relying only on function/docstring-derived defaults.

## Tests

```bash
python -m pytest tests/server/transforms/test_search.py
python -m ruff check fastmcp_slim/fastmcp/server/transforms/search/base.py fastmcp_slim/fastmcp/server/transforms/search/regex.py fastmcp_slim/fastmcp/server/transforms/search/bm25.py tests/server/transforms/test_search.py
```