### PR TITLE
Fix #4500: Do not log errors for ToolErrors

### DIFF
--- a/fastmcp_slim/fastmcp/exceptions.py
+++ b/fastmcp_slim/fastmcp/exceptions.py
@@ -59,6 +59,9 @@ class ResourceError(FastMCPError):
 class ToolError(FastMCPError):
     """Error in tool operations."""
 
+    def __init__(self, *args: object, log_level: int = logging.INFO) -> None:
+        super().__init__(*args, log_level=log_level)
+
 
 class PromptError(FastMCPError):
     """Error in prompt operations."""


### PR DESCRIPTION
Set default log_level for ToolError to logging.INFO instead of inheriting logging.ERROR to prevent expected tool failures from triggering error alerts.

## Description

Closes #4500

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read CONTRIBUTING.md
- [ ] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [ ] If I used an LLM, it followed the repo's contributing conventions (not generic output)