### PR TITLE
Path-scope authorization-server metadata discovery for subpath deployments

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/auth.py
+++ b/fastmcp_slim/fastmcp/server/auth/auth.py
@@ -720,6 +720,46 @@ class OAuthProvider(
         """
         return await self.load_access_token(token)
 
+    def _path_scope_authorization_server_metadata(
+        self, routes: list[Route]
+    ) -> list[Route]:
+        """Scope the authorization-server metadata route to the issuer subpath.
+
+        ``server/http.py`` mounts :meth:`get_routes` directly, so when the server
+        is deployed under a ``base_url``/``issuer_url`` subpath the
+        authorization-server metadata route must be path-scoped here (RFC 8414
+        path-aware discovery) — otherwise it lands at the host root
+        ``/.well-known/oauth-authorization-server`` and collides with any other
+        OAuth server sharing the host under a different subpath.
+        :meth:`get_well_known_routes` performs the equivalent scoping for callers
+        that mount the well-known routes manually. See PrefectHQ/fastmcp#4390.
+        """
+        if not self.issuer_url:
+            return routes
+
+        issuer_path = urlparse(str(self.issuer_url)).path.rstrip("/")
+        if not issuer_path or issuer_path == "/":
+            return routes
+
+        scoped_routes: list[Route] = []
+        for route in routes:
+            if (
+                isinstance(route, Route)
+                and route.path == "/.well-known/oauth-authorization-server"
+            ):
+                scoped_routes.append(
+                    Route(
+                        f"/.well-known/oauth-authorization-server{issuer_path}",
+                        endpoint=route.endpoint,
+                        methods=route.methods,
+                        name=route.name,
+                        include_in_schema=route.include_in_schema,
+                    )
+                )
+            else:
+                scoped_routes.append(route)
+        return scoped_routes
+
     def get_routes(
         self,
         mcp_path: str | None = None,
@@ -797,6 +837,11 @@ class OAuthProvider(
         # Add base routes
         oauth_routes.extend(super().get_routes(mcp_path))
 
+        # RFC 8414 path-aware discovery: server/http.py mounts these routes
+        # directly, so the authorization-server metadata route must be scoped to
+        # the issuer subpath here (not only in get_well_known_routes). See #4390.
+        oauth_routes = self._path_scope_authorization_server_metadata(oauth_routes)
+
         return oauth_routes
 
     def get_well_known_routes(
@@ -829,7 +874,9 @@ class OAuthProvider(
 
         new_routes = []
         for route in routes:
-            if route.path != "/.well-known/oauth-authorization-server":
+            # Match by prefix so the authorization-server metadata route is still
+            # recognized after get_routes() has path-scoped it (see #4390).
+            if not route.path.startswith("/.well-known/oauth-authorization-server"):
                 new_routes.append(route)
                 continue
 

--- a/tests/server/auth/test_oauth_mounting.py
+++ b/tests/server/auth/test_oauth_mounting.py
@@ -11,7 +11,7 @@ import pytest
 from key_value.aio.stores.memory import MemoryStore
 from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
-from starlette.routing import Mount
+from starlette.routing import Mount, Route
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import RemoteAuthProvider
@@ -267,6 +267,97 @@ class TestOAuthMounting:
                 "https://api.example.com/api",
                 "https://api.example.com/api/",
             ]
+
+    def test_get_routes_authorization_server_metadata_is_path_scoped(
+        self, test_tokens
+    ):
+        """Regression test for issue #4390.
+
+        ``server/http.py`` mounts ``get_routes()`` directly, so the
+        authorization-server metadata route it returns must be path-scoped when
+        the server is deployed under a ``base_url`` subpath. Otherwise two
+        servers sharing a host under different subpaths both claim the host-root
+        ``/.well-known/oauth-authorization-server`` and only one can win.
+        """
+        auth_provider = OAuthProxy(
+            upstream_authorization_endpoint="https://upstream.example.com/authorize",
+            upstream_token_endpoint="https://upstream.example.com/token",
+            upstream_client_id="test-client-id",
+            upstream_client_secret="unused",
+            token_verifier=StaticTokenVerifier(tokens=test_tokens),
+            base_url="https://api.example.com/vault",  # deployed under /vault
+            client_storage=MemoryStore(),
+        )
+
+        route_paths = {
+            route.path
+            for route in auth_provider.get_routes(mcp_path="/mcp")
+            if isinstance(route, Route)
+        }
+
+        # Path-scoped per RFC 8414 ...
+        assert "/.well-known/oauth-authorization-server/vault" in route_paths
+        # ... and NOT at the colliding host root.
+        assert "/.well-known/oauth-authorization-server" not in route_paths
+        # Protected-resource metadata stays path-scoped (RFC 9728), unchanged.
+        assert any(
+            path.startswith("/.well-known/oauth-protected-resource")
+            for path in route_paths
+        )
+
+    def test_get_routes_and_well_known_agree_on_auth_server_path(self, test_tokens):
+        """get_routes() and get_well_known_routes() must expose the same single
+        authorization-server metadata path for a subpath deployment (#4390)."""
+        auth_provider = OAuthProxy(
+            upstream_authorization_endpoint="https://upstream.example.com/authorize",
+            upstream_token_endpoint="https://upstream.example.com/token",
+            upstream_client_id="test-client-id",
+            upstream_client_secret="unused",
+            token_verifier=StaticTokenVerifier(tokens=test_tokens),
+            base_url="https://api.example.com/vault",
+            client_storage=MemoryStore(),
+        )
+
+        def auth_server_paths(routes):
+            return sorted(
+                route.path
+                for route in routes
+                if isinstance(route, Route)
+                and route.path.startswith("/.well-known/oauth-authorization-server")
+            )
+
+        expected = ["/.well-known/oauth-authorization-server/vault"]
+        assert auth_server_paths(auth_provider.get_routes(mcp_path="/mcp")) == expected
+        assert (
+            auth_server_paths(auth_provider.get_well_known_routes(mcp_path="/mcp"))
+            == expected
+        )
+
+    def test_get_routes_authorization_server_metadata_root_deployment(
+        self, test_tokens
+    ):
+        """Root deployments keep the host-root metadata path (no #4390 regression)."""
+        auth_provider = OAuthProxy(
+            upstream_authorization_endpoint="https://upstream.example.com/authorize",
+            upstream_token_endpoint="https://upstream.example.com/token",
+            upstream_client_id="test-client-id",
+            upstream_client_secret="unused",
+            token_verifier=StaticTokenVerifier(tokens=test_tokens),
+            base_url="https://api.example.com",  # root, no subpath
+            client_storage=MemoryStore(),
+        )
+
+        route_paths = {
+            route.path
+            for route in auth_provider.get_routes(mcp_path="/mcp")
+            if isinstance(route, Route)
+        }
+
+        assert "/.well-known/oauth-authorization-server" in route_paths
+        assert not any(
+            path.startswith("/.well-known/oauth-authorization-server/")
+            for path in route_paths
+        )
 
     async def test_oauth_authorization_server_metadata_path_aware_discovery(
         self, test_tokens


### PR DESCRIPTION
## Description

Closes #4390.

`server/http.py` mounts `OAuthProvider.get_routes()` directly, but that method exposed the authorization-server metadata at the host root `/.well-known/oauth-authorization-server` even when the server is deployed under a `base_url` subpath. Two OAuth servers sharing a host under different subpaths therefore collide on the same discovery URL. The path-aware route existed only in `get_well_known_routes()`, which `http.py` does not mount.

This path-scopes the authorization-server metadata route to the issuer path in `get_routes()` (RFC 8414), matching how `get_well_known_routes()` and protected-resource metadata (RFC 9728) already behave. Root deployments are unchanged.

## Contribution type

- [x] Bug fix (well-scoped fix for a clearly broken behavior)

## Checklist

- [x] This PR addresses an existing issue (#4390)
- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes

## Tests

New regression tests in `tests/server/auth/test_oauth_mounting.py`:

- `test_get_routes_authorization_server_metadata_is_path_scoped` — a subpath deployment exposes `/.well-known/oauth-authorization-server/vault`, not the host-root path.
- `test_get_routes_and_well_known_agree_on_auth_server_path` — `get_routes()` and `get_well_known_routes()` agree on the single authorization-server metadata path.
- `test_get_routes_authorization_server_metadata_root_deployment` — root deployments keep the host-root path (no regression).
