### PR TITLE
Improve DescopeProvider scope discovery and well-known URL support

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/providers/descope.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/descope.py
@@ -21,6 +21,92 @@ from fastmcp.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+_OPENID_CONFIGURATION_SUFFIX = "/.well-known/openid-configuration"
+_OAUTH_AUTHORIZATION_SERVER_SUFFIX = "/.well-known/oauth-authorization-server"
+
+
+def _normalize_openid_configuration_url(
+    config_url: str,
+) -> tuple[str, str]:
+    """Return (issuer_url, openid_configuration_url) from a Descope config URL."""
+    config_url = config_url.rstrip("/")
+    if config_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
+        issuer_url = config_url[: -len(_OPENID_CONFIGURATION_SUFFIX)]
+        return issuer_url, config_url
+
+    openid_configuration_url = f"{config_url}{_OPENID_CONFIGURATION_SUFFIX}"
+    return config_url, openid_configuration_url
+
+
+def _parse_descope_config_url(
+    config_url: str,
+) -> tuple[str, str, str, str]:
+    """Parse a Descope well-known URL into connection details.
+
+    Supports both resource-specific MCP Server URLs:
+        /v1/apps/agentic/{project_id}/{mcp_server_id}/.well-known/openid-configuration
+    and project-level inbound app URLs:
+        /v1/apps/{project_id}/.well-known/openid-configuration
+
+    Returns:
+        Tuple of (descope_base_url, project_id, issuer_url, openid_configuration_url)
+    """
+    issuer_url, openid_configuration_url = _normalize_openid_configuration_url(config_url)
+    parsed_url = urlparse(issuer_url)
+    path_parts = parsed_url.path.strip("/").split("/")
+    descope_base_url = f"{parsed_url.scheme}://{parsed_url.netloc}".rstrip("/")
+
+    if "agentic" in path_parts:
+        agentic_index = path_parts.index("agentic")
+        if agentic_index + 1 >= len(path_parts):
+            raise ValueError(
+                f"Could not extract project_id from config_url: {issuer_url}"
+            )
+        project_id = path_parts[agentic_index + 1]
+    elif "apps" in path_parts:
+        apps_index = path_parts.index("apps")
+        if apps_index + 1 >= len(path_parts):
+            raise ValueError(
+                f"Could not extract project_id from config_url: {issuer_url}"
+            )
+        project_id = path_parts[apps_index + 1]
+        if project_id == "agentic":
+            raise ValueError(
+                f"Could not extract project_id from config_url: {issuer_url}"
+            )
+    else:
+        raise ValueError(
+            "Could not parse config_url: expected a Descope apps well-known URL "
+            f"(/v1/apps/{{project_id}}/... or /v1/apps/agentic/{{project_id}}/...): "
+            f"{issuer_url}"
+        )
+
+    return descope_base_url, project_id, issuer_url, openid_configuration_url
+
+
+def _oauth_authorization_server_url(openid_configuration_url: str) -> str:
+    if openid_configuration_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
+        return openid_configuration_url[: -len(_OPENID_CONFIGURATION_SUFFIX)] + (
+            _OAUTH_AUTHORIZATION_SERVER_SUFFIX
+        )
+    return f"{openid_configuration_url.rstrip('/')}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
+
+
+def _fetch_openid_configuration(openid_configuration_url: str) -> dict | None:
+    try:
+        response = httpx.get(openid_configuration_url, timeout=10.0)
+        response.raise_for_status()
+        metadata = response.json()
+        if isinstance(metadata, dict):
+            return metadata
+    except Exception:
+        logger.warning(
+            "Failed to fetch Descope OpenID configuration from %s",
+            openid_configuration_url,
+            exc_info=True,
+        )
+    return None
+
 
 class DescopeProvider(RemoteAuthProvider):
     """Descope metadata provider for DCR (Dynamic Client Registration).
@@ -40,7 +126,9 @@ class DescopeProvider(RemoteAuthProvider):
 
     2. Note your Well-Known URL:
        - Save your Well-Known URL from [MCP Server Settings](https://app.descope.com/mcp-servers)
-       - Format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
+       - Recommended format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
+       - Project-level format is also supported:
+         ``https://.../v1/apps/P.../.well-known/openid-configuration``
 
     For detailed setup instructions, see:
     https://docs.descope.com/identity-federation/inbound-apps/creating-inbound-apps#method-2-dynamic-client-registration-dcr
@@ -77,55 +165,43 @@ class DescopeProvider(RemoteAuthProvider):
 
         Args:
             base_url: Public URL of this FastMCP server
-            config_url: Your Descope Well-Known URL (e.g., "https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration")
-                This is the new recommended way. If provided, project_id and descope_base_url are ignored.
+            config_url: Your Descope Well-Known URL. Prefer the MCP Server-specific URL
+                (``/v1/apps/agentic/P.../M.../.well-known/openid-configuration``). Project-level
+                URLs (``/v1/apps/P.../.well-known/openid-configuration``) are also supported.
+                If provided, project_id and descope_base_url are ignored.
             project_id: Your Descope Project ID (e.g., "P2abc123"). Used with descope_base_url for backwards compatibility.
             descope_base_url: Your Descope base URL (e.g., "https://api.descope.com"). Used with project_id for backwards compatibility.
-            required_scopes: Optional list of scopes that must be present in validated tokens.
-                These scopes will be included in the protected resource metadata.
-            scopes_supported: Optional list of scopes to advertise in OAuth metadata.
-                If None, uses required_scopes. Use this when the scopes clients should
-                request differ from the scopes enforced on tokens.
+            required_scopes: Scopes that must be present in validated tokens. When omitted,
+                tokens are not rejected for missing global scopes.
+            scopes_supported: Scopes advertised to MCP clients via protected resource metadata.
+                When omitted, scopes are discovered from ``scopes_supported`` in the configured
+                well-known OpenID document. Defaults to ``required_scopes`` when neither is
+                provided.
             resource_name: Optional name for the protected resource metadata.
             resource_documentation: Optional documentation URL for the protected resource.
             token_verifier: Optional token verifier. If None, creates JWT verifier for Descope
         """
         self.base_url = AnyHttpUrl(str(base_url).rstrip("/"))
