### PR TITLE
Don't mutate the caller's schema in compress_schema

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema.py
@@ -498,6 +498,11 @@ def _single_pass_optimize(
     if not (prune_defs or prune_titles or prune_additional_properties):
         return schema  # Nothing to do
 
+    # Work on a copy so the caller's schema is never mutated (see docstring). The
+    # pruning phases below pop keys/$defs in place, which would otherwise corrupt a
+    # shared dict such as a live Tool.input_schema passed straight to compress_schema.
+    schema = copy.deepcopy(schema)
+
     # Phase 1: Collect references and apply simple cleanups
     # Track which $defs are referenced from the main schema and from other $defs
     root_refs: set[str] = set()  # $defs referenced directly from main schema

--- a/tests/utilities/test_json_schema.py
+++ b/tests/utilities/test_json_schema.py
@@ -358,6 +358,39 @@ class TestDereferenceRefs:
 class TestCompressSchema:
     """Tests for the compress_schema function."""
 
+    def test_does_not_mutate_input(self):
+        """compress_schema must return a new dict and leave the caller's schema
+        untouched, even when it prunes titles, additionalProperties and unused
+        $defs (a live Tool.input_schema is passed straight in at some call sites)."""
+        schema = {
+            "type": "object",
+            "title": "MySchema",
+            "additionalProperties": False,
+            "properties": {
+                "a": {"type": "string", "title": "A"},
+                "b": {
+                    "type": "object",
+                    "title": "B",
+                    "properties": {"c": {"type": "integer", "title": "C"}},
+                },
+            },
+            "$defs": {"Unused": {"type": "string", "title": "Unused"}},
+        }
+        original = copy.deepcopy(schema)
+
+        result = compress_schema(
+            schema, prune_titles=True, prune_additional_properties=True
+        )
+
+        # The input is untouched...
+        assert schema == original
+        assert result is not schema
+        # ...and the returned copy really was optimized (so it is not a no-op).
+        assert "title" not in result
+        assert "title" not in result["properties"]["b"]["properties"]["c"]
+        assert "additionalProperties" not in result
+        assert "$defs" not in result
+
     def test_preserves_refs_by_default(self):
         """Test that compress_schema preserves $refs by default."""
         schema = {


### PR DESCRIPTION
Closes #4493.

## Summary

`compress_schema()` mutates the caller's schema in place, directly contradicting its own documented contract. `_single_pass_optimize` (which `compress_schema` calls) states:

> Immutable design prevents shared reference bugs
> schema: JSON schema dict to optimize (**not modified**)
> Returns: A **new** optimized schema dict

But its pruning phases `.pop()` `title`, `additionalProperties`, and unused `$defs` off the **passed-in** dict:

```python
>>> from fastmcp.utilities.json_schema import compress_schema
>>> schema = {"type": "object", "title": "S", "additionalProperties": False,
...           "properties": {"a": {"type": "string", "title": "A"}},
...           "$defs": {"Unused": {"type": "string"}}}
>>> compress_schema(schema, prune_titles=True, prune_additional_properties=True)
{'type': 'object', 'properties': {'a': {'type': 'string'}}}
>>> schema  # the caller's object was stripped in place
{'type': 'object', 'properties': {'a': {'type': 'string'}}}
```

This bites at real call sites that pass a live object — e.g. `client/sampling/handlers/google_genai.py` calls `compress_schema(tool.input_schema, ...)` when converting a tool for Gemini, which permanently strips `title`/`additionalProperties`/`$defs` off the shared `Tool` object — exactly the "shared reference bug" the docstring says it prevents.

## Fix

Deep-copy the schema before the in-place pruning phases, matching the sibling `_prune_param` which already does `schema = copy.deepcopy(schema)`. One line; `copy` is already imported. Because the copy happens at the single entry point (`_single_pass_optimize`), it covers every `compress_schema` caller.

## Test

Adds `TestCompressSchema::test_does_not_mutate_input` (mirroring the existing `_prune_param` non-mutation test): a schema with a title, `additionalProperties`, nested titles and an unused `$def` is left untouched after `compress_schema(..., prune_titles=True, prune_additional_properties=True)`, and the returned copy is confirmed to actually be optimized (so it isn't a no-op). It fails on the current code and passes with the fix; the full `test_json_schema.py` suite passes and `ruff` check + format are clean.
