### PR TITLE
Make transformed tool `required` order deterministic

### DIFF
--- a/fastmcp_slim/fastmcp/tools/tool_transform.py
+++ b/fastmcp_slim/fastmcp/tools/tool_transform.py
@@ -707,7 +707,8 @@ class TransformedTool(Tool):
         schema = {
             "type": "object",
             "properties": new_props,
-            "required": list(new_required),
+            # Iterate props (not the set) for deterministic ordering
+            "required": [p for p in new_props if p in new_required],
             "additionalProperties": False,
         }
 
@@ -899,7 +900,11 @@ class TransformedTool(Tool):
         result = {
             "type": "object",
             "properties": merged_props,
-            "required": list(final_required),
+            # Iterate props (not the set) for deterministic ordering; keep any
+            # required names not present in properties (sorted) rather than
+            # silently dropping them.
+            "required": [p for p in merged_props if p in final_required]
+            + sorted(final_required - set(merged_props)),
             "additionalProperties": False,
         }
 

--- a/tests/tools/tool_transform/test_tool_transform.py
+++ b/tests/tools/tool_transform/test_tool_transform.py
@@ -41,6 +41,23 @@ def test_tool_from_tool_no_change(add_tool):
     assert new_tool.description == add_tool.description
 
 
+def test_transformed_tool_required_order_is_deterministic():
+    """`required` must follow property order, not set iteration order.
+
+    Set iteration order varies with PYTHONHASHSEED, which broke snapshot
+    tests of tools/list output across processes.
+    """
+
+    def fn(alpha: int, beta: str, gamma: float, delta: bool, epsilon: int) -> str:
+        return "x"
+
+    base = Tool.from_function(fn)
+    transformed = Tool.from_tool(base, transform_args={"alpha": ArgTransform(name="a")})
+    props = list(transformed.parameters["properties"])
+    assert transformed.parameters["required"] == props
+    assert props == ["a", "beta", "gamma", "delta", "epsilon"]
+
+
 def test_from_tool_accepts_decorated_function():
     @tool
     def search(q: str, limit: int = 10) -> list[str]:


### PR DESCRIPTION
Fixes https://github.com/PrefectHQ/fastmcp/issues/4565 

Snapshot-testing `tools/list` output was impossible for servers using transformed tools: the JSON changed between test runs. The cause is that `TransformedTool` built its `required` array with `list(set)`, so the order depended on Python's per-process hash randomization (`PYTHONHASHSEED`) — every fresh interpreter could produce a different ordering of the same schema.

This PR makes `required` follow the schema's property order in both `_create_forwarding_transform` and `_merge_schema_with_precedence`, so the wire format is stable across processes (and easier to read). Verified by hashing `tools/list` JSON under several `PYTHONHASHSEED` values: previously every seed produced a different result; now they're identical.

```python
base = Tool.from_function(fn)  # fn(alpha, beta, gamma, delta, epsilon)
transformed = Tool.from_tool(base, transform_args={"alpha": ArgTransform(name="a")})

transformed.parameters["required"]
# before: ['delta', 'a', 'epsilon', 'gamma', 'beta']  (varies per process)
# after:  ['a', 'beta', 'gamma', 'delta', 'epsilon']  (always property order)
```

Label: bugs

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot)
