### PR TITLE
Improve DescopeProvider scope discovery and well-known URL support

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/providers/descope.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/descope.py
@@ -21,6 +21,92 @@ from fastmcp.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+_OPENID_CONFIGURATION_SUFFIX = "/.well-known/openid-configuration"
+_OAUTH_AUTHORIZATION_SERVER_SUFFIX = "/.well-known/oauth-authorization-server"
+
+
+def _normalize_openid_configuration_url(
+    config_url: str,
+) -> tuple[str, str]:
+    """Return (issuer_url, openid_configuration_url) from a Descope config URL."""
+    config_url = config_url.rstrip("/")
+    if config_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
+        issuer_url = config_url[: -len(_OPENID_CONFIGURATION_SUFFIX)]
+        return issuer_url, config_url
+
+    openid_configuration_url = f"{config_url}{_OPENID_CONFIGURATION_SUFFIX}"
+    return config_url, openid_configuration_url
+
+
+def _parse_descope_config_url(
+    config_url: str,
+) -> tuple[str, str, str, str]:
+    """Parse a Descope well-known URL into connection details.
+
+    Supports both resource-specific MCP Server URLs:
+        /v1/apps/agentic/{project_id}/{mcp_server_id}/.well-known/openid-configuration
+    and project-level inbound app URLs:
+        /v1/apps/{project_id}/.well-known/openid-configuration
+
+    Returns:
+        Tuple of (descope_base_url, project_id, issuer_url, openid_configuration_url)
+    """
+    issuer_url, openid_configuration_url = _normalize_openid_configuration_url(config_url)
+    parsed_url = urlparse(issuer_url)
+    path_parts = parsed_url.path.strip("/").split("/")
+    descope_base_url = f"{parsed_url.scheme}://{parsed_url.netloc}".rstrip("/")
+
+    if "agentic" in path_parts:
+        agentic_index = path_parts.index("agentic")
+        if agentic_index + 1 >= len(path_parts):
+            raise ValueError(
+                f"Could not extract project_id from config_url: {issuer_url}"
+            )
+        project_id = path_parts[agentic_index + 1]
+    elif "apps" in path_parts:
+        apps_index = path_parts.index("apps")
+        if apps_index + 1 >= len(path_parts):
+            raise ValueError(
+                f"Could not extract project_id from config_url: {issuer_url}"
+            )
+        project_id = path_parts[apps_index + 1]
+        if project_id == "agentic":
+            raise ValueError(
+                f"Could not extract project_id from config_url: {issuer_url}"
+            )
+    else:
+        raise ValueError(
+            "Could not parse config_url: expected a Descope apps well-known URL "
+            f"(/v1/apps/{{project_id}}/... or /v1/apps/agentic/{{project_id}}/...): "
+            f"{issuer_url}"
+        )
+
+    return descope_base_url, project_id, issuer_url, openid_configuration_url
+
+
+def _oauth_authorization_server_url(openid_configuration_url: str) -> str:
+    if openid_configuration_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
+        return openid_configuration_url[: -len(_OPENID_CONFIGURATION_SUFFIX)] + (
+            _OAUTH_AUTHORIZATION_SERVER_SUFFIX
+        )
+    return f"{openid_configuration_url.rstrip('/')}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
+
+
+def _fetch_openid_configuration(openid_configuration_url: str) -> dict | None:
+    try:
+        response = httpx.get(openid_configuration_url, timeout=10.0)
+        response.raise_for_status()
+        metadata = response.json()
+        if isinstance(metadata, dict):
+            return metadata
+    except Exception:
+        logger.warning(
+            "Failed to fetch Descope OpenID configuration from %s",
+            openid_configuration_url,
+            exc_info=True,
+        )
+    return None
+
 
 class DescopeProvider(RemoteAuthProvider):
     """Descope metadata provider for DCR (Dynamic Client Registration).
@@ -40,7 +126,9 @@ class DescopeProvider(RemoteAuthProvider):
 
     2. Note your Well-Known URL:
        - Save your Well-Known URL from [MCP Server Settings](https://app.descope.com/mcp-servers)
-       - Format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
+       - Recommended format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
+       - Project-level format is also supported:
+         ``https://.../v1/apps/P.../.well-known/openid-configuration``
 
     For detailed setup instructions, see:
     https://docs.descope.com/identity-federation/inbound-apps/creating-inbound-apps#method-2-dynamic-client-registration-dcr
@@ -77,55 +165,43 @@ class DescopeProvider(RemoteAuthProvider):
 
         Args:
             base_url: Public URL of this FastMCP server
-            config_url: Your Descope Well-Known URL (e.g., "https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration")
-                This is the new recommended way. If provided, project_id and descope_base_url are ignored.
+            config_url: Your Descope Well-Known URL. Prefer the MCP Server-specific URL
+                (``/v1/apps/agentic/P.../M.../.well-known/openid-configuration``). Project-level
+                URLs (``/v1/apps/P.../.well-known/openid-configuration``) are also supported.
+                If provided, project_id and descope_base_url are ignored.
             project_id: Your Descope Project ID (e.g., "P2abc123"). Used with descope_base_url for backwards compatibility.
             descope_base_url: Your Descope base URL (e.g., "https://api.descope.com"). Used with project_id for backwards compatibility.
-            required_scopes: Optional list of scopes that must be present in validated tokens.
-                These scopes will be included in the protected resource metadata.
-            scopes_supported: Optional list of scopes to advertise in OAuth metadata.
-                If None, uses required_scopes. Use this when the scopes clients should
-                request differ from the scopes enforced on tokens.
+            required_scopes: Scopes that must be present in validated tokens. When omitted,
+                tokens are not rejected for missing global scopes.
+            scopes_supported: Scopes advertised to MCP clients via protected resource metadata.
+                When omitted, scopes are discovered from ``scopes_supported`` in the configured
+                well-known OpenID document. Defaults to ``required_scopes`` when neither is
+                provided.
             resource_name: Optional name for the protected resource metadata.
             resource_documentation: Optional documentation URL for the protected resource.
             token_verifier: Optional token verifier. If None, creates JWT verifier for Descope
         """
         self.base_url = AnyHttpUrl(str(base_url).rstrip("/"))
