### PR TITLE
Deprecate ctx.sample and add clear errors for push features on 2026 connections

### DIFF
--- a/docs/development/v4-notes/change-register.mdx
+++ b/docs/development/v4-notes/change-register.mdx
@@ -245,23 +245,31 @@ The push-style Context features that require the server to call back into the cl
 | `ctx.info` / logging notifications | Supported | Supported |
 | Tools, resources, prompts, completions | Supported | Supported |
 | `ctx.elicit` | Supported | Not yet — MRTR rewrite pending |
-| `ctx.sample` | Supported | Not yet — being removed in 4.0 |
+| `ctx.sample` / `ctx.sample_step` | Supported (deprecated) | Removed — call an LLM server-side |
 | `ctx.list_roots` | Supported | Not yet — MRTR rewrite pending |
 | Tasks (via the FastMCP client) | Supported | Not yet |
 
-Tools that rely on `ctx.elicit`, `ctx.sample`, or `ctx.list_roots` continue to work against clients on the session-based eras.
+Tools that rely on `ctx.elicit` or `ctx.list_roots` continue to work against clients on the session-based eras. Sampling is the exception: it is deprecated on every era and will not return on modern connections (see the Deprecated entry below).
 
-Ordinary `ctx.info` and `ctx.sample` usage now emits an SDK-level `MCPDeprecationWarning` ("The logging/sampling capability is deprecated as of 2026-07-28 (SEP-2577)"). The warnings come from the SDK, not FastMCP, and are benign — the features keep working on session-based connections per the matrix. Users will see them and wonder, so the upgrade guide calls them out explicitly.
+Ordinary `ctx.info` usage emits an SDK-level `MCPDeprecationWarning` ("The logging capability is deprecated as of 2026-07-28 (SEP-2577)"). That warning comes from the SDK, not FastMCP, and is benign — logging keeps working on session-based connections per the matrix. `ctx.sample`/`ctx.sample_step` additionally emit a FastMCP-owned `FastMCPDeprecationWarning` (see below). The upgrade guide calls both out explicitly.
 
 Wire interop across the transition is verified: a 3.4.3 client against a v4 server and a v4 client against a 3.4.3 server are bidirectionally clean across 9 operations over HTTP (WS2).
 
 *Verify:* `docs/getting-started/upgrading/from-fastmcp-3.mdx` (the published matrix and SDK-warning note), `tests/server/test_protocol_eras.py`.
 
-### Push-feature degradation quality — Known gap
+### Sampling deprecated, era-gated — Deprecated
 
-The degradation error differs by feature on a `2026-07-28` connection: `ctx.list_roots` raises a clear `NoBackChannelError`, while `ctx.elicit` / `ctx.sample` surface a bare "Method not found" because those methods were removed from the 2026 server-request registry. This is sdk-feedback #10 and is captured by a strict xfail in `test_protocol_eras.py`. FastMCP's planned fix is to era-gate `ctx.elicit`/`ctx.sample` to raise a clear message before the wire.
+`ctx.sample()` and `ctx.sample_step()` are deprecated and slated for removal in a future FastMCP release. Server-initiated sampling relies on the `createMessage` back-channel that SEP-2577 removed from the wire as of `2026-07-28`, and unlike elicitation it has no multi-round-trip replacement (the agentic loop would exhaust the round-trip budget). Both methods now emit a `FastMCPDeprecationWarning` once per process (gated on `settings.deprecation_warnings`), and on a `2026-07-28` connection they raise a clear `ToolError` before touching the wire. The client-side sampling handler infrastructure (anthropic/openai/google_genai) is retained for future MRTR work and is not deprecated. The migration is to call an LLM directly from your server rather than borrowing the client's model.
 