+        self.openid_configuration_url: str | None = None
+        self.oauth_authorization_server_metadata_url: str | None = None
 
-        # Parse scopes if provided as string
-        parsed_scopes = (
+        parsed_required_scopes = (
             parse_scopes(required_scopes) if required_scopes is not None else None
+        )
+        parsed_scopes_supported = (
+            parse_scopes(scopes_supported) if scopes_supported is not None else None
         )
 
         # Determine which API is being used
         if config_url is not None:
-            # New API: use config_url
-            # Strip /.well-known/openid-configuration from config_url if present
-            issuer_url = str(config_url)
-            if issuer_url.endswith("/.well-known/openid-configuration"):
-                issuer_url = issuer_url[: -len("/.well-known/openid-configuration")]
-
-            # Parse the issuer URL to extract descope_base_url and project_id for other uses
-            parsed_url = urlparse(issuer_url)
-            path_parts = parsed_url.path.strip("/").split("/")
-
-            # Extract project_id from path (format: /v1/apps/agentic/P.../M...)
-            if "agentic" in path_parts:
-                agentic_index = path_parts.index("agentic")
-                if agentic_index + 1 < len(path_parts):
-                    self.project_id = path_parts[agentic_index + 1]
-                else:
-                    raise ValueError(
-                        f"Could not extract project_id from config_url: {issuer_url}"
-                    )
-            else:
-                raise ValueError(
-                    f"Could not find 'agentic' in config_url path: {issuer_url}"
-                )
-
-            # Extract descope_base_url (scheme + netloc)
-            self.descope_base_url = f"{parsed_url.scheme}://{parsed_url.netloc}".rstrip(
-                "/"
+            (
+                self.descope_base_url,
+                self.project_id,
+                issuer_url,
+                self.openid_configuration_url,
+            ) = _parse_descope_config_url(str(config_url))
+            self.oauth_authorization_server_metadata_url = (
+                _oauth_authorization_server_url(self.openid_configuration_url)
             )
         elif project_id is not None and descope_base_url is not None:
             # Old API: use project_id and descope_base_url
@@ -137,10 +213,36 @@ class DescopeProvider(RemoteAuthProvider):
             self.descope_base_url = descope_base_url_str
             # Old issuer format
             issuer_url = f"{self.descope_base_url}/v1/apps/{self.project_id}"
+            self.openid_configuration_url = (
+                f"{issuer_url}{_OPENID_CONFIGURATION_SUFFIX}"
+            )
+            self.oauth_authorization_server_metadata_url = (
+                f"{issuer_url}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
+            )
         else:
             raise ValueError(
                 "Either config_url (new API) or both project_id and descope_base_url (old API) must be provided"
             )
+
+        if (
+            parsed_scopes_supported is None
+            and parsed_required_scopes is None
+            and self.openid_configuration_url is not None
+        ):
+            openid_configuration = _fetch_openid_configuration(
+                self.openid_configuration_url
+            )
+            if openid_configuration is not None:
+                discovered_scopes = openid_configuration.get("scopes_supported")
+                if isinstance(discovered_scopes, list):
+                    parsed_scopes_supported = [
+                        scope for scope in discovered_scopes if isinstance(scope, str)
+                    ]
+                    if parsed_scopes_supported:
+                        logger.info(
+                            "Discovered scopes_supported from Descope well-known: %s",
+                            parsed_scopes_supported,
+                        )
 
         # Create default JWT verifier if none provided
         if token_verifier is None:
@@ -149,7 +251,7 @@ class DescopeProvider(RemoteAuthProvider):
                 issuer=issuer_url,
                 algorithm="RS256",
                 audience=self.project_id,
-                required_scopes=parsed_scopes,
+                required_scopes=parsed_required_scopes,
             )
 
         # Initialize RemoteAuthProvider with Descope as the authorization server
@@ -157,7 +259,7 @@ class DescopeProvider(RemoteAuthProvider):
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(issuer_url)],
             base_url=self.base_url,