+        self.openid_configuration_url: str | None = None
+        self.oauth_authorization_server_metadata_url: str | None = None
 
-        # Parse scopes if provided as string
-        parsed_scopes = (
+        parsed_required_scopes = (
             parse_scopes(required_scopes) if required_scopes is not None else None
+        )
+        parsed_scopes_supported = (
+            parse_scopes(scopes_supported) if scopes_supported is not None else None
         )
 
         # Determine which API is being used
         if config_url is not None:
-            # New API: use config_url
-            # Strip /.well-known/openid-configuration from config_url if present
-            issuer_url = str(config_url)
-            if issuer_url.endswith("/.well-known/openid-configuration"):
-                issuer_url = issuer_url[: -len("/.well-known/openid-configuration")]
-
-            # Parse the issuer URL to extract descope_base_url and project_id for other uses
-            parsed_url = urlparse(issuer_url)
-            path_parts = parsed_url.path.strip("/").split("/")
-
-            # Extract project_id from path (format: /v1/apps/agentic/P.../M...)
-            if "agentic" in path_parts:
-                agentic_index = path_parts.index("agentic")
-                if agentic_index + 1 < len(path_parts):
-                    self.project_id = path_parts[agentic_index + 1]
-                else:
-                    raise ValueError(
-                        f"Could not extract project_id from config_url: {issuer_url}"
-                    )
-            else:
-                raise ValueError(
-                    f"Could not find 'agentic' in config_url path: {issuer_url}"
-                )
-
-            # Extract descope_base_url (scheme + netloc)
-            self.descope_base_url = f"{parsed_url.scheme}://{parsed_url.netloc}".rstrip(
-                "/"
+            (
+                self.descope_base_url,
+                self.project_id,
+                issuer_url,
+                self.openid_configuration_url,
+            ) = _parse_descope_config_url(str(config_url))
+            self.oauth_authorization_server_metadata_url = (
+                _oauth_authorization_server_url(self.openid_configuration_url)
             )
         elif project_id is not None and descope_base_url is not None:
             # Old API: use project_id and descope_base_url
@@ -137,10 +213,36 @@ class DescopeProvider(RemoteAuthProvider):
             self.descope_base_url = descope_base_url_str
             # Old issuer format
             issuer_url = f"{self.descope_base_url}/v1/apps/{self.project_id}"
+            self.openid_configuration_url = (
+                f"{issuer_url}{_OPENID_CONFIGURATION_SUFFIX}"
+            )
+            self.oauth_authorization_server_metadata_url = (
+                f"{issuer_url}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
+            )
         else:
             raise ValueError(
                 "Either config_url (new API) or both project_id and descope_base_url (old API) must be provided"
             )
+
+        if (
+            parsed_scopes_supported is None
+            and parsed_required_scopes is None
+            and self.openid_configuration_url is not None
+        ):
+            openid_configuration = _fetch_openid_configuration(
+                self.openid_configuration_url
+            )
+            if openid_configuration is not None:
+                discovered_scopes = openid_configuration.get("scopes_supported")
+                if isinstance(discovered_scopes, list):
+                    parsed_scopes_supported = [
+                        scope for scope in discovered_scopes if isinstance(scope, str)
+                    ]
+                    if parsed_scopes_supported:
+                        logger.info(
+                            "Discovered scopes_supported from Descope well-known: %s",
+                            parsed_scopes_supported,
+                        )
 
         # Create default JWT verifier if none provided
         if token_verifier is None:
@@ -149,7 +251,7 @@ class DescopeProvider(RemoteAuthProvider):
                 issuer=issuer_url,
                 algorithm="RS256",
                 audience=self.project_id,
-                required_scopes=parsed_scopes,
+                required_scopes=parsed_required_scopes,
             )
 
         # Initialize RemoteAuthProvider with Descope as the authorization server
@@ -157,7 +259,7 @@ class DescopeProvider(RemoteAuthProvider):
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(issuer_url)],
             base_url=self.base_url,
-            scopes_supported=scopes_supported,
+            scopes_supported=parsed_scopes_supported,
             resource_name=resource_name,
             resource_documentation=resource_documentation,
         )
@@ -180,14 +282,27 @@ class DescopeProvider(RemoteAuthProvider):
 
         async def oauth_authorization_server_metadata(request):
             """Forward Descope OAuth authorization server metadata with FastMCP customizations."""
+            metadata_urls = [
+                self.oauth_authorization_server_metadata_url,
+                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}",
+            ]
             try:
                 async with httpx.AsyncClient() as client:
