### PR TITLE
Fix File helper duplicating filename extensions in resource URIs

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/types.py
+++ b/fastmcp_slim/fastmcp/utilities/types.py
@@ -420,10 +420,17 @@ class File:
                 uri_str = self.path.resolve().as_uri()
         elif self.data is not None:
             raw_data = self.data
+            ext = self._mime_type.split("/")[1]
             if self._name:
-                uri_str = f"file:///{self._name}.{self._mime_type.split('/')[1]}"
+                # If the name already includes a file extension, use it
+                # as-is to avoid duplicating extensions (e.g. "report.pdf"
+                # should stay "report.pdf", not become "report.pdf.pdf").
+                if "." in self._name:
+                    uri_str = f"file:///{self._name}"
+                else:
+                    uri_str = f"file:///{self._name}.{ext}"
             else:
-                uri_str = f"file:///resource.{self._mime_type.split('/')[1]}"
+                uri_str = f"file:///resource.{ext}"
         else:
             raise ValueError("No resource data available")
 


### PR DESCRIPTION
## Problem

When creating a data-backed `File` with a name that already includes a file extension, `to_resource_content()` would unconditionally append the MIME type extension, resulting in duplicated extensions.

For example:
- `File(data=b'x', format='pdf', name='report.pdf')` produced `file:///report.pdf.pdf`
- `File(data=b'x', format='octet-stream', name='archive.tar.gz')` produced `file:///archive.tar.gz.octet-stream`

Fixes #4530

## Solution

Check if the provided name already contains a dot (indicating an existing extension). If so, use the name as-is without appending another extension.

## Validation

- All 80 existing tests in `tests/utilities/test_types.py` pass
- Manually verified all cases from issue #4530:
  - `report.pdf` → `file:///report.pdf` ✓
  - `archive.tar.gz` → `file:///archive.tar.gz` ✓
  - `notes.txt` with format='plain' → `file:///notes.txt` ✓
  - No name → `file:///resource.pdf` ✓
  - Name without extension → `file:///report.pdf` ✓