### PR TITLE
Stabilize upgraded ty checks

### DIFF
--- a/fastmcp_slim/fastmcp/client/mixins/task_management.py
+++ b/fastmcp_slim/fastmcp/client/mixins/task_management.py
@@ -128,7 +128,9 @@ class ClientTaskManagementMixin:
             MCPError: If the request results in a TimeoutError | JSONRPCError
         """
         # Send protocol request
-        params = PaginatedRequestParams(cursor=cursor, limit=limit)  # type: ignore[call-arg]  # Optional field in MCP SDK  # ty:ignore[unknown-argument]
+        params = PaginatedRequestParams.model_validate(
+            {"cursor": cursor, "limit": limit}
+        )
         request = ListTasksRequest(params=params)
         server_response = await self._await_with_session_monitoring(
             self.session.send_request(

--- a/fastmcp_slim/fastmcp/client/sampling/handlers/google_genai.py
+++ b/fastmcp_slim/fastmcp/client/sampling/handlers/google_genai.py
@@ -2,6 +2,7 @@
 
 import base64
 from collections.abc import Sequence
+from typing import Any, cast
 from uuid import uuid4
 
 try:
@@ -123,7 +124,7 @@ class GoogleGenaiSamplingHandler:
                     max_output_tokens=params.max_tokens,
                     stop_sequences=params.stop_sequences,
                     thinking_config=thinking_config,
-                    tools=google_tools,  # ty: ignore[invalid-argument-type]
+                    tools=cast(Any, google_tools),
                     tool_config=tool_config,
                 ),
             )

--- a/fastmcp_slim/fastmcp/client/sampling/handlers/openai.py
+++ b/fastmcp_slim/fastmcp/client/sampling/handlers/openai.py
@@ -2,7 +2,7 @@
 
 import json
 from collections.abc import Iterator, Sequence
-from typing import Any, Literal, get_args
+from typing import Any, Literal, cast, get_args
 
 from mcp import ClientSession, ServerSession
 from mcp_types import (
@@ -507,7 +507,7 @@ class OpenAISamplingHandler:
             raise ValueError("No content in response from completion")
 
         return CreateMessageResultWithTools(
-            content=content,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+            content=cast(Any, content),
             role="assistant",
             model=chat_completion.model,
             stop_reason=stop_reason,

--- a/fastmcp_slim/fastmcp/server/providers/prefab_synthesis.py
+++ b/fastmcp_slim/fastmcp/server/providers/prefab_synthesis.py
@@ -15,7 +15,7 @@ the app name + tool name). CSP on the resource is the tool's
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from fastmcp.server.providers.addressing import (
     HASH_LENGTH,
@@ -142,7 +142,7 @@ def _build_resource_for_tool(tool: Tool) -> Resource | None:
     uri = f"ui://prefab/tool/{tool_hash}/renderer.html"
 
     return TextResource(
-        uri=uri,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        uri=cast(Any, uri),
         name=f"Prefab Renderer ({tool.name})",
         text=get_renderer_html(),
         mime_type=UI_MIME_TYPE,

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -100,7 +100,7 @@ logger = get_logger(__name__)
 
 def _version_request_meta(
     version: VersionSpec | None,
-) -> dict[str, Any] | None:
+) -> mcp_types.RequestParamsMeta | None:
     if version is None:
         return None
 
@@ -120,9 +120,8 @@ def _version_request_meta(
     if not version_value:
         return None
 
-    # SDK v2: request `_meta` is a plain dict (the `Meta` type alias), not the
-    # old `RequestParams.Meta` nested model.
-    return {"fastmcp": {"version": version_value}}
+    # RequestParamsMeta does not declare application-specific extension keys.
+    return cast(mcp_types.RequestParamsMeta, {"fastmcp": {"version": version_value}})
 
 
 # The MCP SDK warns "Tool X not listed, no validation will be performed"
@@ -1230,9 +1229,7 @@ class FastMCP(
                     message=mcp_types.CallToolRequestParams(
                         name=name,
                         arguments=arguments or {},
-                        # `_meta` carries the app-level `fastmcp` version key, which the
-                        # reserved-key RequestParamsMeta TypedDict can't express statically.
-                        _meta=_version_request_meta(version),  # type: ignore[unknown-argument]  # ty: ignore[invalid-argument-type]
+                        _meta=_version_request_meta(version),
                     ),
                     source="client",
                     type="request",
@@ -1400,9 +1397,7 @@ class FastMCP(
                 mw_context = MiddlewareContext(
                     message=mcp_types.ReadResourceRequestParams(
                         uri=str(uri),
-                        # `_meta` carries the app-level `fastmcp` version key, which the
-                        # reserved-key RequestParamsMeta TypedDict can't express statically.
-                        _meta=_version_request_meta(version),  # type: ignore[unknown-argument]  # ty: ignore[invalid-argument-type]
+                        _meta=_version_request_meta(version),
                     ),
                     source="client",
                     type="request",
@@ -1579,9 +1574,7 @@ class FastMCP(
                     message=mcp_types.GetPromptRequestParams(
                         name=name,
                         arguments=arguments,
-                        # `_meta` carries the app-level `fastmcp` version key, which the
-                        # reserved-key RequestParamsMeta TypedDict can't express statically.
-                        _meta=_version_request_meta(version),  # type: ignore[unknown-argument]  # ty: ignore[invalid-argument-type]
+                        _meta=_version_request_meta(version),
                     ),
                     source="client",
                     type="request",

--- a/tests/server/auth/oauth_proxy/test_authorization.py
+++ b/tests/server/auth/oauth_proxy/test_authorization.py
@@ -16,11 +16,13 @@ class TestOAuthProxyAuthorization:
 
     async def test_authorize_creates_transaction(self, oauth_proxy):
         """Test that authorize creates transaction and redirects to consent."""
-        client = OAuthClientInformationFull(
-            client_id="test-client",
-            client_secret="test-secret",
-            redirect_uris=[AnyUrl("http://localhost:54321/callback")],
-            jwt_signing_key="test-secret",  # type: ignore[call-arg]  # Optional field in MCP SDK  # ty:ignore[unknown-argument]
+        client = OAuthClientInformationFull.model_validate(
+            {
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+                "redirect_uris": ["http://localhost:54321/callback"],
+                "jwt_signing_key": "test-secret",
+            }
         )
 
         # Register client first (required for consent flow)

--- a/tests/server/auth/test_cimd.py
+++ b/tests/server/auth/test_cimd.py
@@ -93,7 +93,9 @@ class TestCIMDDocument:
     def test_missing_redirect_uris_rejected(self):
         """Test that redirect_uris is required for CIMD."""
         with pytest.raises(ValidationError) as exc_info:
-            CIMDDocument(client_id=AnyHttpUrl("https://example.com/client.json"))
+            CIMDDocument.model_validate(
+                {"client_id": "https://example.com/client.json"}
+            )
         assert "redirect_uris" in str(exc_info.value)
 
     def test_empty_redirect_uris_rejected(self):

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -715,26 +715,28 @@ async def test_canonical_multi_client_with_transforms(tmp_path: Path):
     script_path = tmp_path / "test.py"
     script_path.write_text(server_script)
 
-    config = CanonicalMCPConfig(
-        mcpServers={
-            "test_1": {
-                "command": "python",
-                "args": [str(script_path)],
-                "tools": {  # <--- Will be ignored as it's not valid for a canonical MCPConfig
-                    "add": {
-                        "name": "transformed_add",
-                        "arguments": {
-                            "a": {"name": "transformed_a"},
-                            "b": {"name": "transformed_b"},
-                        },
-                    }
+    config = CanonicalMCPConfig.model_validate(
+        {
+            "mcpServers": {
+                "test_1": {
+                    "command": "python",
+                    "args": [str(script_path)],
+                    "tools": {  # <--- Will be ignored as it's not valid for a canonical MCPConfig
+                        "add": {
+                            "name": "transformed_add",
+                            "arguments": {
+                                "a": {"name": "transformed_a"},
+                                "b": {"name": "transformed_b"},
+                            },
+                        }
+                    },
                 },
-            },
-            "test_2": {
-                "command": "python",
-                "args": [str(script_path)],
-            },
-        }  # type: ignore[reportUnknownArgumentType]  # ty:ignore[invalid-argument-type]
+                "test_2": {
+                    "command": "python",
+                    "args": [str(script_path)],
+                },
+            }
+        }
     )
 
     client = Client(config)

--- a/tests/utilities/test_components.py
+++ b/tests/utilities/test_components.py
@@ -170,9 +170,8 @@ class TestFastMCPComponent:
 
     def test_tags_deduplication(self):
         """Test that tags are deduplicated when passed as a sequence."""
-        component = FastMCPComponent(
-            name="test",
-            tags=["tag1", "tag2", "tag1", "tag2"],  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        component = FastMCPComponent.model_validate(
+            {"name": "test", "tags": ["tag1", "tag2", "tag1", "tag2"]}
         )
         assert component.tags == {"tag1", "tag2"}
 


### PR DESCRIPTION
Upgrade checks resolve newer SDK annotations that remove some historical type mismatches while making other constructor fields statically required. Version-specific `ty` suppressions therefore became fatal when unused, while an intentional negative CIMD validation test became a static error.

This routes deliberately dynamic or invalid Pydantic inputs through runtime validation and uses localized casts only at external SDK compatibility boundaries. The app-specific request metadata cast is centralized, so both committed and upgraded dependency sets type-check without suppressions that oscillate across versions.

```python
CIMDDocument.model_validate({"client_id": "https://example.com/client.json"})
```

Fixes #4509
