### PR TITLE
fix: allow valid scopes on oidc proxy

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
@@ -218,6 +218,7 @@ class OIDCProxy(OAuthProxy):
         token_verifier: TokenVerifier | None = None,
         algorithm: str | None = None,
         required_scopes: list[str] | None = None,
+        valid_scopes: list[str] | None = None,
         verify_id_token: bool = False,
         # FastMCP server configuration
         base_url: AnyHttpUrl | str,
@@ -269,6 +270,7 @@ class OIDCProxy(OAuthProxy):
                 Cannot be used with algorithm or required_scopes parameters (configure these on your verifier instead).
             algorithm: Token verifier algorithm (only used if token_verifier is not provided)
             required_scopes: Required scopes for token validation (only used if token_verifier is not provided)
+            valid_scopes: Scopes clients may request. Defaults to required_scopes.
             verify_id_token: If True, verify the OIDC id_token instead of the access_token.
                 Useful for providers that issue opaque (non-JWT) access tokens, since the
                 id_token is always a standard JWT verifiable via the provider's JWKS.
@@ -414,6 +416,7 @@ class OIDCProxy(OAuthProxy):
             "issuer_url": issuer_url or base_url,
             "service_documentation_url": self.oidc_config.service_documentation,
             "allowed_client_redirect_uris": allowed_client_redirect_uris,
+            "valid_scopes": valid_scopes,
             "client_storage": client_storage,
             "jwt_signing_key": jwt_signing_key,
             "token_endpoint_auth_method": token_endpoint_auth_method,
@@ -461,7 +464,9 @@ class OIDCProxy(OAuthProxy):
         # from the (empty) verifier scopes.
         if verify_id_token and required_scopes:
             self.required_scopes = required_scopes
