### PR TITLE
fix(caching): preserve list icons and partition cache by Accept header (#4455, #4461)

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/caching.py
+++ b/fastmcp_slim/fastmcp/server/middleware/caching.py
@@ -306,7 +306,7 @@ class ResponseCachingMiddleware(Middleware):
         if self._list_tools_settings.get("enabled") is False:
             return await call_next(context)
 
-        cache_key: str = _get_auth_partition_key()
+        cache_key: str = _make_list_cache_key()
 
         if cached_value := await self._list_tools_cache.get(key=cache_key):
             return cached_value
@@ -322,6 +322,8 @@ class ResponseCachingMiddleware(Middleware):
                 parameters=tool.parameters,
                 output_schema=tool.output_schema,
                 annotations=tool.annotations,
+                icons=tool.icons,
+                execution=tool.execution,
                 meta=tool.meta,
                 tags=tool.tags,
             )
@@ -347,7 +349,7 @@ class ResponseCachingMiddleware(Middleware):
         if self._list_resources_settings.get("enabled") is False:
             return await call_next(context)
 
-        cache_key: str = _get_auth_partition_key()
+        cache_key: str = _make_list_cache_key()
 
         if cached_value := await self._list_resources_cache.get(key=cache_key):
             return cached_value
@@ -364,6 +366,7 @@ class ResponseCachingMiddleware(Middleware):
                 meta=resource.meta,
                 mime_type=resource.mime_type,
                 annotations=resource.annotations,
+                icons=resource.icons,
                 uri=resource.uri,
             )
             for resource in resources
@@ -388,7 +391,7 @@ class ResponseCachingMiddleware(Middleware):
         if self._list_prompts_settings.get("enabled") is False:
             return await call_next(context)
 
-        cache_key: str = _get_auth_partition_key()
+        cache_key: str = _make_list_cache_key()
 
         if cached_value := await self._list_prompts_cache.get(key=cache_key):
             return cached_value
@@ -403,6 +406,7 @@ class ResponseCachingMiddleware(Middleware):
                 description=prompt.description,
                 tags=prompt.tags,
                 meta=prompt.meta,
+                icons=prompt.icons,
                 arguments=prompt.arguments,
             )
             for prompt in prompts
@@ -567,6 +571,32 @@ def _get_auth_partition_key() -> str:
     if token is None:
         return ANONYMOUS_AUTH_KEY
     return _hash_cache_key(token.token)
+
+
+def _get_accept_partition_key() -> str:
+    """Return a normalized Accept header value for list-operation cache keys.
+
+    List responses can be serialized differently depending on the client's
+    Accept header (for example plaintext vs structured JSON). Partitioning
+    the cache by Accept prevents one client's negotiated format from being
+    served to another.
+    """
+    from fastmcp.server.dependencies import get_http_headers
+
+    headers = get_http_headers(include={"accept"})
+    accept = headers.get("accept", "").strip().lower()
+    if not accept:
+        return ""
+    return accept
+
+
+def _make_list_cache_key() -> str:
+    """Build a cache key for list operations (tools/resources/prompts)."""
+    auth_key = _get_auth_partition_key()
+    accept_key = _get_accept_partition_key()
+    if accept_key:
+        return _hash_cache_key(f"{auth_key}:{accept_key}")
+    return auth_key
 
 
 def _make_call_tool_cache_key(

--- a/tests/server/middleware/test_caching.py
+++ b/tests/server/middleware/test_caching.py
@@ -38,6 +38,7 @@ from fastmcp.server.middleware.caching import (
     ResponseCachingStatistics,
     _make_call_tool_cache_key,
     _make_get_prompt_cache_key,
+    _make_list_cache_key,
     _make_read_resource_cache_key,
 )
 from fastmcp.server.middleware.middleware import CallNext, MiddlewareContext
@@ -846,3 +847,50 @@ class TestAuthAwareCaching:
             assert {p.name for p in prompts} == {"public_prompt"}
         finally:
             auth_context_var.reset(tok)
+
+
+class TestListCacheKeyPartitioning:
+    """Regression tests for issue #4461: list caches must vary by Accept header."""
+
+    def test_list_cache_key_differs_by_accept_header(self, monkeypatch):
+        accepts = iter(["text/plain", "application/json"])
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_headers",
+            lambda **kwargs: {"accept": next(accepts)},
+        )
+        plain_key = _make_list_cache_key()
+        json_key = _make_list_cache_key()
+
+        assert plain_key != json_key
+
+    def test_list_cache_key_without_accept_uses_auth_partition(self, monkeypatch):
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_headers",
+            lambda **kwargs: {},
+        )
+        assert _make_list_cache_key() == ANONYMOUS_AUTH_KEY
+
+
+class TestListCachingPreservesIcons:
+    """Regression tests for issue #4455: icons must survive list caching."""
+
+    async def test_list_tools_preserves_icons_after_cache_hit(self):
+        from mcp.types import Icon
+
+        mcp_server = FastMCP("IconServer")
+        mcp_server.add_middleware(ResponseCachingMiddleware())
+
+        tool_icon = Icon(src="https://example.com/tool.png")
+
+        @mcp_server.tool(icons=[tool_icon])
+        def greet() -> str:
+            return "hello"
+
+        async with Client(mcp_server) as client:
+            tools_first = await client.list_tools()
+            tools_cached = await client.list_tools()
+
+        assert tools_first[0].icons is not None
+        assert tools_first[0].icons[0].src == "https://example.com/tool.png"
+        assert tools_cached[0].icons is not None
+        assert tools_cached[0].icons[0].src == "https://example.com/tool.png"


### PR DESCRIPTION
## Summary
- Preserve `icons` and `execution` when `ResponseCachingMiddleware` normalizes cached `tools/list` results (fixes #4455).
- Partition list-operation cache keys by the caller's `Accept` header so plaintext and JSON-negotiated list responses are not shared across clients (fixes #4461).
- Add regression tests for icon preservation and Accept-aware cache keys.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

Fixes #4455
Fixes #4461

Made with [Cursor](https://cursor.com)