### PR TITLE
Clarify PR-reopen flow and fix label-race that broke auto-reopen

### DIFF
--- a/.github/scripts/triage-label.sh
+++ b/.github/scripts/triage-label.sh
@@ -46,6 +46,20 @@ for label in "$@"; do
   fi
 done
 
+# Never let triage add or remove the Require Issue Link control labels. Those
+# govern PR enforcement (bypass-issue-check / trusted-contributor are sticky
+# exemptions) and reopening (missing-issue-link is how closed PRs are found),
+# so a prompt-injected triage run must not be able to grant an exemption or
+# break recovery. Enforced here — in code — not merely in the prompt.
+protected=" missing-issue-link bypass-issue-check trusted-contributor "
+for label in "$@"; do
+  lower="${label,,}"
+  if [[ "$protected" == *" $lower "* ]]; then
+    echo "refusing to touch protected control label: $label" >&2
+    exit 1
+  fi
+done
+
 if [[ "$method" == POST ]]; then
   args=()
   for label in "$@"; do

--- a/.github/scripts/triage-label.sh
+++ b/.github/scripts/triage-label.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Locked-down label helper for the Marvin triage workflow.
+#
+# Marvin runs on untrusted issue/PR bodies from non-write users, so it must
+# NOT be handed raw `gh api` (that would expose every endpoint the app token
+# can reach). This helper is the ONLY GitHub write it is allowed to perform:
+# it adds or removes repository labels on the one issue/PR being triaged.
+#
+# The target repo and number come from the environment set by the workflow —
+# never from the model — and the operation is fixed to the additive labels
+# endpoint (POST/DELETE /repos/{repo}/issues/{n}/labels), which works for both
+# issues and PRs and cannot clobber labels applied by other workflows.
+set -euo pipefail
+
+repo="${TRIAGE_REPO:?TRIAGE_REPO not set}"
+number="${TRIAGE_NUMBER:?TRIAGE_NUMBER not set}"
+
+if [[ ! "$number" =~ ^[0-9]+$ ]]; then
+  echo "TRIAGE_NUMBER must be numeric, got: $number" >&2
+  exit 1
+fi
+
+op="${1:-}"
+shift || true
+case "$op" in
+  add) method=POST ;;
+  remove) method=DELETE ;;
+  *)
+    echo "usage: triage-label.sh <add|remove> <label>..." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$#" -eq 0 ]]; then
+  echo "no labels given" >&2
+  exit 1
+fi
+
+# Reject anything that isn't a plausible label name. Notably blocks '/' so a
+# crafted value can't turn the DELETE path into a different endpoint.
+label_re="^[A-Za-z0-9 ._'-]+$"
+for label in "$@"; do
+  if [[ ! "$label" =~ $label_re ]]; then
+    echo "refusing suspicious label name: $label" >&2
+    exit 1
+  fi
+done
+
+if [[ "$method" == POST ]]; then
+  args=()
+  for label in "$@"; do
+    args+=(-f "labels[]=$label")
+  done
+  gh api --method POST "/repos/${repo}/issues/${number}/labels" "${args[@]}"
+else
+  for label in "$@"; do
+    gh api --method DELETE "/repos/${repo}/issues/${number}/labels/${label}"
+  done
+fi

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -49,15 +49,13 @@ jobs:
           PROMPT<<PROMPT_END
           You're an issue triage assistant for FastMCP, a Python framework for building Model Context Protocol servers and clients. Your task is to analyze issues/PRs and apply appropriate labels.
 
-          IMPORTANT: Your primary action should be to apply labels using mcp__github__update_issue. DO NOT post comments EXCEPT when applying the too-long label (see below).
+          IMPORTANT: Your primary action should be to apply labels additively with `gh issue edit`. DO NOT post comments EXCEPT when applying the too-long label (see below).
 
           CRITICAL — LABEL MECHANICS:
