### PR TITLE
fix(skills): strip UTF-8 BOM before parsing frontmatter

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/skills/_common.py
+++ b/fastmcp_slim/fastmcp/server/providers/skills/_common.py
@@ -39,6 +39,11 @@ def parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     Returns:
         Tuple of (frontmatter dict, remaining content)
     """
+    # YAML 1.2 allows a UTF-8 BOM at the start of a character stream; some
+    # Windows editors still emit one. Strip it so "---" is recognized (#4532).
+    if content.startswith("﻿"):
+        content = content[1:]
+
     if not content.startswith("---"):
         return {}, content
 

--- a/tests/server/providers/test_skills_provider.py
+++ b/tests/server/providers/test_skills_provider.py
@@ -36,6 +36,19 @@ version: "1.0.0"
         frontmatter, body = parse_frontmatter(content)
         assert frontmatter["description"] == "A test skill"
         assert frontmatter["version"] == "1.0.0"
+
+    def test_frontmatter_with_utf8_bom(self):
+        content = (
+            "\ufeff---\n"
+            "name: bom-skill\n"
+            "description: Skill saved with a UTF-8 BOM\n"
+            "---\n"
+            "# BOM Skill\n"
+        )
+        frontmatter, body = parse_frontmatter(content)
+        assert frontmatter["name"] == "bom-skill"
+        assert frontmatter["description"] == "Skill saved with a UTF-8 BOM"
+        assert body.startswith("# BOM Skill")
         assert body.strip().startswith("# Skill Content")
 
     def test_frontmatter_with_tags_list(self):


### PR DESCRIPTION
## Summary
`SKILL.md` files saved as UTF-8 with a BOM were discovered as skills but lost their frontmatter: description became the literal `"\ufeff---"` and `frontmatter` was `{}`.

## Change
- Strip a leading UTF-8 BOM in `parse_frontmatter` before looking for `---`
- Add a unit test covering the BOM case

## Test plan
- [x] Manual: `parse_frontmatter("\ufeff---\\nname: bom-skill\\n...")` returns the expected dict
- [ ] CI skills provider tests

Fixes #4532.
