### PR TITLE
fix(server): omit ScalarElicitationType wrapper title from elicitation schemas

### DIFF
--- a/fastmcp_slim/fastmcp/server/elicitation.py
+++ b/fastmcp_slim/fastmcp/server/elicitation.py
@@ -378,6 +378,13 @@ def get_elicitation_schema(response_type: type[T]) -> dict[str, Any]:
     )
     schema = compress_schema(schema)
 
+    # Pydantic emits the internal wrapper class name as a top-level title for
+    # ScalarElicitationType schemas. That value is not meaningful on the wire and
+    # breaks strict clients (e.g. Codex) that reject unknown top-level fields.
+    origin = get_origin(response_type)
+    if origin is ScalarElicitationType or response_type is ScalarElicitationType:
+        schema.pop("title", None)
+
     # Validate the schema to ensure it follows MCP elicitation requirements
     validate_elicitation_json_schema(schema)
 

--- a/tests/client/test_elicitation.py
+++ b/tests/client/test_elicitation.py
@@ -107,11 +107,9 @@ async def test_elicitation_handler_parameters():
         await client.call_tool("test_tool", {})
 
         assert captured_params["message"] == "Test message"
-        assert "ScalarElicitationType" in str(captured_params["response_type"])
         assert captured_params["params"].requested_schema == {
             "properties": {"value": {"title": "Value", "type": "integer"}},
             "required": ["value"],
-            "title": "ScalarElicitationType",
             "type": "object",
         }
         assert captured_params["ctx"] is not None

--- a/tests/client/test_elicitation_enums.py
+++ b/tests/client/test_elicitation_enums.py
@@ -514,3 +514,13 @@ class TestElicitationDefaults:
 
         assert "default" in props["string_field"]
         assert "default" in props["integer_field"]
+
+
+def test_scalar_elicitation_schema_omits_wrapper_title() -> None:
+    """Scalar/list wrappers must not leak the internal class name on the wire."""
+    from fastmcp.server.elicitation import parse_elicit_response_type
+
+    schema = parse_elicit_response_type(["yes", "no"]).schema
+
+    assert "title" not in schema
+    assert schema["properties"]["value"]["enum"] == ["yes", "no"]


### PR DESCRIPTION
## Summary
Strip the internal ScalarElicitationType wrapper title from scalar/list elicitation schemas sent to MCP clients.

## Motivation
Fixes #4477. Pydantic emits the wrapper class name as a top-level title, which breaks strict clients (e.g. Codex).

## Changes
- Drop top-level title in get_elicitation_schema() for ScalarElicitationType wrappers only.
- Update tests and add regression coverage.

## Tests
- uv run pytest tests/client/test_elicitation.py tests/client/test_elicitation_enums.py -q — 55 passed