### PR TITLE
Fix skill frontmatter parsing with UTF-8 BOM

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/skills/_common.py
+++ b/fastmcp_slim/fastmcp/server/providers/skills/_common.py
@@ -39,6 +39,8 @@ def parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     Returns:
         Tuple of (frontmatter dict, remaining content)
     """
+    content = content.removeprefix("\ufeff")
+
     if not content.startswith("---"):
         return {}, content
 

--- a/tests/server/providers/test_skills_provider.py
+++ b/tests/server/providers/test_skills_provider.py
@@ -92,6 +92,26 @@ This is my skill content.
         assert provider.skill_info.description == "A test skill"
         assert len(provider.skill_info.files) == 3
 
+    def test_loads_frontmatter_from_utf8_bom_skill(self, tmp_path: Path):
+        skill_dir = tmp_path / "bom-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "\ufeff---\n"
+            "name: bom-skill\n"
+            "description: Skill saved with a UTF-8 BOM\n"
+            "---\n"
+            "# BOM Skill\n",
+            encoding="utf-8",
+        )
+
+        provider = SkillProvider(skill_path=skill_dir)
+
+        assert provider.skill_info.description == "Skill saved with a UTF-8 BOM"
+        assert provider.skill_info.frontmatter == {
+            "name": "bom-skill",
+            "description": "Skill saved with a UTF-8 BOM",
+        }
+
     def test_raises_if_directory_missing(self, tmp_path: Path):
         with pytest.raises(FileNotFoundError, match="Skill directory not found"):
             SkillProvider(skill_path=tmp_path / "nonexistent")


### PR DESCRIPTION
## Description

`SkillProvider` only recognized YAML frontmatter when the decoded `SKILL.md` began directly with `---`. Python's UTF-8 decoder preserves a leading byte order mark, so a BOM-prefixed file skipped metadata parsing and exposed `\ufeff---` as its description.

This removes one leading BOM at the frontmatter parser boundary before delimiter detection. File decoding and served resource content remain unchanged, and a provider-level regression test covers the reported input.

Closes #4532

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
