### PR TITLE
Docs: add v3.4.4 changelog entries

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,25 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v3.4.4" description="2026-07-08">
+
+**[v3.4.4: Host in Translation](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.4)**
+
+FastMCP 3.4.4 restores HTTP deployment compatibility after the 3.4.3 Host/Origin guard changed default behavior for existing ASGI, serverless, and reverse-proxy deployments. The guard implementation remains available for deployments that opt in with explicit trusted hosts and origins, while 3.x returns to accepting traffic that worked before the patch. This release also adds Hugging Face OAuth provider support, with docs and examples for public and private apps, PKCE, Dynamic Client Registration, and CIMD.
+
+### Enhancements ✨
+* Hugging Face Auth Integration by [@evalstate](https://github.com/evalstate) in [#4385](https://github.com/PrefectHQ/fastmcp/pull/4385)
+### Fixes 🐞
+* Relax host origin guard defaults by [@jlowin](https://github.com/jlowin) in [#4439](https://github.com/PrefectHQ/fastmcp/pull/4439)
+* Restore HTTP host guard compatibility by [@jlowin](https://github.com/jlowin) in [#4472](https://github.com/PrefectHQ/fastmcp/pull/4472)
+
+## New Contributors
+* @evalstate made their first contribution in [#4385](https://github.com/PrefectHQ/fastmcp/pull/4385)
+
+**Full Changelog**: [v3.4.3...v3.4.4](https://github.com/PrefectHQ/fastmcp/compare/v3.4.3...v3.4.4)
+
+</Update>
+
 <Update label="v3.4.3" description="2026-07-05">
 
 **[v3.4.3: The Fast and the Secure-ious](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.3)**

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,22 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 3.4.4" description="July 8, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v3.4.4: Host in Translation"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.4"
+cta="Read the release notes"
+>
+A compatibility patch for HTTP deployments affected by the 3.4.3 Host/Origin guard defaults. FastMCP 3.x now keeps strict Host and Origin validation available for explicit opt-in deployments without rejecting existing ASGI, serverless, and reverse-proxy traffic by default.
+
+🌐 **HTTP compatibility restored** — existing hosted deployments keep accepting their public Host headers unless strict host/origin protection is configured.
+
+🔐 **Guard remains available** — deployments that know their public host and browser origins can still enable strict validation with `host_origin_protection=True`, `allowed_hosts`, and `allowed_origins`.
+
+🤗 **Hugging Face auth** — new OAuth provider support covers public and private Hugging Face apps, with docs and examples for PKCE, Dynamic Client Registration, and CIMD.
+</Card>
+</Update>
+
 <Update label="FastMCP 3.4.3" description="July 5, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v3.4.3: The Fast and the Secure-ious"
@@ -725,4 +741,3 @@ Because life's too short for boilerplate.
 This is where it all started. FastMCP’s launch post introduced a clean, Pythonic way to build MCP servers without the protocol overhead. Just write functions; FastMCP handles the rest. What began as a weekend project quickly became the foundation of a growing ecosystem.
 </Card>
 </Update>
-


### PR DESCRIPTION
FastMCP 3.4.4 needs the hand-maintained docs entries in place before the release is cut, so the published docs include the changelog as soon as the tag is created. This adds the `Host in Translation` release entry to both the full changelog and the updates feed, matching the generated GitHub notes for the Host/Origin compatibility fixes and the Hugging Face auth provider.

The release keeps strict Host/Origin validation available for deployments that opt in intentionally:

```python
app = mcp.http_app(
    host_origin_protection=True,
    allowed_hosts=["mcp.example.com"],
    allowed_origins=["https://app.example.com"],
)
```
