### PR TITLE
Add examples/ to the ty static-analysis gate

### DIFF
--- a/examples/apps/qr_server/qr_server.py
+++ b/examples/apps/qr_server/qr_server.py
@@ -23,7 +23,7 @@ import base64
 import io
 
 import qrcode  # type: ignore[import-untyped]
-from mcp import types
+from mcp_types import ImageContent
 
 from fastmcp import FastMCP
 from fastmcp.apps import AppConfig, ResourceCSP
@@ -153,7 +153,7 @@ def generate_qr(
     img.save(buffer, format="PNG")
     b64 = base64.b64encode(buffer.getvalue()).decode()
     return ToolResult(
-        content=[types.ImageContent(type="image", data=b64, mimeType="image/png")]
+        content=[ImageContent(type="image", data=b64, mime_type="image/png")]
     )
 
 

--- a/examples/apps/quiz/quiz_server.py
+++ b/examples/apps/quiz/quiz_server.py
@@ -12,8 +12,6 @@ Usage:
 
 from __future__ import annotations
 
-from typing import TypedDict
-
 from prefab_ui.actions import SetState, ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage
 from prefab_ui.app import PrefabApp
@@ -30,6 +28,7 @@ from prefab_ui.components import (
     Text,
 )
 from prefab_ui.rx import ERROR, RESULT, Rx
+from typing_extensions import TypedDict
 
 from fastmcp import FastMCP, FastMCPApp
 

--- a/examples/apps/quiz/quiz_server.py
+++ b/examples/apps/quiz/quiz_server.py
@@ -12,6 +12,8 @@ Usage:
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 from prefab_ui.actions import SetState, ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage
 from prefab_ui.app import PrefabApp
@@ -33,7 +35,14 @@ from fastmcp import FastMCP, FastMCPApp
 
 app = FastMCPApp("Quiz")
 
-DEFAULT_QUESTIONS = [
+
+class Question(TypedDict):
+    question: str
+    options: list[str]
+    correct: int
+
+
+DEFAULT_QUESTIONS: list[Question] = [
     {
         "question": "What is the capital of Australia?",
         "options": ["Sydney", "Melbourne", "Canberra", "Perth"],
@@ -102,7 +111,7 @@ def submit_answer(
 @app.ui()
 def take_quiz(
     topic: str = "General Knowledge",
-    questions: list[dict] | None = None,
+    questions: list[Question] | None = None,
 ) -> PrefabApp:
     """Launch a quiz UI.
 

--- a/examples/apps/sales_dashboard/sales_dashboard_server.py
+++ b/examples/apps/sales_dashboard/sales_dashboard_server.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from prefab_ui.components import (
     Card,
     CardContent,
@@ -17,7 +19,15 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("Sales Dashboard")
 
-MONTHLY_REVENUE = [
+
+class MonthlyRevenue(TypedDict):
+    month: str
+    new_business: int
+    expansion: int
+    renewal: int
+
+
+MONTHLY_REVENUE: list[MonthlyRevenue] = [
     {"month": "Jul", "new_business": 182_000, "expansion": 74_000, "renewal": 210_000},
     {"month": "Aug", "new_business": 195_000, "expansion": 81_000, "renewal": 215_000},
     {"month": "Sep", "new_business": 224_000, "expansion": 93_000, "renewal": 208_000},

--- a/examples/auth/aws_oauth/server.py
+++ b/examples/auth/aws_oauth/server.py
@@ -48,6 +48,8 @@ def echo(message: str) -> str:
 async def get_access_token_claims() -> dict:
     """Get the authenticated user's access token claims."""
     token = get_access_token()
+    if token is None:
+        return {"error": "Not authenticated"}
     return {
         "sub": token.claims.get("sub"),
         "username": token.claims.get("username"),

--- a/examples/auth/huggingface_oauth/server.py
+++ b/examples/auth/huggingface_oauth/server.py
@@ -2,6 +2,7 @@ import os
 
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.huggingface import HuggingFaceProvider
+from fastmcp.server.dependencies import get_access_token
 
 auth_provider = HuggingFaceProvider(
     # Your Hugging Face OAuth app client ID
@@ -21,9 +22,9 @@ mcp = FastMCP(name="Hugging Face Secured App", auth=auth_provider)
 @mcp.tool
 async def get_user_info() -> dict:
     """Returns information about the authenticated Hugging Face user."""
-    from fastmcp.server.dependencies import get_access_token
-
     token = get_access_token()
+    if token is None:
+        return {"error": "Not authenticated"}
     return {
         "subject": token.claims.get("sub"),
         "username": token.claims.get("preferred_username"),

--- a/examples/auth/keycloak_oauth/server.py
+++ b/examples/auth/keycloak_oauth/server.py
@@ -33,6 +33,8 @@ def echo(message: str) -> str:
 async def get_access_token_claims() -> dict:
     """Get the authenticated user's access token claims."""
     token = get_access_token()
+    if token is None:
+        return {"error": "Not authenticated"}
     return {
         "sub": token.claims.get("sub"),
         "scope": token.claims.get("scope"),

--- a/examples/custom_tool_serializer_decorator.py
+++ b/examples/custom_tool_serializer_decorator.py
@@ -14,6 +14,7 @@ import yaml
 
 from fastmcp import Client, FastMCP
 from fastmcp.tools import ToolResult
+from fastmcp.types import TextContent
 
 
 def with_serializer(serializer: Callable[[Any], str]):
@@ -59,7 +60,8 @@ async def example_usage():
         # YAML serialized tool
         yaml_result = await client.call_tool("get_example_data", {})
         print("YAML Tool Result:")
-        print(yaml_result.data)
+        if yaml_result.content and isinstance(yaml_result.content[0], TextContent):
+            print(yaml_result.content[0].text)
         print()
 
         # Default JSON serialized tool

--- a/examples/custom_tool_serializer_decorator.py
+++ b/examples/custom_tool_serializer_decorator.py
@@ -12,8 +12,8 @@ from typing import Any
 
 import yaml
 
-from fastmcp import FastMCP
-from fastmcp.tools.tool import ToolResult
+from fastmcp import Client, FastMCP
+from fastmcp.tools import ToolResult
 
 
 def with_serializer(serializer: Callable[[Any], str]):
@@ -55,18 +55,18 @@ def get_json_data() -> dict:
 
 
 async def example_usage():
-    # YAML serialized tool
-    yaml_result = await server._call_tool_mcp("get_example_data", {})
-    print("YAML Tool Result:")
-    print(yaml_result)
-    print()
+    async with Client(server) as client:
+        # YAML serialized tool
+        yaml_result = await client.call_tool("get_example_data", {})
+        print("YAML Tool Result:")
+        print(yaml_result.data)
+        print()
 
-    # Default JSON serialized tool
-    json_result = await server._call_tool_mcp("get_json_data", {})
-    print("JSON Tool Result:")
-    print(json_result)
+        # Default JSON serialized tool
+        json_result = await client.call_tool("get_json_data", {})
+        print("JSON Tool Result:")
+        print(json_result.data)
 
 
 if __name__ == "__main__":
     asyncio.run(example_usage())
-    server.run()

--- a/examples/providers/sqlite/server.py
+++ b/examples/providers/sqlite/server.py
@@ -23,7 +23,7 @@ from rich import print
 
 from fastmcp import Client, FastMCP
 from fastmcp.server.providers import Provider
-from fastmcp.tools.tool import Tool, ToolResult
+from fastmcp.tools import Tool, ToolResult
 
 DB_PATH = Path(__file__).parent / "tools.db"
 

--- a/examples/skills/client.py
+++ b/examples/skills/client.py
@@ -41,7 +41,7 @@ async def main():
         print("=== Resource Templates ===")
         templates = await client.list_resource_templates()
         for t in templates:
-            print(f"  {t.uriTemplate}")
+            print(f"  {t.uri_template}")
         print()
 
         # Read a skill's main file

--- a/examples/task_elicitation.py
+++ b/examples/task_elicitation.py
@@ -51,6 +51,7 @@ async def plan_dinner(ctx: Context) -> str:
         return "Dinner cancelled!"
 
     prefs = result.data
+    assert isinstance(prefs, DinnerPrefs)
     await ctx.report_progress(1, 2, "Planning your menu...")
     await asyncio.sleep(1)
     await ctx.report_progress(2, 2, "Done!")

--- a/examples/text_me.py
+++ b/examples/text_me.py
@@ -28,9 +28,7 @@ from fastmcp import FastMCP
 
 
 class SurgeSettings(BaseSettings):
-    model_config: SettingsConfigDict = SettingsConfigDict(
-        env_prefix="SURGE_", env_file=".env"
-    )
+    model_config = SettingsConfigDict(env_prefix="SURGE_", env_file=".env")
 
     api_key: str
     account_id: str

--- a/examples/tool_result_echo.py
+++ b/examples/tool_result_echo.py
@@ -10,7 +10,7 @@ import time
 from dataclasses import dataclass
 
 from fastmcp import FastMCP
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import ToolResult
 
 mcp = FastMCP("Echo Server")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,14 +137,32 @@ python_functions = ["test_*"]
 addopts = ["--inline-snapshot=disable"]
 
 [tool.ty.src]
-include = ["fastmcp_slim", "fastmcp_remote", "tests"]
-exclude = ["**/node_modules", "**/__pycache__", ".venv", ".git", "dist"]
+include = ["fastmcp_slim", "fastmcp_remote", "tests", "examples"]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    ".venv",
+    ".git",
+    "dist",
+    # Example subtrees excluded from the ty gate. Each either pins its own
+    # fastmcp (resolved against a different install) or requires a third-party
+    # dependency not installed in this tree.
+    "examples/testing_demo",             # own uv.lock, targets fastmcp v1 on purpose
+    "examples/atproto_mcp",              # needs atproto (+ its own package)
+    "examples/smart_home",              # needs phue
+    "examples/apps/qr_server",          # needs qrcode
+    "examples/providers/sqlite",        # needs aiosqlite
+    "examples/memory.py",               # needs asyncpg, numpy, pydantic_ai, pgvector
+    "examples/get_file.py",             # needs aiohttp
+]
 
 [tool.ty.environment]
 python-version = "3.10"
 
 [tool.ty.analysis]
-replace-imports-with-any = ["prefab_ui.**"]
+# prefab_ui is the apps SDK; pyautogui/PIL are optional runtime deps used only
+# inside example tool bodies (screenshot demos) and are not installed here.
+replace-imports-with-any = ["prefab_ui.**", "pyautogui", "PIL", "PIL.**"]
 
 [tool.ty.rules]
 division-by-zero = "warn"


### PR DESCRIPTION
The `examples/` directory sits outside every CI gate — not type-checked, not import-checked, not run. During the SDK v2 migration this bit us four separate times: stale idioms (`from mcp import types`, `mimeType=`, `fastmcp.tools.tool`, `uriTemplate`, `server._call_tool_mcp`) shipped in examples and were only caught by hand, one commit at a time. The prior attempt (#4465) added a bespoke import-resolution test that walked `examples/` and asserted the `fastmcp`/`mcp` imports resolved — but that only ever checked imports, and it was a whole test file to maintain for a narrow slice of what actually goes stale.

This folds `examples/` into the existing `ty` static-analysis gate instead, so every CI run type-checks the examples the same way it checks the library — imports *and* types, on every SDK bump, with no new machinery. The examples were made compliant: the stale SDK idioms are fixed, and genuine type errors are addressed at the source (auth examples narrow `get_access_token()`'s `AccessToken | None` before reading `.claims`, matching the existing guard in `propelauth_oauth`; the sales-dashboard and quiz apps get `TypedDict`s so their heterogeneous data rows type cleanly; `text_me` drops a Liskov-violating `model_config` annotation). Subtrees that can't be checked against this tree's environment are excluded with a one-line reason each: `examples/testing_demo` pins fastmcp v1 on purpose, and `atproto_mcp` / `smart_home` / `apps/qr_server` / `providers/sqlite` / `memory.py` / `get_file.py` require third-party deps (`atproto`, `phue`, `qrcode`, `aiosqlite`, `asyncpg`/`numpy`/`pydantic_ai`/`pgvector`, `aiohttp`) that aren't installed here. The optional screenshot deps (`pyautogui`, `PIL`) are mapped to `Any` alongside the existing `prefab_ui.**` entry.

Before, a renamed SDK symbol in an example reached `main` and was found by a human reading the diff. After, `uv run ty check` fails in CI the moment an example drifts:

```toml
[tool.ty.src]
include = ["fastmcp_slim", "fastmcp_remote", "tests", "examples"]
```

The appropriate label is `chores` (or `enhancements`). ty is the static gate; runtime coverage is partial by nature — the in-memory examples (proxy, mount, search, versioning, the client/server pairs, serializer/tool-result demos) run green locally, while OAuth, sampling, and live-server examples can't run in CI without keys or external services.
