### PR TITLE
Allow per-request strict_input_validation via callable

### DIFF
--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -172,10 +172,10 @@ These parameters tune how the server processes requests and communicates with cl
   How to handle duplicate component registrations
 </ParamField>
 
-<ParamField body="strict_input_validation" type="bool" default="False">
+<ParamField body="strict_input_validation" type="bool | Callable[[], bool]" default="False">
   <VersionBadge version="2.13.0" />
 
-  When `False` (default), FastMCP uses Pydantic's flexible validation that coerces compatible inputs (e.g., `"10"` → `10` for int parameters). When `True`, validates inputs against the exact JSON Schema before calling your function, rejecting type mismatches. See [Input Validation Modes](/servers/tools#input-validation-modes) for details
+  When `False` (default), FastMCP uses Pydantic's flexible validation that coerces compatible inputs (e.g., `"10"` → `10` for int parameters). When `True`, validates inputs in strict mode before calling your function, rejecting type mismatches. Pass a zero-argument callable returning `bool` to resolve strictness per request (for example, based on tenant identity in `Context`). See [Input Validation Modes](/servers/tools#input-validation-modes) for details
 </ParamField>
 
 <ParamField body="mask_error_details" type="bool | None">

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -311,6 +311,31 @@ def add_numbers(a: int, b: int) -> int:
 
 The default flexible validation mode is recommended for most use cases as it handles common LLM client behaviors gracefully while still providing strong type safety through Pydantic's validation.
 
