### PR TITLE
Fix File helper extension handling

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/types.py
+++ b/fastmcp_slim/fastmcp/utilities/types.py
@@ -421,7 +421,12 @@ class File:
         elif self.data is not None:
             raw_data = self.data
             if self._name:
-                uri_str = f"file:///{self._name}.{self._mime_type.split('/')[1]}"
+                extension = (
+                    ""
+                    if Path(self._name).suffix
+                    else f".{self._mime_type.split('/')[1]}"
+                )
+                uri_str = f"file:///{self._name}{extension}"
             else:
                 uri_str = f"file:///resource.{self._mime_type.split('/')[1]}"
         else:

--- a/tests/utilities/test_types.py
+++ b/tests/utilities/test_types.py
@@ -461,6 +461,22 @@ class TestFile:
         if isinstance(resource.resource, BlobResourceContents):
             assert resource.resource.blob == base64.b64encode(test_data).decode()
 
+    def test_to_resource_content_with_data_and_name_without_extension(self):
+        """Test data-backed File URI with a custom name that needs an extension."""
+        file = File(data=b"test file data", format="pdf", name="report")
+        resource = file.to_resource_content()
+
+        assert resource.resource.mime_type == "application/pdf"
+        assert str(resource.resource.uri) == "file:///report.pdf"
+
+    def test_to_resource_content_with_data_preserves_name_extension(self):
+        """Test data-backed File URI preserves a custom name with an extension."""
+        file = File(data=b"test file data", format="pdf", name="report.pdf")
+        resource = file.to_resource_content()
+
+        assert resource.resource.mime_type == "application/pdf"
+        assert str(resource.resource.uri) == "file:///report.pdf"
+
     def test_to_resource_content_with_text_data(self):
         """Test conversion to ResourceContent with text data (TextResourceContents)."""
         test_data = b"hello world"


### PR DESCRIPTION
## Description

Preserve explicit extensions when data-backed `File` helpers build their resource URI.

Closes #4530

Before this change, `File(data=bx, format=pdf, name=report.pdf)` produced `file:///report.pdf.pdf`. The fix keeps caller-provided names with an existing suffix unchanged, while preserving the existing fallback that appends the inferred subtype for names without a suffix.

The affected call chain is a tool returning `File` -> `_convert_to_content()` -> `File.to_resource_content()`. Path-backed files, data-backed files without a custom name, and the existing text/blob resource-content split are unchanged.

Validation:
- `uv sync`
- `PYTHONUTF8=1 uv run --frozen pytest tests/utilities/test_types.py -q` (`82 passed`)
- `PYTHONUTF8=1 uv run pytest tests/tools/tool/test_content.py tests/tools/tool/test_tool.py tests/server/tasks/test_task_return_types.py tests/server/providers/local_provider_tools/test_local_provider_tools.py -q` (`132 passed`)
- `PYTHONUTF8=1 uv run --frozen ruff format --check fastmcp_slim/fastmcp/utilities/types.py tests/utilities/test_types.py`
- `PYTHONUTF8=1 uv run --frozen ruff check fastmcp_slim/fastmcp/utilities/types.py tests/utilities/test_types.py`
- `git diff --check`

Local full-suite notes:
- `PYTHONUTF8=1 uv run prek --refresh run --all-files` reached the hooks successfully after refreshing cache, but `ty check` fails on Windows with existing `fcntl.flock` / `LOCK_EX` / `LOCK_UN` unresolved-attribute diagnostics in `tests/utilities/json_schema_type/test_real_world_schemas.py`.
- `PYTHONUTF8=1 uv run pytest -n auto` fails in this Windows environment on unrelated environment/platform paths, including missing `npx` for conformance, symlink privilege `WinError 1314`, and xdist worker crashes.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [ ] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)