### PR TITLE
Add missing 4.0.0 version badge to Path Security docs

### DIFF
--- a/docs/servers/resources.mdx
+++ b/docs/servers/resources.mdx
@@ -524,6 +524,8 @@ Note that like regular parameters, each wildcard parameter must still be a named
 
 #### Path Security
 
+<VersionBadge version="4.0.0" />
+
 Template parameters are extracted from the request URI and decoded before your function receives them, so a path-traversal payload like `../` or an absolute path can reach a handler that builds filesystem paths or upstream URLs. FastMCP screens every templated resource's parameter values **before the handler runs**, and this screening is **on by default**.
 
 By default, a parameter value is rejected if its `..` path segments would escape the value's own starting depth, if it looks like an absolute path, or if it contains a null byte. A rejected read surfaces a clean "resource not found" error to the client and logs the reason at debug level, so the failing parameter and policy are never revealed on the wire.


### PR DESCRIPTION
An audit of every merged v4 PR (the SDK v2 migration and the 21 labeled PRs since, plus unlabeled doc-touching commits in the window) found the new-feature docs already carry their `4.0.0` version badges — with one exception: the Path Security section added in #4482. This adds that badge, following the file's existing per-section convention (its sibling headings badge the same way).

Label: chores
