### PR TITLE
Fix OAuth request annotation after httpx2 migration

### DIFF
--- a/fastmcp_slim/fastmcp/client/auth/oauth.py
+++ b/fastmcp_slim/fastmcp/client/auth/oauth.py
@@ -349,7 +349,7 @@ class OAuth(OAuthClientProvider):
             else:
                 self.context.update_token_expiry(self.context.current_tokens)
 
-    async def _perform_authorization(self) -> httpx.Request:
+    async def _perform_authorization(self) -> httpx2.Request:
         """Reject expired registrations before attempting authorization."""
         client_info = self.context.client_info
         if (


### PR DESCRIPTION
#4520 added an override annotated as `httpx.Request` after the surrounding OAuth code and MCP SDK had migrated to `httpx2`. The unresolved name breaks Ruff and ty on main.

Use `httpx2.Request`, matching the superclass return type and existing auth-flow API.