-*Verify:* `tests/server/test_protocol_eras.py:319` (strict xfail referencing sdk-feedback #10).
+The dead TODO at `server/context.py` (a background-task sampling relay that was never built) is removed: that relay is not being built, so the note is gone rather than left as a promise.
+
+*Verify:* `fastmcp_slim/fastmcp/server/context.py` (`_warn_sampling_deprecated`, `_is_modern_protocol`, the `sample`/`sample_step` gates), `docs/servers/sampling.mdx` (deprecation banner), `tests/server/test_protocol_eras.py` (warning + era-gate tests).
+
+### Push-feature degradation quality — Resolved (was sdk-feedback #10)
+
+On a `2026-07-28` connection the degradation error used to differ by feature: `ctx.list_roots` raised a clear `NoBackChannelError`, while `ctx.elicit` / `ctx.sample` surfaced a bare "Method not found" because those methods attach a `related_request_id` and reach client dispatch before failing. FastMCP now era-gates `ctx.elicit` and `ctx.sample`/`ctx.sample_step` to raise a clear, era-aware `ToolError` before the wire ("server-initiated sampling is not available on MCP 2026-07-28 connections…" and "elicitation via server-initiated requests is unavailable on 2026-07-28 connections."). The strict xfail that captured #10 is flipped to a passing test.
+
+*Verify:* `tests/server/test_protocol_eras.py` (`test_elicit_sample_degradation_message_is_clear_on_modern`, now a real test), `server/context.py` (era gates).
 
 ### The xfail register — Known gap
 

--- a/docs/getting-started/upgrading/from-fastmcp-3.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-3.mdx
@@ -126,21 +126,23 @@ Ordinary use of `ctx.info` (client logging) and `ctx.sample` now emits an SDK-le
 The logging/sampling capability is deprecated as of 2026-07-28 (SEP-2577)
 ```
 
-These warnings come from the MCP SDK, not from FastMCP, and they are benign: the features keep working on session-based (handshake-era) connections exactly as the protocol table below describes. The SDK is signaling that the `2026-07-28` protocol era removed these capabilities from the wire — the warning is about the protocol's direction, not about your code being broken today.
+These warnings come from the MCP SDK, not from FastMCP. For logging they are benign: `ctx.info` keeps working on session-based connections exactly as the protocol table below describes, and the SDK is only signaling the protocol's direction. For sampling, FastMCP additionally emits its own `FastMCPDeprecationWarning`: `ctx.sample` and `ctx.sample_step` are deprecated and slated for removal, so treat that warning as a prompt to migrate to server-side LLM calls rather than as informational.
 
 ## Protocol version support
 
 FastMCP servers built on the SDK v2 serve multiple protocol eras from the same server. The SDK negotiates the era each client speaks: the sessionless `2026-07-28` era (which discovers capabilities through `server/discover`) and earlier session-based handshake versions are all handled simultaneously. This formally supersedes FastMCP's earlier "latest protocol only" stance — a single server now works with clients across the protocol transition.
 
-Not every Context feature is available on every era yet. The push-style interactions that require the server to call back into the client — elicitation, sampling, and listing roots — depend on the session-based request/response flow of the earlier eras. On a `2026-07-28` connection these raise, because the sessionless era needs a multi-round-trip replacement that is still being built. Logging notifications and the request/response features flow on every era.
+Not every Context feature is available on every era yet. The push-style interactions that require the server to call back into the client — elicitation, sampling, and listing roots — depend on the session-based request/response flow of the earlier eras. On a `2026-07-28` connection these raise a clear, era-aware error rather than reaching the client. Logging notifications and the request/response features flow on every era.
+
+Sampling is the exception that does not come back. `ctx.sample` and `ctx.sample_step` are **deprecated** and will be removed in a future FastMCP release: server-initiated sampling was removed from the wire by SEP-2577, and unlike elicitation it has no multi-round-trip replacement (the agentic loop would exhaust the round-trip budget). The migration is to call an LLM directly from your server rather than borrowing the client's model. See [Sampling](/servers/sampling) for details.
 
 | Context feature | Earlier eras (session-based) | `2026-07-28` (sessionless) |
 | --- | --- | --- |
 | `ctx.info` / logging notifications | Supported | Supported |
 | Tools, resources, prompts, completions | Supported | Supported |
 | `ctx.elicit` | Supported | Not yet — MRTR rewrite pending |
-| `ctx.sample` | Supported | Not yet — MRTR rewrite pending |
+| `ctx.sample` / `ctx.sample_step` | Supported (deprecated) | Removed — call an LLM server-side |
 | `ctx.list_roots` | Supported | Not yet — MRTR rewrite pending |
 | Tasks (via the FastMCP client) | Supported | Not yet |
 
-If your tools rely on `ctx.elicit`, `ctx.sample`, or `ctx.list_roots`, they continue to work against clients on the earlier eras. As the sessionless replacements land, this table will expand.
+If your tools rely on `ctx.elicit` or `ctx.list_roots`, they continue to work against clients on the earlier eras, and the sessionless replacements will expand this table as they land. Sampling is deprecated on every era and will not return on modern connections — migrate those tools to server-side LLM calls.

--- a/docs/servers/sampling.mdx
+++ b/docs/servers/sampling.mdx
@@ -9,6 +9,20 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 <VersionBadge version="2.0.0" />
 
+<Warning>
+**Sampling is deprecated and will be removed in a future FastMCP release.**
+
+`ctx.sample()` and `ctx.sample_step()` rely on server-initiated `createMessage`
+requests, which MCP removed as of the 2026-07-28 protocol (SEP-2577). They work
+only on session-based (handshake-era) connections; on a 2026-07-28 connection
+they raise a clear error rather than reaching the client.
+
+**Migration:** call an LLM directly from your server using your own API key and
+provider SDK instead of borrowing the client's model. There is no drop-in
+replacement on modern connections — this architectural shift is the intended
+answer.
+</Warning>
+
 LLM sampling allows your MCP tools to request text generation from an LLM during execution. This enables tools to leverage AI capabilities for analysis, generation, reasoning, and more—without the client needing to orchestrate multiple calls.
 
 By default, sampling requests are routed to the client's LLM. You can also configure a fallback handler to use a specific provider (like OpenAI) when the client doesn't support sampling, or to always use your own LLM regardless of client capabilities.

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -80,10 +80,12 @@ ResultT = TypeVar("ResultT", default=str)
 # Import ToolChoiceOption from sampling module (after other imports)
 from fastmcp.server.sampling.run import ToolChoiceOption  # noqa: E402
 
-# Warn-once guards for the sampling deprecation. Server-initiated createMessage
+# Warn-once guard for the sampling deprecation. Server-initiated createMessage
 # was removed from MCP as of 2026-07-28 (SEP-2577); the warning fires a single
 # time per process to flag that ctx.sample/ctx.sample_step are on their way out.
-_sample_deprecation_warned = False
+# A mutable set (mutated in place, never rebound) rather than a `global` boolean
+# so the warn-once state is unambiguously read and written from the module.
+_sample_deprecation_warned: set[bool] = set()
 
 _SAMPLING_DEPRECATION_MESSAGE = (
     "ctx.sample() and ctx.sample_step() are deprecated and will be removed in a "
@@ -110,10 +112,9 @@ def _warn_sampling_deprecated() -> None:
     Gated on ``settings.deprecation_warnings`` like every other FastMCP
     deprecation; fires a single time (module-level flag) rather than per call.
     """
-    global _sample_deprecation_warned
     if _sample_deprecation_warned or not fastmcp.settings.deprecation_warnings:
         return
-    _sample_deprecation_warned = True
+    _sample_deprecation_warned.add(True)
     warnings.warn(
         _SAMPLING_DEPRECATION_MESSAGE,
         FastMCPDeprecationWarning,
@@ -918,6 +919,23 @@ class Context:
             return False
         return rc.protocol_version in MODERN_PROTOCOL_VERSIONS
 
+    def _server_can_sample(self) -> bool:
+        """True when a server-configured sampling handler can serve the request
+        without the client back-channel.
+
+        FastMCP supports a server-side sampling handler (``FastMCP(sampling_handler=...)``).
+        With ``sampling_handler_behavior="always"`` the handler always answers;
+        with ``"fallback"`` it answers whenever the client cannot. On modern
+        connections the client back-channel is gone, so either configuration lets
+        the server answer entirely server-side as long as a handler is set. (For
+        ``"always"`` without a handler the sampling implementation raises its own
+        clear "no handler configured" error, which is not an era concern.)
+        """
+        fastmcp = self.fastmcp
+        if fastmcp.sampling_handler_behavior == "always":
+            return True
+        return fastmcp.sampling_handler is not None
+
     async def sample_step(
         self,
         messages: str | Sequence[str | SamplingMessage],
@@ -983,7 +1001,13 @@ class Context:
                 messages = step.history
         """
         _warn_sampling_deprecated()
-        if self._is_modern_protocol():
+        # On modern (2026-07-28) connections the client back-channel is gone
+        # (SEP-2577). A server-configured sampling handler can still answer
+        # entirely server-side; only raise the era error when nothing can serve
+        # the request. When modern, force the handler path (never attempt the
+        # dead client) by passing client_available=False.
+        client_available = not self._is_modern_protocol()
+        if not client_available and not self._server_can_sample():
             raise ToolError(_SAMPLING_MODERN_ERROR)
         return await sample_step_impl(
             self,
@@ -997,6 +1021,7 @@ class Context:
             auto_execute_tools=execute_tools,
             mask_error_details=mask_error_details,
             tool_concurrency=tool_concurrency,
+            client_available=client_available,
         )
 
     @overload
@@ -1093,7 +1118,13 @@ class Context:
             future FastMCP release. Call an LLM directly from your server instead.
         """
         _warn_sampling_deprecated()
-        if self._is_modern_protocol():
+        # On modern (2026-07-28) connections the client back-channel is gone
+        # (SEP-2577). A server-configured sampling handler can still answer
+        # entirely server-side; only raise the era error when nothing can serve
+        # the request. When modern, force the handler path (never attempt the
+        # dead client) by passing client_available=False.
+        client_available = not self._is_modern_protocol()
+        if not client_available and not self._server_can_sample():
             raise ToolError(_SAMPLING_MODERN_ERROR)
         return await sample_impl(  # ty: ignore[invalid-return-type]
             self,
@@ -1106,6 +1137,7 @@ class Context:
             result_type=result_type,
             mask_error_details=mask_error_details,
             tool_concurrency=tool_concurrency,
+            client_available=client_available,
         )
 
     @overload

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -21,12 +21,13 @@ from mcp_types import (
 )
 from mcp_types import Prompt as SDKPrompt
 from mcp_types import Resource as SDKResource
+from mcp_types.version import MODERN_PROTOCOL_VERSIONS
 from pydantic.networks import AnyUrl
 from typing_extensions import TypeVar
 from uncalled_for import SharedContext
 
 import fastmcp
-from fastmcp.exceptions import FastMCPDeprecationWarning
+from fastmcp.exceptions import FastMCPDeprecationWarning, ToolError
 from fastmcp.resources.base import ResourceResult
 from fastmcp.server.dependencies import FastMCPRequestContext, fastmcp_request_ctx
 from fastmcp.server.elicitation import (
@@ -78,6 +79,47 @@ ResultT = TypeVar("ResultT", default=str)
 
 # Import ToolChoiceOption from sampling module (after other imports)
 from fastmcp.server.sampling.run import ToolChoiceOption  # noqa: E402
+
+# Warn-once guards for the sampling deprecation. Server-initiated createMessage
+# was removed from MCP as of 2026-07-28 (SEP-2577); the warning fires a single
+# time per process to flag that ctx.sample/ctx.sample_step are on their way out.
+_sample_deprecation_warned = False
+
+_SAMPLING_DEPRECATION_MESSAGE = (
+    "ctx.sample() and ctx.sample_step() are deprecated and will be removed in a "
+    "future FastMCP release. They rely on server-initiated createMessage "
+    "requests, which were removed from MCP as of 2026-07-28 (SEP-2577), so they "
+    "work only on session-based (handshake-era) connections. Call an LLM "
+    "directly from your server instead."
+)
+
+_SAMPLING_MODERN_ERROR = (
+    "server-initiated sampling is not available on MCP 2026-07-28 connections; "
+    "SEP-2577 removed it — call an LLM from your server instead."
+)
+
+_ELICIT_MODERN_ERROR = (
+    "elicitation via server-initiated requests is unavailable on 2026-07-28 "
+    "connections."
+)
+
+
+def _warn_sampling_deprecated() -> None:
+    """Emit the sampling deprecation warning once per process.
+
+    Gated on ``settings.deprecation_warnings`` like every other FastMCP
+    deprecation; fires a single time (module-level flag) rather than per call.
+    """
+    global _sample_deprecation_warned
+    if _sample_deprecation_warned or not fastmcp.settings.deprecation_warnings:
+        return
+    _sample_deprecation_warned = True
+    warnings.warn(
+        _SAMPLING_DEPRECATION_MESSAGE,
+        FastMCPDeprecationWarning,
+        stacklevel=3,
+    )
+
 
 _current_context: ContextVar[Context | None] = ContextVar("context", default=None)
 
@@ -862,6 +904,20 @@ class Context:
             return
         await self.request_context.close_sse_stream()
 
+    def _is_modern_protocol(self) -> bool:
+        """True when the negotiated MCP protocol era removed the back-channel.
+
+        Reads the negotiated protocol version from the active request context.
+        The 2026-07-28 era (SEP-2577) has no back-channel for server-initiated
+        requests such as sampling/elicitation. Returns False when no request
+        context is available (e.g. background task or pre-session), leaving the
+        existing wire path to surface its own error.
+        """
+        rc = self.request_context
+        if rc is None:
+            return False
+        return rc.protocol_version in MODERN_PROTOCOL_VERSIONS
+
     async def sample_step(
         self,
         messages: str | Sequence[str | SamplingMessage],
@@ -926,6 +982,9 @@ class Context:
                 # Continue with tool results
                 messages = step.history
         """
+        _warn_sampling_deprecated()
+        if self._is_modern_protocol():
+            raise ToolError(_SAMPLING_MODERN_ERROR)
         return await sample_step_impl(
             self,
             messages=messages,
@@ -1027,12 +1086,15 @@ class Context:
             - .result: The typed result (str for text, parsed object for structured)
             - .history: All messages exchanged during sampling
 
-        Note:
-            Background task support for sampling is planned for a future release.
-            Currently, sampling in background tasks requires using the low-level
-            session.create_message() API directly.
+        Deprecated:
+            Server-initiated sampling relies on the createMessage back-channel,
+            which MCP removed as of 2026-07-28 (SEP-2577). This method works only
+            on session-based (handshake-era) connections and will be removed in a
+            future FastMCP release. Call an LLM directly from your server instead.
         """
-        # TODO: Add background task support similar to elicit() when is_background_task
+        _warn_sampling_deprecated()
+        if self._is_modern_protocol():
+            raise ToolError(_SAMPLING_MODERN_ERROR)
         return await sample_impl(  # ty: ignore[invalid-return-type]
             self,
             messages=messages,
@@ -1213,6 +1275,12 @@ class Context:
                 schema=config.schema,
             )
         else:
+            # Foreground push path: server-initiated elicitation needs a
+            # back-channel, which the 2026-07-28 era removed (SEP-2577). Raise a
+            # clear era-aware error before hitting the wire instead of the SDK's
+            # opaque "Method not found". Handshake-era behavior is unchanged.
+            if self._is_modern_protocol():
+                raise ToolError(_ELICIT_MODERN_ERROR)
             # Standard request mode: use session.elicit directly
             result = await self.session.elicit(
                 message=message,

--- a/fastmcp_slim/fastmcp/server/sampling/run.py
+++ b/fastmcp_slim/fastmcp/server/sampling/run.py
@@ -138,12 +138,19 @@ def _parse_model_preferences(
 # --- Standalone functions for sample_step() ---
 
 
-def determine_handler_mode(context: Context, needs_tools: bool) -> bool:
+def determine_handler_mode(
+    context: Context, needs_tools: bool, *, client_available: bool = True
+) -> bool:
     """Determine whether to use fallback handler or client for sampling.
 
     Args:
         context: The MCP context.
         needs_tools: Whether the sampling request requires tool support.
+        client_available: Whether the client back-channel can be reached at all.
+            On modern (2026-07-28) connections the server-initiated createMessage
+            back-channel was removed (SEP-2577), so the client can never serve a
+            sampling request; pass False there to force the server-side handler
+            path (``"fallback"`` behaves like ``"always"`` when a handler exists).
 
     Returns:
         True if fallback handler should be used, False to use client.
@@ -154,11 +161,13 @@ def determine_handler_mode(context: Context, needs_tools: bool) -> bool:
     fastmcp = context.fastmcp
     session = context.session
 
-    # Check what capabilities the client has
-    has_sampling = session.check_client_capability(
+    # Check what capabilities the client has. On connections without a
+    # back-channel the client can never serve the request regardless of the
+    # capabilities it advertised, so treat both as unavailable.
+    has_sampling = client_available and session.check_client_capability(
         capability=ClientCapabilities(sampling=SamplingCapability())
     )
-    has_tools_capability = session.check_client_capability(
+    has_tools_capability = client_available and session.check_client_capability(
         capability=ClientCapabilities(
             sampling=SamplingCapability(tools=SamplingToolsCapability())
         )
@@ -498,11 +507,17 @@ async def sample_step_impl(
     auto_execute_tools: bool = True,
     mask_error_details: bool | None = None,
     tool_concurrency: int | None = None,
+    client_available: bool = True,
 ) -> SampleStep:
     """Implementation of Context.sample_step().
 
     Make a single LLM sampling call. This is a stateless function that makes
     exactly one LLM call and optionally executes any requested tools.
+
+    When ``client_available`` is False (e.g. a modern 2026-07-28 connection with
+    no back-channel), the client is never used and a configured sampling handler
+    serves the request; the caller is responsible for raising a clear era error
+    when no handler can serve it.
     """
     # Convert messages to SamplingMessage objects
     current_messages = prepare_messages(messages)
@@ -517,7 +532,9 @@ async def sample_step_impl(
     )
 
     # Determine whether to use fallback handler or client
-    use_fallback = determine_handler_mode(context, bool(sampling_tools))
+    use_fallback = determine_handler_mode(
+        context, bool(sampling_tools), client_available=client_available
+    )
 
     # Build tool choice
     effective_tool_choice: ToolChoice | None = None
@@ -633,12 +650,18 @@ async def sample_impl(
     result_type: type[ResultT] | None = None,
     mask_error_details: bool | None = None,
     tool_concurrency: int | None = None,
+    client_available: bool = True,
 ) -> SamplingResult[ResultT]:
     """Implementation of Context.sample().
 
     Send a sampling request to the client and await the response. This method
     runs to completion automatically, executing a tool loop until the LLM
     provides a final text response.
+
+    When ``client_available`` is False (e.g. a modern 2026-07-28 connection with
+    no back-channel), the client is never used and a configured sampling handler
+    serves the request; the caller is responsible for raising a clear era error
+    when no handler can serve it.
     """
     # Safety limit to prevent infinite loops
     max_iterations = 100
@@ -675,6 +698,7 @@ async def sample_impl(
             tool_choice=tool_choice,
             mask_error_details=mask_error_details,
             tool_concurrency=tool_concurrency,
+            client_available=client_available,
         )
 
         # Check for final_response tool call for structured output

--- a/tests/server/test_protocol_eras.py
+++ b/tests/server/test_protocol_eras.py
@@ -34,6 +34,7 @@ from mcp_types.version import (
 )
 from pydantic import FileUrl
 
+import fastmcp
 from fastmcp import Client as FastMCPClient
 from fastmcp import Context, FastMCP
 from fastmcp.server.elicitation import AcceptedElicitation
@@ -341,6 +342,91 @@ async def test_elicit_sample_degradation_message_is_clear_on_modern(push_server,
 
 
 # ---------------------------------------------------------------------------
+# 3a-bis. Server-configured sampling handler answers WITHOUT the client
+# back-channel, so ctx.sample()/ctx.sample_step() must keep working on modern
+# connections. The era-gate only fires when nothing can serve the request.
+# ---------------------------------------------------------------------------
+
+
+def _handler_server(behavior) -> FastMCP:
+    """A server whose sampling is answered by a server-side handler."""
+
+    def sampling_handler(messages, params, ctx) -> str:
+        return "handler-answer"
+
+    mcp = FastMCP("handler", sampling_handler=sampling_handler)
+    if behavior is not None:
+        mcp.sampling_handler_behavior = behavior
+
+    @mcp.tool
+    async def do_sample(ctx: Context) -> str:
+        result = await ctx.sample("hello")
+        return f"sampled {result.text}"
+
+    @mcp.tool
+    async def do_sample_step(ctx: Context) -> str:
+        step = await ctx.sample_step("hello")
+        return f"stepped {step.text}"
+
+    return mcp
+
+
+@pytest.mark.parametrize("mode", MODERN_MODES)
+@pytest.mark.parametrize("behavior", ["always", "fallback"])
+@pytest.mark.parametrize("method", ["do_sample", "do_sample_step"])
+async def test_server_sampling_handler_works_on_modern(mode, behavior, method):
+    """A server-side sampling handler answers entirely server-side, so it works
+    on modern (2026-07-28) connections regardless of behavior. The era-gate must
+    NOT block these — nothing touches the removed client back-channel. Crucially,
+    'fallback' must go straight to the handler (no bare client-attempt failure)."""
+    server = _handler_server(behavior)
+    async with SDKClient(_server(server), mode=mode) as client:
+        result = await client.call_tool(method, {})
+    assert result.is_error is False
+    assert "handler-answer" in " ".join(_texts(result.content))
+
+
+@pytest.mark.parametrize("behavior", ["always", "fallback"])
+@pytest.mark.parametrize("method", ["do_sample", "do_sample_step"])
+async def test_server_sampling_handler_works_on_legacy(behavior, method):
+    """Handshake-era behavior is unchanged: the server-side handler still answers
+    on legacy connections."""
+    server = _handler_server(behavior)
+    async with SDKClient(_server(server), mode="legacy") as client:
+        result = await client.call_tool(method, {})
+    assert result.is_error is False
+    assert "handler-answer" in " ".join(_texts(result.content))
+
+
+@pytest.mark.parametrize("mode", MODERN_MODES)
+@pytest.mark.parametrize("method", ["do_sample", "do_sample_step"])
+async def test_sampling_without_handler_still_era_gated_on_modern(
+    push_server, mode, method
+):
+    """With no server-side handler configured, the request would hit the removed
+    client back-channel, so the clear era error still fires on modern."""
+    # push_server only defines do_sample; add a do_sample_step twin inline.
+    mcp = FastMCP("no-handler")
+
+    @mcp.tool
+    async def do_sample(ctx: Context) -> str:
+        result = await ctx.sample("hello")
+        return f"sampled {result.text}"
+
+    @mcp.tool
+    async def do_sample_step(ctx: Context) -> str:
+        step = await ctx.sample_step("hello")
+        return f"stepped {step.text}"
+
+    async with SDKClient(
+        _server(mcp), mode=mode, sampling_callback=_sampling_cb
+    ) as client:
+        result = await client.call_tool(method, {})
+    assert result.is_error is True
+    assert "server-initiated" in " ".join(_texts(result.content)).lower()
+
+
+# ---------------------------------------------------------------------------
 # 3b. Sampling deprecation warning (SEP-2577): ctx.sample/ctx.sample_step warn
 # ---------------------------------------------------------------------------
 
@@ -350,12 +436,13 @@ def reset_sample_warn_flag():
     """Reset the process-wide warn-once flag so a warning can be observed."""
     import fastmcp.server.context as context_module
 
-    original = context_module._sample_deprecation_warned
-    context_module._sample_deprecation_warned = False
+    original = set(context_module._sample_deprecation_warned)
+    context_module._sample_deprecation_warned.clear()
     try:
         yield
     finally:
-        context_module._sample_deprecation_warned = original
+        context_module._sample_deprecation_warned.clear()
+        context_module._sample_deprecation_warned.update(original)
 
 
 @pytest.mark.parametrize("method", ["do_sample", "do_sample_step"])
@@ -421,7 +508,6 @@ async def test_sampling_deprecation_warning_suppressible_via_settings(
     matching the house pattern for every other FastMCP deprecation."""
     import warnings as _warnings
 
-    import fastmcp
     from fastmcp.exceptions import FastMCPDeprecationWarning
 
     monkeypatch.setattr(fastmcp.settings, "deprecation_warnings", False)

--- a/tests/server/test_protocol_eras.py
+++ b/tests/server/test_protocol_eras.py
@@ -34,9 +34,8 @@ from mcp_types.version import (
 )
 from pydantic import FileUrl
 
-import fastmcp
 from fastmcp import Client as FastMCPClient
-from fastmcp import Context, FastMCP
+from fastmcp import Context, FastMCP, settings
 from fastmcp.server.elicitation import AcceptedElicitation
 from fastmcp.server.middleware import Middleware
 
@@ -510,7 +509,7 @@ async def test_sampling_deprecation_warning_suppressible_via_settings(
 
     from fastmcp.exceptions import FastMCPDeprecationWarning
 
-    monkeypatch.setattr(fastmcp.settings, "deprecation_warnings", False)
+    monkeypatch.setattr(settings, "deprecation_warnings", False)
 
     mcp = FastMCP("no-warn")
 

--- a/tests/server/test_protocol_eras.py
+++ b/tests/server/test_protocol_eras.py
@@ -321,21 +321,12 @@ async def test_list_roots_degradation_message_is_clear_on_modern(push_server):
     assert "back-channel" in message and "server-initiated" in message
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "sdk-feedback.md #10: elicitation/sampling attach a related_request_id, "
-        "so at 2026 the request reaches the client _on_request and fails with a "
-        "bare 'Method not found' KeyError instead of an era-aware "
-        "NoBackChannelError. list_roots (no related id) already degrades "
-        "clearly; elicit/sample do not."
-    ),
-)
 @pytest.mark.parametrize("tool", ["do_elicit", "do_sample"])
 async def test_elicit_sample_degradation_message_is_clear_on_modern(push_server, tool):
-    """Characterizes the inconsistency in #10: we WANT elicit/sample to surface
-    an era-aware message (like list_roots does). Currently they surface a bare
-    'Method not found', so this xfails strict until the SDK unifies the path.
+    """FastMCP era-gates elicit/sample: on a 2026-07-28 connection they raise a
+    clear, era-aware error before hitting the wire, instead of the SDK's opaque
+    'Method not found' (sdk-feedback.md #10). Both messages name the removed
+    server-initiated capability so the caller knows why the request degraded.
     """
     async with SDKClient(
         _server(push_server),
@@ -346,7 +337,109 @@ async def test_elicit_sample_degradation_message_is_clear_on_modern(push_server,
         result = await client.call_tool(tool, {})
     assert result.is_error is True
     message = " ".join(_texts(result.content)).lower()
-    assert "back-channel" in message or "server-initiated" in message
+    assert "server-initiated" in message
+
+
+# ---------------------------------------------------------------------------
+# 3b. Sampling deprecation warning (SEP-2577): ctx.sample/ctx.sample_step warn
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reset_sample_warn_flag():
+    """Reset the process-wide warn-once flag so a warning can be observed."""
+    import fastmcp.server.context as context_module
+
+    original = context_module._sample_deprecation_warned
+    context_module._sample_deprecation_warned = False
+    try:
+        yield
+    finally:
+        context_module._sample_deprecation_warned = original
+
+
+@pytest.mark.parametrize("method", ["do_sample", "do_sample_step"])
+async def test_sampling_emits_deprecation_warning(reset_sample_warn_flag, method):
+    """`ctx.sample()` and `ctx.sample_step()` emit a FastMCPDeprecationWarning
+    naming SEP-2577 and the server-side-LLM migration path."""
+    from fastmcp.exceptions import FastMCPDeprecationWarning
+
+    mcp = FastMCP("warn")
+
+    @mcp.tool
+    async def do_sample(ctx: Context) -> str:
+        await ctx.sample("hello")
+        return "ok"
+
+    @mcp.tool
+    async def do_sample_step(ctx: Context) -> str:
+        await ctx.sample_step("hello")
+        return "ok"
+
+    with pytest.warns(FastMCPDeprecationWarning, match="SEP-2577"):
+        async with SDKClient(
+            _server(mcp), mode="legacy", sampling_callback=_sampling_cb
+        ) as client:
+            await client.call_tool(method, {})
+
+
+async def test_sampling_deprecation_warning_fires_once_per_process(
+    reset_sample_warn_flag,
+):
+    """The deprecation warning is warn-once: a second sample call in the same
+    process does not re-warn."""
+    from fastmcp.exceptions import FastMCPDeprecationWarning
+
+    mcp = FastMCP("warn-once")
+
+    @mcp.tool
+    async def do_sample(ctx: Context) -> str:
+        await ctx.sample("hello")
+        return "ok"
+
+    with pytest.warns(FastMCPDeprecationWarning):
+        async with SDKClient(
+            _server(mcp), mode="legacy", sampling_callback=_sampling_cb
+        ) as client:
+            await client.call_tool("do_sample", {})
+
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", FastMCPDeprecationWarning)
+        async with SDKClient(
+            _server(mcp), mode="legacy", sampling_callback=_sampling_cb
+        ) as client:
+            result = await client.call_tool("do_sample", {})
+    assert result.is_error is False
+
+
+async def test_sampling_deprecation_warning_suppressible_via_settings(
+    reset_sample_warn_flag, monkeypatch
+):
+    """Setting `deprecation_warnings=False` suppresses the sampling warning,
+    matching the house pattern for every other FastMCP deprecation."""
+    import warnings as _warnings
+
+    import fastmcp
+    from fastmcp.exceptions import FastMCPDeprecationWarning
+
+    monkeypatch.setattr(fastmcp.settings, "deprecation_warnings", False)
+
+    mcp = FastMCP("no-warn")
+
+    @mcp.tool
+    async def do_sample(ctx: Context) -> str:
+        await ctx.sample("hello")
+        return "ok"
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", FastMCPDeprecationWarning)
+        async with SDKClient(
+            _server(mcp), mode="legacy", sampling_callback=_sampling_cb
+        ) as client:
+            result = await client.call_tool("do_sample", {})
+    assert result.is_error is False
 
 
 @pytest.mark.parametrize("mode", MODERN_MODES)


### PR DESCRIPTION
Server-side sampling is built on server-initiated `createMessage` requests, which SEP-2577 removed from the MCP protocol as of 2026-07-28 — the capability only exists on session-based (handshake-era) connections and has no future in the protocol. This deprecates `ctx.sample()` and `ctx.sample_step()` ahead of their removal in a later 4.x release: both now emit a once-per-process `FastMCPDeprecationWarning` (suppressible via settings, as usual), with the migration story stated plainly — call an LLM directly from your server.

It also fixes the opaque failure mode on modern connections. Previously, `ctx.sample()`/`ctx.elicit()` on a 2026-07-28 connection died deep in dispatch with a bare "Method not found" (while `ctx.list_roots()` got a clear back-channel error). Both now raise a clear, actionable error before touching the wire:

```
server-initiated sampling is not available on MCP 2026-07-28 connections;
SEP-2577 removed it — call an LLM from your server instead.
```

The two strict xfails tracking that degradation gap are now real passing tests. Handshake-era behavior is unchanged — sampling and elicitation keep working for every current client — and the client-side sampling handler infrastructure is deliberately retained. Docs: deprecation banner on the sampling guide, corrected protocol-era matrix in the upgrade guide, change-register entries.

Labels: enhancements, v4.
