### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/docs/clients/sampling.mdx
+++ b/docs/clients/sampling.mdx
@@ -128,7 +128,7 @@ client = Client(
 ```
 
 <Note>
-Install the OpenAI handler with `pip install fastmcp[openai]`.
+Install the OpenAI handler with `pip install 'fastmcp[openai]'`.
 </Note>
 
 ### Anthropic Handler
@@ -146,7 +146,7 @@ client = Client(
 ```
 
 <Note>
-Install the Anthropic handler with `pip install fastmcp[anthropic]`.
+Install the Anthropic handler with `pip install 'fastmcp[anthropic]'`.
 </Note>
 
 ### Google Gemini Handler
@@ -164,7 +164,7 @@ client = Client(
 ```
 
 <Note>
-Install the Google Gemini handler with `pip install fastmcp[gemini]`.
+Install the Google Gemini handler with `pip install 'fastmcp[gemini]'`.
 </Note>
 
 ## Sampling Capabilities

--- a/docs/servers/sampling.mdx
+++ b/docs/servers/sampling.mdx
@@ -137,7 +137,7 @@ Client support for sampling is optional—some clients may not implement it. To 
 FastMCP provides built-in handlers for [OpenAI and Anthropic APIs](/clients/sampling#built-in-handlers). These handlers support the full sampling API including tools, automatically converting your Python functions to each provider's format.
 
 <Note>
-Install handlers with `pip install fastmcp[openai]` or `pip install fastmcp[anthropic]`.
+Install handlers with `pip install 'fastmcp[openai]'` or `pip install 'fastmcp[anthropic]'`.
 </Note>
 
 ```python

--- a/docs/v2/clients/sampling.mdx
+++ b/docs/v2/clients/sampling.mdx
@@ -212,7 +212,7 @@ client = Client(
 ```
 
 <Note>
-Install the OpenAI handler with `pip install fastmcp[openai]`.
+Install the OpenAI handler with `pip install 'fastmcp[openai]'`.
 </Note>
 
 ### Anthropic Handler
@@ -246,7 +246,7 @@ client = Client(
 ```
 
 <Note>
-Install the Anthropic handler with `pip install fastmcp[anthropic]`.
+Install the Anthropic handler with `pip install 'fastmcp[anthropic]'`.
 </Note>
 
 ### Tool Execution

--- a/docs/v2/servers/sampling.mdx
+++ b/docs/v2/servers/sampling.mdx
@@ -446,7 +446,7 @@ Client support for sampling is optional—some clients may not implement it. To 
 FastMCP provides built-in handlers for [OpenAI and Anthropic APIs](/v2/clients/sampling#built-in-handlers). These handlers support the full sampling API including tools, automatically converting your Python functions to each provider's format.
 
 <Note>
-Install handlers with `pip install fastmcp[openai]` or `pip install fastmcp[anthropic]`.
+Install handlers with `pip install 'fastmcp[openai]'` or `pip install 'fastmcp[anthropic]'`.
 </Note>
 
 ```python

--- a/examples/sampling/README.md
+++ b/examples/sampling/README.md
@@ -5,7 +5,7 @@ These examples demonstrate FastMCP's sampling API, which allows server tools to 
 ## Prerequisites
 
 ```bash
-pip install fastmcp[anthropic]
+pip install 'fastmcp[anthropic]'
 export ANTHROPIC_API_KEY=your-key
 ```
 

--- a/examples/sampling/README.md
+++ b/examples/sampling/README.md
@@ -59,4 +59,4 @@ from fastmcp.client.sampling.handlers.openai import OpenAISamplingHandler
 handler = OpenAISamplingHandler(default_model="gpt-4o-mini")
 ```
 
-And install with `pip install fastmcp[openai]`.
+And install with `pip install 'fastmcp[openai]'`.

--- a/fastmcp_slim/fastmcp/cli/apps_dev.py
+++ b/fastmcp_slim/fastmcp/cli/apps_dev.py
@@ -1052,7 +1052,7 @@ def _build_picker_html(tools: list[dict[str, Any]]) -> str:
         from prefab_ui.components.form import Form
         from prefab_ui.rx import RESULT, Rx
     except ImportError:
-        return "<html><body><p>prefab-ui not installed. Run: pip install fastmcp[apps]</p></body></html>"
+        return "<html><body><p>prefab-ui not installed. Run: pip install 'fastmcp[apps]'</p></body></html>"
 
     if not tools:
         with Column(gap=4, css_class="p-6 max-w-2xl mx-auto") as view:

--- a/fastmcp_slim/fastmcp/client/sampling/handlers/anthropic.py
+++ b/fastmcp_slim/fastmcp/client/sampling/handlers/anthropic.py
@@ -41,7 +41,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "The `anthropic` package is not installed. "
-        "Install it with `pip install fastmcp-slim[anthropic]` or add `anthropic` to your dependencies."
+        "Install it with `pip install 'fastmcp-slim[anthropic]'` or add `anthropic` to your dependencies."
     ) from e
 
 __all__ = ["AnthropicSamplingHandler"]

--- a/fastmcp_slim/fastmcp/client/sampling/handlers/google_genai.py
+++ b/fastmcp_slim/fastmcp/client/sampling/handlers/google_genai.py
@@ -28,7 +28,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "The `google-genai` package is not installed. "
-        "Install it with `pip install fastmcp-slim[gemini]` or add `google-genai` "
+        "Install it with `pip install 'fastmcp-slim[gemini]'` or add `google-genai` "
         "to your dependencies."
     ) from e
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `examples/sampling/README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`