### PR TITLE
Fix percent-encoded skill file names unreadable in resources mode

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py
+++ b/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py
@@ -288,7 +288,9 @@ class SkillProvider(Provider):
         # Main skill file
         resources.append(
             SkillResource(
-                uri=AnyUrl(f"skill://{skill.name}/{self._main_file_name}"),
+                uri=AnyUrl(
+                    f"skill://{skill.name}/{quote(self._main_file_name, safe='/')}"
+                ),
                 name=f"{skill.name}/{self._main_file_name}",
                 description=skill.description,
                 mime_type="text/markdown",

--- a/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py
+++ b/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py
@@ -7,6 +7,7 @@ import mimetypes
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Literal, cast
+from urllib.parse import quote, unquote
 
 from mcp.shared.path_security import PathEscapeError, safe_join
 from pydantic import AnyUrl
@@ -318,7 +319,9 @@ class SkillProvider(Provider):
                 mime_type, _ = mimetypes.guess_type(file_info.path)
                 resources.append(
                     SkillFileResource(
-                        uri=AnyUrl(f"skill://{skill.name}/{file_info.path}"),
+                        uri=AnyUrl(
+                            f"skill://{skill.name}/{quote(file_info.path, safe='/')}"
+                        ),
                         name=f"{skill.name}/{file_info.path}",
                         description=f"File from {skill.name} skill",
                         mime_type=mime_type or "application/octet-stream",
@@ -347,6 +350,7 @@ class SkillProvider(Provider):
         skill_name, file_path = parts
         if skill_name != skill.name:
             return None
+        file_path = unquote(file_path)
 
         if file_path == "_manifest":
             return SkillResource(

--- a/tests/server/providers/test_skills_provider.py
+++ b/tests/server/providers/test_skills_provider.py
@@ -176,6 +176,26 @@ This is my skill content.
             assert isinstance(result[0], TextResourceContents)
             assert "# My Skill" in result[0].text
 
+    async def test_read_main_file_with_literal_percent_in_name(self, tmp_path: Path):
+        """A custom main_file_name containing a literal '%' must round-trip
+        through the same encode/decode path as supporting files (#4545)."""
+        skill_dir = tmp_path / "percent-main-skill"
+        skill_dir.mkdir()
+        (skill_dir / "MAIN%20FILE.md").write_text("# Demo\n")
+
+        mcp = FastMCP("Test")
+        mcp.add_provider(
+            SkillProvider(skill_path=skill_dir, main_file_name="MAIN%20FILE.md")
+        )
+
+        async with Client(mcp) as client:
+            resources = await client.list_resources()
+            main = next(
+                r for r in resources if r.name == "percent-main-skill/MAIN%20FILE.md"
+            )
+            result = await client.read_resource(main.uri)
+            assert "# Demo" in result[0].text
+
     async def test_read_manifest(self, single_skill_dir: Path):
         mcp = FastMCP("Test")
         mcp.add_provider(SkillProvider(skill_path=single_skill_dir))

--- a/tests/server/providers/test_skills_provider.py
+++ b/tests/server/providers/test_skills_provider.py
@@ -230,6 +230,76 @@ This is my skill content.
             result = await client.read_resource(AnyUrl("skill://my-skill/reference.md"))
             assert "# Reference" in result[0].text
 
+    async def test_read_supporting_file_with_space_in_name(self, tmp_path: Path):
+        """Percent-encoded resource URIs for supporting files must round-trip (#4545)."""
+        skill_dir = tmp_path / "space-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Skill\n")
+        (skill_dir / "setup guide.md").write_text("SPACE OK")
+
+        mcp = FastMCP("Test")
+        mcp.add_provider(
+            SkillProvider(skill_path=skill_dir, supporting_files="resources")
+        )
+
+        async with Client(mcp) as client:
+            resources = await client.list_resources()
+            supporting = next(
+                r for r in resources if r.name == "space-skill/setup guide.md"
+            )
+            assert str(supporting.uri) == "skill://space-skill/setup%20guide.md"
+
+            result = await client.read_resource(supporting.uri)
+            assert result[0].text == "SPACE OK"
+
+    async def test_read_supporting_file_with_utf8_name(self, tmp_path: Path):
+        skill_dir = tmp_path / "utf8-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Skill\n")
+        (skill_dir / "café.md").write_text("UTF8 OK", encoding="utf-8")
+
+        mcp = FastMCP("Test")
+        mcp.add_provider(
+            SkillProvider(skill_path=skill_dir, supporting_files="resources")
+        )
+
+        async with Client(mcp) as client:
+            resources = await client.list_resources()
+            supporting = next(r for r in resources if r.name == "utf8-skill/café.md")
+
+            result = await client.read_resource(supporting.uri)
+            assert result[0].text == "UTF8 OK"
+
+    async def test_percent_encoded_name_does_not_collide_with_space(
+        self, tmp_path: Path
+    ):
+        """A filename that already contains a literal '%20' must not be confused
+        with a space-containing filename once both are percent-encoded into
+        resource URIs (#4545)."""
+        skill_dir = tmp_path / "percent-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Skill\n")
+        (skill_dir / "setup guide.md").write_text("SPACE OK")
+        (skill_dir / "setup%20guide.md").write_text("LITERAL PERCENT OK")
+
+        mcp = FastMCP("Test")
+        mcp.add_provider(
+            SkillProvider(skill_path=skill_dir, supporting_files="resources")
+        )
+
+        async with Client(mcp) as client:
+            resources = await client.list_resources()
+            by_name = {r.name: r for r in resources}
+            space_uri = by_name["percent-skill/setup guide.md"].uri
+            literal_uri = by_name["percent-skill/setup%20guide.md"].uri
+
+            assert str(space_uri) != str(literal_uri)
+
+            space_result = await client.read_resource(space_uri)
+            literal_result = await client.read_resource(literal_uri)
+            assert space_result[0].text == "SPACE OK"
+            assert literal_result[0].text == "LITERAL PERCENT OK"
+
     async def test_skill_resource_meta(self, single_skill_dir: Path):
         """SkillResource populates meta with skill name and is_manifest."""
         provider = SkillProvider(skill_path=single_skill_dir)


### PR DESCRIPTION
`SkillProvider(..., supporting_files="resources")` lists supporting files using `AnyUrl`, which implicitly percent-encodes the path (e.g. `setup guide.md` → `skill://demo/setup%20guide.md`). But `_get_resource()` compared that encoded URI directly against the unencoded filename it scanned from disk, so reading the exact URI `list_resources()` had just returned failed with "Resource not found." Template mode didn't have this bug because URI template matching already decodes captured segments.

This switches supporting-file URIs to explicit `quote()`/`unquote()` (matching the pattern already used in `resources/template.py`) instead of relying on `AnyUrl`'s implicit encoding:

```python
provider = SkillProvider(skill_dir, supporting_files="resources")
resources = await provider.list_resources()
# skill://demo/setup%20guide.md
await client.read_resource(resources[-1].uri)  # now succeeds
```

Explicit encoding also closes an ambiguity: a file literally named `setup%20guide.md` would otherwise collide with `setup guide.md` once both were run through `AnyUrl`'s implicit encoding, since it treats an already-valid `%20` escape as pass-through rather than re-escaping the `%`. With explicit `quote()`, the literal `%` is escaped to `%25`, so the two round-trip to distinct URIs.

Fixes #4545
