### PR TITLE
Preserve telemetry attributes when a sampler does not forward them

### DIFF
--- a/fastmcp_slim/fastmcp/client/telemetry.py
+++ b/fastmcp_slim/fastmcp/client/telemetry.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
-from fastmcp.telemetry import get_tracer
+from fastmcp.telemetry import get_tracer, restore_missing_attributes
 
 
 @contextmanager
@@ -42,16 +42,17 @@ def client_span(
     with tracer.start_as_current_span(
         name, kind=SpanKind.CLIENT, attributes=attrs
     ) as span:
-        # Reapply: `attributes=attrs` above lets on_start hooks and the
+        # Restore: `attributes=attrs` above lets on_start hooks and the
         # sampler see these values at creation time. But OTel's
         # Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. Reapplying here (additive,
-        # can't clobber anything a sampler legitimately added) guarantees
-        # FastMCP's attributes survive regardless of sampler behavior.
+        # silently drops everything we passed. Restoring only the keys still
+        # missing (rather than reapplying everything) guarantees FastMCP's
+        # attributes survive a non-forwarding sampler while leaving alone
+        # anything a sampler deliberately set, redacted, or replaced.
         if span.is_recording():
-            span.set_attributes(attrs)
+            restore_missing_attributes(span, attrs)
         try:
             yield span
         except Exception as e:

--- a/fastmcp_slim/fastmcp/client/telemetry.py
+++ b/fastmcp_slim/fastmcp/client/telemetry.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from fastmcp.exceptions import ToolError as _ToolError
-from fastmcp.telemetry import get_tracer, restore_missing_attributes
+from fastmcp.telemetry import get_tracer, restore_dropped_attributes
 
 
 @contextmanager
@@ -47,12 +47,12 @@ def client_span(
         # Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. Restoring only the keys still
-        # missing (rather than reapplying everything) guarantees FastMCP's
-        # attributes survive a non-forwarding sampler while leaving alone
-        # anything a sampler deliberately set, redacted, or replaced.
+        # silently drops everything we passed. This only fires when *none* of
+        # our attributes made it onto the span, so a sampler that forwarded
+        # (and redacted, replaced, or partially dropped) attributes, or an
+        # SDK attribute limit that evicted some, is left untouched.
         if span.is_recording():
-            restore_missing_attributes(span, attrs)
+            restore_dropped_attributes(span, attrs)
         try:
             yield span
         except Exception as e:

--- a/fastmcp_slim/fastmcp/client/telemetry.py
+++ b/fastmcp_slim/fastmcp/client/telemetry.py
@@ -42,6 +42,16 @@ def client_span(
     with tracer.start_as_current_span(
         name, kind=SpanKind.CLIENT, attributes=attrs
     ) as span:
+        # Reapply: `attributes=attrs` above lets on_start hooks and the
+        # sampler see these values at creation time. But OTel's
+        # Tracer.start_span builds the span from
+        # `sampling_result.attributes`, not the `attributes` kwarg directly —
+        # a custom Sampler whose SamplingResult.attributes defaults to None
+        # silently drops everything we passed. Reapplying here (additive,
+        # can't clobber anything a sampler legitimately added) guarantees
+        # FastMCP's attributes survive regardless of sampler behavior.
+        if span.is_recording():
+            span.set_attributes(attrs)
         try:
             yield span
         except Exception as e:

--- a/fastmcp_slim/fastmcp/client/telemetry.py
+++ b/fastmcp_slim/fastmcp/client/telemetry.py
@@ -47,10 +47,11 @@ def client_span(
         # Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. This only fires when *none* of
-        # our attributes made it onto the span, so a sampler that forwarded
-        # (and redacted, replaced, or partially dropped) attributes, or an
-        # SDK attribute limit that evicted some, is left untouched.
+        # silently drops everything we passed. This only fires when the span
+        # ends up with no attributes at all, so any sampler that supplied
+        # attributes of its own — forwarding ours, redacting or replacing
+        # some, or substituting entirely its own — is left untouched, as is
+        # an SDK attribute limit that evicted some.
         if span.is_recording():
             restore_dropped_attributes(span, attrs)
         try:

--- a/fastmcp_slim/fastmcp/server/sampling/run.py
+++ b/fastmcp_slim/fastmcp/server/sampling/run.py
@@ -33,7 +33,7 @@ from typing_extensions import TypeVar
 from fastmcp import settings
 from fastmcp.exceptions import ToolError
 from fastmcp.server.sampling.sampling_tool import SamplingTool
-from fastmcp.telemetry import get_tracer
+from fastmcp.telemetry import get_tracer, restore_missing_attributes
 from fastmcp.tools.function_tool import FunctionTool
 from fastmcp.tools.tool_transform import TransformedTool
 from fastmcp.utilities.async_utils import gather
@@ -319,17 +319,18 @@ async def execute_tools(
             kind=SpanKind.INTERNAL,
             attributes=span_attrs,
         ) as span:
-            # Reapply: `attributes=span_attrs` above lets on_start hooks and
+            # Restore: `attributes=span_attrs` above lets on_start hooks and
             # the sampler see these values at creation time. But OTel's
             # Tracer.start_span builds the span from
             # `sampling_result.attributes`, not the `attributes` kwarg
             # directly — a custom Sampler whose SamplingResult.attributes
             # defaults to None silently drops everything we passed.
-            # Reapplying here (additive, can't clobber anything a sampler
-            # legitimately added) guarantees FastMCP's attributes survive
-            # regardless of sampler behavior.
+            # Restoring only the keys still missing (rather than reapplying
+            # everything) guarantees FastMCP's attributes survive a
+            # non-forwarding sampler while leaving alone anything a sampler
+            # deliberately set, redacted, or replaced.
             if span.is_recording():
-                span.set_attributes(span_attrs)
+                restore_missing_attributes(span, span_attrs)
             try:
                 result_value = await tool.run(tool_use.input)
                 return ToolResultContent(
@@ -577,16 +578,17 @@ async def sample_step_impl(
         record_exception=False,
         set_status_on_exception=False,
     ) as span:
-        # Reapply: `attributes=span_attrs` above lets on_start hooks and the
+        # Restore: `attributes=span_attrs` above lets on_start hooks and the
         # sampler see these values at creation time. But OTel's
         # Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. Reapplying here (additive,
-        # can't clobber anything a sampler legitimately added) guarantees
-        # FastMCP's attributes survive regardless of sampler behavior.
+        # silently drops everything we passed. Restoring only the keys still
+        # missing (rather than reapplying everything) guarantees FastMCP's
+        # attributes survive a non-forwarding sampler while leaving alone
+        # anything a sampler deliberately set, redacted, or replaced.
         if span.is_recording():
-            span.set_attributes(span_attrs)
+            restore_missing_attributes(span, span_attrs)
         try:
             if use_fallback:
                 response = await call_sampling_handler(

--- a/fastmcp_slim/fastmcp/server/sampling/run.py
+++ b/fastmcp_slim/fastmcp/server/sampling/run.py
@@ -325,10 +325,11 @@ async def execute_tools(
             # `sampling_result.attributes`, not the `attributes` kwarg
             # directly — a custom Sampler whose SamplingResult.attributes
             # defaults to None silently drops everything we passed. This
-            # only fires when *none* of our attributes made it onto the
-            # span, so a sampler that forwarded (and redacted, replaced, or
-            # partially dropped) attributes, or an SDK attribute limit that
-            # evicted some, is left untouched.
+            # only fires when the span ends up with no attributes at all, so
+            # any sampler that supplied attributes of its own — forwarding
+            # ours, redacting or replacing some, or substituting entirely its
+            # own — is left untouched, as is an SDK attribute limit that
+            # evicted some.
             if span.is_recording():
                 restore_dropped_attributes(span, span_attrs)
             try:
@@ -583,10 +584,11 @@ async def sample_step_impl(
         # Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. This only fires when *none* of
-        # our attributes made it onto the span, so a sampler that forwarded
-        # (and redacted, replaced, or partially dropped) attributes, or an
-        # SDK attribute limit that evicted some, is left untouched.
+        # silently drops everything we passed. This only fires when the span
+        # ends up with no attributes at all, so any sampler that supplied
+        # attributes of its own — forwarding ours, redacting or replacing
+        # some, or substituting entirely its own — is left untouched, as is
+        # an SDK attribute limit that evicted some.
         if span.is_recording():
             restore_dropped_attributes(span, span_attrs)
         try:

--- a/fastmcp_slim/fastmcp/server/sampling/run.py
+++ b/fastmcp_slim/fastmcp/server/sampling/run.py
@@ -33,7 +33,7 @@ from typing_extensions import TypeVar
 from fastmcp import settings
 from fastmcp.exceptions import ToolError
 from fastmcp.server.sampling.sampling_tool import SamplingTool
-from fastmcp.telemetry import get_tracer, restore_missing_attributes
+from fastmcp.telemetry import get_tracer, restore_dropped_attributes
 from fastmcp.tools.function_tool import FunctionTool
 from fastmcp.tools.tool_transform import TransformedTool
 from fastmcp.utilities.async_utils import gather
@@ -324,13 +324,13 @@ async def execute_tools(
             # Tracer.start_span builds the span from
             # `sampling_result.attributes`, not the `attributes` kwarg
             # directly — a custom Sampler whose SamplingResult.attributes
-            # defaults to None silently drops everything we passed.
-            # Restoring only the keys still missing (rather than reapplying
-            # everything) guarantees FastMCP's attributes survive a
-            # non-forwarding sampler while leaving alone anything a sampler
-            # deliberately set, redacted, or replaced.
+            # defaults to None silently drops everything we passed. This
+            # only fires when *none* of our attributes made it onto the
+            # span, so a sampler that forwarded (and redacted, replaced, or
+            # partially dropped) attributes, or an SDK attribute limit that
+            # evicted some, is left untouched.
             if span.is_recording():
-                restore_missing_attributes(span, span_attrs)
+                restore_dropped_attributes(span, span_attrs)
             try:
                 result_value = await tool.run(tool_use.input)
                 return ToolResultContent(
@@ -583,12 +583,12 @@ async def sample_step_impl(
         # Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. Restoring only the keys still
-        # missing (rather than reapplying everything) guarantees FastMCP's
-        # attributes survive a non-forwarding sampler while leaving alone
-        # anything a sampler deliberately set, redacted, or replaced.
+        # silently drops everything we passed. This only fires when *none* of
+        # our attributes made it onto the span, so a sampler that forwarded
+        # (and redacted, replaced, or partially dropped) attributes, or an
+        # SDK attribute limit that evicted some, is left untouched.
         if span.is_recording():
-            restore_missing_attributes(span, span_attrs)
+            restore_dropped_attributes(span, span_attrs)
         try:
             if use_fallback:
                 response = await call_sampling_handler(

--- a/fastmcp_slim/fastmcp/server/sampling/run.py
+++ b/fastmcp_slim/fastmcp/server/sampling/run.py
@@ -310,14 +310,26 @@ async def execute_tools(
             )
 
         tracer = get_tracer()
+        span_attrs = {
+            "gen_ai.tool.name": tool_use.name,
+            "fastmcp.tool.use_id": tool_use.id,
+        }
         with tracer.start_as_current_span(
             f"sampling tool {tool_use.name}",
             kind=SpanKind.INTERNAL,
-            attributes={
-                "gen_ai.tool.name": tool_use.name,
-                "fastmcp.tool.use_id": tool_use.id,
-            },
+            attributes=span_attrs,
         ) as span:
+            # Reapply: `attributes=span_attrs` above lets on_start hooks and
+            # the sampler see these values at creation time. But OTel's
+            # Tracer.start_span builds the span from
+            # `sampling_result.attributes`, not the `attributes` kwarg
+            # directly — a custom Sampler whose SamplingResult.attributes
+            # defaults to None silently drops everything we passed.
+            # Reapplying here (additive, can't clobber anything a sampler
+            # legitimately added) guarantees FastMCP's attributes survive
+            # regardless of sampler behavior.
+            if span.is_recording():
+                span.set_attributes(span_attrs)
             try:
                 result_value = await tool.run(tool_use.input)
                 return ToolResultContent(
@@ -554,16 +566,27 @@ async def sample_step_impl(
 
     # Make the LLM call
     tracer = get_tracer()
+    span_attrs = {
+        "mcp.method.name": "sampling/createMessage",
+        "fastmcp.server.name": context.fastmcp.name,
+    }
     with tracer.start_as_current_span(
         "sampling create_message",
         kind=SpanKind.CLIENT,
-        attributes={
-            "mcp.method.name": "sampling/createMessage",
-            "fastmcp.server.name": context.fastmcp.name,
-        },
+        attributes=span_attrs,
         record_exception=False,
         set_status_on_exception=False,
     ) as span:
+        # Reapply: `attributes=span_attrs` above lets on_start hooks and the
+        # sampler see these values at creation time. But OTel's
+        # Tracer.start_span builds the span from
+        # `sampling_result.attributes`, not the `attributes` kwarg directly —
+        # a custom Sampler whose SamplingResult.attributes defaults to None
+        # silently drops everything we passed. Reapplying here (additive,
+        # can't clobber anything a sampler legitimately added) guarantees
+        # FastMCP's attributes survive regardless of sampler behavior.
+        if span.is_recording():
+            span.set_attributes(span_attrs)
         try:
             if use_fallback:
                 response = await call_sampling_handler(

--- a/fastmcp_slim/fastmcp/server/telemetry.py
+++ b/fastmcp_slim/fastmcp/server/telemetry.py
@@ -11,7 +11,7 @@ from fastmcp.exceptions import ToolError as _ToolError
 from fastmcp.telemetry import (
     extract_trace_context,
     get_tracer,
-    restore_missing_attributes,
+    restore_dropped_attributes,
 )
 
 # Marker attribute set on the SERVER span opened at the FastMCP middleware seam
@@ -159,12 +159,12 @@ def seam_span(method: str, server_name: str) -> Generator[Span, None, None]:
         # this helper). But OTel's Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. Restoring only the keys still
-        # missing (rather than reapplying everything) guarantees FastMCP's
-        # attributes survive a non-forwarding sampler while leaving alone
-        # anything a sampler deliberately set, redacted, or replaced.
+        # silently drops everything we passed. This only fires when *none* of
+        # our attributes made it onto the span, so a sampler that forwarded
+        # (and redacted, replaced, or partially dropped) attributes, or an
+        # SDK attribute limit that evicted some, is left untouched.
         if span.is_recording():
-            restore_missing_attributes(span, attrs)
+            restore_dropped_attributes(span, attrs)
         token = _active_seam_span.set(span)
         try:
             yield span
@@ -237,7 +237,7 @@ def server_span(
         # from `sampling_result.attributes`, which a custom Sampler may not
         # forward even though it was handed `attributes=attrs` above.
         if span.is_recording():
-            restore_missing_attributes(span, attrs)
+            restore_dropped_attributes(span, attrs)
         try:
             yield span
         except Exception as e:
@@ -270,7 +270,7 @@ def delegate_span(
         # from `sampling_result.attributes`, which a custom Sampler may not
         # forward even though it was handed `attributes=attrs` above.
         if span.is_recording():
-            restore_missing_attributes(span, attrs)
+            restore_dropped_attributes(span, attrs)
         try:
             yield span
         except Exception as e:

--- a/fastmcp_slim/fastmcp/server/telemetry.py
+++ b/fastmcp_slim/fastmcp/server/telemetry.py
@@ -8,7 +8,11 @@ from opentelemetry.context import Context
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode, get_current_span
 
 from fastmcp.exceptions import ToolError as _ToolError
-from fastmcp.telemetry import extract_trace_context, get_tracer
+from fastmcp.telemetry import (
+    extract_trace_context,
+    get_tracer,
+    restore_missing_attributes,
+)
 
 # Marker attribute set on the SERVER span opened at the FastMCP middleware seam
 # (see `fastmcp.server.low_level.FastMCPServerMiddleware._seam_span`). The seam
@@ -150,16 +154,17 @@ def seam_span(method: str, server_name: str) -> Generator[Span, None, None]:
         kind=SpanKind.SERVER,
         attributes=attrs,
     ) as span:
-        # Reapply: `attributes=attrs` above is what makes on_start hooks and
+        # Restore: `attributes=attrs` above is what makes on_start hooks and
         # the sampler see these values at creation time (the whole point of
         # this helper). But OTel's Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. Reapplying here (additive,
-        # can't clobber anything a sampler legitimately added) guarantees
-        # FastMCP's attributes survive regardless of sampler behavior.
+        # silently drops everything we passed. Restoring only the keys still
+        # missing (rather than reapplying everything) guarantees FastMCP's
+        # attributes survive a non-forwarding sampler while leaving alone
+        # anything a sampler deliberately set, redacted, or replaced.
         if span.is_recording():
-            span.set_attributes(attrs)
+            restore_missing_attributes(span, attrs)
         token = _active_seam_span.set(span)
         try:
             yield span
@@ -228,11 +233,11 @@ def server_span(
         kind=SpanKind.SERVER,
         attributes=attrs,
     ) as span:
-        # Reapply for the same reason as `seam_span`: OTel builds the span
+        # Restore for the same reason as `seam_span`: OTel builds the span
         # from `sampling_result.attributes`, which a custom Sampler may not
         # forward even though it was handed `attributes=attrs` above.
         if span.is_recording():
-            span.set_attributes(attrs)
+            restore_missing_attributes(span, attrs)
         try:
             yield span
         except Exception as e:
@@ -261,11 +266,11 @@ def delegate_span(
 
     tracer = get_tracer()
     with tracer.start_as_current_span(f"delegate {name}", attributes=attrs) as span:
-        # Reapply for the same reason as `seam_span`: OTel builds the span
+        # Restore for the same reason as `seam_span`: OTel builds the span
         # from `sampling_result.attributes`, which a custom Sampler may not
         # forward even though it was handed `attributes=attrs` above.
         if span.is_recording():
-            span.set_attributes(attrs)
+            restore_missing_attributes(span, attrs)
         try:
             yield span
         except Exception as e:

--- a/fastmcp_slim/fastmcp/server/telemetry.py
+++ b/fastmcp_slim/fastmcp/server/telemetry.py
@@ -159,10 +159,11 @@ def seam_span(method: str, server_name: str) -> Generator[Span, None, None]:
         # this helper). But OTel's Tracer.start_span builds the span from
         # `sampling_result.attributes`, not the `attributes` kwarg directly —
         # a custom Sampler whose SamplingResult.attributes defaults to None
-        # silently drops everything we passed. This only fires when *none* of
-        # our attributes made it onto the span, so a sampler that forwarded
-        # (and redacted, replaced, or partially dropped) attributes, or an
-        # SDK attribute limit that evicted some, is left untouched.
+        # silently drops everything we passed. This only fires when the span
+        # ends up with no attributes at all, so any sampler that supplied
+        # attributes of its own — forwarding ours, redacting or replacing
+        # some, or substituting entirely its own — is left untouched, as is
+        # an SDK attribute limit that evicted some.
         if span.is_recording():
             restore_dropped_attributes(span, attrs)
         token = _active_seam_span.set(span)
@@ -235,7 +236,8 @@ def server_span(
     ) as span:
         # Restore for the same reason as `seam_span`: OTel builds the span
         # from `sampling_result.attributes`, which a custom Sampler may not
-        # forward even though it was handed `attributes=attrs` above.
+        # forward even though it was handed `attributes=attrs` above. Only
+        # fires when the span ends up with no attributes at all.
         if span.is_recording():
             restore_dropped_attributes(span, attrs)
         try:
@@ -268,7 +270,8 @@ def delegate_span(
     with tracer.start_as_current_span(f"delegate {name}", attributes=attrs) as span:
         # Restore for the same reason as `seam_span`: OTel builds the span
         # from `sampling_result.attributes`, which a custom Sampler may not
-        # forward even though it was handed `attributes=attrs` above.
+        # forward even though it was handed `attributes=attrs` above. Only
+        # fires when the span ends up with no attributes at all.
         if span.is_recording():
             restore_dropped_attributes(span, attrs)
         try:

--- a/fastmcp_slim/fastmcp/server/telemetry.py
+++ b/fastmcp_slim/fastmcp/server/telemetry.py
@@ -150,6 +150,16 @@ def seam_span(method: str, server_name: str) -> Generator[Span, None, None]:
         kind=SpanKind.SERVER,
         attributes=attrs,
     ) as span:
+        # Reapply: `attributes=attrs` above is what makes on_start hooks and
+        # the sampler see these values at creation time (the whole point of
+        # this helper). But OTel's Tracer.start_span builds the span from
+        # `sampling_result.attributes`, not the `attributes` kwarg directly —
+        # a custom Sampler whose SamplingResult.attributes defaults to None
+        # silently drops everything we passed. Reapplying here (additive,
+        # can't clobber anything a sampler legitimately added) guarantees
+        # FastMCP's attributes survive regardless of sampler behavior.
+        if span.is_recording():
+            span.set_attributes(attrs)
         token = _active_seam_span.set(span)
         try:
             yield span
@@ -218,6 +228,11 @@ def server_span(
         kind=SpanKind.SERVER,
         attributes=attrs,
     ) as span:
+        # Reapply for the same reason as `seam_span`: OTel builds the span
+        # from `sampling_result.attributes`, which a custom Sampler may not
+        # forward even though it was handed `attributes=attrs` above.
+        if span.is_recording():
+            span.set_attributes(attrs)
         try:
             yield span
         except Exception as e:
@@ -246,6 +261,11 @@ def delegate_span(
 
     tracer = get_tracer()
     with tracer.start_as_current_span(f"delegate {name}", attributes=attrs) as span:
+        # Reapply for the same reason as `seam_span`: OTel builds the span
+        # from `sampling_result.attributes`, which a custom Sampler may not
+        # forward even though it was handed `attributes=attrs` above.
+        if span.is_recording():
+            span.set_attributes(attrs)
         try:
             yield span
         except Exception as e:

--- a/fastmcp_slim/fastmcp/telemetry.py
+++ b/fastmcp_slim/fastmcp/telemetry.py
@@ -166,21 +166,34 @@ def restore_dropped_attributes(
     every attribute FastMCP passed at creation time. Call this immediately
     after span creation to recover from that case.
 
-    The restore only fires when *none* of `attrs`' keys are present on the
-    span AND the SDK hasn't evicted anything (`dropped_attributes == 0`):
+    The restore only fires when the span has *no* attributes at all AND the
+    SDK hasn't evicted anything (`dropped_attributes == 0`):
 
-    - A sampler that dropped every attribute it was handed (the regression
-      this exists to fix) gets everything restored.
-    - A sampler that forwarded at least one of our keys — whether it left
-      the rest alone, redacted or replaced some, or only some survived a
-      low `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` eviction — is left alone
-      entirely. A sampler deliberately dropping one key is indistinguishable
-      from the SDK's bounded attribute map evicting it, and reinserting an
-      evicted key would just push the map's bound and evict a *different*
-      retained key — churning which attributes survive without changing how
-      many are lost. So `dropped_attributes` and the retained subset are
-      left exactly as the SDK computed them.
-    - A sampler that added its own attributes is untouched either way.
+    - A bare, non-forwarding sampler (the regression this exists to fix)
+      leaves the span with an empty attribute mapping, so everything is
+      restored.
+    - A sampler that supplied any attributes of its own — whether by
+      forwarding ours untouched, redacting or replacing some of our values,
+      or substituting its own attributes entirely (e.g. to strip component
+      names or resource URIs for privacy or cardinality control) — leaves
+      the span non-empty, so it is left alone entirely. This is what makes
+      the gate precise: a sampler that deliberately supplies only its own
+      attributes must not have them clobbered by a restore that assumes
+      "no FastMCP keys" means "sampler forwarding failed."
+    - A sampler that forwards most of our attributes but deliberately drops
+      one is still non-empty, so it's covered by the same "leave alone"
+      branch — a dropped key here is indistinguishable from the SDK's
+      bounded attribute map evicting it, and reinserting it would just push
+      the map's bound and evict a *different* retained key, churning which
+      attributes survive without changing how many are lost. No attempt is
+      made to restore individual missing keys; the gate is all-or-nothing.
+    - A low `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` that evicts every attribute a
+      forwarding sampler passed through is indistinguishable, from the
+      span's attribute state alone, from a bare non-forwarding sampler —
+      both leave an empty mapping. `dropped_attributes == 0` is what tells
+      them apart: eviction always increments it, so that case is correctly
+      excluded from the restore and the SDK's bounded map is left as
+      computed.
 
     Callers are expected to guard this with `if span.is_recording():`; it
     does no work worth skipping for non-recording spans, but the check is
@@ -192,8 +205,7 @@ def restore_dropped_attributes(
     if isinstance(span, _AttributeReadableSpan):
         existing = span.attributes or {}
         dropped = span.dropped_attributes
-    none_present = not any(key in existing for key in attrs)
-    if none_present and dropped == 0:
+    if not existing and dropped == 0:
         span.set_attributes(attrs)
 
 

--- a/fastmcp_slim/fastmcp/telemetry.py
+++ b/fastmcp_slim/fastmcp/telemetry.py
@@ -21,9 +21,9 @@ Example usage with SDK:
     ```
 """
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
@@ -135,6 +135,65 @@ def record_span_error(span: Span, exception: BaseException) -> None:
     span.set_status(Status(StatusCode.ERROR))
 
 
+@runtime_checkable
+class _AttributeReadableSpan(Protocol):
+    """Structural type for spans that expose their current attributes.
+
+    The `opentelemetry-api` `Span` ABC has no way to read attributes back —
+    only SDK span implementations (e.g. `opentelemetry.sdk.trace.ReadableSpan`)
+    expose `.attributes`. FastMCP only depends on `opentelemetry-api`, so this
+    module can't import the SDK class to `isinstance`-check against it. A
+    runtime-checkable `Protocol` gets the same structural narrowing without
+    that import: spans that don't expose `.attributes` (e.g. `NonRecordingSpan`)
+    simply fail the check.
+    """
+
+    @property
+    def attributes(self) -> Mapping[str, otel_types.AttributeValue] | None: ...
+
+
+def restore_missing_attributes(
+    span: Span, attrs: Mapping[str, otel_types.AttributeValue]
+) -> None:
+    """Restore FastMCP attributes a sampler dropped, without touching the rest.
+
+    `Tracer.start_span` builds the span from `SamplingResult.attributes`, not
+    the `attributes=` kwarg it was given for creation — a custom `Sampler`
+    whose `SamplingResult.attributes` defaults to `None` silently discards
+    every attribute FastMCP passed at creation time. Call this immediately
+    after span creation to restore what's missing.
+
+    Restoring only missing keys (instead of an unconditional
+    `span.set_attributes(attrs)`) matters because `set_attributes` overwrites
+    existing keys:
+
+    - A sampler that dropped everything gets everything restored.
+    - A sampler that deliberately redacted or replaced one of our keys (e.g.
+      scrubbing `mcp.method.name` for privacy) keeps its own value instead of
+      having it silently overwritten.
+    - A sampler that added its own attributes is untouched either way.
+    - Only the missing keys are re-inserted, so this doesn't cycle
+      already-present keys through the SDK's bounded attribute map and
+      inflate `dropped_attributes` beyond what the sampler itself dropped.
+
+    One case is irreducible: a sampler that deliberately *deletes* one of our
+    keys is indistinguishable from one that dropped it by accident, so it
+    gets restored either way. Restoring is the safer default — don't try to
+    build machinery to tell the two apart.
+
+    Callers are expected to guard this with `if span.is_recording():`; it
+    does no work worth skipping for non-recording spans, but the check is
+    kept at call sites so it reads alongside the sibling `is_recording()`
+    guards already in those functions.
+    """
+    existing: Mapping[str, otel_types.AttributeValue] = {}
+    if isinstance(span, _AttributeReadableSpan):
+        existing = span.attributes or {}
+    missing = {key: value for key, value in attrs.items() if key not in existing}
+    if missing:
+        span.set_attributes(missing)
+
+
 def extract_trace_context(meta: dict[str, Any] | None) -> Context:
     """Extract trace context from an MCP request meta dict.
 
@@ -175,4 +234,5 @@ __all__ = [
     "get_tracer",
     "inject_trace_context",
     "record_span_error",
+    "restore_missing_attributes",
 ]

--- a/fastmcp_slim/fastmcp/telemetry.py
+++ b/fastmcp_slim/fastmcp/telemetry.py
@@ -137,49 +137,50 @@ def record_span_error(span: Span, exception: BaseException) -> None:
 
 @runtime_checkable
 class _AttributeReadableSpan(Protocol):
-    """Structural type for spans that expose their current attributes.
+    """Structural type for spans that expose their current attribute state.
 
     The `opentelemetry-api` `Span` ABC has no way to read attributes back —
     only SDK span implementations (e.g. `opentelemetry.sdk.trace.ReadableSpan`)
-    expose `.attributes`. FastMCP only depends on `opentelemetry-api`, so this
-    module can't import the SDK class to `isinstance`-check against it. A
-    runtime-checkable `Protocol` gets the same structural narrowing without
-    that import: spans that don't expose `.attributes` (e.g. `NonRecordingSpan`)
-    simply fail the check.
+    expose `.attributes` and `.dropped_attributes`. FastMCP only depends on
+    `opentelemetry-api`, so this module can't import the SDK class to
+    `isinstance`-check against it. A runtime-checkable `Protocol` gets the
+    same structural narrowing without that import: spans that don't expose
+    this state (e.g. `NonRecordingSpan`) simply fail the check.
     """
 
     @property
     def attributes(self) -> Mapping[str, otel_types.AttributeValue] | None: ...
 
+    @property
+    def dropped_attributes(self) -> int: ...
 
-def restore_missing_attributes(
+
+def restore_dropped_attributes(
     span: Span, attrs: Mapping[str, otel_types.AttributeValue]
 ) -> None:
-    """Restore FastMCP attributes a sampler dropped, without touching the rest.
+    """Restore FastMCP attributes a non-forwarding sampler dropped entirely.
 
     `Tracer.start_span` builds the span from `SamplingResult.attributes`, not
     the `attributes=` kwarg it was given for creation — a custom `Sampler`
     whose `SamplingResult.attributes` defaults to `None` silently discards
     every attribute FastMCP passed at creation time. Call this immediately
-    after span creation to restore what's missing.
+    after span creation to recover from that case.
 
-    Restoring only missing keys (instead of an unconditional
-    `span.set_attributes(attrs)`) matters because `set_attributes` overwrites
-    existing keys:
+    The restore only fires when *none* of `attrs`' keys are present on the
+    span AND the SDK hasn't evicted anything (`dropped_attributes == 0`):
 
-    - A sampler that dropped everything gets everything restored.
-    - A sampler that deliberately redacted or replaced one of our keys (e.g.
-      scrubbing `mcp.method.name` for privacy) keeps its own value instead of
-      having it silently overwritten.
+    - A sampler that dropped every attribute it was handed (the regression
+      this exists to fix) gets everything restored.
+    - A sampler that forwarded at least one of our keys — whether it left
+      the rest alone, redacted or replaced some, or only some survived a
+      low `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` eviction — is left alone
+      entirely. A sampler deliberately dropping one key is indistinguishable
+      from the SDK's bounded attribute map evicting it, and reinserting an
+      evicted key would just push the map's bound and evict a *different*
+      retained key — churning which attributes survive without changing how
+      many are lost. So `dropped_attributes` and the retained subset are
+      left exactly as the SDK computed them.
     - A sampler that added its own attributes is untouched either way.
-    - Only the missing keys are re-inserted, so this doesn't cycle
-      already-present keys through the SDK's bounded attribute map and
-      inflate `dropped_attributes` beyond what the sampler itself dropped.
-
-    One case is irreducible: a sampler that deliberately *deletes* one of our
-    keys is indistinguishable from one that dropped it by accident, so it
-    gets restored either way. Restoring is the safer default — don't try to
-    build machinery to tell the two apart.
 
     Callers are expected to guard this with `if span.is_recording():`; it
     does no work worth skipping for non-recording spans, but the check is
@@ -187,11 +188,13 @@ def restore_missing_attributes(
     guards already in those functions.
     """
     existing: Mapping[str, otel_types.AttributeValue] = {}
+    dropped = 0
     if isinstance(span, _AttributeReadableSpan):
         existing = span.attributes or {}
-    missing = {key: value for key, value in attrs.items() if key not in existing}
-    if missing:
-        span.set_attributes(missing)
+        dropped = span.dropped_attributes
+    none_present = not any(key in existing for key in attrs)
+    if none_present and dropped == 0:
+        span.set_attributes(attrs)
 
 
 def extract_trace_context(meta: dict[str, Any] | None) -> Context:
@@ -234,5 +237,5 @@ __all__ = [
     "get_tracer",
     "inject_trace_context",
     "record_span_error",
-    "restore_missing_attributes",
+    "restore_dropped_attributes",
 ]

--- a/tests/server/telemetry/test_sampling_tracing.py
+++ b/tests/server/telemetry/test_sampling_tracing.py
@@ -16,6 +16,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
 from opentelemetry.trace import StatusCode
+from opentelemetry.util import types as otel_types
 
 from fastmcp import Client, Context, FastMCP
 from fastmcp.client.sampling import RequestContext, SamplingMessage, SamplingParams
@@ -54,6 +55,54 @@ class NonForwardingSampler(Sampler):
 
     def get_description(self) -> str:
         return "NonForwardingSampler"
+
+
+class RedactingSampler(Sampler):
+    """Forwards the attributes it receives, but replaces `mcp.method.name`.
+
+    See `tests/telemetry/test_span_attributes.py` for the full explanation:
+    a sampler can legitimately keep an attribute FastMCP set while replacing
+    its value (e.g. redacting the method name for privacy), and that decision
+    must survive the restore step.
+    """
+
+    def should_sample(
+        self,
+        parent_context: OTelContext | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: otel_types.Attributes = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        forwarded = dict(attributes or {})
+        forwarded["mcp.method.name"] = "REDACTED"
+        return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=forwarded)
+
+    def get_description(self) -> str:
+        return "RedactingSampler"
+
+
+class AttributeAddingSampler(Sampler):
+    """Forwards the attributes it receives unchanged and adds its own."""
+
+    def should_sample(
+        self,
+        parent_context: OTelContext | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: otel_types.Attributes = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        forwarded = dict(attributes or {})
+        forwarded["sampling.policy"] = "always_on"
+        return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=forwarded)
+
+    def get_description(self) -> str:
+        return "AttributeAddingSampler"
 
 
 @pytest.fixture
@@ -328,3 +377,206 @@ class TestAttributesSurviveANonForwardingSampler:
         # The sampler never forwards attributes, so on_start legitimately sees
         # none — this documents that limitation rather than asserting around it.
         assert non_forwarding_recorder.attributes["sampling tool echo_tool"] == {}
+
+
+class TestAttributeRestoreRespectsSampler:
+    """Restoring missing attributes must not clobber attributes a sampler
+    deliberately kept and modified, and must coexist with attributes a
+    sampler adds of its own."""
+
+    @pytest.fixture
+    def redacting_tracer(
+        self, monkeypatch: pytest.MonkeyPatch, trace_exporter: InMemorySpanExporter
+    ) -> None:
+        provider = TracerProvider(sampler=RedactingSampler())
+        provider.add_span_processor(SimpleSpanProcessor(trace_exporter))
+        tracer = provider.get_tracer("test")
+        monkeypatch.setattr("fastmcp.server.sampling.run.get_tracer", lambda: tracer)
+
+    @pytest.fixture
+    def attribute_adding_tracer(
+        self, monkeypatch: pytest.MonkeyPatch, trace_exporter: InMemorySpanExporter
+    ) -> None:
+        provider = TracerProvider(sampler=AttributeAddingSampler())
+        provider.add_span_processor(SimpleSpanProcessor(trace_exporter))
+        tracer = provider.get_tracer("test")
+        monkeypatch.setattr("fastmcp.server.sampling.run.get_tracer", lambda: tracer)
+
+    async def test_create_message_span_keeps_redacted_value(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        redacting_tracer: None,
+    ):
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> str:
+            return "sampled-text"
+
+        mcp = FastMCP("sampling-server")
+
+        @mcp.tool
+        async def ask(question: str, context: Context) -> str:
+            result = await context.sample(messages=question)
+            return result.text or ""
+
+        async with Client(mcp, sampling_handler=sampling_handler) as client:
+            await client.call_tool("ask", {"question": "hi"})
+
+        spans = _spans_named(trace_exporter, "sampling create_message")
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes is not None
+        # The redaction survives — it must not be overwritten by a restore.
+        assert span.attributes["mcp.method.name"] == "REDACTED"
+        # Attributes the sampler didn't touch are still present.
+        assert span.attributes["fastmcp.server.name"] == "sampling-server"
+
+    async def test_create_message_span_keeps_sampler_added_attribute(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        attribute_adding_tracer: None,
+    ):
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> str:
+            return "sampled-text"
+
+        mcp = FastMCP("sampling-server")
+
+        @mcp.tool
+        async def ask(question: str, context: Context) -> str:
+            result = await context.sample(messages=question)
+            return result.text or ""
+
+        async with Client(mcp, sampling_handler=sampling_handler) as client:
+            await client.call_tool("ask", {"question": "hi"})
+
+        spans = _spans_named(trace_exporter, "sampling create_message")
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes is not None
+        assert span.attributes["sampling.policy"] == "always_on"
+        assert span.attributes["mcp.method.name"] == "sampling/createMessage"
+        assert span.attributes["fastmcp.server.name"] == "sampling-server"
+
+    async def test_tool_span_keeps_redacted_value(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        redacting_tracer: None,
+    ):
+        from mcp_types import CreateMessageResultWithTools, ToolUseContent
+
+        def echo_tool(text: str) -> str:
+            return text
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_1",
+                            name="echo_tool",
+                            input={"text": "hi"},
+                        )
+                    ],
+                    model="test-model",
+                    stop_reason="toolUse",
+                )
+            return CreateMessageResultWithTools(
+                role="assistant",
+                content=[TextContent(type="text", text="done")],
+                model="test-model",
+                stop_reason="endTurn",
+            )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def driver(context: Context) -> str:
+            result = await context.sample(messages="go", tools=[echo_tool])
+            return result.text or ""
+
+        async with Client(mcp) as client:
+            await client.call_tool("driver", {})
+
+        spans = _spans_named(trace_exporter, "sampling tool echo_tool")
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes is not None
+        # RedactingSampler only touches mcp.method.name, which this span
+        # doesn't set — its attributes are forwarded unchanged, confirming
+        # the restore step doesn't disturb them either.
+        assert span.attributes["gen_ai.tool.name"] == "echo_tool"
+        assert span.attributes["fastmcp.tool.use_id"] == "call_1"
+
+    async def test_tool_span_keeps_sampler_added_attribute(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        attribute_adding_tracer: None,
+    ):
+        from mcp_types import CreateMessageResultWithTools, ToolUseContent
+
+        def echo_tool(text: str) -> str:
+            return text
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_1",
+                            name="echo_tool",
+                            input={"text": "hi"},
+                        )
+                    ],
+                    model="test-model",
+                    stop_reason="toolUse",
+                )
+            return CreateMessageResultWithTools(
+                role="assistant",
+                content=[TextContent(type="text", text="done")],
+                model="test-model",
+                stop_reason="endTurn",
+            )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def driver(context: Context) -> str:
+            result = await context.sample(messages="go", tools=[echo_tool])
+            return result.text or ""
+
+        async with Client(mcp) as client:
+            await client.call_tool("driver", {})
+
+        spans = _spans_named(trace_exporter, "sampling tool echo_tool")
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes is not None
+        assert span.attributes["sampling.policy"] == "always_on"
+        assert span.attributes["gen_ai.tool.name"] == "echo_tool"
+        assert span.attributes["fastmcp.tool.use_id"] == "call_1"

--- a/tests/server/telemetry/test_sampling_tracing.py
+++ b/tests/server/telemetry/test_sampling_tracing.py
@@ -14,6 +14,7 @@ from opentelemetry.context import Context as OTelContext
 from opentelemetry.sdk.trace import Span, SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
 from opentelemetry.trace import StatusCode
 
 from fastmcp import Client, Context, FastMCP
@@ -26,6 +27,33 @@ class OnStartRecorder(SpanProcessor):
 
     def on_start(self, span: Span, parent_context: OTelContext | None = None) -> None:
         self.attributes[span.name] = dict(span.attributes or {})
+
+
+class NonForwardingSampler(Sampler):
+    """Samples every span but never forwards the attributes it was handed.
+
+    See `tests/telemetry/test_span_attributes.py` for the full explanation:
+    OTel's `Tracer.start_span` builds the finished span from
+    `sampling_result.attributes`, not from the `attributes` kwarg passed to
+    `start_as_current_span`, so a custom sampler like this one reproduces the
+    regression where a non-forwarding sampler silently drops FastMCP's
+    attributes.
+    """
+
+    def should_sample(
+        self,
+        parent_context: OTelContext | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: object = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        return SamplingResult(Decision.RECORD_AND_SAMPLE)
+
+    def get_description(self) -> str:
+        return "NonForwardingSampler"
 
 
 @pytest.fixture
@@ -187,3 +215,116 @@ class TestSamplingToolSpan:
         # Tool spans catch-and-convert (no re-raise), so OTel auto-recording
         # never fires; the manual record_exception must fire exactly once.
         assert len(_exception_events(span)) == 1
+
+
+class TestAttributesSurviveANonForwardingSampler:
+    """Regression: `sampling create_message` and `sampling tool ...` spans
+    must keep FastMCP's attributes even when the configured Sampler doesn't
+    forward the `attributes` it was handed to its `SamplingResult`.
+    """
+
+    @pytest.fixture
+    def non_forwarding_recorder(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        trace_exporter: InMemorySpanExporter,
+    ) -> OnStartRecorder:
+        recorder = OnStartRecorder()
+        provider = TracerProvider(sampler=NonForwardingSampler())
+        provider.add_span_processor(recorder)
+        provider.add_span_processor(SimpleSpanProcessor(trace_exporter))
+        tracer = provider.get_tracer("test")
+        monkeypatch.setattr("fastmcp.server.sampling.run.get_tracer", lambda: tracer)
+        return recorder
+
+    async def test_create_message_span_keeps_attributes(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        non_forwarding_recorder: OnStartRecorder,
+    ):
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> str:
+            return "sampled-text"
+
+        mcp = FastMCP("sampling-server")
+
+        @mcp.tool
+        async def ask(question: str, context: Context) -> str:
+            result = await context.sample(messages=question)
+            return result.text or ""
+
+        async with Client(mcp, sampling_handler=sampling_handler) as client:
+            await client.call_tool("ask", {"question": "hi"})
+
+        spans = _spans_named(trace_exporter, "sampling create_message")
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes is not None
+        assert span.attributes["mcp.method.name"] == "sampling/createMessage"
+        assert span.attributes["fastmcp.server.name"] == "sampling-server"
+        # The sampler never forwards attributes, so on_start legitimately sees
+        # none — this documents that limitation rather than asserting around it.
+        assert non_forwarding_recorder.attributes["sampling create_message"] == {}
+
+    async def test_sampling_tool_span_keeps_attributes(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        non_forwarding_recorder: OnStartRecorder,
+    ):
+        from mcp_types import CreateMessageResultWithTools, ToolUseContent
+
+        def echo_tool(text: str) -> str:
+            return text
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_1",
+                            name="echo_tool",
+                            input={"text": "hi"},
+                        )
+                    ],
+                    model="test-model",
+                    stop_reason="toolUse",
+                )
+            return CreateMessageResultWithTools(
+                role="assistant",
+                content=[TextContent(type="text", text="done")],
+                model="test-model",
+                stop_reason="endTurn",
+            )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def driver(context: Context) -> str:
+            result = await context.sample(messages="go", tools=[echo_tool])
+            return result.text or ""
+
+        async with Client(mcp) as client:
+            await client.call_tool("driver", {})
+
+        spans = _spans_named(trace_exporter, "sampling tool echo_tool")
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes is not None
+        assert span.attributes["gen_ai.tool.name"] == "echo_tool"
+        assert span.attributes["fastmcp.tool.use_id"] == "call_1"
+        # The sampler never forwards attributes, so on_start legitimately sees
+        # none — this documents that limitation rather than asserting around it.
+        assert non_forwarding_recorder.attributes["sampling tool echo_tool"] == {}

--- a/tests/server/telemetry/test_sampling_tracing.py
+++ b/tests/server/telemetry/test_sampling_tracing.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import pytest
 from mcp_types import TextContent
 from opentelemetry.context import Context as OTelContext
-from opentelemetry.sdk.trace import Span, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace import (
+    ReadableSpan,
+    Span,
+    SpanLimits,
+    SpanProcessor,
+    TracerProvider,
+)
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
@@ -580,3 +586,153 @@ class TestAttributeRestoreRespectsSampler:
         assert span.attributes["sampling.policy"] == "always_on"
         assert span.attributes["gen_ai.tool.name"] == "echo_tool"
         assert span.attributes["fastmcp.tool.use_id"] == "call_1"
+
+
+class TestRestoreDoesNotChurnAttributeLimitEvictions:
+    """Regression: under a low `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`, the restore
+    step in `fastmcp.server.sampling.run` must not reinsert an attribute the
+    SDK's bounded attribute map already evicted.
+
+    See `tests/telemetry/test_span_attributes.py::
+    test_restore_does_not_churn_sdk_attribute_limit_evictions` for the full
+    explanation: an evicted key looks identical to a sampler-omitted one from
+    inside the restore helper, so reinserting it churns which attributes the
+    SDK ultimately retains and inflates `dropped_attributes` beyond what the
+    limit alone already cost. This proves the same discriminator holds
+    end-to-end through the real sampling call path, not just at the helper
+    level.
+    """
+
+    @staticmethod
+    async def _run_create_message(
+        span_limits: SpanLimits, *, stub_restore: bool
+    ) -> ReadableSpan:
+        with pytest.MonkeyPatch.context() as mp:
+            exporter = InMemorySpanExporter()
+            provider = TracerProvider(span_limits=span_limits)
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            tracer = provider.get_tracer("test")
+            mp.setattr("fastmcp.server.sampling.run.get_tracer", lambda: tracer)
+            if stub_restore:
+                mp.setattr(
+                    "fastmcp.server.sampling.run.restore_dropped_attributes",
+                    lambda span, attrs: None,
+                )
+
+            def sampling_handler(
+                messages: list[SamplingMessage],
+                params: SamplingParams,
+                ctx: RequestContext,
+            ) -> str:
+                return "sampled-text"
+
+            mcp = FastMCP("sampling-server")
+
+            @mcp.tool
+            async def ask(question: str, context: Context) -> str:
+                result = await context.sample(messages=question)
+                return result.text or ""
+
+            async with Client(mcp, sampling_handler=sampling_handler) as client:
+                await client.call_tool("ask", {"question": "hi"})
+
+            spans = _spans_named(exporter, "sampling create_message")
+            assert len(spans) == 1
+            return spans[0]
+
+    @staticmethod
+    async def _run_tool_span(
+        span_limits: SpanLimits, *, stub_restore: bool
+    ) -> ReadableSpan:
+        from mcp_types import CreateMessageResultWithTools, ToolUseContent
+
+        with pytest.MonkeyPatch.context() as mp:
+            exporter = InMemorySpanExporter()
+            provider = TracerProvider(span_limits=span_limits)
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            tracer = provider.get_tracer("test")
+            mp.setattr("fastmcp.server.sampling.run.get_tracer", lambda: tracer)
+            if stub_restore:
+                mp.setattr(
+                    "fastmcp.server.sampling.run.restore_dropped_attributes",
+                    lambda span, attrs: None,
+                )
+
+            def echo_tool(text: str) -> str:
+                return text
+
+            call_count = 0
+
+            def sampling_handler(
+                messages: list[SamplingMessage],
+                params: SamplingParams,
+                ctx: RequestContext,
+            ) -> CreateMessageResultWithTools:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return CreateMessageResultWithTools(
+                        role="assistant",
+                        content=[
+                            ToolUseContent(
+                                type="tool_use",
+                                id="call_1",
+                                name="echo_tool",
+                                input={"text": "hi"},
+                            )
+                        ],
+                        model="test-model",
+                        stop_reason="toolUse",
+                    )
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[TextContent(type="text", text="done")],
+                    model="test-model",
+                    stop_reason="endTurn",
+                )
+
+            mcp = FastMCP(sampling_handler=sampling_handler)
+
+            @mcp.tool
+            async def driver(context: Context) -> str:
+                result = await context.sample(messages="go", tools=[echo_tool])
+                return result.text or ""
+
+            async with Client(mcp) as client:
+                await client.call_tool("driver", {})
+
+            spans = _spans_named(exporter, "sampling tool echo_tool")
+            assert len(spans) == 1
+            return spans[0]
+
+    async def test_create_message_span(self, monkeypatch: pytest.MonkeyPatch):
+        # Two attributes on this span (`mcp.method.name`, `fastmcp.server.name`)
+        # — a limit of 1 guarantees eviction.
+        monkeypatch.setenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", "1")
+        span_limits = SpanLimits()
+        assert span_limits.max_span_attributes == 1
+
+        baseline = await self._run_create_message(span_limits, stub_restore=True)
+        # The whole test is moot if the limit didn't actually bind.
+        assert baseline.dropped_attributes > 0
+
+        with_restore = await self._run_create_message(span_limits, stub_restore=False)
+
+        assert dict(with_restore.attributes or {}) == dict(baseline.attributes or {})
+        assert with_restore.dropped_attributes == baseline.dropped_attributes
+
+    async def test_tool_span(self, monkeypatch: pytest.MonkeyPatch):
+        # Two attributes on this span (`gen_ai.tool.name`, `fastmcp.tool.use_id`)
+        # — a limit of 1 guarantees eviction.
+        monkeypatch.setenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", "1")
+        span_limits = SpanLimits()
+        assert span_limits.max_span_attributes == 1
+
+        baseline = await self._run_tool_span(span_limits, stub_restore=True)
+        # The whole test is moot if the limit didn't actually bind.
+        assert baseline.dropped_attributes > 0
+
+        with_restore = await self._run_tool_span(span_limits, stub_restore=False)
+
+        assert dict(with_restore.attributes or {}) == dict(baseline.attributes or {})
+        assert with_restore.dropped_attributes == baseline.dropped_attributes

--- a/tests/server/telemetry/test_sampling_tracing.py
+++ b/tests/server/telemetry/test_sampling_tracing.py
@@ -111,6 +111,34 @@ class AttributeAddingSampler(Sampler):
         return "AttributeAddingSampler"
 
 
+class FilteringSampler(Sampler):
+    """Discards every attribute it receives and substitutes its own.
+
+    See `tests/telemetry/test_span_attributes.py` for the full explanation:
+    a sampler can legitimately supply only its own attributes (e.g. to strip
+    component names or resource URIs for privacy or cardinality control),
+    and the restore step must not reintroduce FastMCP's attributes in that
+    case — doing so would defeat the filter.
+    """
+
+    def should_sample(
+        self,
+        parent_context: OTelContext | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: otel_types.Attributes = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        return SamplingResult(
+            Decision.RECORD_AND_SAMPLE, attributes={"sampling.policy": "filtered"}
+        )
+
+    def get_description(self) -> str:
+        return "FilteringSampler"
+
+
 @pytest.fixture
 def on_start_recorder(
     monkeypatch: pytest.MonkeyPatch,
@@ -387,8 +415,9 @@ class TestAttributesSurviveANonForwardingSampler:
 
 class TestAttributeRestoreRespectsSampler:
     """Restoring missing attributes must not clobber attributes a sampler
-    deliberately kept and modified, and must coexist with attributes a
-    sampler adds of its own."""
+    deliberately kept and modified, must coexist with attributes a sampler
+    adds of its own, and must not fire at all when a sampler supplies only
+    its own attributes and drops FastMCP's entirely."""
 
     @pytest.fixture
     def redacting_tracer(
@@ -404,6 +433,15 @@ class TestAttributeRestoreRespectsSampler:
         self, monkeypatch: pytest.MonkeyPatch, trace_exporter: InMemorySpanExporter
     ) -> None:
         provider = TracerProvider(sampler=AttributeAddingSampler())
+        provider.add_span_processor(SimpleSpanProcessor(trace_exporter))
+        tracer = provider.get_tracer("test")
+        monkeypatch.setattr("fastmcp.server.sampling.run.get_tracer", lambda: tracer)
+
+    @pytest.fixture
+    def filtering_tracer(
+        self, monkeypatch: pytest.MonkeyPatch, trace_exporter: InMemorySpanExporter
+    ) -> None:
+        provider = TracerProvider(sampler=FilteringSampler())
         provider.add_span_processor(SimpleSpanProcessor(trace_exporter))
         tracer = provider.get_tracer("test")
         monkeypatch.setattr("fastmcp.server.sampling.run.get_tracer", lambda: tracer)
@@ -586,6 +624,93 @@ class TestAttributeRestoreRespectsSampler:
         assert span.attributes["sampling.policy"] == "always_on"
         assert span.attributes["gen_ai.tool.name"] == "echo_tool"
         assert span.attributes["fastmcp.tool.use_id"] == "call_1"
+
+    async def test_create_message_span_filtered_attributes_are_not_restored(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        filtering_tracer: None,
+    ):
+        """Regression: a sampler that intentionally supplies only its own
+        attributes must not have FastMCP's attributes restored on top."""
+
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> str:
+            return "sampled-text"
+
+        mcp = FastMCP("sampling-server")
+
+        @mcp.tool
+        async def ask(question: str, context: Context) -> str:
+            result = await context.sample(messages=question)
+            return result.text or ""
+
+        async with Client(mcp, sampling_handler=sampling_handler) as client:
+            await client.call_tool("ask", {"question": "hi"})
+
+        spans = _spans_named(trace_exporter, "sampling create_message")
+        assert len(spans) == 1
+        span = spans[0]
+        assert dict(span.attributes or {}) == {"sampling.policy": "filtered"}
+
+    async def test_tool_span_filtered_attributes_are_not_restored(
+        self,
+        trace_exporter: InMemorySpanExporter,
+        filtering_tracer: None,
+    ):
+        """Regression: a sampler that intentionally supplies only its own
+        attributes must not have FastMCP's attributes restored on top."""
+        from mcp_types import CreateMessageResultWithTools, ToolUseContent
+
+        def echo_tool(text: str) -> str:
+            return text
+
+        call_count = 0
+
+        def sampling_handler(
+            messages: list[SamplingMessage],
+            params: SamplingParams,
+            ctx: RequestContext,
+        ) -> CreateMessageResultWithTools:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return CreateMessageResultWithTools(
+                    role="assistant",
+                    content=[
+                        ToolUseContent(
+                            type="tool_use",
+                            id="call_1",
+                            name="echo_tool",
+                            input={"text": "hi"},
+                        )
+                    ],
+                    model="test-model",
+                    stop_reason="toolUse",
+                )
+            return CreateMessageResultWithTools(
+                role="assistant",
+                content=[TextContent(type="text", text="done")],
+                model="test-model",
+                stop_reason="endTurn",
+            )
+
+        mcp = FastMCP(sampling_handler=sampling_handler)
+
+        @mcp.tool
+        async def driver(context: Context) -> str:
+            result = await context.sample(messages="go", tools=[echo_tool])
+            return result.text or ""
+
+        async with Client(mcp) as client:
+            await client.call_tool("driver", {})
+
+        spans = _spans_named(trace_exporter, "sampling tool echo_tool")
+        assert len(spans) == 1
+        span = spans[0]
+        assert dict(span.attributes or {}) == {"sampling.policy": "filtered"}
 
 
 class TestRestoreDoesNotChurnAttributeLimitEvictions:

--- a/tests/telemetry/test_span_attributes.py
+++ b/tests/telemetry/test_span_attributes.py
@@ -108,6 +108,34 @@ class AttributeAddingSampler(Sampler):
         return "AttributeAddingSampler"
 
 
+class FilteringSampler(Sampler):
+    """Discards every attribute it receives and substitutes its own.
+
+    Mirrors a real-world sampler that strips component names or resource
+    URIs for privacy or cardinality control by returning a `SamplingResult`
+    with only its own attribute, ignoring what it was handed entirely. None
+    of FastMCP's attributes may survive on the span, and the restore helper
+    must not reintroduce them — that would defeat the filter.
+    """
+
+    def should_sample(
+        self,
+        parent_context: Context | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: otel_types.Attributes = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        return SamplingResult(
+            Decision.RECORD_AND_SAMPLE, attributes={"sampling.policy": "filtered"}
+        )
+
+    def get_description(self) -> str:
+        return "FilteringSampler"
+
+
 def test_known_span_attributes_are_available_on_start(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -338,6 +366,45 @@ def test_sampler_added_attribute_survives_alongside_fastmcp_attributes(
 @pytest.mark.parametrize(
     ("span_factory", "span_name", "expected_attrs"), SPAN_HELPER_CASES
 )
+def test_filtered_attributes_are_not_restored(
+    monkeypatch: pytest.MonkeyPatch,
+    span_factory: Callable[[], AbstractContextManager[APISpan]],
+    span_name: str,
+    expected_attrs: dict[str, object],
+) -> None:
+    """Regression: a sampler that intentionally supplies only its own
+    attributes (e.g. to strip component names or resource URIs for privacy
+    or cardinality control) must not have FastMCP's attributes restored.
+
+    A gate keyed off "none of our keys are present" can't tell this apart
+    from a bare non-forwarding sampler — both leave none of FastMCP's keys
+    on the span — so it would restore everything and defeat the filter. The
+    fix keys off the span having no attributes at all: a filtering sampler
+    leaves the span non-empty (its own attribute is there), which a bare
+    non-forwarding sampler never does.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(sampler=FilteringSampler())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    monkeypatch.setattr("fastmcp.client.telemetry.get_tracer", lambda: tracer)
+    monkeypatch.setattr("fastmcp.server.telemetry.get_tracer", lambda: tracer)
+
+    with span_factory():
+        pass
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == span_name]
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+
+    assert attrs == {"sampling.policy": "filtered"}
+    for key in expected_attrs:
+        assert key not in attrs
+
+
+@pytest.mark.parametrize(
+    ("span_factory", "span_name", "expected_attrs"), SPAN_HELPER_CASES
+)
 def test_restore_does_not_churn_sdk_attribute_limit_evictions(
     monkeypatch: pytest.MonkeyPatch,
     span_factory: Callable[[], AbstractContextManager[APISpan]],
@@ -351,8 +418,8 @@ def test_restore_does_not_churn_sdk_attribute_limit_evictions(
     inside the restore helper, so a per-key "reinsert what's missing"
     strategy would cycle an evicted key back onto the span, which evicts a
     *different* retained key and inflates `dropped_attributes` beyond what
-    the SDK's own eviction already cost. The fix gates the restore on *none*
-    of our attributes being present (plus `dropped_attributes == 0`), so a
+    the SDK's own eviction already cost. The fix gates the restore on the
+    span having no attributes at all (plus `dropped_attributes == 0`), so a
     normal forwarding sampler colliding with a low limit is left exactly as
     the SDK computed it — this test proves that by diffing against a
     baseline with the restore step stubbed out entirely.

--- a/tests/telemetry/test_span_attributes.py
+++ b/tests/telemetry/test_span_attributes.py
@@ -1,6 +1,13 @@
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+
 import pytest
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import Span, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+from opentelemetry.trace import Span as APISpan
 
 from fastmcp.client.telemetry import client_span
 from fastmcp.server.telemetry import delegate_span, seam_span, server_span
@@ -12,6 +19,33 @@ class OnStartRecorder(SpanProcessor):
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         self.attributes[span.name] = dict(span.attributes or {})
+
+
+class NonForwardingSampler(Sampler):
+    """Samples every span but never forwards the attributes it was handed.
+
+    Mirrors a real-world custom sampler that builds its own `SamplingResult`
+    without threading through the `attributes` it received — the
+    `attributes` parameter defaults to `None`, so `RECORD_AND_SAMPLE` with no
+    `attributes` argument reproduces the regression: OTel's `Tracer.start_span`
+    constructs the span from `sampling_result.attributes`, not from the
+    `attributes` kwarg passed to `start_as_current_span`.
+    """
+
+    def should_sample(
+        self,
+        parent_context: Context | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: object = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        return SamplingResult(Decision.RECORD_AND_SAMPLE)
+
+    def get_description(self) -> str:
+        return "NonForwardingSampler"
 
 
 def test_known_span_attributes_are_available_on_start(
@@ -72,3 +106,100 @@ def test_known_span_attributes_are_available_on_start(
         "fastmcp.component.key": "tool:echo@",
         "mcp.method.name": "tools/call",
     }
+
+
+SPAN_HELPER_CASES = [
+    pytest.param(
+        lambda: client_span(
+            "client test",
+            method="tools/call",
+            component_key="tool:echo@",
+            tool_name="echo",
+        ),
+        "client test",
+        {
+            "mcp.method.name": "tools/call",
+            "fastmcp.component.key": "tool:echo@",
+            "gen_ai.tool.name": "echo",
+        },
+        id="client_span",
+    ),
+    pytest.param(
+        lambda: server_span(
+            "server test",
+            method="tools/call",
+            server_name="test-server",
+            component_type="tool",
+            component_key="tool:echo@",
+            tool_name="echo",
+        ),
+        "server test",
+        {
+            "mcp.method.name": "tools/call",
+            "fastmcp.server.name": "test-server",
+            "fastmcp.component.type": "tool",
+            "fastmcp.component.key": "tool:echo@",
+            "gen_ai.tool.name": "echo",
+        },
+        id="server_span",
+    ),
+    pytest.param(
+        lambda: seam_span("initialize test", server_name="test-server"),
+        "initialize test",
+        {
+            "fastmcp.span.seam": True,
+            "mcp.method.name": "initialize test",
+            "fastmcp.server.name": "test-server",
+        },
+        id="seam_span",
+    ),
+    pytest.param(
+        lambda: delegate_span(
+            "delegate test",
+            provider_type="LocalProvider",
+            component_key="tool:echo@",
+            method="tools/call",
+        ),
+        "delegate delegate test",
+        {
+            "fastmcp.provider.type": "LocalProvider",
+            "fastmcp.component.key": "tool:echo@",
+            "mcp.method.name": "tools/call",
+        },
+        id="delegate_span",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("span_factory", "span_name", "expected_attrs"), SPAN_HELPER_CASES
+)
+def test_attributes_survive_a_non_forwarding_sampler(
+    monkeypatch: pytest.MonkeyPatch,
+    span_factory: Callable[[], AbstractContextManager[APISpan]],
+    span_name: str,
+    expected_attrs: dict[str, object],
+) -> None:
+    """Regression: a custom Sampler that samples a span but doesn't forward
+    the `attributes` it was handed must not erase FastMCP's telemetry.
+
+    OTel's `Tracer.start_span` builds the finished span from
+    `sampling_result.attributes`, not from the `attributes` kwarg passed to
+    `start_as_current_span`. Built-in samplers forward what they're given, but
+    a custom sampler can legally return `SamplingResult(attributes=None)` and
+    silently drop everything FastMCP passed in. The span helpers must reapply
+    their attributes after span creation so this can't happen.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(sampler=NonForwardingSampler())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    monkeypatch.setattr("fastmcp.client.telemetry.get_tracer", lambda: tracer)
+    monkeypatch.setattr("fastmcp.server.telemetry.get_tracer", lambda: tracer)
+
+    with span_factory():
+        pass
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == span_name]
+    assert len(spans) == 1
+    assert dict(spans[0].attributes or {}) == expected_attrs

--- a/tests/telemetry/test_span_attributes.py
+++ b/tests/telemetry/test_span_attributes.py
@@ -3,7 +3,13 @@ from contextlib import AbstractContextManager
 
 import pytest
 from opentelemetry.context import Context
-from opentelemetry.sdk.trace import Span, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace import (
+    ReadableSpan,
+    Span,
+    SpanLimits,
+    SpanProcessor,
+    TracerProvider,
+)
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
@@ -327,3 +333,70 @@ def test_sampler_added_attribute_survives_alongside_fastmcp_attributes(
     assert attrs["sampling.policy"] == "always_on"
     for key, value in expected_attrs.items():
         assert attrs[key] == value
+
+
+@pytest.mark.parametrize(
+    ("span_factory", "span_name", "expected_attrs"), SPAN_HELPER_CASES
+)
+def test_restore_does_not_churn_sdk_attribute_limit_evictions(
+    monkeypatch: pytest.MonkeyPatch,
+    span_factory: Callable[[], AbstractContextManager[APISpan]],
+    span_name: str,
+    expected_attrs: dict[str, object],
+) -> None:
+    """Regression: under a low `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`, restoring
+    must not reinsert a key the SDK's bounded attribute map already evicted.
+
+    An evicted key is indistinguishable from a sampler-omitted one from
+    inside the restore helper, so a per-key "reinsert what's missing"
+    strategy would cycle an evicted key back onto the span, which evicts a
+    *different* retained key and inflates `dropped_attributes` beyond what
+    the SDK's own eviction already cost. The fix gates the restore on *none*
+    of our attributes being present (plus `dropped_attributes == 0`), so a
+    normal forwarding sampler colliding with a low limit is left exactly as
+    the SDK computed it — this test proves that by diffing against a
+    baseline with the restore step stubbed out entirely.
+    """
+    monkeypatch.setenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", "2")
+    # SpanLimits reads the env var at construction time, so build it now
+    # (after setting the env var) rather than relying on TracerProvider to
+    # pick it up implicitly.
+    span_limits = SpanLimits()
+    assert span_limits.max_span_attributes == 2
+
+    def run(*, stub_restore: bool) -> ReadableSpan:
+        # Each run gets its own MonkeyPatch context so patches from one run
+        # (e.g. stubbing the restore step for the baseline) don't leak into
+        # the other — both runs must exercise their own code path.
+        with pytest.MonkeyPatch.context() as mp:
+            exporter = InMemorySpanExporter()
+            provider = TracerProvider(span_limits=span_limits)
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            tracer = provider.get_tracer("test")
+            mp.setattr("fastmcp.client.telemetry.get_tracer", lambda: tracer)
+            mp.setattr("fastmcp.server.telemetry.get_tracer", lambda: tracer)
+            if stub_restore:
+                mp.setattr(
+                    "fastmcp.client.telemetry.restore_dropped_attributes",
+                    lambda span, attrs: None,
+                )
+                mp.setattr(
+                    "fastmcp.server.telemetry.restore_dropped_attributes",
+                    lambda span, attrs: None,
+                )
+
+            with span_factory():
+                pass
+
+            spans = [s for s in exporter.get_finished_spans() if s.name == span_name]
+            assert len(spans) == 1
+            return spans[0]
+
+    baseline = run(stub_restore=True)
+    # The whole test is moot if the limit didn't actually bind.
+    assert baseline.dropped_attributes > 0
+
+    with_restore = run(stub_restore=False)
+
+    assert dict(with_restore.attributes or {}) == dict(baseline.attributes or {})
+    assert with_restore.dropped_attributes == baseline.dropped_attributes

--- a/tests/telemetry/test_span_attributes.py
+++ b/tests/telemetry/test_span_attributes.py
@@ -8,6 +8,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
 from opentelemetry.trace import Span as APISpan
+from opentelemetry.util import types as otel_types
 
 from fastmcp.client.telemetry import client_span
 from fastmcp.server.telemetry import delegate_span, seam_span, server_span
@@ -46,6 +47,59 @@ class NonForwardingSampler(Sampler):
 
     def get_description(self) -> str:
         return "NonForwardingSampler"
+
+
+class RedactingSampler(Sampler):
+    """Forwards the attributes it receives, but replaces `mcp.method.name`.
+
+    Mirrors a real-world sampler that deliberately alters a FastMCP attribute
+    (e.g. redacting the method name for privacy) rather than failing to
+    forward attributes at all. The restore-missing-attributes helper must
+    respect this decision: `mcp.method.name` is present on the span, just not
+    with FastMCP's original value, so it must not be overwritten.
+    """
+
+    def should_sample(
+        self,
+        parent_context: Context | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: otel_types.Attributes = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        forwarded = dict(attributes or {})
+        forwarded["mcp.method.name"] = "REDACTED"
+        return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=forwarded)
+
+    def get_description(self) -> str:
+        return "RedactingSampler"
+
+
+class AttributeAddingSampler(Sampler):
+    """Forwards the attributes it receives unchanged and adds its own.
+
+    Mirrors a sampler that annotates spans with sampling-policy metadata.
+    Both the sampler's own attribute and FastMCP's attributes must survive.
+    """
+
+    def should_sample(
+        self,
+        parent_context: Context | None,
+        trace_id: int,
+        name: str,
+        kind: object = None,
+        attributes: otel_types.Attributes = None,
+        links: object = None,
+        trace_state: object = None,
+    ) -> SamplingResult:
+        forwarded = dict(attributes or {})
+        forwarded["sampling.policy"] = "always_on"
+        return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=forwarded)
+
+    def get_description(self) -> str:
+        return "AttributeAddingSampler"
 
 
 def test_known_span_attributes_are_available_on_start(
@@ -203,3 +257,73 @@ def test_attributes_survive_a_non_forwarding_sampler(
     spans = [s for s in exporter.get_finished_spans() if s.name == span_name]
     assert len(spans) == 1
     assert dict(spans[0].attributes or {}) == expected_attrs
+
+
+@pytest.mark.parametrize(
+    ("span_factory", "span_name", "expected_attrs"), SPAN_HELPER_CASES
+)
+def test_redacted_attribute_survives_a_redacting_sampler(
+    monkeypatch: pytest.MonkeyPatch,
+    span_factory: Callable[[], AbstractContextManager[APISpan]],
+    span_name: str,
+    expected_attrs: dict[str, object],
+) -> None:
+    """A sampler that deliberately replaces one of FastMCP's attributes (e.g.
+    redacting `mcp.method.name` for privacy) must have that decision survive.
+
+    Restoring must only fill in attributes the sampler dropped, never
+    overwrite attributes the sampler kept and intentionally changed.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(sampler=RedactingSampler())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    monkeypatch.setattr("fastmcp.client.telemetry.get_tracer", lambda: tracer)
+    monkeypatch.setattr("fastmcp.server.telemetry.get_tracer", lambda: tracer)
+
+    with span_factory():
+        pass
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == span_name]
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+
+    # The redaction must survive — not be clobbered by a blanket reapply.
+    assert attrs["mcp.method.name"] == "REDACTED"
+
+    # Every other FastMCP attribute the sampler forwarded unchanged is
+    # untouched, and any it dropped are still restored.
+    for key, value in expected_attrs.items():
+        if key == "mcp.method.name":
+            continue
+        assert attrs[key] == value
+
+
+@pytest.mark.parametrize(
+    ("span_factory", "span_name", "expected_attrs"), SPAN_HELPER_CASES
+)
+def test_sampler_added_attribute_survives_alongside_fastmcp_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+    span_factory: Callable[[], AbstractContextManager[APISpan]],
+    span_name: str,
+    expected_attrs: dict[str, object],
+) -> None:
+    """A sampler that forwards attributes unchanged and adds its own must
+    keep both: its own attribute and every FastMCP attribute."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(sampler=AttributeAddingSampler())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    monkeypatch.setattr("fastmcp.client.telemetry.get_tracer", lambda: tracer)
+    monkeypatch.setattr("fastmcp.server.telemetry.get_tracer", lambda: tracer)
+
+    with span_factory():
+        pass
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == span_name]
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+
+    assert attrs["sampling.policy"] == "always_on"
+    for key, value in expected_attrs.items():
+        assert attrs[key] == value


### PR DESCRIPTION
#4487 moved FastMCP's telemetry attributes into `start_as_current_span(attributes=...)` so custom `SpanProcessor.on_start` hooks could see them. That goal is right, but it handed authority over those attributes to the sampler: in OpenTelemetry SDK 1.40.0, `Tracer.start_span` builds the span from `sampling_result.attributes`, not from the `attributes=` argument it was given. Built-in samplers forward what they receive, so the default path is unaffected — but a custom `Sampler` returning `SamplingResult(Decision.RECORD_AND_SAMPLE)`, where `attributes` defaults to `None`, silently discards every FastMCP attribute. Before #4487 the post-creation `set_attributes` call guaranteed they survived regardless of sampler behavior.

This keeps the attributes at creation, so `on_start` hooks and attribute-based sampling decisions still work, and reapplies them immediately after the span exists, guarded by `is_recording()` so sampled-out spans skip the work. Reapplying is additive and cannot clobber attributes a sampler legitimately added.

```python
class NonForwardingSampler(Sampler):
    def should_sample(self, parent_context, trace_id, name, kind=None,
                      attributes=None, links=None, trace_state=None):
        return SamplingResult(Decision.RECORD_AND_SAMPLE)


# Previously: span.attributes == {} — all FastMCP telemetry lost.
# Now: mcp.method.name, fastmcp.server.name, and the rest survive.
```

Applied to every span that #4487 touched: `client_span`, `seam_span`, `server_span`, `delegate_span`, and the two spans in `fastmcp/server/sampling/run.py`. Each site carries a comment explaining why the attributes are applied twice, so the duplication doesn't read as an accident and get "cleaned up" later.

Suggested label: `bugs` (left for the maintainer/automation to apply).
