### PR TITLE
Reject positional-only tool parameters

### DIFF
--- a/fastmcp_slim/fastmcp/tools/function_parsing.py
+++ b/fastmcp_slim/fastmcp/tools/function_parsing.py
@@ -182,8 +182,16 @@ class ParsedFunction:
     ) -> ParsedFunction:
         if validate:
             sig = inspect.signature(fn)
-            # Reject functions with *args or **kwargs
+            # Reject signatures that cannot be represented by MCP's
+            # object-shaped tool arguments.
             for param in sig.parameters.values():
+                if param.kind == inspect.Parameter.POSITIONAL_ONLY:
+                    raise ValueError(
+                        "Functions with positional-only parameters are not "
+                        "supported as tools because MCP passes tool arguments by "
+                        "name. Replace them with standard parameters that can be "
+                        "passed as keywords."
+                    )
                 if param.kind == inspect.Parameter.VAR_POSITIONAL:
                     raise ValueError("Functions with *args are not supported as tools")
                 if param.kind == inspect.Parameter.VAR_KEYWORD:

--- a/tests/tools/tool/test_tool.py
+++ b/tests/tools/tool/test_tool.py
@@ -341,6 +341,32 @@ class TestToolFromFunction:
         ):
             Tool.from_function(func)
 
+    def test_tool_with_positional_only_parameters_not_allowed(self):
+        def func(a: int, /, b: int) -> int:
+            return a + b
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Functions with positional-only parameters are not supported as "
+                "tools.*standard parameters"
+            ),
+        ):
+            Tool.from_function(func)
+
+    def test_tool_with_keyword_capable_parameters(self):
+        def func(a: int, *, b: int) -> int:
+            return a + b
+
+        tool = Tool.from_function(func)
+
+        assert tool.parameters["type"] == "object"
+        assert tool.parameters["required"] == ["a", "b"]
+        assert tool.parameters["properties"] == {
+            "a": {"type": "integer"},
+            "b": {"type": "integer"},
+        }
+
     def test_tool_with_varkwargs_not_allowed(self):
         def func(a: int, b: int, **kwargs: int) -> int:
             """Add two numbers."""


### PR DESCRIPTION
Python positional-only parameters produce an array-shaped call schema, but MCP tool arguments are always passed as a named object. FastMCP previously registered these functions as tools even though every normal MCP invocation would fail argument binding.

Tool construction now rejects positional-only parameters at the shared function-parsing boundary with an error explaining that MCP passes arguments by name. Standard positional-or-keyword and keyword-only parameters remain supported.

```python
# Use a keyword-capable parameter for MCP tools.
def lookup(item_id: int) -> str:
    return str(item_id)
```

Fixes #4508