+#### Per-request strictness (multi-tenant)
+
+For servers shared across tenants with different client capabilities, pass a zero-argument callable instead of a fixed `bool`. FastMCP invokes it on each tool call (and at task submission) to decide whether to validate in strict mode:
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_access_token
+
+TENANTS_WITH_CLIENT_STRICT = {"tenant-a", "tenant-b"}
+
+def resolve_strict() -> bool:
+    """Skip server-side strict checks when the client already enforces schema."""
+    token = get_access_token()
+    if token is None or not token.claims:
+        return False
+    tenant_id = token.claims.get("tenant_id")
+    if tenant_id is None:
+        return False
+    return tenant_id not in TENANTS_WITH_CLIENT_STRICT
+
+mcp = FastMCP("MultiTenant", strict_input_validation=resolve_strict)
+```
+
+The callable runs during an active MCP request, so it can also read sync request-scoped data your middleware sets (for example, via a `contextvars.ContextVar`). For `task=True` tools, prefer auth claims over ad-hoc request state if strictness must stay consistent in background workers.
+
 ### Parameter Metadata
 
 You can provide additional metadata about parameters in several ways:

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -316,6 +316,9 @@ class StateValue(FastMCPBaseModel):
     value: Any
 
 
+StrictInputValidationSetting = bool | Callable[[], bool]
+
+
 class FastMCP(
     AggregateProvider,
     LifespanMixin,
@@ -340,7 +343,7 @@ class FastMCP(
         on_duplicate: DuplicateBehavior | None = None,
         mask_error_details: bool | None = None,
         dereference_schemas: bool = True,
-        strict_input_validation: bool | None = None,
+        strict_input_validation: StrictInputValidationSetting | None = None,
         list_page_size: int | None = None,
         resource_security: ResourceSecurity | None = DEFAULT_RESOURCE_SECURITY,
         cache_ttl: int | None = None,
@@ -454,7 +457,16 @@ class FastMCP(
                     tool = Tool.from_function(tool)
                 self.add_tool(tool)
 
-        self.strict_input_validation: bool = (
+        if strict_input_validation is not None and not (
+            isinstance(strict_input_validation, bool)
+            or callable(strict_input_validation)
+        ):
+            raise TypeError(
+                "strict_input_validation must be a bool or a zero-argument callable "
+                "returning bool"
+            )
+
+        self.strict_input_validation: StrictInputValidationSetting = (
             strict_input_validation
             if strict_input_validation is not None
             else fastmcp.settings.strict_input_validation

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -128,15 +128,20 @@ def _strict_input_validation() -> bool:
     """Whether the running server enforces strict argument validation.
 
     Reads ``strict_input_validation`` off the active request's ``FastMCP``
-    instance. Returns ``False`` outside a request context (e.g. a tool invoked
-    directly in tests), preserving the default coercing behavior.
+    instance, invoking it when stored as a zero-argument callable. Returns
+    ``False`` outside a request context (e.g. a tool invoked directly in
+    tests), preserving the default coercing behavior.
     """
     from fastmcp.server.context import _current_context
 
     context = _current_context.get(None)
     if context is None:
         return False
-    return context.fastmcp.strict_input_validation
+
+    setting = context.fastmcp.strict_input_validation
+    if callable(setting):
+        return bool(setting())
+    return setting
 
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/tests/server/tasks/test_task_tools.py
+++ b/tests/server/tasks/test_task_tools.py
@@ -141,6 +141,32 @@ async def test_task_submission_honors_strict_input_validation():
     assert "notifications/tasks/status" not in recorder.methods
 
 
+async def test_task_submission_honors_callable_strict_input_validation():
+    """Callable strict settings apply at task submission, not just sync calls."""
+    strict_enabled = False
+
+    def resolve_strict() -> bool:
+        return strict_enabled
+
+    server = FastMCP(
+        "callable-strict-task-server", strict_input_validation=resolve_strict
+    )
+
+    @server.tool(task=True)
+    async def square(n: int) -> int:
+        return n * n
+
+    async with Client(server) as client:
+        strict_enabled = True
+        with pytest.raises(ToolError):
+            await client.call_tool("square", {"n": "1"})
+
+        task = await client.call_tool("square", {"n": "1"}, task=True)
+        assert task.returned_immediately
+        with pytest.raises(ToolError):
+            await task.result()
+
+
 async def test_task_submission_valid_argument_under_strict_validation():
     """A well-typed argument still submits fine when strict validation is on."""
     server = FastMCP("strict-task-valid-server", strict_input_validation=True)

--- a/tests/server/test_input_validation.py
+++ b/tests/server/test_input_validation.py
@@ -351,6 +351,75 @@ class TestEdgeCases:
             assert result.content[0].text == "6"
 
 
+class TestCallableStrictInputValidation:
+    """Per-request strict mode via a zero-argument callable."""
+
+    async def test_callable_toggles_strict_per_invocation(self):
+        """Callable strict setting is resolved on each tool call."""
+        strict_enabled = False
+
+        def resolve_strict() -> bool:
+            return strict_enabled
+
+        mcp = FastMCP("TestServer", strict_input_validation=resolve_strict)
+
+        @mcp.tool
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        async with Client(mcp) as client:
+            strict_enabled = False
+            result = await client.call_tool("add", {"a": "1", "b": "2"})
+            assert isinstance(result.content[0], TextContent)
+            assert result.content[0].text == "3"
+
+            strict_enabled = True
+            with pytest.raises(Exception):
+                await client.call_tool("add", {"a": "1", "b": "2"})
+
+    async def test_callable_reads_middleware_context(self):
+        """Callable can read request-scoped state set by middleware."""
+        from contextvars import ContextVar
+
+        from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+        strict_for_request: ContextVar[bool] = ContextVar(
+            "strict_for_request", default=False
+        )
+
+        class StrictFlagMiddleware(Middleware):
+            async def on_call_tool(self, context: MiddlewareContext, call_next):
+                token = strict_for_request.set(True)
+                try:
+                    return await call_next(context)
+                finally:
+                    strict_for_request.reset(token)
+
+        def resolve_strict() -> bool:
+            return strict_for_request.get()
+
+        mcp = FastMCP("TestServer", strict_input_validation=resolve_strict)
+        mcp.add_middleware(StrictFlagMiddleware())
+
+        @mcp.tool
+        def double(n: int) -> int:
+            return n * 2
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception):
+                await client.call_tool("double", {"n": "2"})
+
+            result = await client.call_tool("double", {"n": 2})
+            assert isinstance(result.content[0], TextContent)
+            assert result.content[0].text == "4"
+
+    def test_invalid_strict_input_validation_type_raises(self):
+        from typing import Any, cast
+
+        with pytest.raises(TypeError, match="strict_input_validation must be"):
+            FastMCP("TestServer", strict_input_validation=cast(Any, "yes"))
+
+
 class TestExpectedToolFailureLogging:
     async def test_validation_error_logs_warning_without_traceback(self, caplog):
         mcp = FastMCP("TestServer", strict_input_validation=False)


### PR DESCRIPTION
Multi-tenant MCP servers often need different input-validation strictness per tenant: some clients already enforce schema-constrained decoding, while others rely on the server. Today `strict_input_validation` is fixed at `FastMCP` construction, so a single process cannot serve both.

Post-#4437, `_strict_input_validation()` already reads the flag on every tool call (sync path and task submission). This change widens the stored type to `bool | Callable[[], bool]` and invokes the callable when present. Plain `bool` behavior is unchanged; `FASTMCP_STRICT_INPUT_VALIDATION` stays bool-only.

Fixes #4510

```python
from fastmcp import FastMCP
from fastmcp.server.dependencies import get_access_token

def resolve_strict() -> bool:
    token = get_access_token()
    tenant = (token.claims or {}).get("tenant_id") if token else None
    return tenant not in {"tenant-a", "tenant-b"}  # client-side strict tenants

mcp = FastMCP("MultiTenant", strict_input_validation=resolve_strict)
```