### PR TITLE
Bump pinned Claude models to current versions

### DIFF
--- a/.github/actions/run-claude/action.yml
+++ b/.github/actions/run-claude/action.yml
@@ -40,7 +40,7 @@ inputs:
   model:
     description: "Model to use for Claude"
     required: false
-    default: "claude-opus-4-6"
+    default: "claude-opus-4-8"
 
   allowed-bots:
     description: "Allowed bot usernames, or '*' for all bots"

--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -103,7 +103,7 @@ jobs:
             --allowedTools "Bash(gh issue view:*)","Bash(gh search:*)","Bash(gh issue list:*)","Bash(gh api:*)","Bash(gh issue comment:*)",Task
           settings: |
             {
-              "model": "claude-sonnet-4-6",
+              "model": "claude-sonnet-5",
               "env": {
                 "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}"
               }

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -156,7 +156,7 @@ jobs:
             --allowedTools "Bash(gh label list:*)","Bash(bash .github/scripts/triage-label.sh:*)",mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
           settings: |
             {
-              "model": "claude-sonnet-4-6",
+              "model": "claude-sonnet-5",
               "env": {
                 "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}",
                 "TRIAGE_REPO": "${{ github.repository }}",


### PR DESCRIPTION
Three workflow model pins had drifted behind current versions: `marvin-label-triage.yml` and `marvin-dedupe-issues.yml` were still pinned to `claude-sonnet-4-6`, and `run-claude`'s default model was `claude-opus-4-6`. This bumps all three to the current releases (`claude-sonnet-5` and `claude-opus-4-8`). This is routine version hygiene, kept deliberately separate from the in-flight allowlist/permission fixes touching these same workflows, so a behavior change in triage can't be misattributed to a model swap.

One open risk worth flagging for review: `anthropics/claude-code-action@v1` bundles a pinned Claude Code version (2.1.215 at the v1 tag), and we haven't verified that version accepts these newer model identifiers. If it validates model names against a known list, an unrecognized string could fail at runtime. Worth watching the first run of each affected workflow after merge, or triggering a canary `workflow_dispatch` before relying on it.
