### PR TITLE
Only fail triage when a granted tool is denied

### DIFF
--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -153,7 +153,7 @@ jobs:
           allowed_non_write_users: "*"
           allowed_bots: "marvin-context-protocol"
           claude_args: |
-            --allowedTools "Bash(gh label list:*)","Bash(bash .github/scripts/triage-label.sh:*)",mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request_files
+            --allowedTools "Bash(gh label list:*)","Bash(bash .github/scripts/triage-label.sh:*)",mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__add_issue_comment,mcp__github__get_pull_request,mcp__github__get_pull_request_files
           settings: |
             {
               "model": "claude-sonnet-5",
@@ -164,11 +164,16 @@ jobs:
               }
             }
 
-      # Triage is fire-and-forget: nobody watches a green run, so a blocked tool
-      # call has to fail the job or it goes unnoticed indefinitely. A too-narrow
-      # allowlist silently produced zero labels across a dozen PRs before anyone
-      # spotted it, because the run still reported success.
-      - name: Fail if any tool call was denied
+      # Triage is fire-and-forget: nobody watches a green run, so a broken
+      # allowlist has to fail the job or it goes unnoticed indefinitely — a
+      # mangled pattern silently produced zero labels across a dozen PRs
+      # because the run still reported success.
+      #
+      # Only denials of commands we MEANT to grant indicate that breakage. An
+      # agent reaching for something never on the allowlist (falling back to
+      # `gh issue view` when the API is down, say) is behaving normally, and
+      # failing on that would cry wolf during every GitHub incident.
+      - name: Fail if an allowlisted tool was denied
         if: always() && steps.marvin.conclusion != 'skipped'
         env:
           EXECUTION_FILE: ${{ steps.marvin.outputs.execution_file }}
@@ -190,23 +195,31 @@ jobs:
           # Anchor to result entries rather than recursing with `..`, which
           # descends into each denial's `tool_input` and double-counts any
           # denied command that happens to mention the field name.
-          if ! denials=$(jq -s '
+          if ! summary=$(jq -sr '
                 [ .[] | if type == "array" then .[] else . end ]
                 | map(select(type == "object" and .type == "result"))
-                | map(
-                    [ (.permission_denials | if type == "array" then length else 0 end),
-                      (.permission_denials_count | if type == "number" then . else 0 end) ]
-                    | max
-                  )
-                | add // 0
+                | map(.permission_denials // []) | flatten
+                | map(.tool_input.command // "")
+                | { total: length,
+                    granted: map(select(
+                      startswith("gh label list")
+                      or startswith("bash .github/scripts/triage-label.sh")
+                    ))
+                  }
+                | "\(.total)\t\(.granted | length)\t\(.granted | join(" | "))"
               ' "$file"); then
             echo "::error::Could not parse Marvin execution log ($file)."
             exit 1
           fi
-          echo "Permission denials: $denials"
-          if [[ "$denials" -gt 0 ]]; then
-            echo "::error::Marvin was denied $denials tool call(s), so triage likely applied no labels. Check the --allowedTools allowlist in this workflow: any Bash(...) pattern containing a space must be individually quoted, or it gets torn apart by whitespace splitting before it reaches the permission matcher."
+          IFS=$'\t' read -r total granted commands <<<"$summary"
+          echo "Denied tool calls: $total (of which allowlisted: $granted)"
+
+          if [[ "$granted" -gt 0 ]]; then
+            echo "::error::Marvin was denied $granted call(s) to tools this workflow grants, so it could not apply labels: ${commands}. The --allowedTools value is not reaching the permission matcher intact — claude_args is lexed with shell-quote, so any Bash(...) pattern containing a space must be quoted or it is split into fragments."
             exit 1
+          fi
+          if [[ "$total" -gt 0 ]]; then
+            echo "::notice::Marvin was denied $total call(s), none of them to tools this workflow grants. That is expected when it probes for a tool we deliberately withhold; the allowlist is intact."
           fi
 
       - name: Upload Marvin execution log


### PR DESCRIPTION
The allowlist fix in #4560 worked — a live run confirms `gh label list --repo PrefectHQ/fastmcp --limit 100` now executes, where it had been denied in every prior run. But that same run failed the job, and for the wrong reason.

GitHub was returning 503s at the time. Marvin called `mcp__github__get_issue` six times, got nothing back, and fell back to `gh issue view`, `gh pr view`, `search_issues`, and `get_pull_request`. None of those are on the allowlist, so all were correctly denied — and the guard, which failed on *any* denial, treated that as a broken allowlist. Its error message then confidently blamed pattern quoting, which was intact. A misleading error is worse than no error; the next person would have spent an hour re-fixing something that already worked.

A denial always means "this call didn't match the allowlist." What distinguishes a bug from normal behavior is whether we *intended* to grant it. The guard now fails only when a command the workflow explicitly grants is refused, and emits a notice otherwise:

```
Denied tool calls: 5 (of which allowlisted: 0)
::notice::Marvin was denied 5 call(s), none of them to tools this workflow grants.
```

Checked against four real execution logs: it fails both historically-broken runs (5-of-5 and 5-of-9 denials were `gh label list` and the label helper), passes the outage run, and stays silent on a clean one.

Also grants `mcp__github__get_pull_request`. The allowlist had `get_pull_request_files` but not the tool that reads a PR's title and body, so on a PR the agent had only `get_issue` — which is what sent it hunting for denied fallbacks in the first place.
