### PR TITLE
🐛fix: add titles and descriptions to synthetic search tools

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/search/base.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/base.py
@@ -241,7 +241,21 @@ class BaseSearchTransform(CatalogTransform):
                 )
             return await ctx.fastmcp.call_tool(name, arguments)
 
-        return Tool.from_function(fn=call_tool, name=self._call_tool_name)
+        title = " ".join(
+            word.capitalize()
+            for word in self._call_tool_name.replace("-", "_").split("_")
+        )
+        description = (
+            f"Call a tool by name with the given arguments. "
+            f"Use this to execute tools discovered via {self._search_tool_name}."
+        )
+
+        return Tool.from_function(
+            fn=call_tool,
+            name=self._call_tool_name,
+            title=title,
+            description=description,
+        )
 
     # ------------------------------------------------------------------
     # Serialization

--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -126,7 +126,22 @@ class BM25SearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, query)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        title = " ".join(
+            word.capitalize()
+            for word in self._search_tool_name.replace("-", "_").split("_")
+        )
+        description = (
+            "Search for tools using natural language. "
+            "Returns matching tool definitions ranked by relevance, "
+            "in the same format as list_tools."
+        )
+
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=title,
+            description=description,
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         current_hash = _catalog_hash(tools)

--- a/fastmcp_slim/fastmcp/server/transforms/search/regex.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/regex.py
@@ -37,7 +37,21 @@ class RegexSearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, pattern)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        title = " ".join(
+            word.capitalize()
+            for word in self._search_tool_name.replace("-", "_").split("_")
+        )
+        description = (
+            "Search for tools matching a regex pattern. "
+            "Returns matching tool definitions in the same format as list_tools."
+        )
+
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=title,
+            description=description,
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         try:

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -137,6 +137,37 @@ class TestBaseTransformBehavior:
         assert await mcp.get_tool("find_tools") is not None
         assert await mcp.get_tool("run_tool") is not None
 
+    async def test_synthetic_tools_have_titles_and_descriptions(self):
+        mcp = _make_server_with_tools()
+        mcp.add_transform(RegexSearchTransform())
+        tools = await mcp.list_tools()
+
+        search_tool = next(t for t in tools if t.name == "search_tools")
+        assert search_tool.title == "Search Tools"
+        assert search_tool.description is not None
+        assert "Search for tools matching a regex pattern" in search_tool.description
+
+        call_tool = next(t for t in tools if t.name == "call_tool")
+        assert call_tool.title == "Call Tool"
+        assert call_tool.description is not None
+        assert "Call a tool by name with the given arguments" in call_tool.description
+
+    async def test_custom_synthetic_tool_names_have_correct_titles(self):
+        mcp = _make_server_with_tools()
+        mcp.add_transform(
+            RegexSearchTransform(
+                search_tool_name="find_records_tools",
+                call_tool_name="execute_custom_tool",
+            )
+        )
+        tools = await mcp.list_tools()
+
+        search_tool = next(t for t in tools if t.name == "find_records_tools")
+        assert search_tool.title == "Find Records Tools"
+
+        call_tool = next(t for t in tools if t.name == "execute_custom_tool")
+        assert call_tool.title == "Execute Custom Tool"
+
     async def test_search_respects_visibility_filtering(self):
         """Tools disabled via Visibility transform should not appear in search."""
         mcp = _make_server_with_tools()


### PR DESCRIPTION
## Description

When search transforms (like `RegexSearchTransform` or `BM25SearchTransform`) are active, they collapse the tool catalog and generate synthetic proxy tools (`search_tools` and `call_tool`). However, these synthetic tools were generated without a `title` or `description` field. Strict MCP clients, such as ChatGPT's web client, reject and silently drop any tool that lacks a title. This effectively breaks the entire search-based tool discovery mechanism for these clients.

This PR updates the synthetic tool generators to explicitly set both `title` and `description` when creating them. The titles are dynamically formatted from the configured tool names (e.g. `call_tool` becomes `Call Tool`, and `search_tools` becomes `Search Tools`), supporting custom names seamlessly.

Here is how the synthetic tool looks when registered:

```python
# Before this PR, search_tools and call_tool returned from list_tools
# had empty/null titles and descriptions in MCP responses.

# Now, they carry clear user-facing titles and descriptions:
# Tool: search_tools
# Title: "Search Tools"
# Description: "Search for tools using natural language..."
```

Closes #4414
Closes #4418

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)