-                    response = await client.get(
-                        f"{self.descope_base_url}/v1/apps/{self.project_id}/.well-known/oauth-authorization-server"
+                    last_error: Exception | None = None
+                    for metadata_url in metadata_urls:
+                        if not metadata_url:
+                            continue
+                        try:
+                            response = await client.get(metadata_url)
+                            response.raise_for_status()
+                            metadata = response.json()
+                            return JSONResponse(metadata)
+                        except Exception as exc:
+                            last_error = exc
+                            continue
+                    raise last_error or RuntimeError(
+                        "No Descope authorization server metadata URL configured"
                     )
-                    response.raise_for_status()
-                    metadata = response.json()
-                    return JSONResponse(metadata)
             except Exception as e:
                 return JSONResponse(
                     {

--- a/fastmcp_slim/fastmcp/server/auth/providers/descope.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/descope.py
@@ -21,84 +21,45 @@ from fastmcp.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
-_OPENID_CONFIGURATION_SUFFIX = "/.well-known/openid-configuration"
-_OAUTH_AUTHORIZATION_SERVER_SUFFIX = "/.well-known/oauth-authorization-server"
+_OPENID_WK = "/.well-known/openid-configuration"
+_OAUTH_WK = "/.well-known/oauth-authorization-server"
 
 
-def _normalize_openid_configuration_url(
-    config_url: str,
-) -> tuple[str, str]:
-    """Return (issuer_url, openid_configuration_url) from a Descope config URL."""
-    config_url = config_url.rstrip("/")
-    if config_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
-        issuer_url = config_url[: -len(_OPENID_CONFIGURATION_SUFFIX)]
-        return issuer_url, config_url
+def _parse_descope_config_url(config_url: str) -> tuple[str, str, str, str]:
+    openid_url = config_url.rstrip("/")
+    if not openid_url.endswith(_OPENID_WK):
+        openid_url = f"{openid_url}{_OPENID_WK}"
 
-    openid_configuration_url = f"{config_url}{_OPENID_CONFIGURATION_SUFFIX}"
-    return config_url, openid_configuration_url
+    issuer_url = openid_url[: -len(_OPENID_WK)]
+    parsed = urlparse(issuer_url)
+    parts = parsed.path.strip("/").split("/")
+    descope_base_url = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
 
-
-def _parse_descope_config_url(
-    config_url: str,
-) -> tuple[str, str, str, str]:
-    """Parse a Descope well-known URL into connection details.
-
-    Supports both resource-specific MCP Server URLs:
-        /v1/apps/agentic/{project_id}/{mcp_server_id}/.well-known/openid-configuration
-    and project-level inbound app URLs:
-        /v1/apps/{project_id}/.well-known/openid-configuration
-
-    Returns:
-        Tuple of (descope_base_url, project_id, issuer_url, openid_configuration_url)
-    """
-    issuer_url, openid_configuration_url = _normalize_openid_configuration_url(config_url)
-    parsed_url = urlparse(issuer_url)
-    path_parts = parsed_url.path.strip("/").split("/")
-    descope_base_url = f"{parsed_url.scheme}://{parsed_url.netloc}".rstrip("/")
-
-    if "agentic" in path_parts:
-        agentic_index = path_parts.index("agentic")
-        if agentic_index + 1 >= len(path_parts):
-            raise ValueError(
-                f"Could not extract project_id from config_url: {issuer_url}"
-            )
-        project_id = path_parts[agentic_index + 1]
-    elif "apps" in path_parts:
-        apps_index = path_parts.index("apps")
-        if apps_index + 1 >= len(path_parts):
-            raise ValueError(
-                f"Could not extract project_id from config_url: {issuer_url}"
-            )
-        project_id = path_parts[apps_index + 1]
+    if "agentic" in parts:
+        index = parts.index("agentic") + 1
+        project_id = parts[index] if index < len(parts) else ""
+    elif "apps" in parts:
+        index = parts.index("apps") + 1
+        project_id = parts[index] if index < len(parts) else ""
         if project_id == "agentic":
-            raise ValueError(
-                f"Could not extract project_id from config_url: {issuer_url}"
-            )
+            project_id = ""
     else:
-        raise ValueError(
-            "Could not parse config_url: expected a Descope apps well-known URL "
-            f"(/v1/apps/{{project_id}}/... or /v1/apps/agentic/{{project_id}}/...): "
-            f"{issuer_url}"
-        )
+        project_id = ""
 
-    return descope_base_url, project_id, issuer_url, openid_configuration_url
+    if not project_id:
+        raise ValueError(f"Could not extract project_id from config_url: {issuer_url}")
 
-
-def _oauth_authorization_server_url(openid_configuration_url: str) -> str:
-    if openid_configuration_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
-        return openid_configuration_url[: -len(_OPENID_CONFIGURATION_SUFFIX)] + (
-            _OAUTH_AUTHORIZATION_SERVER_SUFFIX
-        )
-    return f"{openid_configuration_url.rstrip('/')}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
+    return descope_base_url, project_id, issuer_url, openid_url
 
 
-def _fetch_openid_configuration(openid_configuration_url: str) -> dict | None:
+def _discover_scopes(openid_configuration_url: str) -> list[str] | None:
     try:
         response = httpx.get(openid_configuration_url, timeout=10.0)
         response.raise_for_status()
-        metadata = response.json()
-        if isinstance(metadata, dict):
-            return metadata
+        scopes = response.json().get("scopes_supported")
+        if isinstance(scopes, list):
+            parsed = [scope for scope in scopes if isinstance(scope, str)]
+            return parsed or None
     except Exception:
         logger.warning(
             "Failed to fetch Descope OpenID configuration from %s",
@@ -126,9 +87,7 @@ class DescopeProvider(RemoteAuthProvider):
 
     2. Note your Well-Known URL:
        - Save your Well-Known URL from [MCP Server Settings](https://app.descope.com/mcp-servers)
-       - Recommended format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
-       - Project-level format is also supported:
-         ``https://.../v1/apps/P.../.well-known/openid-configuration``
+       - Format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
 
     For detailed setup instructions, see:
     https://docs.descope.com/identity-federation/inbound-apps/creating-inbound-apps#method-2-dynamic-client-registration-dcr
@@ -161,29 +120,7 @@ class DescopeProvider(RemoteAuthProvider):
         resource_documentation: AnyHttpUrl | None = None,
         token_verifier: TokenVerifier | None = None,
     ):
-        """Initialize Descope metadata provider.
-
-        Args:
-            base_url: Public URL of this FastMCP server
-            config_url: Your Descope Well-Known URL. Prefer the MCP Server-specific URL
-                (``/v1/apps/agentic/P.../M.../.well-known/openid-configuration``). Project-level
-                URLs (``/v1/apps/P.../.well-known/openid-configuration``) are also supported.
-                If provided, project_id and descope_base_url are ignored.
-            project_id: Your Descope Project ID (e.g., "P2abc123"). Used with descope_base_url for backwards compatibility.
-            descope_base_url: Your Descope base URL (e.g., "https://api.descope.com"). Used with project_id for backwards compatibility.
-            required_scopes: Scopes that must be present in validated tokens. When omitted,
-                tokens are not rejected for missing global scopes.
-            scopes_supported: Scopes advertised to MCP clients via protected resource metadata.
-                When omitted, scopes are discovered from ``scopes_supported`` in the configured
-                well-known OpenID document. Defaults to ``required_scopes`` when neither is
-                provided.
-            resource_name: Optional name for the protected resource metadata.
-            resource_documentation: Optional documentation URL for the protected resource.
-            token_verifier: Optional token verifier. If None, creates JWT verifier for Descope
-        """
         self.base_url = AnyHttpUrl(str(base_url).rstrip("/"))
-        self.openid_configuration_url: str | None = None
-        self.oauth_authorization_server_metadata_url: str | None = None
 
         parsed_required_scopes = (
             parse_scopes(required_scopes) if required_scopes is not None else None
@@ -192,7 +129,6 @@ class DescopeProvider(RemoteAuthProvider):
             parse_scopes(scopes_supported) if scopes_supported is not None else None
         )
 
-        # Determine which API is being used
         if config_url is not None:
             (
                 self.descope_base_url,
@@ -200,51 +136,29 @@ class DescopeProvider(RemoteAuthProvider):
                 issuer_url,
                 self.openid_configuration_url,
             ) = _parse_descope_config_url(str(config_url))
-            self.oauth_authorization_server_metadata_url = (
-                _oauth_authorization_server_url(self.openid_configuration_url)
-            )
         elif project_id is not None and descope_base_url is not None:
-            # Old API: use project_id and descope_base_url
             self.project_id = project_id
             descope_base_url_str = str(descope_base_url).rstrip("/")
-            # Ensure descope_base_url has a scheme
             if not descope_base_url_str.startswith(("http://", "https://")):
                 descope_base_url_str = f"https://{descope_base_url_str}"
             self.descope_base_url = descope_base_url_str
-            # Old issuer format
             issuer_url = f"{self.descope_base_url}/v1/apps/{self.project_id}"
-            self.openid_configuration_url = (
-                f"{issuer_url}{_OPENID_CONFIGURATION_SUFFIX}"
-            )
-            self.oauth_authorization_server_metadata_url = (
-                f"{issuer_url}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
-            )
+            self.openid_configuration_url = f"{issuer_url}{_OPENID_WK}"
         else:
             raise ValueError(
                 "Either config_url (new API) or both project_id and descope_base_url (old API) must be provided"
             )
 
+        self.oauth_authorization_server_metadata_url = (
+            self.openid_configuration_url.replace(_OPENID_WK, _OAUTH_WK)
+        )
+
         if (
             parsed_scopes_supported is None
             and parsed_required_scopes is None
-            and self.openid_configuration_url is not None
         ):
-            openid_configuration = _fetch_openid_configuration(
-                self.openid_configuration_url
-            )
-            if openid_configuration is not None:
-                discovered_scopes = openid_configuration.get("scopes_supported")
-                if isinstance(discovered_scopes, list):
-                    parsed_scopes_supported = [
-                        scope for scope in discovered_scopes if isinstance(scope, str)
-                    ]
-                    if parsed_scopes_supported:
-                        logger.info(
-                            "Discovered scopes_supported from Descope well-known: %s",
-                            parsed_scopes_supported,
-                        )
+            parsed_scopes_supported = _discover_scopes(self.openid_configuration_url)
 
-        # Create default JWT verifier if none provided
         if token_verifier is None:
             token_verifier = JWTVerifier(
                 jwks_uri=f"{self.descope_base_url}/{self.project_id}/.well-known/jwks.json",
@@ -254,7 +168,6 @@ class DescopeProvider(RemoteAuthProvider):
                 required_scopes=parsed_required_scopes,
             )
 
-        # Initialize RemoteAuthProvider with Descope as the authorization server
         super().__init__(
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(issuer_url)],
@@ -268,41 +181,22 @@ class DescopeProvider(RemoteAuthProvider):
         self,
         mcp_path: str | None = None,
     ) -> list[Route]:
-        """Get OAuth routes including Descope authorization server metadata forwarding.
-
-        This returns the standard protected resource routes plus an authorization server
-        metadata endpoint that forwards Descope's OAuth metadata to clients.
-
-        Args:
-            mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
-                This is used to advertise the resource URL in metadata.
-        """
-        # Get the standard protected resource routes from RemoteAuthProvider
         routes = super().get_routes(mcp_path)
 
         async def oauth_authorization_server_metadata(request):
-            """Forward Descope OAuth authorization server metadata with FastMCP customizations."""
             metadata_urls = [
                 self.oauth_authorization_server_metadata_url,
-                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}",
+                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_WK}",
             ]
             try:
                 async with httpx.AsyncClient() as client:
-                    last_error: Exception | None = None
                     for metadata_url in metadata_urls:
-                        if not metadata_url:
-                            continue
                         try:
                             response = await client.get(metadata_url)
                             response.raise_for_status()
-                            metadata = response.json()
-                            return JSONResponse(metadata)
-                        except Exception as exc:
-                            last_error = exc
+                            return JSONResponse(response.json())
+                        except Exception:
                             continue
-                    raise last_error or RuntimeError(
-                        "No Descope authorization server metadata URL configured"
-                    )
             except Exception as e:
                 return JSONResponse(
                     {
@@ -312,7 +206,14 @@ class DescopeProvider(RemoteAuthProvider):
                     status_code=500,
                 )
 
-        # Add Descope authorization server metadata forwarding
+            return JSONResponse(
+                {
+                    "error": "server_error",
+                    "error_description": "Failed to fetch Descope metadata",
+                },
+                status_code=500,
+            )
+
         routes.append(
             Route(
                 "/.well-known/oauth-authorization-server",

--- a/fastmcp_slim/fastmcp/server/auth/providers/descope.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/descope.py
@@ -283,10 +283,12 @@ class DescopeProvider(RemoteAuthProvider):
             routes = super().get_routes(mcp_path)
 
         async def oauth_authorization_server_metadata(request):
-            metadata_urls = [
-                self.oauth_authorization_server_metadata_url,
-                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_WK}",
-            ]
+            metadata_urls = [self.oauth_authorization_server_metadata_url]
+            project_metadata_url = (
+                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_WK}"
+            )
+            if project_metadata_url != self.oauth_authorization_server_metadata_url:
+                metadata_urls.append(project_metadata_url)
             try:
                 async with httpx2.AsyncClient() as client:
                     for metadata_url in metadata_urls:

--- a/fastmcp_slim/fastmcp/server/auth/providers/descope.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/descope.py
@@ -181,8 +181,13 @@ class DescopeProvider(RemoteAuthProvider):
         # metadata request (see get_routes) so construction never performs I/O
         # and a transient failure can be retried instead of being frozen for the
         # provider's lifetime.
+        custom_verifier_scopes = (
+            token_verifier.scopes_supported if token_verifier is not None else []
+        )
         self._scopes_discovery_enabled = (
-            parsed_scopes_supported is None and parsed_required_scopes is None
+            parsed_scopes_supported is None
+            and parsed_required_scopes is None
+            and not custom_verifier_scopes
         )
         self._discovered_scopes: list[str] | None = None
         self._scopes_discovered = False
@@ -235,16 +240,20 @@ class DescopeProvider(RemoteAuthProvider):
         """
 
         async def protected_resource_metadata(request: Request) -> Response:
+            scopes_supported = await self._get_scopes_supported()
             metadata = ProtectedResourceMetadata(
                 resource=resource_url,
                 authorization_servers=self.authorization_servers,
-                scopes_supported=await self._get_scopes_supported(),
+                scopes_supported=scopes_supported,
                 resource_name=self.resource_name,
                 resource_documentation=self.resource_documentation,
             )
+            cache_control = (
+                "public, max-age=3600" if self._scopes_discovered else "no-store"
+            )
             return PydanticJSONResponse(
                 content=metadata,
-                headers={"Cache-Control": "public, max-age=3600"},
+                headers={"Cache-Control": cache_control},
             )
 
         well_known_path = urlparse(str(build_resource_metadata_url(resource_url))).path

--- a/fastmcp_slim/fastmcp/server/auth/providers/descope.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/descope.py
@@ -7,11 +7,16 @@ for seamless MCP client authentication.
 
 from __future__ import annotations
 
+import asyncio
 from urllib.parse import urlparse
 
 import httpx
+from mcp.server.auth.json_response import PydanticJSONResponse
+from mcp.server.auth.routes import build_resource_metadata_url, cors_middleware
+from mcp.shared.auth import ProtectedResourceMetadata
 from pydantic import AnyHttpUrl
-from starlette.responses import JSONResponse
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from fastmcp.server.auth import RemoteAuthProvider, TokenVerifier
@@ -52,10 +57,11 @@ def _parse_descope_config_url(config_url: str) -> tuple[str, str, str, str]:
     return descope_base_url, project_id, issuer_url, openid_url
 
 
-def _discover_scopes(openid_configuration_url: str) -> list[str] | None:
+async def _discover_scopes(openid_configuration_url: str) -> list[str] | None:
     try:
-        response = httpx.get(openid_configuration_url, timeout=10.0)
-        response.raise_for_status()
+        async with httpx.AsyncClient() as client:
+            response = await client.get(openid_configuration_url, timeout=10.0)
+            response.raise_for_status()
         scopes = response.json().get("scopes_supported")
         if isinstance(scopes, list):
             parsed = [scope for scope in scopes if isinstance(scope, str)]
@@ -153,11 +159,18 @@ class DescopeProvider(RemoteAuthProvider):
             self.openid_configuration_url.replace(_OPENID_WK, _OAUTH_WK)
         )
 
-        if (
-            parsed_scopes_supported is None
-            and parsed_required_scopes is None
-        ):
-            parsed_scopes_supported = _discover_scopes(self.openid_configuration_url)
+        # Advertised scopes are discovered from Descope's OpenID configuration
+        # only when the caller supplied neither explicit advertised scopes nor
+        # required scopes. Discovery is deferred to the first protected resource
+        # metadata request (see get_routes) so construction never performs I/O
+        # and a transient failure can be retried instead of being frozen for the
+        # provider's lifetime.
+        self._scopes_discovery_enabled = (
+            parsed_scopes_supported is None and parsed_required_scopes is None
+        )
+        self._discovered_scopes: list[str] | None = None
+        self._scopes_discovered = False
+        self._scopes_discovery_lock = asyncio.Lock()
 
         if token_verifier is None:
             token_verifier = JWTVerifier(
@@ -177,11 +190,71 @@ class DescopeProvider(RemoteAuthProvider):
             resource_documentation=resource_documentation,
         )
 
+    async def _get_scopes_supported(self) -> list[str] | None:
+        """Return the advertised scopes, discovering them lazily if enabled.
+
+        The result of a successful discovery is cached for the provider's
+        lifetime. Transient failures return ``None`` without caching, so the
+        next protected resource metadata request retries discovery.
+        """
+        if self._scopes_discovered:
+            return self._discovered_scopes
+
+        async with self._scopes_discovery_lock:
+            if self._scopes_discovered:
+                return self._discovered_scopes
+
+            scopes = await _discover_scopes(self.openid_configuration_url)
+            if scopes is not None:
+                self._discovered_scopes = scopes
+                self._scopes_discovered = True
+            return scopes
+
+    def _create_protected_resource_route(self, resource_url: AnyHttpUrl) -> Route:
+        """Build a protected resource metadata route that discovers scopes lazily.
+
+        Mirrors ``create_protected_resource_routes`` (RFC 9728) but resolves
+        ``scopes_supported`` per request so the value can be discovered from
+        Descope after construction.
+        """
+
+        async def protected_resource_metadata(request: Request) -> Response:
+            metadata = ProtectedResourceMetadata(
+                resource=resource_url,
+                authorization_servers=self.authorization_servers,
+                scopes_supported=await self._get_scopes_supported(),
+                resource_name=self.resource_name,
+                resource_documentation=self.resource_documentation,
+            )
+            return PydanticJSONResponse(
+                content=metadata,
+                headers={"Cache-Control": "public, max-age=3600"},
+            )
+
+        well_known_path = urlparse(str(build_resource_metadata_url(resource_url))).path
+        return Route(
+            well_known_path,
+            endpoint=cors_middleware(protected_resource_metadata, ["GET", "OPTIONS"]),
+            methods=["GET", "OPTIONS"],
+        )
+
     def get_routes(
         self,
         mcp_path: str | None = None,
     ) -> list[Route]:
-        routes = super().get_routes(mcp_path)
+        if self._scopes_discovery_enabled:
+            # Serve protected resource metadata from an async handler that
+            # discovers scopes_supported lazily. The parent's static route would
+            # freeze the (as-yet-unknown) scopes at startup.
+            self.set_mcp_path(mcp_path)
+            routes = []
+            resource_url = self._get_resource_url(mcp_path)
+            if resource_url:
+                routes.append(self._create_protected_resource_route(resource_url))
+        else:
+            # Advertised scopes are already known; the parent builds the static
+            # protected resource metadata route with no network access.
+            routes = super().get_routes(mcp_path)
 
         async def oauth_authorization_server_metadata(request):
             metadata_urls = [

--- a/tests/server/auth/providers/test_descope.py
+++ b/tests/server/auth/providers/test_descope.py
@@ -1,7 +1,7 @@
 """Tests for Descope OAuth provider."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -94,24 +94,94 @@ class TestDescopeProvider:
             "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/oauth-authorization-server"
         )
 
-    def test_discover_scopes_supported_from_well_known(self):
-        """Test that scopes_supported are discovered from Descope well-known metadata."""
+    def test_construction_is_network_free(self):
+        """Construction must not perform discovery I/O, even when it is enabled."""
         config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+
+        no_network = AsyncMock(side_effect=AssertionError("no network during init"))
+        with patch("httpx.AsyncClient.get", new=no_network):
+            provider = DescopeProvider(
+                config_url=config_url,
+                base_url="https://myserver.com",
+            )
+
+        # Discovery is enabled but deferred; nothing has been fetched yet.
+        assert provider._scopes_discovery_enabled is True
+        assert provider._scopes_supported is None
+        assert provider._discovered_scopes is None
+        assert provider._scopes_discovered is False
+        assert provider.token_verifier.required_scopes == []
+
+    async def test_discover_scopes_supported_lazily(self):
+        """scopes_supported are discovered lazily and cached after first fetch."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+        provider = DescopeProvider(
+            config_url=config_url,
+            base_url="https://myserver.com",
+        )
+
         mock_response = httpx.Response(
             200,
             json=PROJECT_LEVEL_OPENID_CONFIGURATION,
             request=httpx.Request("GET", config_url),
         )
 
-        with patch("httpx.get", return_value=mock_response) as mock_get:
-            provider = DescopeProvider(
-                config_url=config_url,
-                base_url="https://myserver.com",
-            )
+        with patch(
+            "httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)
+        ) as mock_get:
+            scopes = await provider._get_scopes_supported()
+            # A second call returns the cached result without another fetch.
+            scopes_again = await provider._get_scopes_supported()
 
-        mock_get.assert_called_once_with(config_url, timeout=10.0)
-        assert provider._scopes_supported == ["mcp:skyflow"]
-        assert provider.token_verifier.required_scopes == []
+        assert scopes == ["mcp:skyflow"]
+        assert scopes_again == ["mcp:skyflow"]
+        assert provider._discovered_scopes == ["mcp:skyflow"]
+        assert provider._scopes_discovered is True
+        mock_get.assert_awaited_once()
+
+    async def test_scope_discovery_retries_after_transient_failure(self):
+        """A transient discovery failure is not cached and is retried."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+        provider = DescopeProvider(
+            config_url=config_url,
+            base_url="https://myserver.com",
+        )
+
+        failing = AsyncMock(side_effect=httpx.ConnectError("boom"))
+        with patch("httpx.AsyncClient.get", new=failing):
+            first = await provider._get_scopes_supported()
+
+        # Failure yields no scopes and is not frozen for the provider's lifetime.
+        assert first is None
+        assert provider._scopes_discovered is False
+        assert provider._discovered_scopes is None
+
+        mock_response = httpx.Response(
+            200,
+            json=PROJECT_LEVEL_OPENID_CONFIGURATION,
+            request=httpx.Request("GET", config_url),
+        )
+        with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+            second = await provider._get_scopes_supported()
+
+        assert second == ["mcp:skyflow"]
+        assert provider._scopes_discovered is True
+
+    def test_get_routes_is_network_free(self):
+        """get_routes must not perform discovery I/O when building routes."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+        provider = DescopeProvider(
+            config_url=config_url,
+            base_url="https://myserver.com",
+        )
+
+        no_network = AsyncMock(side_effect=AssertionError("no network at get_routes"))
+        with patch("httpx.AsyncClient.get", new=no_network):
+            routes = provider.get_routes("/mcp")
+
+        paths = [route.path for route in routes]
+        assert any("oauth-protected-resource" in path for path in paths)
+        assert any("oauth-authorization-server" in path for path in paths)
 
     def test_scopes_supported_and_required_scopes_can_differ(self):
         """Test that scopes_supported and required_scopes can be configured independently."""
@@ -126,32 +196,30 @@ class TestDescopeProvider:
         assert provider.token_verifier.required_scopes == ["mcp:read"]
 
     def test_explicit_required_scopes_skip_discovery(self):
-        """Test that explicit required_scopes skip well-known discovery."""
+        """Test that explicit required_scopes disable well-known discovery."""
         config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
 
-        with patch("httpx.get") as mock_get:
-            provider = DescopeProvider(
-                config_url=config_url,
-                base_url="https://myserver.com",
-                required_scopes=["custom:scope"],
-            )
+        provider = DescopeProvider(
+            config_url=config_url,
+            base_url="https://myserver.com",
+            required_scopes=["custom:scope"],
+        )
 
-        mock_get.assert_not_called()
+        assert provider._scopes_discovery_enabled is False
         assert provider.token_verifier.required_scopes == ["custom:scope"]
         assert provider._scopes_supported is None
 
     def test_explicit_scopes_supported_skip_discovery(self):
-        """Test that explicit scopes_supported skip well-known discovery."""
+        """Test that explicit scopes_supported disable well-known discovery."""
         config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
 
-        with patch("httpx.get") as mock_get:
-            provider = DescopeProvider(
-                config_url=config_url,
-                base_url="https://myserver.com",
-                scopes_supported=["custom:advertised"],
-            )
+        provider = DescopeProvider(
+            config_url=config_url,
+            base_url="https://myserver.com",
+            scopes_supported=["custom:advertised"],
+        )
 
-        mock_get.assert_not_called()
+        assert provider._scopes_discovery_enabled is False
         assert provider._scopes_supported == ["custom:advertised"]
         assert provider.token_verifier.required_scopes == []
 
@@ -310,6 +378,28 @@ def client_with_headless_oauth(mcp_server_url: str) -> Client:
 
 
 class TestDescopeProviderIntegration:
+    async def test_protected_resource_metadata_serves_discovered_scopes(self):
+        """The protected resource metadata endpoint advertises discovered scopes."""
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/agentic/P2test123/M123/.well-known/openid-configuration",
+            base_url="http://localhost:4321",
+        )
+        mcp = FastMCP(auth=provider)
+
+        with patch(
+            "fastmcp.server.auth.providers.descope._discover_scopes",
+            new=AsyncMock(return_value=["mcp:skyflow"]),
+        ):
+            async with run_server_async(mcp, transport="http") as url:
+                metadata_url = url.replace(
+                    "/mcp", "/.well-known/oauth-protected-resource/mcp"
+                )
+                async with httpx.AsyncClient() as client:
+                    response = await client.get(metadata_url)
+
+        response.raise_for_status()
+        assert response.json()["scopes_supported"] == ["mcp:skyflow"]
+
     async def test_unauthorized_access(self, mcp_server_url: str):
         # SDK v2 surfaces the server's 401 as a generic MCPError at the client
         # boundary rather than re-raising httpx.HTTPStatusError.

--- a/tests/server/auth/providers/test_descope.py
+++ b/tests/server/auth/providers/test_descope.py
@@ -15,7 +15,7 @@ from fastmcp.utilities.tests import HeadlessOAuth, run_server_async
 
 PROJECT_LEVEL_OPENID_CONFIGURATION = {
     "issuer": "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU",
-    "scopes_supported": ["mcp:skyflow"],
+    "scopes_supported": ["mcp:read"],
     "jwks_uri": "https://api.descope.com/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/jwks.json",
 }
 
@@ -133,9 +133,9 @@ class TestDescopeProvider:
             # A second call returns the cached result without another fetch.
             scopes_again = await provider._get_scopes_supported()
 
-        assert scopes == ["mcp:skyflow"]
-        assert scopes_again == ["mcp:skyflow"]
-        assert provider._discovered_scopes == ["mcp:skyflow"]
+        assert scopes == ["mcp:read"]
+        assert scopes_again == ["mcp:read"]
+        assert provider._discovered_scopes == ["mcp:read"]
         assert provider._scopes_discovered is True
         mock_get.assert_awaited_once()
 
@@ -164,7 +164,7 @@ class TestDescopeProvider:
         with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
             second = await provider._get_scopes_supported()
 
-        assert second == ["mcp:skyflow"]
+        assert second == ["mcp:read"]
         assert provider._scopes_discovered is True
 
     def test_get_routes_is_network_free(self):
@@ -388,7 +388,7 @@ class TestDescopeProviderIntegration:
 
         with patch(
             "fastmcp.server.auth.providers.descope._discover_scopes",
-            new=AsyncMock(return_value=["mcp:skyflow"]),
+            new=AsyncMock(return_value=["mcp:read"]),
         ):
             async with run_server_async(mcp, transport="http") as url:
                 metadata_url = url.replace(
@@ -398,7 +398,7 @@ class TestDescopeProviderIntegration:
                     response = await client.get(metadata_url)
 
         response.raise_for_status()
-        assert response.json()["scopes_supported"] == ["mcp:skyflow"]
+        assert response.json()["scopes_supported"] == ["mcp:read"]
 
     async def test_unauthorized_access(self, mcp_server_url: str):
         # SDK v2 surfaces the server's 401 as a generic MCPError at the client

--- a/tests/server/auth/providers/test_descope.py
+++ b/tests/server/auth/providers/test_descope.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import httpx2
 import pytest
 from mcp import MCPError
+from starlette.requests import Request
 
 from fastmcp import Client, FastMCP
 from fastmcp.client.transports import StreamableHttpTransport
@@ -209,6 +210,35 @@ class TestDescopeProvider:
         paths = [route.path for route in routes]
         assert any("oauth-protected-resource" in path for path in paths)
         assert any("oauth-authorization-server" in path for path in paths)
+
+    async def test_project_level_metadata_failure_is_not_retried(self):
+        """Identical project-level primary and fallback URLs are fetched once."""
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/P2abc123/.well-known/openid-configuration",
+            base_url="https://myserver.com",
+        )
+        metadata_route = next(
+            route
+            for route in provider.get_routes("/mcp")
+            if route.path == "/.well-known/oauth-authorization-server"
+        )
+        request = Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": metadata_route.path,
+                "headers": [],
+            }
+        )
+
+        failing = AsyncMock(side_effect=httpx2.ConnectError("boom"))
+        with patch("httpx2.AsyncClient.get", new=failing):
+            response = await metadata_route.endpoint(request)
+
+        assert response.status_code == 500
+        failing.assert_awaited_once_with(
+            provider.oauth_authorization_server_metadata_url
+        )
 
     def test_scopes_supported_and_required_scopes_can_differ(self):
         """Test that scopes_supported and required_scopes can be configured independently."""

--- a/tests/server/auth/providers/test_descope.py
+++ b/tests/server/auth/providers/test_descope.py
@@ -3,6 +3,7 @@
 import os
 from unittest.mock import patch
 
+import httpx
 import pytest
 from mcp import MCPError
 
@@ -11,6 +12,12 @@ from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.server.auth.providers.descope import DescopeProvider
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.utilities.tests import HeadlessOAuth, run_server_async
+
+PROJECT_LEVEL_OPENID_CONFIGURATION = {
+    "issuer": "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU",
+    "scopes_supported": ["mcp:skyflow"],
+    "jwks_uri": "https://api.descope.com/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/jwks.json",
+}
 
 
 class TestDescopeProvider:
@@ -65,6 +72,88 @@ class TestDescopeProvider:
         )
         assert str(provider3.descope_base_url) == "https://api.descope.com"
         assert provider3.project_id == "P2abc123"
+
+    def test_project_level_config_url_parsing(self):
+        """Test project-level well-known URLs without the agentic path segment."""
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration",
+            base_url="https://myserver.com",
+        )
+
+        assert provider.project_id == "P2v9EBlmO4XTrOwMRfsY1jeUONxU"
+        assert str(provider.descope_base_url) == "https://api.descope.com"
+        assert isinstance(provider.token_verifier, JWTVerifier)
+        assert (
+            provider.token_verifier.issuer
+            == "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU"
+        )
+        assert provider.openid_configuration_url == (
+            "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+        )
+        assert provider.oauth_authorization_server_metadata_url == (
+            "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/oauth-authorization-server"
+        )
+
+    def test_discover_scopes_supported_from_well_known(self):
+        """Test that scopes_supported are discovered from Descope well-known metadata."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+        mock_response = httpx.Response(
+            200,
+            json=PROJECT_LEVEL_OPENID_CONFIGURATION,
+            request=httpx.Request("GET", config_url),
+        )
+
+        with patch("httpx.get", return_value=mock_response) as mock_get:
+            provider = DescopeProvider(
+                config_url=config_url,
+                base_url="https://myserver.com",
+            )
+
+        mock_get.assert_called_once_with(config_url, timeout=10.0)
+        assert provider._scopes_supported == ["mcp:skyflow"]
+        assert provider.token_verifier.required_scopes == []
+
+    def test_scopes_supported_and_required_scopes_can_differ(self):
+        """Test that scopes_supported and required_scopes can be configured independently."""
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/agentic/P2abc123/M123/.well-known/openid-configuration",
+            base_url="https://myserver.com",
+            scopes_supported=["mcp:read", "mcp:write"],
+            required_scopes=["mcp:read"],
+        )
+
+        assert provider._scopes_supported == ["mcp:read", "mcp:write"]
+        assert provider.token_verifier.required_scopes == ["mcp:read"]
+
+    def test_explicit_required_scopes_skip_discovery(self):
+        """Test that explicit required_scopes skip well-known discovery."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+
+        with patch("httpx.get") as mock_get:
+            provider = DescopeProvider(
+                config_url=config_url,
+                base_url="https://myserver.com",
+                required_scopes=["custom:scope"],
+            )
+
+        mock_get.assert_not_called()
+        assert provider.token_verifier.required_scopes == ["custom:scope"]
+        assert provider._scopes_supported is None
+
+    def test_explicit_scopes_supported_skip_discovery(self):
+        """Test that explicit scopes_supported skip well-known discovery."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+
+        with patch("httpx.get") as mock_get:
+            provider = DescopeProvider(
+                config_url=config_url,
+                base_url="https://myserver.com",
+                scopes_supported=["custom:advertised"],
+            )
+
+        mock_get.assert_not_called()
+        assert provider._scopes_supported == ["custom:advertised"]
+        assert provider.token_verifier.required_scopes == []
 
     def test_requires_config_url_or_project_id_and_descope_base_url(self):
         """Test that either config_url or both project_id and descope_base_url are required."""

