### PR TITLE
Handle expired OAuth client registrations

### DIFF
--- a/fastmcp_slim/fastmcp/client/auth/oauth.py
+++ b/fastmcp_slim/fastmcp/client/auth/oauth.py
@@ -51,6 +51,10 @@ class ClientNotFoundError(Exception):
     """Raised when OAuth client credentials are not found on the server."""
 
 
+class ExpiredClientRegistrationError(Exception):
+    """Raised when dynamic registration returns an expired client secret."""
+
+
 async def check_if_auth_required(
     mcp_url: str, httpx_kwargs: dict[str, Any] | None = None
 ) -> bool:
@@ -345,6 +349,20 @@ class OAuth(OAuthClientProvider):
             else:
                 self.context.update_token_expiry(self.context.current_tokens)
 
+    async def _perform_authorization(self) -> httpx.Request:
+        """Reject expired registrations before attempting authorization."""
+        client_info = self.context.client_info
+        if (
+            client_info is not None
+            and client_info.client_secret is not None
+            and client_info.client_secret_expires_at
+            and client_info.client_secret_expires_at <= int(time.time())
+        ):
+            raise ExpiredClientRegistrationError(
+                "OAuth dynamic registration returned an expired client secret"
+            )
+        return await super()._perform_authorization()
+
     async def redirect_handler(self, authorization_url: str) -> None:
         """Open browser for authorization, with pre-flight check for invalid client."""
         # Pre-flight check to detect invalid client_id before opening browser
@@ -434,7 +452,7 @@ class OAuth(OAuthClientProvider):
                     except StopAsyncIteration:
                         break
 
-        except ClientNotFoundError:
+        except (ClientNotFoundError, ExpiredClientRegistrationError) as exc:
             # Static credentials are fixed — retrying won't help. Surface the
             # error so the user can correct their client_id / client_secret.
             if self._static_client_info is not None:
@@ -442,10 +460,10 @@ class OAuth(OAuthClientProvider):
                     "OAuth server rejected the static client credentials. "
                     "Verify that the client_id (and client_secret, if provided) "
                     "are correct and that the client is registered with the server."
-                ) from None
+                ) from exc
 
             logger.debug(
-                "OAuth client not found on server, clearing cache and retrying..."
+                "OAuth client registration is invalid, clearing cache and retrying..."
             )
             # Clear cached state and retry once
             self._initialized = False

--- a/fastmcp_slim/fastmcp/client/auth/oauth.py
+++ b/fastmcp_slim/fastmcp/client/auth/oauth.py
@@ -166,6 +166,11 @@ class TokenStorageAdapter(TokenStorage):
 
         if client_info.client_secret_expires_at:
             ttl = client_info.client_secret_expires_at - int(time.time())
