### PR TITLE
fix(types): preserve explicit File name extensions in resource URIs

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/types.py
+++ b/fastmcp_slim/fastmcp/utilities/types.py
@@ -421,7 +421,15 @@ class File:
         elif self.data is not None:
             raw_data = self.data
             if self._name:
-                uri_str = f"file:///{self._name}.{self._mime_type.split('/')[1]}"
+                # Preserve explicit filenames that already include an extension
+                # (e.g. report.pdf, archive.tar.gz). Only append the MIME subtype
+                # when the provided name has no suffix. (#4530)
+                name = self._name
+                if Path(name).suffix:
+                    filename = name
+                else:
+                    filename = f"{name}.{self._mime_type.split('/')[1]}"
+                uri_str = f"file:///{filename}"
             else:
                 uri_str = f"file:///resource.{self._mime_type.split('/')[1]}"
         else:

--- a/tests/utilities/test_types.py
+++ b/tests/utilities/test_types.py
@@ -461,6 +461,21 @@ class TestFile:
         if isinstance(resource.resource, BlobResourceContents):
             assert resource.resource.blob == base64.b64encode(test_data).decode()
 
+    def test_to_resource_content_preserves_name_with_extension(self):
+        """Explicit names that already include an extension must not get another. (#4530)"""
+        resource = File(data=b"x", format="pdf", name="report.pdf").to_resource_content()
+        assert str(resource.resource.uri) == "file:///report.pdf"
+
+        resource = File(
+            data=b"x", format="octet-stream", name="archive.tar.gz"
+        ).to_resource_content()
+        assert str(resource.resource.uri) == "file:///archive.tar.gz"
+
+    def test_to_resource_content_appends_extension_when_name_has_none(self):
+        """Bare names still receive a MIME-derived extension."""
+        resource = File(data=b"x", format="pdf", name="report").to_resource_content()
+        assert str(resource.resource.uri) == "file:///report.pdf"
+
     def test_to_resource_content_with_text_data(self):
         """Test conversion to ResourceContent with text data (TextResourceContents)."""
         test_data = b"hello world"


### PR DESCRIPTION
## Summary

Data-backed `File.to_resource_content()` always appended a MIME subtype to `name`, so `report.pdf` became `report.pdf.pdf` and `archive.tar.gz` became `archive.tar.gz.octet-stream` (#4530).

Only append the subtype when the provided name has **no** path suffix. Bare names like `report` still become `report.pdf`.

## Testing

```bash
pytest tests/utilities/test_types.py::TestFile::test_to_resource_content_with_data \
  tests/utilities/test_types.py::TestFile::test_to_resource_content_preserves_name_with_extension \
  tests/utilities/test_types.py::TestFile::test_to_resource_content_appends_extension_when_name_has_none -q
# 3 passed
```

Fixes #4530