--- a/tests/server/auth/providers/test_descope.py
+++ b/tests/server/auth/providers/test_descope.py
@@ -223,6 +223,23 @@ class TestDescopeProvider:
         assert provider._scopes_supported == ["custom:advertised"]
         assert provider.token_verifier.required_scopes == []
 
+    def test_custom_token_verifier_scopes_skip_discovery(self):
+        """Scopes supplied by a custom verifier retain the parent behavior."""
+        token_verifier = JWTVerifier(
+            public_key="secret",
+            algorithm="HS256",
+            required_scopes=["custom:scope"],
+        )
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/P2abc123/.well-known/openid-configuration",
+            base_url="https://myserver.com",
+            token_verifier=token_verifier,
+        )
+
+        assert provider._scopes_discovery_enabled is False
+        assert provider._scopes_supported is None
+        assert provider.token_verifier.scopes_supported == ["custom:scope"]
+
     def test_requires_config_url_or_project_id_and_descope_base_url(self):
         """Test that either config_url or both project_id and descope_base_url are required."""
         # Should raise error when neither API is provided
@@ -399,6 +416,30 @@ class TestDescopeProviderIntegration:
 
         response.raise_for_status()
         assert response.json()["scopes_supported"] == ["mcp:read"]
+        assert response.headers["cache-control"] == "public, max-age=3600"
+
+    async def test_failed_scope_discovery_is_not_cached(self):
+        """Clients can retry metadata discovery immediately after a failure."""
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/agentic/P2test123/M123/.well-known/openid-configuration",
+            base_url="http://localhost:4321",
+        )
+        mcp = FastMCP(auth=provider)
+
+        with patch(
+            "fastmcp.server.auth.providers.descope._discover_scopes",
+            new=AsyncMock(return_value=None),
+        ):
+            async with run_server_async(mcp, transport="http") as url:
+                metadata_url = url.replace(
+                    "/mcp", "/.well-known/oauth-protected-resource/mcp"
+                )
+                async with httpx2.AsyncClient() as client:
+                    response = await client.get(metadata_url)
+
+        response.raise_for_status()
+        assert "scopes_supported" not in response.json()
+        assert response.headers["cache-control"] == "no-store"
 
     async def test_unauthorized_access(self, mcp_server_url: str):
         # SDK v2 surfaces the server's 401 as a generic MCPError at the client


### PR DESCRIPTION
Resolves: #4490

Descope MCP servers expose resource-specific scopes in their OpenID well-known document, but `DescopeProvider` previously required the `agentic` URL shape and did not discover those scopes automatically. That forced duplicate configuration and made project-level inbound app URLs unusable.

This updates `DescopeProvider` to accept both MCP Server-specific and project-level well-known URLs, discover `scopes_supported` from Descope when neither `scopes_supported` nor `required_scopes` is set, and forward authorization-server metadata from the matching well-known path. `required_scopes` and `scopes_supported` remain independently configurable for cases where advertised scopes should differ from enforced scopes.

```python
DescopeProvider(
    config_url="https://api.descope.com/v1/apps/P.../.well-known/openid-configuration",
    base_url="https://your-server.com",
    scopes_supported=["mcp:read", "mcp:write"],  # advertised to clients
    required_scopes=["mcp:read"],                 # enforced on tokens
)
```

🤖 Generated with Cursor

Made with [Cursor](https://cursor.com)