-            self.update_default_scopes(required_scopes)
+            self.update_default_scopes(
+                valid_scopes if valid_scopes is not None else required_scopes
+            )
 
     def _get_verification_token(
         self, upstream_token_set: UpstreamTokenSet

--- a/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
@@ -94,6 +94,7 @@ class Auth0Provider(OIDCProxy):
         resource_base_url: AnyHttpUrl | str | None = None,
         issuer_url: AnyHttpUrl | str | None = None,
         required_scopes: list[str] | None = None,
+        valid_scopes: list[str] | None = None,
         redirect_path: str | None = None,
         allowed_client_redirect_uris: list[str] | None = None,
         client_storage: AsyncKeyValue | None = None,
@@ -122,6 +123,7 @@ class Auth0Provider(OIDCProxy):
             issuer_url: Issuer URL for OAuth metadata (defaults to base_url). Use root-level URL
                 to avoid 404s during discovery when mounting under a path.
             required_scopes: Required Auth0 scopes (defaults to ["openid"])
+            valid_scopes: Scopes clients may request. Defaults to required_scopes.
             redirect_path: Redirect path configured in Auth0 application
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 If None (default), all URIs are allowed. If empty list, no URIs are allowed.
@@ -153,6 +155,9 @@ class Auth0Provider(OIDCProxy):
         auth0_required_scopes = (
             parse_scopes(required_scopes) if required_scopes is not None else ["openid"]
         )
+        auth0_valid_scopes = (
+            parse_scopes(valid_scopes) if valid_scopes is not None else None
+        )
 
         super().__init__(
             config_url=config_url,
@@ -165,6 +170,7 @@ class Auth0Provider(OIDCProxy):
             issuer_url=issuer_url,
             redirect_path=redirect_path,
             required_scopes=auth0_required_scopes,
+            valid_scopes=auth0_valid_scopes,
             allowed_client_redirect_uris=allowed_client_redirect_uris,
             client_storage=client_storage,
             jwt_signing_key=jwt_signing_key,

--- a/fastmcp_slim/fastmcp/server/auth/providers/aws.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/aws.py
@@ -135,6 +135,7 @@ class AWSCognitoProvider(OIDCProxy):
         issuer_url: AnyHttpUrl | str | None = None,
         redirect_path: str = "/auth/callback",
         required_scopes: list[str] | None = None,
+        valid_scopes: list[str] | None = None,
         allowed_client_redirect_uris: list[str] | None = None,
         client_storage: AsyncKeyValue | None = None,
         jwt_signing_key: str | bytes | None = None,
@@ -163,6 +164,7 @@ class AWSCognitoProvider(OIDCProxy):
                 to avoid 404s during discovery when mounting under a path.
             redirect_path: Redirect path configured in Cognito app (defaults to "/auth/callback")
             required_scopes: Required Cognito scopes (defaults to ["openid"])
+            valid_scopes: Scopes clients may request. Defaults to required_scopes.
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 If None (default), all URIs are allowed. If empty list, no URIs are allowed.
             client_storage: Storage backend for OAuth state (client registrations, encrypted tokens).
@@ -193,6 +195,9 @@ class AWSCognitoProvider(OIDCProxy):
         required_scopes_final = (
             parse_scopes(required_scopes) if required_scopes is not None else ["openid"]
         )
+        valid_scopes_final = (
+            parse_scopes(valid_scopes) if valid_scopes is not None else None
+        )
 
         # Construct OIDC discovery URL
         config_url = f"https://cognito-idp.{aws_region}.amazonaws.com/{user_pool_id}/.well-known/openid-configuration"
@@ -216,6 +221,7 @@ class AWSCognitoProvider(OIDCProxy):
             redirect_path=redirect_path,
             allowed_client_redirect_uris=allowed_client_redirect_uris,
             client_storage=client_storage,
+            valid_scopes=valid_scopes_final,
             jwt_signing_key=jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             consent_csp_policy=consent_csp_policy,

--- a/fastmcp_slim/fastmcp/server/auth/providers/oci.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/oci.py
@@ -131,6 +131,7 @@ class OCIProvider(OIDCProxy):
         audience: str | None = None,
         issuer_url: AnyHttpUrl | str | None = None,
         required_scopes: list[str] | None = None,
+        valid_scopes: list[str] | None = None,
         redirect_path: str | None = None,
         allowed_client_redirect_uris: list[str] | None = None,
         client_storage: AsyncKeyValue | None = None,
@@ -158,6 +159,7 @@ class OCIProvider(OIDCProxy):
             audience: OCI API audience (optional)
             issuer_url: Issuer URL for OCI IAM Domain metadata. This will override issuer URL from the discovery URL.
             required_scopes: Required OCI scopes (defaults to ["openid"])
+            valid_scopes: Scopes clients may request. Defaults to required_scopes.
             redirect_path: Redirect path configured in OCI IAM Domain Integrated Application. The default is "/auth/callback".
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
             fallback_refresh_token_expiry_seconds: Lifetime for the FastMCP-issued
@@ -176,6 +178,9 @@ class OCIProvider(OIDCProxy):
         oci_required_scopes = (
             parse_scopes(required_scopes) if required_scopes is not None else ["openid"]
         )
+        oci_valid_scopes = (
+            parse_scopes(valid_scopes) if valid_scopes is not None else None
+        )
 
         super().__init__(
             config_url=config_url,
@@ -188,6 +193,7 @@ class OCIProvider(OIDCProxy):
             issuer_url=issuer_url,
             redirect_path=redirect_path,
             required_scopes=oci_required_scopes,
+            valid_scopes=oci_valid_scopes,
             allowed_client_redirect_uris=allowed_client_redirect_uris,
             client_storage=client_storage,
             jwt_signing_key=jwt_signing_key,

--- a/tests/server/auth/providers/test_auth0.py
+++ b/tests/server/auth/providers/test_auth0.py
@@ -97,3 +97,31 @@ class TestAuth0Provider:
             assert str(provider.base_url) == TEST_BASE_URL
             assert provider._redirect_path == "/auth/callback"
             assert provider._token_validator.required_scopes == ["openid"]
+
+    def test_valid_scopes_passed_through(self, valid_oidc_configuration_dict):
+        """Test valid_scopes is passed to OIDCProxy."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            oidc_config = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+            mock_get.return_value = oidc_config
+
+            provider = Auth0Provider(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                audience=TEST_AUDIENCE,
+                base_url=TEST_BASE_URL,
+                required_scopes=["openid"],
+                valid_scopes=["openid", "offline_access"],
+                jwt_signing_key="test-secret",
+            )
+
+            assert provider._token_validator.required_scopes == ["openid"]
+            assert provider.client_registration_options is not None
+            assert provider.client_registration_options.valid_scopes == [
+                "openid",
+                "offline_access",
+            ]

--- a/tests/server/auth/providers/test_aws.py
+++ b/tests/server/auth/providers/test_aws.py
@@ -86,6 +86,26 @@ class TestAWSCognitoProvider:
             assert provider._token_validator.required_scopes == ["openid"]
             assert provider.aws_region == "eu-central-1"
 
+    def test_valid_scopes_passed_through(self):
+        """Test valid_scopes is passed to OIDCProxy."""
+        with mock_cognito_oidc_discovery():
+            provider = AWSCognitoProvider(
+                user_pool_id="us-east-1_XXXXXXXXX",
+                client_id="test_client",
+                client_secret="test_secret",
+                base_url="https://example.com",
+                required_scopes=["openid"],
+                valid_scopes=["openid", "offline_access"],
+                jwt_signing_key="test-secret",
+            )
+
+            assert provider._token_validator.required_scopes == ["openid"]
+            assert provider.client_registration_options is not None
+            assert provider.client_registration_options.valid_scopes == [
+                "openid",
+                "offline_access",
+            ]
+
     def test_oidc_discovery_integration(self):
         """Test that OIDC discovery endpoints are used correctly."""
         with mock_cognito_oidc_discovery():

--- a/tests/server/auth/providers/test_oci.py
+++ b/tests/server/auth/providers/test_oci.py
@@ -85,3 +85,31 @@ class TestOCIProvider:
             assert str(provider.base_url) == TEST_BASE_URL
             assert provider._redirect_path == TEST_REDIRECT_PATH
             assert provider._token_validator.required_scopes == TEST_REQUIRED_SCOPES
+
+    def test_valid_scopes_passed_through(self, valid_oidc_configuration_dict):
+        """Test valid_scopes is passed to OIDCProxy."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            oidc_config = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+            mock_get.return_value = oidc_config
+
+            provider = OCIProvider(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                base_url=TEST_BASE_URL,
+                required_scopes=["openid"],
+                valid_scopes=["openid", "offline_access"],
+                client_storage=MemoryStore(),
+                jwt_signing_key="test-secret-key",
+            )
+
+            assert provider._token_validator.required_scopes == ["openid"]
+            assert provider.client_registration_options is not None
+            assert provider.client_registration_options.valid_scopes == [
+                "openid",
+                "offline_access",
+            ]

--- a/tests/server/auth/test_oidc_proxy.py
+++ b/tests/server/auth/test_oidc_proxy.py
@@ -518,6 +518,71 @@ class TestOIDCProxyInitialization:
             assert proxy._token_validator.audience == "oidc-proxy-test-audience"
             assert proxy._token_validator.required_scopes == ["required", "scopes"]
 
+    def test_valid_scopes_initialization(self, valid_oidc_configuration_dict):
+        """Test valid_scopes are advertised separately from required_scopes."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            oidc_config = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+            mock_get.return_value = oidc_config
+
+            proxy = OIDCProxy(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                base_url=TEST_BASE_URL,
+                required_scopes=["openid"],
+                valid_scopes=["openid", "offline_access"],
+                jwt_signing_key="test-secret",
+            )
+
+            validate_proxy(mock_get, proxy, oidc_config)
+
+            assert proxy._token_validator.required_scopes == ["openid"]
+            assert proxy.client_registration_options is not None
+            assert proxy.client_registration_options.valid_scopes == [
+                "openid",
+                "offline_access",
+            ]
+            assert proxy.client_registration_options.default_scopes == [
+                "openid",
+                "offline_access",
+            ]
+
+    def test_valid_scopes_preserved_with_id_token_verification(
+        self, valid_oidc_configuration_dict
+    ):
+        """Test verify_id_token does not collapse valid_scopes to required_scopes."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            oidc_config = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+            mock_get.return_value = oidc_config
+
+            proxy = OIDCProxy(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                base_url=TEST_BASE_URL,
+                required_scopes=["openid"],
+                valid_scopes=["openid", "offline_access"],
+                verify_id_token=True,
+                jwt_signing_key="test-secret",
+            )
+
+            validate_proxy(mock_get, proxy, oidc_config)
+
+            assert proxy.required_scopes == ["openid"]
+            assert proxy.client_registration_options is not None
+            assert proxy.client_registration_options.valid_scopes == [
+                "openid",
+                "offline_access",
+            ]
+
     def test_extra_parameters_initialization(self, valid_oidc_configuration_dict):
         """Test other parameters initialization."""
         with patch(


### PR DESCRIPTION
Fixes #4588

## Summary

Adds a `valid_scopes` parameter to `OIDCProxy` and the OIDC-backed provider wrappers (`Auth0Provider`, `AWSCognitoProvider`, and `OCIProvider`), then forwards it to `OAuthProxy`.

This lets server authors advertise and allow optional client-requested scopes for dynamic client registration while keeping `required_scopes` as the token validation floor.

Also documents the new option in the OIDC proxy docs and the Auth0, AWS Cognito, and OCI provider examples.

## Testing

```bash
.venv/Scripts/python.exe -m pytest tests/server/auth/test_oidc_proxy.py tests/server/auth/providers/test_auth0.py tests/server/auth/providers/test_aws.py tests/server/auth/providers/test_oci.py
.venv/Scripts/python.exe -m ruff check fastmcp_slim/fastmcp/server/auth/oidc_proxy.py fastmcp_slim/fastmcp/server/auth/providers/auth0.py fastmcp_slim/fastmcp/server/auth/providers/aws.py fastmcp_slim/fastmcp/server/auth/providers/oci.py tests/server/auth/test_oidc_proxy.py tests/server/auth/providers/test_auth0.py tests/server/auth/providers/test_aws.py tests/server/auth/providers/test_oci.py
.venv/Scripts/python.exe -m ruff format --check fastmcp_slim/fastmcp/server/auth/oidc_proxy.py fastmcp_slim/fastmcp/server/auth/providers/auth0.py fastmcp_slim/fastmcp/server/auth/providers/aws.py fastmcp_slim/fastmcp/server/auth/providers/oci.py tests/server/auth/test_oidc_proxy.py tests/server/auth/providers/test_auth0.py tests/server/auth/providers/test_aws.py tests/server/auth/providers/test_oci.py
git diff --check
```