-            scopes_supported=scopes_supported,
+            scopes_supported=parsed_scopes_supported,
             resource_name=resource_name,
             resource_documentation=resource_documentation,
         )
@@ -180,14 +282,27 @@ class DescopeProvider(RemoteAuthProvider):
 
         async def oauth_authorization_server_metadata(request):
             """Forward Descope OAuth authorization server metadata with FastMCP customizations."""
+            metadata_urls = [
+                self.oauth_authorization_server_metadata_url,
+                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}",
+            ]
             try:
                 async with httpx.AsyncClient() as client:
-                    response = await client.get(
-                        f"{self.descope_base_url}/v1/apps/{self.project_id}/.well-known/oauth-authorization-server"
+                    last_error: Exception | None = None
+                    for metadata_url in metadata_urls:
+                        if not metadata_url:
+                            continue
+                        try:
+                            response = await client.get(metadata_url)
+                            response.raise_for_status()
+                            metadata = response.json()
+                            return JSONResponse(metadata)
+                        except Exception as exc:
+                            last_error = exc
+                            continue
+                    raise last_error or RuntimeError(
+                        "No Descope authorization server metadata URL configured"
                     )
-                    response.raise_for_status()
-                    metadata = response.json()
-                    return JSONResponse(metadata)
             except Exception as e:
                 return JSONResponse(
                     {

--- a/fastmcp_slim/fastmcp/server/auth/providers/descope.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/descope.py
@@ -21,84 +21,45 @@ from fastmcp.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
-_OPENID_CONFIGURATION_SUFFIX = "/.well-known/openid-configuration"
-_OAUTH_AUTHORIZATION_SERVER_SUFFIX = "/.well-known/oauth-authorization-server"
+_OPENID_WK = "/.well-known/openid-configuration"
+_OAUTH_WK = "/.well-known/oauth-authorization-server"
 
 
-def _normalize_openid_configuration_url(
-    config_url: str,
-) -> tuple[str, str]:
-    """Return (issuer_url, openid_configuration_url) from a Descope config URL."""
-    config_url = config_url.rstrip("/")
-    if config_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
-        issuer_url = config_url[: -len(_OPENID_CONFIGURATION_SUFFIX)]
-        return issuer_url, config_url
+def _parse_descope_config_url(config_url: str) -> tuple[str, str, str, str]:
+    openid_url = config_url.rstrip("/")
+    if not openid_url.endswith(_OPENID_WK):
+        openid_url = f"{openid_url}{_OPENID_WK}"
 
-    openid_configuration_url = f"{config_url}{_OPENID_CONFIGURATION_SUFFIX}"
-    return config_url, openid_configuration_url
+    issuer_url = openid_url[: -len(_OPENID_WK)]
+    parsed = urlparse(issuer_url)
+    parts = parsed.path.strip("/").split("/")
+    descope_base_url = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
 
-
-def _parse_descope_config_url(
-    config_url: str,
-) -> tuple[str, str, str, str]:
-    """Parse a Descope well-known URL into connection details.
-
-    Supports both resource-specific MCP Server URLs:
-        /v1/apps/agentic/{project_id}/{mcp_server_id}/.well-known/openid-configuration
-    and project-level inbound app URLs:
-        /v1/apps/{project_id}/.well-known/openid-configuration
-
-    Returns:
-        Tuple of (descope_base_url, project_id, issuer_url, openid_configuration_url)
-    """
-    issuer_url, openid_configuration_url = _normalize_openid_configuration_url(config_url)
-    parsed_url = urlparse(issuer_url)
-    path_parts = parsed_url.path.strip("/").split("/")
-    descope_base_url = f"{parsed_url.scheme}://{parsed_url.netloc}".rstrip("/")
-
-    if "agentic" in path_parts:
-        agentic_index = path_parts.index("agentic")
-        if agentic_index + 1 >= len(path_parts):
-            raise ValueError(
-                f"Could not extract project_id from config_url: {issuer_url}"
-            )
-        project_id = path_parts[agentic_index + 1]
-    elif "apps" in path_parts:
-        apps_index = path_parts.index("apps")
-        if apps_index + 1 >= len(path_parts):
-            raise ValueError(
-                f"Could not extract project_id from config_url: {issuer_url}"
-            )
-        project_id = path_parts[apps_index + 1]
+    if "agentic" in parts:
+        index = parts.index("agentic") + 1
+        project_id = parts[index] if index < len(parts) else ""
+    elif "apps" in parts:
+        index = parts.index("apps") + 1
+        project_id = parts[index] if index < len(parts) else ""
         if project_id == "agentic":
-            raise ValueError(
-                f"Could not extract project_id from config_url: {issuer_url}"
-            )
+            project_id = ""
     else:
-        raise ValueError(
-            "Could not parse config_url: expected a Descope apps well-known URL "
-            f"(/v1/apps/{{project_id}}/... or /v1/apps/agentic/{{project_id}}/...): "
-            f"{issuer_url}"
-        )
+        project_id = ""
 
-    return descope_base_url, project_id, issuer_url, openid_configuration_url
+    if not project_id:
+        raise ValueError(f"Could not extract project_id from config_url: {issuer_url}")
 
-
-def _oauth_authorization_server_url(openid_configuration_url: str) -> str:
-    if openid_configuration_url.endswith(_OPENID_CONFIGURATION_SUFFIX):
-        return openid_configuration_url[: -len(_OPENID_CONFIGURATION_SUFFIX)] + (
-            _OAUTH_AUTHORIZATION_SERVER_SUFFIX
-        )
-    return f"{openid_configuration_url.rstrip('/')}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
+    return descope_base_url, project_id, issuer_url, openid_url
 
 
-def _fetch_openid_configuration(openid_configuration_url: str) -> dict | None:
+def _discover_scopes(openid_configuration_url: str) -> list[str] | None:
     try:
         response = httpx.get(openid_configuration_url, timeout=10.0)
         response.raise_for_status()
-        metadata = response.json()
-        if isinstance(metadata, dict):
-            return metadata
+        scopes = response.json().get("scopes_supported")
+        if isinstance(scopes, list):
+            parsed = [scope for scope in scopes if isinstance(scope, str)]
+            return parsed or None
     except Exception:
         logger.warning(
             "Failed to fetch Descope OpenID configuration from %s",
@@ -126,9 +87,7 @@ class DescopeProvider(RemoteAuthProvider):
 
     2. Note your Well-Known URL:
        - Save your Well-Known URL from [MCP Server Settings](https://app.descope.com/mcp-servers)
-       - Recommended format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
-       - Project-level format is also supported:
-         ``https://.../v1/apps/P.../.well-known/openid-configuration``
+       - Format: ``https://.../v1/apps/agentic/P.../M.../.well-known/openid-configuration``
 
     For detailed setup instructions, see:
     https://docs.descope.com/identity-federation/inbound-apps/creating-inbound-apps#method-2-dynamic-client-registration-dcr
@@ -161,29 +120,7 @@ class DescopeProvider(RemoteAuthProvider):
         resource_documentation: AnyHttpUrl | None = None,
         token_verifier: TokenVerifier | None = None,
     ):
-        """Initialize Descope metadata provider.
-
-        Args:
-            base_url: Public URL of this FastMCP server
-            config_url: Your Descope Well-Known URL. Prefer the MCP Server-specific URL
-                (``/v1/apps/agentic/P.../M.../.well-known/openid-configuration``). Project-level
-                URLs (``/v1/apps/P.../.well-known/openid-configuration``) are also supported.
-                If provided, project_id and descope_base_url are ignored.
-            project_id: Your Descope Project ID (e.g., "P2abc123"). Used with descope_base_url for backwards compatibility.
-            descope_base_url: Your Descope base URL (e.g., "https://api.descope.com"). Used with project_id for backwards compatibility.
-            required_scopes: Scopes that must be present in validated tokens. When omitted,
-                tokens are not rejected for missing global scopes.
-            scopes_supported: Scopes advertised to MCP clients via protected resource metadata.
-                When omitted, scopes are discovered from ``scopes_supported`` in the configured
-                well-known OpenID document. Defaults to ``required_scopes`` when neither is
-                provided.
-            resource_name: Optional name for the protected resource metadata.
-            resource_documentation: Optional documentation URL for the protected resource.
-            token_verifier: Optional token verifier. If None, creates JWT verifier for Descope
-        """
         self.base_url = AnyHttpUrl(str(base_url).rstrip("/"))
-        self.openid_configuration_url: str | None = None
-        self.oauth_authorization_server_metadata_url: str | None = None
 
         parsed_required_scopes = (
             parse_scopes(required_scopes) if required_scopes is not None else None
@@ -192,7 +129,6 @@ class DescopeProvider(RemoteAuthProvider):
             parse_scopes(scopes_supported) if scopes_supported is not None else None
         )
 
-        # Determine which API is being used
         if config_url is not None:
             (
                 self.descope_base_url,
@@ -200,51 +136,29 @@ class DescopeProvider(RemoteAuthProvider):
                 issuer_url,
                 self.openid_configuration_url,
             ) = _parse_descope_config_url(str(config_url))
-            self.oauth_authorization_server_metadata_url = (
-                _oauth_authorization_server_url(self.openid_configuration_url)
-            )
         elif project_id is not None and descope_base_url is not None:
-            # Old API: use project_id and descope_base_url
             self.project_id = project_id
             descope_base_url_str = str(descope_base_url).rstrip("/")
-            # Ensure descope_base_url has a scheme
             if not descope_base_url_str.startswith(("http://", "https://")):
                 descope_base_url_str = f"https://{descope_base_url_str}"
             self.descope_base_url = descope_base_url_str
-            # Old issuer format
             issuer_url = f"{self.descope_base_url}/v1/apps/{self.project_id}"
-            self.openid_configuration_url = (
-                f"{issuer_url}{_OPENID_CONFIGURATION_SUFFIX}"
-            )
-            self.oauth_authorization_server_metadata_url = (
-                f"{issuer_url}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}"
-            )
+            self.openid_configuration_url = f"{issuer_url}{_OPENID_WK}"
         else:
             raise ValueError(
                 "Either config_url (new API) or both project_id and descope_base_url (old API) must be provided"
             )
 
+        self.oauth_authorization_server_metadata_url = (
+            self.openid_configuration_url.replace(_OPENID_WK, _OAUTH_WK)
+        )
+
         if (
             parsed_scopes_supported is None
             and parsed_required_scopes is None
-            and self.openid_configuration_url is not None
         ):
-            openid_configuration = _fetch_openid_configuration(
-                self.openid_configuration_url
-            )
-            if openid_configuration is not None:
-                discovered_scopes = openid_configuration.get("scopes_supported")
-                if isinstance(discovered_scopes, list):
-                    parsed_scopes_supported = [
-                        scope for scope in discovered_scopes if isinstance(scope, str)
-                    ]
-                    if parsed_scopes_supported:
-                        logger.info(
-                            "Discovered scopes_supported from Descope well-known: %s",
-                            parsed_scopes_supported,
-                        )
+            parsed_scopes_supported = _discover_scopes(self.openid_configuration_url)
 
-        # Create default JWT verifier if none provided
         if token_verifier is None:
             token_verifier = JWTVerifier(
                 jwks_uri=f"{self.descope_base_url}/{self.project_id}/.well-known/jwks.json",
@@ -254,7 +168,6 @@ class DescopeProvider(RemoteAuthProvider):
                 required_scopes=parsed_required_scopes,
             )
 
-        # Initialize RemoteAuthProvider with Descope as the authorization server
         super().__init__(
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(issuer_url)],
@@ -268,41 +181,22 @@ class DescopeProvider(RemoteAuthProvider):
         self,
         mcp_path: str | None = None,
     ) -> list[Route]:
-        """Get OAuth routes including Descope authorization server metadata forwarding.
-
-        This returns the standard protected resource routes plus an authorization server
-        metadata endpoint that forwards Descope's OAuth metadata to clients.
-
-        Args:
-            mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
-                This is used to advertise the resource URL in metadata.
-        """
-        # Get the standard protected resource routes from RemoteAuthProvider
         routes = super().get_routes(mcp_path)
 
         async def oauth_authorization_server_metadata(request):
-            """Forward Descope OAuth authorization server metadata with FastMCP customizations."""
             metadata_urls = [
                 self.oauth_authorization_server_metadata_url,
-                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_AUTHORIZATION_SERVER_SUFFIX}",
+                f"{self.descope_base_url}/v1/apps/{self.project_id}{_OAUTH_WK}",
             ]
             try:
                 async with httpx.AsyncClient() as client:
-                    last_error: Exception | None = None
                     for metadata_url in metadata_urls:
-                        if not metadata_url:
-                            continue
                         try:
                             response = await client.get(metadata_url)
                             response.raise_for_status()
-                            metadata = response.json()
-                            return JSONResponse(metadata)
-                        except Exception as exc:
-                            last_error = exc
+                            return JSONResponse(response.json())
+                        except Exception:
                             continue
-                    raise last_error or RuntimeError(
-                        "No Descope authorization server metadata URL configured"
-                    )
             except Exception as e:
                 return JSONResponse(
                     {
@@ -312,7 +206,14 @@ class DescopeProvider(RemoteAuthProvider):
                     status_code=500,
                 )
 
-        # Add Descope authorization server metadata forwarding
+            return JSONResponse(
+                {
+                    "error": "server_error",
+                    "error_description": "Failed to fetch Descope metadata",
+                },
+                status_code=500,
+            )
+
         routes.append(
             Route(
                 "/.well-known/oauth-authorization-server",

--- a/tests/server/auth/providers/test_descope.py
+++ b/tests/server/auth/providers/test_descope.py
@@ -3,6 +3,7 @@
 import os
 from unittest.mock import patch
 
+import httpx
 import pytest
 from mcp import MCPError
 
@@ -11,6 +12,12 @@ from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.server.auth.providers.descope import DescopeProvider
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.utilities.tests import HeadlessOAuth, run_server_async
+
+PROJECT_LEVEL_OPENID_CONFIGURATION = {
+    "issuer": "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU",
+    "scopes_supported": ["mcp:skyflow"],
+    "jwks_uri": "https://api.descope.com/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/jwks.json",
+}
 
 
 class TestDescopeProvider:
@@ -65,6 +72,88 @@ class TestDescopeProvider:
         )
         assert str(provider3.descope_base_url) == "https://api.descope.com"
         assert provider3.project_id == "P2abc123"
+
+    def test_project_level_config_url_parsing(self):
+        """Test project-level well-known URLs without the agentic path segment."""
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration",
+            base_url="https://myserver.com",
+        )
+
+        assert provider.project_id == "P2v9EBlmO4XTrOwMRfsY1jeUONxU"
+        assert str(provider.descope_base_url) == "https://api.descope.com"
+        assert isinstance(provider.token_verifier, JWTVerifier)
+        assert (
+            provider.token_verifier.issuer
+            == "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU"
+        )
+        assert provider.openid_configuration_url == (
+            "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+        )
+        assert provider.oauth_authorization_server_metadata_url == (
+            "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/oauth-authorization-server"
+        )
+
+    def test_discover_scopes_supported_from_well_known(self):
+        """Test that scopes_supported are discovered from Descope well-known metadata."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+        mock_response = httpx.Response(
+            200,
+            json=PROJECT_LEVEL_OPENID_CONFIGURATION,
+            request=httpx.Request("GET", config_url),
+        )
+
+        with patch("httpx.get", return_value=mock_response) as mock_get:
+            provider = DescopeProvider(
+                config_url=config_url,
+                base_url="https://myserver.com",
+            )
+
+        mock_get.assert_called_once_with(config_url, timeout=10.0)
+        assert provider._scopes_supported == ["mcp:skyflow"]
+        assert provider.token_verifier.required_scopes == []
+
+    def test_scopes_supported_and_required_scopes_can_differ(self):
+        """Test that scopes_supported and required_scopes can be configured independently."""
+        provider = DescopeProvider(
+            config_url="https://api.descope.com/v1/apps/agentic/P2abc123/M123/.well-known/openid-configuration",
+            base_url="https://myserver.com",
+            scopes_supported=["mcp:read", "mcp:write"],
+            required_scopes=["mcp:read"],
+        )
+
+        assert provider._scopes_supported == ["mcp:read", "mcp:write"]
+        assert provider.token_verifier.required_scopes == ["mcp:read"]
+
+    def test_explicit_required_scopes_skip_discovery(self):
+        """Test that explicit required_scopes skip well-known discovery."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+
+        with patch("httpx.get") as mock_get:
+            provider = DescopeProvider(
+                config_url=config_url,
+                base_url="https://myserver.com",
+                required_scopes=["custom:scope"],
+            )
+
+        mock_get.assert_not_called()
+        assert provider.token_verifier.required_scopes == ["custom:scope"]
+        assert provider._scopes_supported is None
+
+    def test_explicit_scopes_supported_skip_discovery(self):
+        """Test that explicit scopes_supported skip well-known discovery."""
+        config_url = "https://api.descope.com/v1/apps/P2v9EBlmO4XTrOwMRfsY1jeUONxU/.well-known/openid-configuration"
+
+        with patch("httpx.get") as mock_get:
+            provider = DescopeProvider(
+                config_url=config_url,
+                base_url="https://myserver.com",
+                scopes_supported=["custom:advertised"],
+            )
+
+        mock_get.assert_not_called()
+        assert provider._scopes_supported == ["custom:advertised"]
+        assert provider.token_verifier.required_scopes == []
 
     def test_requires_config_url_or_project_id_and_descope_base_url(self):
         """Test that either config_url or both project_id and descope_base_url are required."""


### PR DESCRIPTION
Resolves: https://github.com/PrefectHQ/fastmcp/issues/4490

Descope MCP servers expose resource-specific scopes in their OpenID well-known document, but `DescopeProvider` required the `agentic` URL shape and did not discover those scopes automatically.

This updates `DescopeProvider` to accept MCP Server-specific and project-level well-known URLs, discover `scopes_supported` from Descope when neither scope param is set, and forward authorization-server metadata from the matching well-known path. `required_scopes` and `scopes_supported` remain independently configurable.

```python
DescopeProvider(
    config_url="https://api.descope.com/v1/apps/P.../.well-known/openid-configuration",
    base_url="https://your-server.com",
    scopes_supported=["mcp:read", "mcp:write"],
    required_scopes=["mcp:read"],
)
```

🤖 Generated with Cursor

Made with [Cursor](https://cursor.com)