### PR TITLE
Make examples/ actually trigger the ty gate

### DIFF
--- a/.github/workflows/run-static.yml
+++ b/.github/workflows/run-static.yml
@@ -10,6 +10,7 @@ on:
       - "fastmcp_slim/**"
       - "fastmcp_remote/**"
       - "tests/**"
+      - "examples/**"
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         entry: uv run --isolated ty check
         language: system
         types: [python]
-        files: ^fastmcp_slim/|^tests/
+        files: ^fastmcp_slim/|^tests/|^examples/
         pass_filenames: false
         require_serial: true
 


### PR DESCRIPTION
#4466 added `examples/` to `[tool.ty.src] include` so CI would type-check examples, but the `ty` prek hook's `files:` scope and the static-analysis workflow's push path triggers both still omitted `examples/`. Locally, a commit touching only `examples/` never matched the hook's file filter, so `ty` silently skipped rather than ran. On the CI side, `prek-action` always invokes `prek run --all-files`, so a PR touching `examples/` was already covered end-to-end once #4466 merged — but a direct push to `main` (bypassing a PR) touching only `examples/` wouldn't even trigger the workflow, since `examples/**` wasn't in the push `paths:` list.

This closes both gaps: the `ty` hook's `files:` regex now includes `^examples/`, and the workflow's push `paths:` now includes `examples/**`. Verified by staging a deliberate type error in an example file and running `prek run --files <file>` (not `--all-files`) — before the fix the `ty` hook is skipped entirely; after the fix it runs and fails with the expected diagnostic, then passes again once the error is reverted.

Follow-up to #4466. `bugs` would be the appropriate label.