+            if ttl <= 0:
+                await self._storage_client_info.delete(
+                    key=self._get_client_info_cache_key()
+                )
+                return
 
         await self._storage_client_info.put(
             key=self._get_client_info_cache_key(),

--- a/tests/client/auth/test_oauth_client.py
+++ b/tests/client/auth/test_oauth_client.py
@@ -5,13 +5,17 @@ from urllib.parse import urlparse
 
 import httpx
 import pytest
+from key_value.aio.stores.memory import MemoryStore
 from mcp import MCPError
+from mcp.shared.auth import OAuthClientInformationFull
 from mcp_types import TextResourceContents
+from pydantic import AnyUrl
 
 import fastmcp.client.auth.oauth as oauth_module
 import fastmcp.utilities.http as http_module
 from fastmcp.client import Client
 from fastmcp.client.auth import OAuth
+from fastmcp.client.auth.oauth import TokenStorageAdapter
 from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.server.auth.auth import ClientRegistrationOptions
 from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
@@ -43,6 +47,23 @@ def fastmcp_server(issuer_url: str):
         return "Hello from authenticated resource!"
 
     return server
+
+
+class ExpiredFirstRegistrationProvider(InMemoryOAuthProvider):
+    def __init__(self, base_url: str):
+        super().__init__(
+            base_url=base_url,
+            client_registration_options=ClientRegistrationOptions(enabled=True),
+        )
+        self.registration_count = 0
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        self.registration_count += 1
+        if self.registration_count == 1:
+            client_info.client_secret = "expired-secret"
+            client_info.client_secret_expires_at = int(time.time()) - 1
+            client_info.token_endpoint_auth_method = "client_secret_post"
+        await super().register_client(client_info)
 
 
 @pytest.fixture
@@ -137,6 +158,23 @@ async def test_oauth_server_metadata_discovery(streamable_http_server: str):
         # The endpoints should be properly formed URLs
         assert metadata["authorization_endpoint"].startswith(server_base_url)
         assert metadata["token_endpoint"].startswith(server_base_url)
+
+
+async def test_expired_dynamic_registration_is_retried():
+    port = find_available_port()
+    base_url = f"http://127.0.0.1:{port}"
+    provider = ExpiredFirstRegistrationProvider(base_url)
+    server = FastMCP("TestServer", auth=provider)
+
+    async with run_server_async(server, port=port, transport="http") as url:
+        client = Client(
+            transport=StreamableHttpTransport(url),
+            auth=HeadlessOAuth(mcp_url=url),
+        )
+        async with client:
+            assert await client.ping()
+
+    assert provider.registration_count == 2
 
 
 class TestOAuthClientUrlHandling:
@@ -563,12 +601,6 @@ class TestTokenStorageTTL:
 
 class TestClientInfoStorageTTL:
     async def test_expired_client_info_removes_stale_registration(self):
-        from key_value.aio.stores.memory import MemoryStore
-        from mcp.shared.auth import OAuthClientInformationFull
-        from pydantic import AnyUrl
-
-        from fastmcp.client.auth.oauth import TokenStorageAdapter
-
         storage = MemoryStore()
         adapter = TokenStorageAdapter(
             async_key_value=storage, server_url="https://test"
@@ -593,12 +625,6 @@ class TestClientInfoStorageTTL:
         assert await adapter.get_client_info() is None
 
     async def test_never_expiring_client_info_is_stored(self):
-        from key_value.aio.stores.memory import MemoryStore
-        from mcp.shared.auth import OAuthClientInformationFull
-        from pydantic import AnyUrl
-
-        from fastmcp.client.auth.oauth import TokenStorageAdapter
-
         adapter = TokenStorageAdapter(
             async_key_value=MemoryStore(), server_url="https://test"
         )
@@ -614,12 +640,6 @@ class TestClientInfoStorageTTL:
         assert await adapter.get_client_info() == client_info
 
     async def test_future_expiring_client_info_is_stored(self):
-        from key_value.aio.stores.memory import MemoryStore
-        from mcp.shared.auth import OAuthClientInformationFull
-        from pydantic import AnyUrl
-
-        from fastmcp.client.auth.oauth import TokenStorageAdapter
-
         adapter = TokenStorageAdapter(
             async_key_value=MemoryStore(), server_url="https://test"
         )

--- a/tests/client/auth/test_oauth_client.py
+++ b/tests/client/auth/test_oauth_client.py
@@ -559,3 +559,77 @@ class TestTokenStorageTTL:
 
         await adapter.clear()
         assert await adapter.get_token_expiry() is None
+
+
+class TestClientInfoStorageTTL:
+    async def test_expired_client_info_removes_stale_registration(self):
+        from key_value.aio.stores.memory import MemoryStore
+        from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
+
+        from fastmcp.client.auth.oauth import TokenStorageAdapter
+
+        storage = MemoryStore()
+        adapter = TokenStorageAdapter(
+            async_key_value=storage, server_url="https://test"
+        )
+        current = OAuthClientInformationFull(
+            client_id="current-client",
+            client_secret="current-secret",
+            client_secret_expires_at=0,
+            redirect_uris=[AnyUrl("http://localhost/callback")],
+        )
+        await adapter.set_client_info(current)
+        assert await adapter.get_client_info() == current
+
+        expired = current.model_copy(
+            update={
+                "client_id": "expired-client",
+                "client_secret_expires_at": int(time.time()) - 1,
+            }
+        )
+        await adapter.set_client_info(expired)
+
+        assert await adapter.get_client_info() is None
+
+    async def test_never_expiring_client_info_is_stored(self):
+        from key_value.aio.stores.memory import MemoryStore
+        from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
+
+        from fastmcp.client.auth.oauth import TokenStorageAdapter
+
+        adapter = TokenStorageAdapter(
+            async_key_value=MemoryStore(), server_url="https://test"
+        )
+        client_info = OAuthClientInformationFull(
+            client_id="never-expiring-client",
+            client_secret="secret",
+            client_secret_expires_at=0,
+            redirect_uris=[AnyUrl("http://localhost/callback")],
+        )
+
+        await adapter.set_client_info(client_info)
+
+        assert await adapter.get_client_info() == client_info
+
+    async def test_future_expiring_client_info_is_stored(self):
+        from key_value.aio.stores.memory import MemoryStore
+        from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
+
+        from fastmcp.client.auth.oauth import TokenStorageAdapter
+
+        adapter = TokenStorageAdapter(
+            async_key_value=MemoryStore(), server_url="https://test"
+        )
+        client_info = OAuthClientInformationFull(
+            client_id="future-expiring-client",
+            client_secret="secret",
+            client_secret_expires_at=int(time.time()) + 60,
+            redirect_uris=[AnyUrl("http://localhost/callback")],
+        )
+
+        await adapter.set_client_info(client_info)
+
+        assert await adapter.get_client_info() == client_info


### PR DESCRIPTION
OAuth registration responses can contain a `client_secret_expires_at` timestamp that is already in the past. Deriving a storage TTL from that value produced a non-positive TTL, causing the OAuth client to fail before it could discard the unusable registration and register again.

Expired registrations now remove any cached client information and skip persistence. The `0` value retains its RFC-defined never-expiring behavior, while future expirations continue to use a positive TTL.

```python
if expires_at and expires_at <= now:
    await client_info_storage.delete(key=cache_key)
```

Fixes #4457