-          - `mcp__github__update_issue` REPLACES all labels on the issue — it does not add to them.
-          - Before applying labels, read the issue's current labels with `mcp__github__get_issue`.
-          - Always include any existing labels you want to keep alongside the new ones.
-          - Only apply labels that exist in the repository (from `gh label list` in step 1). Never invent labels.
-          - NEVER strip these workflow-control labels: `missing-issue-link`, `bypass-issue-check`, `trusted-contributor`. If any are present on the issue/PR, you MUST carry them forward unchanged in your update, in addition to the category/area labels you apply. They are managed by the Require Issue Link workflow — not category labels — so don't reason about whether they fit; just preserve them. Removing `missing-issue-link` in particular prevents an auto-closed PR from reopening once its author is assigned to the linked issue.
-          - IMMEDIATELY before you call `mcp__github__update_issue`, re-read the current labels with `mcp__github__get_issue` and merge them into the set you send — do not rely on a snapshot from earlier in your run. The Require Issue Link workflow runs concurrently and may add a control label to this PR while you work; since `update_issue` replaces the whole set, a stale snapshot would silently drop it.
+          - Apply labels ADDITIVELY: `gh issue edit <NUMBER> --add-label "label1,label2"`. This ONLY adds the labels you name and leaves every existing label untouched.
+          - NEVER use a replace-all label operation. Other workflows apply their own labels concurrently — notably the Require Issue Link workflow's `missing-issue-link` control label, which must survive or an auto-closed PR won't reopen when its author is assigned. `--add-label` cannot clobber those; a replace can. So never reason about which existing labels to "keep" — additive means they all stay.
+          - Only apply labels that exist in the repository (from `gh label list` in step 1). Never invent labels — `--add-label` errors on unknown labels.
+          - If (and only if) you must correct a label you believe is wrong, remove just that one with `gh issue edit <NUMBER> --remove-label "wrong-label"`. Never remove a label you didn't set out to change, and never touch the control labels above.
 
           Issue/PR Information:
           - REPO: ${{ github.repository }}
@@ -133,7 +131,7 @@ jobs:
           - DON'T MERGE: Only if PR author explicitly states it's not ready
 
           4. Apply selected labels:
-             Use mcp__github__update_issue to apply your selected labels
+             Add them with `gh issue edit <NUMBER> --add-label "..."` (comma-separated). Additive only — never replace.
              DO NOT post any comments unless applying too-long (see above)
           PROMPT_END
           EOF
@@ -151,7 +149,7 @@ jobs:
           allowed_non_write_users: "*"
           allowed_bots: "marvin-context-protocol"
           claude_args: |
