### PR TITLE
Restore Mintlify's fixed banner positioning

### DIFF
--- a/docs/css/banner.css
+++ b/docs/css/banner.css
@@ -9,7 +9,6 @@
   padding-top: 12px !important;
   padding-bottom: 12px !important;
   overflow: hidden !important;
-  position: relative;
 }
 
 #banner::before {


### PR DESCRIPTION
The banner contrast change added `position: relative` to `#banner` to give the animated `::before` overlay a containing block. That was unnecessary — Mintlify already positions the banner via Tailwind utilities (`relative` on mobile, `lg:fixed lg:top-0 lg:left-0` on desktop) — and it silently overrode them, because an ID selector outranks a class. On desktop the banner computed to `relative` instead of `fixed`.

That override produced a visible vertical gap under the banner on the docs site. Mintlify keeps a sibling spacer element, `h-[var(--banner-height,0px)]`, whose job is to reserve room for a banner that is `fixed` and therefore out of flow. With the banner forced back into flow, its height was counted twice: once by the banner itself and again by the spacer. Removing the declaration restores `position: fixed` at the `lg` breakpoint and collapses the duplicate space. The `::before` overlay is unaffected, since both `relative` and `fixed` establish a containing block for it.

Measured on the live site at 1900px, with `--banner-height: 44px`:

| | banner position | navbar height | wordmark top | gap under banner |
| --- | --- | --- | --- | --- |
| before | `relative` | 144px | 104px | 60px |
| after | `fixed` | 100px | 60px | 16px |

```css
#banner {
  /* no `position` here — Mintlify sets `relative` / `lg:fixed` itself */
  overflow: hidden !important;
}
```

Note for anyone verifying this locally: `--banner-height` is set by Mintlify's JS after load, so a measurement taken immediately on navigation sees a zero-height spacer and shows no difference. Let the page settle before comparing.
