### PR TITLE
Fix AI workflow allowlists being destroyed by tokenization

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -100,7 +100,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
           allowed_non_write_users: "*"
           claude_args: |
-            --allowedTools Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh api:*),Bash(gh issue comment:*),Task
+            --allowedTools "Bash(gh issue view:*)","Bash(gh search:*)","Bash(gh issue list:*)","Bash(gh api:*)","Bash(gh issue comment:*)",Task
           settings: |
             {
               "model": "claude-sonnet-4-6",

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -153,7 +153,7 @@ jobs:
           allowed_non_write_users: "*"
           allowed_bots: "marvin-context-protocol"
           claude_args: |
-            --allowedTools Bash(gh label list:*),Bash(bash .github/scripts/triage-label.sh:*),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
+            --allowedTools "Bash(gh label list:*)","Bash(bash .github/scripts/triage-label.sh:*)",mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
           settings: |
             {
               "model": "claude-sonnet-4-6",
@@ -182,11 +182,14 @@ jobs:
             exit 0
           fi
 
-          # -s so this reads both a JSON array and a stream of JSON objects.
-          denials=$(jq -s '[.. | objects | .permission_denials_count? // empty] | add // 0' "$file" 2>/dev/null || echo 0)
+          # The persisted execution log carries a `permission_denials` array on
+          # each result entry, not the `permission_denials_count` scalar that
+          # only appears in the action's own condensed stdout summary. -s so
+          # this reads both a JSON array and a stream of JSON objects.
+          denials=$(jq -s '[.. | objects | .permission_denials? // empty] | flatten | length' "$file" 2>/dev/null || echo 0)
           echo "Permission denials: $denials"
           if [[ "$denials" -gt 0 ]]; then
-            echo "::error::Marvin was denied $denials tool call(s), so triage likely applied no labels. Check the --allowedTools allowlist in this workflow (Bash patterns need a ':*' suffix to permit arguments)."
+            echo "::error::Marvin was denied $denials tool call(s), so triage likely applied no labels. Check the --allowedTools allowlist in this workflow: any Bash(...) pattern containing a space must be individually quoted, or it gets torn apart by whitespace splitting before it reaches the permission matcher."
             exit 1
           fi
 

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -174,19 +174,35 @@ jobs:
           EXECUTION_FILE: ${{ steps.marvin.outputs.execution_file }}
         run: |
           file="${EXECUTION_FILE:-}"
-          if [[ -z "$file" || ! -f "$file" ]]; then
+          if [[ -z "$file" || ! -s "$file" ]]; then
             file="${RUNNER_TEMP}/claude-execution-output.json"
           fi
-          if [[ ! -f "$file" ]]; then
-            echo "::warning::No Marvin execution log found; cannot verify tool permissions."
-            exit 0
+          # A missing or empty log means we cannot tell a clean run from a
+          # blocked one, which is the exact failure this step exists to catch.
+          if [[ ! -s "$file" ]]; then
+            echo "::error::No Marvin execution log found; cannot verify tool permissions."
+            exit 1
           fi
 
-          # The persisted execution log carries a `permission_denials` array on
-          # each result entry, not the `permission_denials_count` scalar that
-          # only appears in the action's own condensed stdout summary. -s so
-          # this reads both a JSON array and a stream of JSON objects.
-          denials=$(jq -s '[.. | objects | .permission_denials? // empty] | flatten | length' "$file" 2>/dev/null || echo 0)
+          # The persisted log carries a `permission_denials` array on each
+          # `type: result` entry; the `permission_denials_count` scalar only
+          # appears in the action's condensed stdout summary, never on disk.
+          # Anchor to result entries rather than recursing with `..`, which
+          # descends into each denial's `tool_input` and double-counts any
+          # denied command that happens to mention the field name.
+          if ! denials=$(jq -s '
+                [ .[] | if type == "array" then .[] else . end ]
+                | map(select(type == "object" and .type == "result"))
+                | map(
+                    [ (.permission_denials | if type == "array" then length else 0 end),
+                      (.permission_denials_count | if type == "number" then . else 0 end) ]
+                    | max
+                  )
+                | add // 0
+              ' "$file"); then
+            echo "::error::Could not parse Marvin execution log ($file)."
+            exit 1
+          fi
           echo "Permission denials: $denials"
           if [[ "$denials" -gt 0 ]]; then
             echo "::error::Marvin was denied $denials tool call(s), so triage likely applied no labels. Check the --allowedTools allowlist in this workflow: any Bash(...) pattern containing a space must be individually quoted, or it gets torn apart by whitespace splitting before it reaches the permission matcher."


### PR DESCRIPTION
#4555 fixed the wrong layer. The real problem is that `claude_args` is lexed with the `shell-quote` package, so any permission pattern containing a space is torn into fragments before it ever reaches the permission matcher. The action's own log shows what our input became:

```
"allowedTools": ["Bash(gh", "label", "list)", "Bash(bash", ".github/scripts/triage-label.sh:*)", ...]
```

Not one of those is a valid rule. That includes `Bash(bash .github/scripts/triage-label.sh:*)` — the pattern guarding the label helper itself — which means the locked-down helper has never once been permitted to run. `gh label list` was denied for the same reason, and since the prompt correctly forbids inventing labels, triage then applied nothing and exited green. Wrapping each space-containing pattern in quotes makes them survive: comma-splitting happens *after* quote removal, so quoted patterns arrive intact.

`marvin-dedupe-issues.yml` had it worse — *every* one of its `Bash(...)` patterns contains a space, and `Task` was glued onto the tail of the last fragment, so the parallel search agents its prompt requires could never launch either. That workflow has been a complete no-op, reporting success, since it shipped.

The denial guard from #4555 was also inert. It keyed on `permission_denials_count`, which appears only in the action's condensed stdout summary and never in the log that actually gets written to disk — so it read `0` unconditionally. The persisted log carries a `permission_denials` array on each `type: result` entry instead. The corrected query anchors to those entries rather than recursing with `..`, which would descend into each denial's own `tool_input` and inflate the count (a real case: 2 denials counted as 5). The surrounding shell also failed open on a missing, empty, or unparseable log; all three now fail the job, since "no log" and "clean run" must not look alike.

Verified against two real execution-log artifacts pulled from actual runs, which report 5 and 9 denials — both of which the old guard scored as zero.
