### PR TITLE
fix(tools): order transformed tool required list deterministically

### DIFF
--- a/fastmcp_slim/fastmcp/tools/tool_transform.py
+++ b/fastmcp_slim/fastmcp/tools/tool_transform.py
@@ -707,7 +707,9 @@ class TransformedTool(Tool):
         schema = {
             "type": "object",
             "properties": new_props,
-            "required": list(new_required),
+            # Order `required` by property position so the schema is deterministic
+            # across processes; `list(set(...))` depends on PYTHONHASHSEED.
+            "required": [name for name in new_props if name in new_required],
             "additionalProperties": False,
         }
 

--- a/tests/tools/tool_transform/test_tool_transform.py
+++ b/tests/tools/tool_transform/test_tool_transform.py
@@ -133,6 +133,25 @@ def test_tool_change_arg_name(add_tool):
     assert new_tool.parameters["required"] == ["new_x"]
 
 
+def test_transformed_required_follows_property_order():
+    """A transformed tool's ``required`` list follows the property order, so the
+    schema is deterministic across processes rather than depending on set
+    iteration order (``PYTHONHASHSEED``). Regression test for #4565.
+    """
+
+    def base(alpha: int, beta: str, gamma: float, delta: bool, epsilon: int) -> str:
+        return "x"
+
+    new_tool = Tool.from_tool(
+        Tool.from_function(base), transform_args={"alpha": ArgTransform(name="a")}
+    )
+
+    required = new_tool.parameters["required"]
+    property_order = list(new_tool.parameters["properties"])
+    assert required == [name for name in property_order if name in set(required)]
+    assert required == ["a", "beta", "gamma", "delta", "epsilon"]
+
+
 def test_tool_change_arg_description(add_tool):
     new_tool = Tool.from_tool(
         add_tool, transform_args={"old_x": ArgTransform(description="new description")}


### PR DESCRIPTION
`Tool.from_tool(...)` builds a transformed tool's `required` array from a `set`, so `list(new_required)` serializes in whatever order the interpreter's hash seed produces. The same server emits a differently-ordered `required` in its `tools/list` schema on every fresh process, which breaks snapshot tests and any consumer that expects a stable schema.

The fix orders `required` by property position — the same insertion order already used for `properties` — so it is deterministic and matches how JSON Schema and Pydantic conventionally present required fields. `new_required` stays a set for its membership checks; only the emitted list is ordered.

```python
mcp.add_tool(Tool.from_tool(base, name="renamed", transform_args={"alpha": ArgTransform(name="a")}))

# before: order varied per process, e.g. ['delta', 'a', 'epsilon', 'gamma', 'beta']
# after:  follows property order on every run: ['a', 'beta', 'gamma', 'delta', 'epsilon']