-            --allowedTools Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
+            --allowedTools Bash(gh label list),Bash(gh issue edit:*),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
           settings: |
             {
               "model": "claude-sonnet-4-6",

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -49,13 +49,15 @@ jobs:
           PROMPT<<PROMPT_END
           You're an issue triage assistant for FastMCP, a Python framework for building Model Context Protocol servers and clients. Your task is to analyze issues/PRs and apply appropriate labels.
 
-          IMPORTANT: Your primary action should be to apply labels additively with `gh issue edit`. DO NOT post comments EXCEPT when applying the too-long label (see below).
+          IMPORTANT: Your primary action should be to apply labels additively via the REST labels endpoint (`gh api`). DO NOT post comments EXCEPT when applying the too-long label (see below).
 
           CRITICAL — LABEL MECHANICS:
-          - Apply labels ADDITIVELY: `gh issue edit <NUMBER> --add-label "label1,label2"`. This ONLY adds the labels you name and leaves every existing label untouched.
-          - NEVER use a replace-all label operation. Other workflows apply their own labels concurrently — notably the Require Issue Link workflow's `missing-issue-link` control label, which must survive or an auto-closed PR won't reopen when its author is assigned. `--add-label` cannot clobber those; a replace can. So never reason about which existing labels to "keep" — additive means they all stay.
-          - Only apply labels that exist in the repository (from `gh label list` in step 1). Never invent labels — `--add-label` errors on unknown labels.
-          - If (and only if) you must correct a label you believe is wrong, remove just that one with `gh issue edit <NUMBER> --remove-label "wrong-label"`. Never remove a label you didn't set out to change, and never touch the control labels above.
+          - Apply labels ADDITIVELY through the REST labels endpoint, which works for BOTH issues and PRs and only adds the labels you name (existing labels are left untouched):
+            `gh api --method POST /repos/${{ github.repository }}/issues/<NUMBER>/labels -f "labels[]=label1" -f "labels[]=label2"`
+            `<NUMBER>` is the issue/PR number from the info block above; use one `-f "labels[]=..."` per label.
+          - Do NOT use `gh issue edit`, `gh pr edit`, or any replace-all operation. `gh issue edit` cannot resolve PR numbers, and a replace-all would clobber labels applied concurrently by other workflows — notably the Require Issue Link workflow's `missing-issue-link` control label, which must survive or an auto-closed PR won't reopen when its author is assigned. The POST endpoint above is additive and works on both issues and PRs, so it avoids both problems.
+          - Only apply labels that exist in the repository (from `gh label list` in step 1). Never invent labels.
+          - If (and only if) you must correct a label you believe is wrong, remove just that one: `gh api --method DELETE /repos/${{ github.repository }}/issues/<NUMBER>/labels/<label-name>`. Never remove a label you didn't set out to change, and never touch the control labels above.
 
           Issue/PR Information:
           - REPO: ${{ github.repository }}
@@ -131,7 +133,7 @@ jobs:
           - DON'T MERGE: Only if PR author explicitly states it's not ready
 
           4. Apply selected labels:
-             Add them with `gh issue edit <NUMBER> --add-label "..."` (comma-separated). Additive only — never replace.
+             Add them with `gh api --method POST /repos/${{ github.repository }}/issues/<NUMBER>/labels -f "labels[]=..."` (one `-f "labels[]=..."` per label). Additive and works on both issues and PRs — never replace.
              DO NOT post any comments unless applying too-long (see above)
           PROMPT_END
           EOF
@@ -149,7 +151,7 @@ jobs:
           allowed_non_write_users: "*"
           allowed_bots: "marvin-context-protocol"
           claude_args: |
-            --allowedTools Bash(gh label list),Bash(gh issue edit:*),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
+            --allowedTools Bash(gh label list),Bash(gh api:*),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
           settings: |
             {
               "model": "claude-sonnet-4-6",

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -49,15 +49,16 @@ jobs:
           PROMPT<<PROMPT_END
           You're an issue triage assistant for FastMCP, a Python framework for building Model Context Protocol servers and clients. Your task is to analyze issues/PRs and apply appropriate labels.
 
-          IMPORTANT: Your primary action should be to apply labels additively via the REST labels endpoint (`gh api`). DO NOT post comments EXCEPT when applying the too-long label (see below).
+          IMPORTANT: Your primary action should be to apply labels using the locked-down helper `.github/scripts/triage-label.sh`. DO NOT post comments EXCEPT when applying the too-long label (see below).
 
           CRITICAL — LABEL MECHANICS:
-          - Apply labels ADDITIVELY through the REST labels endpoint, which works for BOTH issues and PRs and only adds the labels you name (existing labels are left untouched):
-            `gh api --method POST /repos/${{ github.repository }}/issues/<NUMBER>/labels -f "labels[]=label1" -f "labels[]=label2"`
-            `<NUMBER>` is the issue/PR number from the info block above; use one `-f "labels[]=..."` per label.
-          - Do NOT use `gh issue edit`, `gh pr edit`, or any replace-all operation. `gh issue edit` cannot resolve PR numbers, and a replace-all would clobber labels applied concurrently by other workflows — notably the Require Issue Link workflow's `missing-issue-link` control label, which must survive or an auto-closed PR won't reopen when its author is assigned. The POST endpoint above is additive and works on both issues and PRs, so it avoids both problems.
+          - Apply labels ONLY through the helper, which adds or removes repository labels on THIS issue/PR. It already knows the target repo and number (from the workflow environment) — you never pass them:
+            add:    `bash .github/scripts/triage-label.sh add "label1" "label2"`
+            remove: `bash .github/scripts/triage-label.sh remove "label1"`
+          - The helper uses the additive REST labels endpoint, so it works for both issues and PRs and never clobbers labels applied by other workflows — notably the Require Issue Link workflow's `missing-issue-link` control label, which must survive or an auto-closed PR won't reopen when its author is assigned.
+          - The helper is your ONLY GitHub write access. Do NOT use raw `gh api`, `gh issue edit`, `gh pr edit`, or any other mutation — they are not available to you.
           - Only apply labels that exist in the repository (from `gh label list` in step 1). Never invent labels.
-          - If (and only if) you must correct a label you believe is wrong, remove just that one: `gh api --method DELETE /repos/${{ github.repository }}/issues/<NUMBER>/labels/<label-name>`. Never remove a label you didn't set out to change, and never touch the control labels above.
+          - Use `remove` only to correct a label you believe is wrong, and never remove the control labels `missing-issue-link`, `bypass-issue-check`, or `trusted-contributor`.
 
           Issue/PR Information:
           - REPO: ${{ github.repository }}
@@ -133,7 +134,7 @@ jobs:
           - DON'T MERGE: Only if PR author explicitly states it's not ready
 
           4. Apply selected labels:
-             Add them with `gh api --method POST /repos/${{ github.repository }}/issues/<NUMBER>/labels -f "labels[]=..."` (one `-f "labels[]=..."` per label). Additive and works on both issues and PRs — never replace.
+             Add them with `bash .github/scripts/triage-label.sh add "label1" "label2"`.
              DO NOT post any comments unless applying too-long (see above)
           PROMPT_END
           EOF
@@ -151,11 +152,13 @@ jobs:
           allowed_non_write_users: "*"
           allowed_bots: "marvin-context-protocol"
           claude_args: |
-            --allowedTools Bash(gh label list),Bash(gh api:*),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
+            --allowedTools Bash(gh label list),Bash(bash .github/scripts/triage-label.sh:*),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
           settings: |
             {
               "model": "claude-sonnet-4-6",
               "env": {
-                "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}"
+                "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}",
+                "TRIAGE_REPO": "${{ github.repository }}",
+                "TRIAGE_NUMBER": "${{ github.event.issue.number || github.event.pull_request.number || inputs.issue_number }}"
               }
             }

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -56,6 +56,7 @@ jobs:
           - Before applying labels, read the issue's current labels with `mcp__github__get_issue`.
           - Always include any existing labels you want to keep alongside the new ones.
           - Only apply labels that exist in the repository (from `gh label list` in step 1). Never invent labels.
+          - NEVER strip these workflow-control labels: `missing-issue-link`, `bypass-issue-check`, `trusted-contributor`. If any are present on the issue/PR, you MUST carry them forward unchanged in your update, in addition to the category/area labels you apply. They are managed by the Require Issue Link workflow — not category labels — so don't reason about whether they fit; just preserve them. Removing `missing-issue-link` in particular prevents an auto-closed PR from reopening once its author is assigned to the linked issue.
 
           Issue/PR Information:
           - REPO: ${{ github.repository }}

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -57,6 +57,7 @@ jobs:
           - Always include any existing labels you want to keep alongside the new ones.
           - Only apply labels that exist in the repository (from `gh label list` in step 1). Never invent labels.
           - NEVER strip these workflow-control labels: `missing-issue-link`, `bypass-issue-check`, `trusted-contributor`. If any are present on the issue/PR, you MUST carry them forward unchanged in your update, in addition to the category/area labels you apply. They are managed by the Require Issue Link workflow — not category labels — so don't reason about whether they fit; just preserve them. Removing `missing-issue-link` in particular prevents an auto-closed PR from reopening once its author is assigned to the linked issue.
+          - IMMEDIATELY before you call `mcp__github__update_issue`, re-read the current labels with `mcp__github__get_issue` and merge them into the set you send — do not rely on a snapshot from earlier in your run. The Require Issue Link workflow runs concurrently and may add a control label to this PR while you work; since `update_issue` replaces the whole set, a stale snapshot would silently drop it.
 
           Issue/PR Information:
           - REPO: ${{ github.repository }}

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -359,12 +359,11 @@ jobs:
                 : "you aren't assigned to the issue it references";
               const steps = kind === 'no-link'
                 ? [
-                    `1. Find or [open an issue](https://github.com/${owner}/${repo}/issues/new/choose) describing the change.`,
-                    '2. Comment on that issue to ask a maintainer to assign it to you.',
-                    "3. Add `Fixes #<issue>`, `Closes #<issue>`, or `Resolves #<issue>` to **this** PR's description — edit it in place.",
+                    `1. Find or [open an issue](https://github.com/${owner}/${repo}/issues/new/choose) describing the change — if you open it, you have first claim on it.`,
+                    "2. Add `Fixes #<issue>`, `Closes #<issue>`, or `Resolves #<issue>` to **this** PR's description — edit it in place, don't open a new PR.",
                   ]
                 : [
-                    '1. Comment on the linked issue to ask a maintainer to assign it to you.',
+                    "1. If you opened the linked issue, a maintainer will assign you when they pick it up and this PR reopens automatically. If someone else opened it, the PR reopens only if a maintainer chooses to assign it to you — please don't comment to ask.",
                   ];
 
               const commentBody = [

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -354,28 +354,30 @@ jobs:
             async function enforceFailure(kind) {
               await addLabel();
 
-              const intro = kind === 'no-link'
-                ? '**This PR has been automatically closed** because its description does not reference a tracked issue.'
-                : '**This PR has been automatically closed** because you are not assigned to the issue it references.';
+              const reason = kind === 'no-link'
+                ? "it doesn't reference a tracked issue assigned to you"
+                : "you aren't assigned to the issue it references";
               const steps = kind === 'no-link'
                 ? [
                     `1. Find or [open an issue](https://github.com/${owner}/${repo}/issues/new/choose) describing the change.`,
-                    '2. Comment on the issue to ask a maintainer to assign it to you.',
-                    '3. Add `Fixes #<issue>`, `Closes #<issue>`, or `Resolves #<issue>` to the PR description.',
-                    '4. Once you are assigned and the link is present, the PR reopens automatically.',
+                    '2. Comment on that issue to ask a maintainer to assign it to you.',
+                    "3. Add `Fixes #<issue>`, `Closes #<issue>`, or `Resolves #<issue>` to **this** PR's description — edit it in place.",
                   ]
                 : [
                     '1. Comment on the linked issue to ask a maintainer to assign it to you.',
-                    '2. Once a maintainer assigns you, the PR reopens automatically.',
                   ];
 
               const commentBody = [
                 MARKER,
-                intro,
+                "**Don't open a new pull request — this one reopens on its own.** It's closed for " +
+                  `now because ${reason}, but the moment that's fixed it reopens automatically. Keep this ` +
+                  'PR and edit it; opening a fresh duplicate just starts you over and creates more to triage.',
                 '',
-                `Per [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md), an external PR must reference an issue that is assigned to its author. To proceed:`,
+                `Per [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md), an external PR must reference an issue that's assigned to its author. To get there:`,
                 '',
                 ...steps,
+                '',
+                "Once you're assigned and the link is present, this PR reopens automatically — no further action needed.",
                 '',
                 `*Maintainers: reopen this PR or remove the \`${LABEL}\` label to bypass this check.*`,
               ].join('\n');

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,13 @@ That's it. No need to diagnose root causes, propose API designs, or suggest impl
 
 We encourage you to use LLMs to help identify bugs, write MREs, and prepare contributions. But if you do, your LLM must take into account the conventions and contributing guidelines of this repo — including how we want issues formatted and when it's appropriate to open a PR. Generic LLM output that ignores these guidelines tells us the contribution wasn't made thoughtfully, and we will close it. A good AI-assisted contribution is indistinguishable from a good human one. A bad one is obvious.
 
+If you're driving an agent: do **not** have it post comments asking to be assigned to an issue or announcing that it intends to work on one. Those comments are ignored. If the agent intends to contribute, open a PR instead — it will be gated on assignment (see below). Comment on an issue only to propose a genuinely novel, differentiated solution, never to claim a task that's already described.
+
 ## When to open a pull request
 
-An open issue is not an invitation to submit a PR. Issues track problems; whether and how to solve them is a separate decision. If you want to work on something, propose your approach in the issue first and ask a maintainer to assign it to you — especially for anything beyond a trivial fix. External PRs that reference an issue not assigned to their author are closed automatically (see [PR guidelines](#pr-guidelines)).
+An open issue is not an invitation to submit a PR, and it is not a queue you join by commenting. Issues track problems; who implements them and how is a separate decision maintainers make, and whoever opened the issue has first claim on it.
+
+**Don't post drive-by comments claiming an issue** — "can I work on this?", "please assign me", "I'll take this." They don't affect who gets assigned, they're the most common form of noise we get, and automated versions are ignored. Whoever opens the issue has first claim on it; if that's you, a maintainer will assign you. If you want to implement something someone else reported, just open a PR — you don't need permission to try, and competing PRs are fine — but it's reviewed only if a maintainer assigns you to the issue, which usually won't happen if the reporter intends to handle it. The one comment worth posting is a genuinely different approach worth discussing; a substantive design proposal is welcome, a bare claim on the task is not.
 
 **Bug fixes** — PRs are welcome for simple, well-scoped bug fixes where the problem and solution are both straightforward. "The function raises `TypeError` when passed `None` because of a missing guard" is a good candidate. If the fix requires design decisions or touches multiple subsystems, open an issue with a design proposal instead.
 
@@ -34,7 +38,8 @@ An open issue is not an invitation to submit a PR. Issues track problems; whethe
 
 If you do open a PR:
 
-- **Reference an issue you're assigned to.** Every PR must reference a tracked issue using an auto-close keyword (`Fixes #123`, `Closes #123`, or `Resolves #123`), and the referenced issue must be assigned to you. If there isn't an issue, open one; then comment to ask a maintainer to assign it to you. This lets us deconflict effort and steer the approach before you invest time in code. External PRs that don't meet both conditions are automatically labeled `missing-issue-link` and closed; they reopen automatically once the link is present and you're assigned.
+- **Reference an issue you're assigned to.** Every PR must reference a tracked issue using an auto-close keyword (`Fixes #123`, `Closes #123`, or `Resolves #123`), and the referenced issue must be assigned to you. If there isn't an issue, open one. This lets us deconflict effort and steer the approach before you invest time in code. External PRs that don't meet both conditions are automatically labeled `missing-issue-link` and closed; they reopen automatically once the link is present and you're assigned.
+- **If your PR was auto-closed, don't open a new one.** Edit the *existing* PR to add the issue link, get assigned to that issue, and it reopens on its own — the branch and history are preserved. A duplicate PR just starts you over and adds to the triage pile.
 - **Keep it focused.** One logical change per PR. Don't bundle unrelated fixes or refactors.
 - **Match existing patterns.** Follow the code style, type annotation conventions, and test patterns you see in the codebase. Run `uv run prek run --all-files` before submitting.
 - **Write tests.** Bug fixes should include a test that fails without the fix. Enhancements should include tests for the new behavior.


### PR DESCRIPTION
## Description

Our anti-spam automation was producing two kinds of collateral damage, plus a genuine bug that silently broke the auto-reopen path.

**Duplicate PRs.** When the issue-link gate auto-closes a PR, contributors were creating an issue and then opening a *brand-new* duplicate PR — because the close comment led with "closed" and buried "reopens automatically" as step 4. The reopen mechanism already exists; people just never read far enough to know it. The comment now leads with the reassurance:

> **Don't open a new pull request — this one reopens on its own.** It's closed for now because *[reason]*, but the moment that's fixed it reopens automatically. Keep this PR and edit it…

CONTRIBUTING gains a matching bullet: if your PR was auto-closed, edit the existing one — branch and history are preserved — don't open a duplicate.

**Issue-claim comment spam.** CONTRIBUTING now tells contributors, and their agents explicitly, not to post drive-by "can I work on this?" / "please assign me" comments. The model is stated plainly: whoever opens the issue has first claim, competing PRs are fine, and an unassigned PR simply isn't reviewed — so the constructive move is to open a PR, not to stake a claim in a comment.

**Label-race bug (the real breakage).** `marvin-label-triage` and `require-issue-link` both fire on PR open. Triage applies labels via `update_issue`, which *replaces* the entire label set — so Marvin, which only knows category/area labels, was silently dropping `missing-issue-link`. That label is exactly how `reopen-on-assignment` finds the closed PR to reopen; without it, an assigned author's PR never comes back. Triage is now instructed to always carry the require-issue-link control labels (`missing-issue-link`, `bypass-issue-check`, `trusted-contributor`) forward unchanged.

## Contribution type

- [x] Documentation improvement (contributor-facing docs + workflow messaging)
- [x] Bug fix (triage bot stripping a load-bearing label)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have self-reviewed my changes
- [ ] Tests — n/a (workflow YAML + docs; no runtime surface)

Suggested labels: `documentation`, `tests` (CI/workflow area).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te5E2EPmG4eUjDPfNoHZdn)_