### PR TITLE
Add stateless session state (UserSession / SessionId)

### DIFF
--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -78,11 +78,14 @@ async def add_to_cart(item: str, session_id: SessionId) -> str:
 the agent supplies it. `SessionId` is a marker type so the framework
 auto-populates the argument's description with the protocol:
 
-> "Session identifier. Call `create_session` to obtain one, then pass it here to
-> persist state across calls in the same session."
+> "Session identifier. Use a tool to create a session, then pass the resulting id
+> here to persist state across calls in the same session."
 
 The tool becomes self-teaching — an agent reads the schema and learns the
-create-then-pass contract with no hand-prompting. `await ctx.get_session(session_id)`
+create-then-pass contract with no hand-prompting. The description names no
+specific tool: composition can rename the lifecycle tool (mounting under a
+namespace exposes it as `child_create_session`), so it points at the
+*capability* rather than a name that may not exist under that mount. `await ctx.get_session(session_id)`
 resolves it to a `Session` keyed by `(principal, session_id)` (named
 `get_session`, not `session`, because `ctx.session` already exposes the raw
 `ServerSession`), **validating** that the id was created under this principal —

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -66,7 +66,7 @@ from fastmcp.server.dependencies import get_context
 
 @mcp.tool
 async def add_to_cart(item: str, session_id: SessionId) -> str:
-    session = get_context().get_session(session_id)
+    session = await get_context().get_session(session_id)
     cart = await session.get("cart", default=[])
     cart.append(item)
     await session.set("cart", cart)
@@ -81,10 +81,12 @@ auto-populates the argument's description with the protocol:
 > persist state across calls in the same session."
 
 The tool becomes self-teaching — an agent reads the schema and learns the
-create-then-pass contract with no hand-prompting. `ctx.get_session(session_id)`
+create-then-pass contract with no hand-prompting. `await ctx.get_session(session_id)`
 resolves it to a `Session` keyed by `(principal, session_id)` (named
 `get_session`, not `session`, because `ctx.session` already exposes the raw
-`ServerSession`). Use it when a user needs more than one session.
+`ServerSession`), **validating** that the id was created under this principal —
+an unknown or foreign id raises `InvalidSession` rather than opening a fresh
+bucket. Use it when a user needs more than one session.
 
 ## The `Session` object
 
@@ -93,34 +95,33 @@ Async accessors over the server store, scoped to one `(principal, session_id)`:
 - `await session.get(key, default=None)`
 - `await session.set(key, value)`
 - `await session.delete(key)`
-- `await session.clear()`
+- `await session.clear()` — empties user state but **keeps the session valid**.
+- `await session.end()` — deletes the session (what `end_session` calls).
 
 A session's state is stored as a **single dict under one key**
-(`session:{principal}:{session_id}`). `get`/`set`/`delete` read-modify-write that
-dict; `clear` / `end_session` delete the one key. One key per session means one
-TTL per session (the store's), refreshed on write — no key index to maintain, and
-`end_session` is a single delete. (Trade-off: concurrent writes to one session
-race on the read-modify-write; session state is small and typically driven
-serially by one agent, so this is acceptable — noted, not hidden.)
+(`session:{principal}:{session_id}`). That dict holds user state in a `state`
+sub-dict alongside a small `_created` marker, so a created-but-empty session is
+distinguishable from a missing one even if the store collapses empty dicts.
+`get`/`set`/`delete` read-modify-write the sub-dict and never touch the marker;
+`clear` resets the sub-dict but leaves the marker (the session still resolves);
+`end` deletes the key. Namespacing user state under `state` is what keeps a user
+key named `_created` from colliding with the marker. One key per session means
+one TTL per session (the store's), refreshed on write — no key index to maintain,
+and `end` is a single delete. (Trade-off: concurrent writes to one session race
+on the read-modify-write; session state is small and typically driven serially by
+one agent, so this is acceptable — noted, not hidden.)
 
-## `SessionProvider` — auto-wired
+## `SessionProvider` — required for `session_id`
 
 Session ids are minted by `SessionProvider`, which contributes two tools:
 
-- `create_session()` → mints an unguessable `uuid4` and returns it as a string.
-- `end_session(session_id: SessionId)` → clears that session's state.
+- `create_session()` → mints an unguessable `uuid4`, **records** the session
+  under the current principal, and returns the id as a string.
+- `end_session(session_id: SessionId)` → validates the id, then deletes the
+  session so it no longer resolves.
 
-**Declaring a `session_id: SessionId` argument on any tool auto-registers the
-default `SessionProvider`** — the developer does not have to remember
-`add_provider(SessionProvider())`. The `create_session` / `end_session` tools are
-real and appear in the normal tool listing; the visible `session_id` argument
-implies the lifecycle plumbing, so FastMCP wires it. The decision is made when
-tools are listed by scanning the server's registered tools, so it is independent
-of registration order: a `session_id` tool added after construction still
-activates it.
-
-Registering a `SessionProvider` yourself still works and takes precedence — the
-auto-registered one steps aside, so there is never a duplicate:
+Because an id is only valid once `create_session` has recorded it, a server whose
+tools declare `session_id: SessionId` **must register a `SessionProvider`**:
 
 ```python
 from fastmcp.server.sessions import SessionProvider
@@ -128,15 +129,22 @@ from fastmcp.server.sessions import SessionProvider
 mcp.add_provider(SessionProvider())
 ```
 
+If a tool declares `session_id` and no provider is registered, FastMCP raises
+`SessionProviderRequiredError` naming the offending tool and the fix. The check
+runs on both the tool-listing and tool-resolution paths and re-scans the live
+local tool set each time, so it is independent of registration order — a
+`session_id` tool added after construction is still caught before it can be
+called, and there is no way to reach a handler without the check having run.
+
 `SessionProvider` subclasses `Provider`, takes **no store** (uses the server's)
-and **no ttl** (the store's). It exists only to hand out unguessable ids.
+and **no ttl** (the store's). It exists to mint and end owned ids.
 `create_session` matters most without auth, where an unguessable id is the only
 defense against a caller *guessing* onto another session.
 
-**Opt out** with `FastMCP(auto_session_provider=False)`. Use it for
-bring-your-own-key apps: a tool takes a `session_id` whose value is the caller's
-own session/user identity, so `create_session` is unwanted. With auto-wiring off
-you can still `add_provider(SessionProvider())` explicitly if you want it.
+When an application already mints its own identifiers — conversation ids, workflow
+ids — take them as ordinary string arguments rather than `SessionId`, and register
+no provider; `SessionId` is specifically the create-then-pass contract backed by
+`create_session`.
 
 ## Security
 
@@ -174,10 +182,11 @@ the above:
    wire into the same parameter-detection path as `Context`. `UserSession` is the
    injection marker; the injected value is a `Session`.
 5. **`session_id: SessionId`** marker type: string in the schema, auto-filled
-   description, `ctx.get_session(id)` resolver.
-6. **`SessionProvider(Provider)`** with `create_session` / `end_session`,
-   auto-registered when a tool declares `session_id: SessionId` (or added
-   explicitly via `add_provider`); opt out with `auto_session_provider=False`.
+   description, `await ctx.get_session(id)` resolver that validates the id.
+6. **`SessionProvider(Provider)`** with `create_session` (records the session) /
+   `end_session` (deletes it), registered explicitly via `add_provider`. A tool
+   declaring `session_id: SessionId` with no provider raises
+   `SessionProviderRequiredError`.
 7. Rewrite the tests to cover both patterns, principal isolation, no-auth
    behavior, and `end_session`.
 

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -133,10 +133,12 @@ mcp.add_provider(SessionProvider())
 
 If a tool declares `session_id` and no provider is registered, FastMCP raises
 `SessionProviderRequiredError` naming the offending tool and the fix. The check
-runs on both the tool-listing and tool-resolution paths and re-scans the live
-local tool set each time, so it is independent of registration order — a
-`session_id` tool added after construction is still caught before it can be
-called, and there is no way to reach a handler without the check having run.
+covers every tool the server can produce, not only decorator-registered ones: on
+`list_tools` it runs against the full aggregated tool set (across all
+providers), and on resolution it runs against the specific tool just resolved —
+so a `session_id` tool sourced from a custom `Provider` is covered exactly like
+one registered with `@mcp.tool`, and there is no way to reach a handler without
+the check having run.
 
 `SessionProvider` subclasses `Provider`, takes **no store** (uses the server's)
 and **no ttl** (the store's). It exists to mint and end owned ids.

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -62,7 +62,8 @@ so its `get`/`set`/`delete`/`clear` accessors work as usual.
 ### Distinct sessions — an argument
 
 ```python
-from fastmcp.server.sessions import SessionId, get_session
+from fastmcp.server.sessions import SessionId
+from fastmcp.server.dependencies import get_session
 
 @mcp.tool
 async def add_to_cart(item: str, session_id: SessionId) -> str:

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -43,18 +43,20 @@ invisible-degradation failure this whole feature exists to remove.
 ### Per-user state — injected
 
 ```python
-from fastmcp.server.sessions import Session
+from fastmcp.server.sessions import UserSession
 
 @mcp.tool
-async def remember(fact: str, session: Session) -> str:
+async def remember(fact: str, session: UserSession) -> str:
     await session.set("fact", fact)
     return "noted"
 ```
 
-`session: Session` is **dependency-injected** (like `ctx: Context`): keyed by the
-request's authenticated principal, not present in the input schema, nothing for
-the agent to pass. Requires auth — with no principal it raises a clear error. Use
-it when one bucket per user is what you want.
+`session: UserSession` is **dependency-injected** (like `ctx: Context`): keyed by
+the request's authenticated principal, not present in the input schema, nothing
+for the agent to pass. Requires auth — with no principal it raises a clear error.
+Use it when one bucket per user is what you want. `UserSession` is only the
+injection annotation — the value the handler receives is an ordinary `Session`,
+so its `get`/`set`/`delete`/`clear` accessors work as usual.
 
 ### Distinct sessions — an argument
 
@@ -101,9 +103,24 @@ TTL per session (the store's), refreshed on write — no key index to maintain, 
 race on the read-modify-write; session state is small and typically driven
 serially by one agent, so this is acceptable — noted, not hidden.)
 
-## `SessionProvider` — optional
+## `SessionProvider` — auto-wired
 
-Session ids are minted by an opt-in provider, added like any other:
+Session ids are minted by `SessionProvider`, which contributes two tools:
+
+- `create_session()` → mints an unguessable `uuid4` and returns it as a string.
+- `end_session(session_id: SessionId)` → clears that session's state.
+
+**Declaring a `session_id: SessionId` argument on any tool auto-registers the
+default `SessionProvider`** — the developer does not have to remember
+`add_provider(SessionProvider())`. The `create_session` / `end_session` tools are
+real and appear in the normal tool listing; the visible `session_id` argument
+implies the lifecycle plumbing, so FastMCP wires it. The decision is made when
+tools are listed by scanning the server's registered tools, so it is independent
+of registration order: a `session_id` tool added after construction still
+activates it.
+
+Registering a `SessionProvider` yourself still works and takes precedence — the
+auto-registered one steps aside, so there is never a duplicate:
 
 ```python
 from fastmcp.server.sessions import SessionProvider
@@ -111,17 +128,15 @@ from fastmcp.server.sessions import SessionProvider
 mcp.add_provider(SessionProvider())
 ```
 
-`SessionProvider` subclasses `Provider` and contributes two tools:
-
-- `create_session()` → mints an unguessable `uuid4` and returns it as a string.
-- `end_session(session_id: SessionId)` → clears that session's state.
-
-It takes **no store** (uses the server's) and **no ttl** (the store's). It exists
-only to hand out unguessable ids. It is not required: a tool can take a
-`session_id` and the id can be anything the caller supplies — an app that already
-has its own session/user identity passes that directly (bring-your-own-key).
+`SessionProvider` subclasses `Provider`, takes **no store** (uses the server's)
+and **no ttl** (the store's). It exists only to hand out unguessable ids.
 `create_session` matters most without auth, where an unguessable id is the only
 defense against a caller *guessing* onto another session.
+
+**Opt out** with `FastMCP(auto_session_provider=False)`. Use it for
+bring-your-own-key apps: a tool takes a `session_id` whose value is the caller's
+own session/user identity, so `create_session` is unwanted. With auto-wiring off
+you can still `add_provider(SessionProvider())` explicitly if you want it.
 
 ## Security
 
@@ -155,12 +170,14 @@ the above:
 2. **Remove the `SessionCodec`/sealing** — ids are bare `uuid4`.
 3. **`Session` object** with async `get`/`set`/`delete`/`clear` over the server
    store, single-dict-per-session key scheme.
-4. **`session: Session`** injection (principal-keyed; error without auth) — wire
-   into the same parameter-detection path as `Context`.
+4. **`session: UserSession`** injection (principal-keyed; error without auth) —
+   wire into the same parameter-detection path as `Context`. `UserSession` is the
+   injection marker; the injected value is a `Session`.
 5. **`session_id: SessionId`** marker type: string in the schema, auto-filled
    description, `ctx.get_session(id)` resolver.
-6. **`SessionProvider(Provider)`** with `create_session` / `end_session`, added via
-   `add_provider`.
+6. **`SessionProvider(Provider)`** with `create_session` / `end_session`,
+   auto-registered when a tool declares `session_id: SessionId` (or added
+   explicitly via `add_provider`); opt out with `auto_session_provider=False`.
 7. Rewrite the tests to cover both patterns, principal isolation, no-auth
    behavior, and `end_session`.
 

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -30,8 +30,9 @@ State is keyed by `(principal, session_id)`. A request under principal B keys
 into B's own namespace — it can never address A's keys no matter what
 `session_id` it passes. The id only organizes sessions *within* a principal. The
 handle is a bare `uuid4` string; it is **not sealed** — the principal prefix is
-the wall, and an unknown id simply resolves to an empty session in the caller's
-own namespace.
+the wall. Sessions are also create-then-validate (below): an id that was never
+minted by `create_session` under this principal is rejected outright, not
+resolved to an empty session.
 
 ## Two explicit patterns
 

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -64,7 +64,7 @@ from fastmcp.server.dependencies import get_context
 
 @mcp.tool
 async def add_to_cart(item: str, session_id: SessionId) -> str:
-    session = get_context().session(session_id)
+    session = get_context().get_session(session_id)
     cart = await session.get("cart", default=[])
     cart.append(item)
     await session.set("cart", cart)
@@ -79,9 +79,10 @@ auto-populates the argument's description with the protocol:
 > persist state across calls in the same session."
 
 The tool becomes self-teaching — an agent reads the schema and learns the
-create-then-pass contract with no hand-prompting. `ctx.session(session_id)`
-resolves it to a `Session` keyed by `(principal, session_id)`. Use it when a user
-needs more than one session.
+create-then-pass contract with no hand-prompting. `ctx.get_session(session_id)`
+resolves it to a `Session` keyed by `(principal, session_id)` (named
+`get_session`, not `session`, because `ctx.session` already exposes the raw
+`ServerSession`). Use it when a user needs more than one session.
 
 ## The `Session` object
 
@@ -157,7 +158,7 @@ the above:
 4. **`session: Session`** injection (principal-keyed; error without auth) — wire
    into the same parameter-detection path as `Context`.
 5. **`session_id: SessionId`** marker type: string in the schema, auto-filled
-   description, `ctx.session(id)` resolver.
+   description, `ctx.get_session(id)` resolver.
 6. **`SessionProvider(Provider)`** with `create_session` / `end_session`, added via
    `add_provider`.
 7. Rewrite the tests to cover both patterns, principal isolation, no-auth

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -117,7 +117,7 @@ and `end` is a single delete. (Trade-off: concurrent writes to one session race
 on the read-modify-write; session state is small and typically driven serially by
 one agent, so this is acceptable — noted, not hidden.)
 
-## `SessionProvider` — required for `session_id`
+## `SessionProvider`
 
 Session ids are minted by `SessionProvider`, which contributes two tools:
 
@@ -126,8 +126,8 @@ Session ids are minted by `SessionProvider`, which contributes two tools:
 - `end_session(session_id: SessionId)` → validates the id, then deletes the
   session so it no longer resolves.
 
-Because an id is only valid once `create_session` has recorded it, a server whose
-tools declare `session_id: SessionId` **must register a `SessionProvider`**:
+Register it whenever your tools take a `session_id` — providers are the idiomatic
+way to add functionality like this:
 
 ```python
 from fastmcp.server.sessions import SessionProvider
@@ -135,14 +135,16 @@ from fastmcp.server.sessions import SessionProvider
 mcp.add_provider(SessionProvider())
 ```
 
-If a tool declares `session_id` and no provider is registered, FastMCP raises
-`SessionProviderRequiredError` naming the offending tool and the fix. The check
-covers every tool the server can produce, not only decorator-registered ones: on
-`list_tools` it runs against the full aggregated tool set (across all
-providers), and on resolution it runs against the specific tool just resolved —
-so a `session_id` tool sourced from a custom `Provider` is covered exactly like
-one registered with `@mcp.tool`, and there is no way to reach a handler without
-the check having run.
+There is **no enforcement** that a provider is registered, and there was: an
+earlier version scanned the tool set at list/resolve time and raised if a
+`session_id` tool had no provider. That check had to reason about the whole
+composition pipeline — `isinstance` on providers, unwrapping namespaced ones,
+tool transforms, session visibility, enabled state — and produced false
+positives that broke valid servers (a namespaced provider, a session-disabled
+tool). It was deleted. The guarantee never needed it: `get_session` validates
+that an id was recorded (create-then-validate), so a server with no provider
+simply cannot mint ids, and every `get_session` rejects — a misconfiguration
+caught the first time the tools run, not a security hole.
 
 `SessionProvider` subclasses `Provider`, takes **no store** (uses the server's)
 and **no ttl** (the store's). It exists to mint and end owned ids.
@@ -192,9 +194,8 @@ the above:
 5. **`session_id: SessionId`** marker type: string in the schema, auto-filled
    description, `await ctx.get_session(id)` resolver that validates the id.
 6. **`SessionProvider(Provider)`** with `create_session` (records the session) /
-   `end_session` (deletes it), registered explicitly via `add_provider`. A tool
-   declaring `session_id: SessionId` with no provider raises
-   `SessionProviderRequiredError`.
+   `end_session` (deletes it), registered explicitly via `add_provider`. No
+   enforcement that it is present — `get_session`'s validation is the guarantee.
 7. Rewrite the tests to cover both patterns, principal isolation, no-auth
    behavior, and `end_session`.
 

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -105,8 +105,10 @@ Async accessors over the server store, scoped to one `(principal, session_id)`:
 - `await session.end()` — deletes the session (what `end_session` calls).
 
 A session's state is stored as a **single dict under one key**
-(`session:{principal}:{session_id}`). That dict holds user state in a `state`
-sub-dict alongside a small `_created` marker, so a created-but-empty session is
+(`session:{sha256(principal)}:{session_id}`, and `session:anon:{session_id}` when
+unauthenticated — the principal is hashed into a fixed-length, delimiter-safe
+segment, never embedded raw). That dict holds user state in a `state` sub-dict
+alongside a small `_created` marker, so a created-but-empty session is
 distinguishable from a missing one even if the store collapses empty dicts.
 `get`/`set`/`delete` read-modify-write the sub-dict and never touch the marker;
 `clear` resets the sub-dict but leaves the marker (the session still resolves);

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -1,0 +1,172 @@
+# Stateless session state (2026-07-28)
+
+> Design proposal. Status: building.
+
+## Problem
+
+The `2026-07-28` era is stateless by protocol construction: each request builds a
+fresh `Connection`, `connection.session_id` is always `None`, and
+`connection.state` is a new dict that is discarded when the request returns. So
+`ctx.session_id` mints a throwaway `uuid4` per request, and `ctx.set_state` /
+`ctx.get_state` **silently never round-trip** — no error, just lost data.
+
+Users who want cross-call state on a modern connection (a cart, a conversation,
+accumulated context) have no safe mechanism today, and the failure is invisible:
+the code reads as "works" while quietly returning the wrong thing.
+
+The one thing every modern request carries that is stable and *non-spoofable* is
+the authenticated principal — `get_access_token().claims["sub"]`, or the
+`(client_id, issuer, subject)` triple. Everything else on the wire
+(`client_info`, `client_capabilities`) is client-declared and forgeable.
+
+## Goals
+
+- Offer secure, cross-request **session-scoped state** on modern connections.
+- Work with **any client** — no reliance on client-side `_meta` cooperation. The
+  session handle travels as a normal tool argument.
+- **Non-spoofable isolation** when authenticated; an **unforgeable** handle even
+  without auth.
+- Reuse what exists: the SDK's AES-GCM sealed envelope
+  (`mcp.server.request_state`) and FastMCP's `AsyncKeyValue` store abstraction.
+- Replace silent data loss with **clear errors**.
+
+## Non-goals
+
+- Server→client push or notifications for session lifecycle (that is the
+  subscriptions workstream).
+- Reconstructing handshake-era session semantics on modern connections.
+
+## Design
+
+### One surface: scoped state
+
+Extend the existing `ctx.get_state` / `ctx.set_state` with a `scope`:
+
+```python
+ctx.get_state("cart", scope=Scope.SESSION)   # sealed session handle; many per principal
+ctx.get_state("prefs", scope=Scope.USER)     # authenticated principal; spans sessions
+ctx.get_state("scratch", scope=Scope.REQUEST) # per-request; dies with the request (today)
+```
+
+The scope selects the storage key prefix and the isolation guarantee:
+
+| Scope | Key prefix | Isolation |
+| --- | --- | --- |
+| `REQUEST` | the per-request connection | request lifetime only |
+| `SESSION` | `(principal, session_id)` | sealed + principal-bound (auth) / unforgeable (no auth) |
+| `USER` | `principal` | auth-bound; requires authentication |
+
+`USER` scope *is* the auth-tuple option; `SESSION` scope *is* the sealed token.
+`set_state`/`get_state` already exist and already key off `session_id` — this
+makes the scope **explicit** instead of implicitly-session and silently broken on
+modern.
+
+### The session handle (sealed token)
+
+A session is identified by a token minted server-side:
+
+- payload = `{session_id, principal, exp}`, AES-GCM sealed via the SDK's
+  `AESGCMRequestStateCodec` under a `RequestStateSecurity` key.
+- On use, the framework unseals, verifies expiry, and — when auth is present —
+  verifies the token's principal matches the request's authenticated principal.
+  Foreign, expired, or tampered → rejected with a clear error; the client never
+  learns why.
+
+Unlike the MRTR `request_state` seal, the session token binds **principal +
+expiry only** (it drops the SDK boundary's per-request binding), so it survives
+across *different* tool calls rather than a single round.
+
+### Transport: tool argument (decided)
+
+The handle travels as a **tool argument**, not `_meta` — `_meta` would require
+client-side cooperation, and the point is to work with any client. The framework
+may peek `_meta` first as an optimization, but the contract is argument-based. An
+annotation marks the parameter and owns the crypto:
+
+```python
+from typing import Annotated
+from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_context
+from fastmcp.sessions import Session, Scope
+
+mcp = FastMCP("shop")
+
+
+@mcp.tool
+def add_to_cart(item: str, session: Annotated[str, Session()]) -> str:
+    ctx = get_context()
+    cart = ctx.get_state("cart", scope=Scope.SESSION, default=[])
+    cart.append(item)
+    ctx.set_state("cart", cart, scope=Scope.SESSION)
+    return f"{len(cart)} items in cart"
+```
+
+The `Session()` annotation names the parameter carrying the sealed token. The
+framework unseals + verifies it once, binds the session identity to the request
+context, and the tool body reads/writes through `ctx.get_state(scope=SESSION)`.
+Authors never touch crypto or key schemes.
+
+### SessionProvider
+
+An opt-in provider that supplies the lifecycle:
+
+- Registers `create_session` and `end_session` tools. The client calls
+  `create_session`, receives an opaque sealed token, and threads it into later
+  calls.
+- Owns the backing store — an `AsyncKeyValue` (default `MemoryStore`; a Redis
+  store for multi-replica), keyed by `(principal, session_id)`.
+- Applies a TTL so abandoned sessions clear without an explicit `end_session`.
+
+```python
+mcp = FastMCP("shop", session_provider=SessionProvider(store=redis_store, ttl=3600))
+```
+
+### Guarantee tiers
+
+- **Authenticated:** the token binds the principal; a token echoed under a
+  different principal is rejected by the seal. Strong cross-client isolation,
+  multiple sessions per user.
+- **Unauthenticated:** no principal to bind, but the seal is still unforgeable —
+  a client cannot fabricate a valid token or guess into another session. This is
+  single-tenant-safe; there is no cross-client wall beyond unforgeability, and
+  the docs say so plainly.
+
+### Fallback
+
+When the transport genuinely has a session (handshake / stateful, an
+`mcp-session-id` is present), `SESSION` scope can key off it directly with no
+token round-trip. The sealed-token path is the modern/stateless story.
+
+### Gating: no more silent loss
+
+On a modern connection with no valid handle:
+
+- `SESSION` access raises a clear error naming the fix ("no active session — call
+  `create_session` and pass its token").
+- `USER` access without auth raises a clear auth-required error.
+- `REQUEST` always works.
+
+This replaces today's silent per-request `uuid4`.
+
+## Build plan
+
+1. **Scoped store.** `Scope` enum; `get_state` / `set_state(scope=)` over a
+   pluggable `AsyncKeyValue`; `REQUEST` keeps current behavior; `SESSION` / `USER`
+   error-gate when unavailable.
+2. **Session codec.** Seal / unseal `{session_id, principal, exp}` via the SDK
+   AES-GCM codec; verify principal + expiry; reject foreign / expired / tampered.
+3. **SessionProvider.** `create_session` / `end_session` tools, `AsyncKeyValue`
+   store, TTL, `(principal, session_id)` key scheme.
+4. **`Session()` annotation + boundary.** Unseal / verify the token argument once,
+   bind identity to the request context; error-gate cleanly.
+5. **Docs.** The scoped-state guide, the two-tier guarantee doc, and the migration
+   note from the old `set_state`.
+
+## Open questions
+
+- Handle shape: inject a `SessionHandle` object vs. keep it pure
+  `ctx.get_state(scope=SESSION)`? (Proposed: context-primary; the annotation only
+  establishes identity.)
+- `USER` key: `sub` alone, or the full `(client_id, issuer, subject)` triple?
+- `create_session` return shape — the sealed token as a plain string the model
+  echoes back on later calls.

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -62,12 +62,11 @@ so its `get`/`set`/`delete`/`clear` accessors work as usual.
 ### Distinct sessions — an argument
 
 ```python
-from fastmcp.server.sessions import SessionId
-from fastmcp.server.dependencies import get_context
+from fastmcp.server.sessions import SessionId, get_session
 
 @mcp.tool
 async def add_to_cart(item: str, session_id: SessionId) -> str:
-    session = await get_context().get_session(session_id)
+    session = await get_session(session_id)
     cart = await session.get("cart", default=[])
     cart.append(item)
     await session.set("cart", cart)
@@ -85,12 +84,14 @@ The tool becomes self-teaching — an agent reads the schema and learns the
 create-then-pass contract with no hand-prompting. The description names no
 specific tool: composition can rename the lifecycle tool (mounting under a
 namespace exposes it as `child_create_session`), so it points at the
-*capability* rather than a name that may not exist under that mount. `await ctx.get_session(session_id)`
-resolves it to a `Session` keyed by `(principal, session_id)` (named
-`get_session`, not `session`, because `ctx.session` already exposes the raw
-`ServerSession`), **validating** that the id was created under this principal —
-an unknown or foreign id raises `InvalidSession` rather than opening a fresh
-bucket. Use it when a user needs more than one session.
+*capability* rather than a name that may not exist under that mount.
+
+The standalone `await get_session(session_id)` resolves the id to a `Session`
+keyed by `(principal, session_id)`, **validating** that it was created under this
+principal — an unknown or foreign id raises `InvalidSession` rather than opening a
+fresh bucket. It is a plain function, not a `Context` method, so it needs no
+foreground context and works from a `task=True` tool's worker. Use this pattern
+when a user needs more than one session.
 
 ## The `Session` object
 
@@ -194,7 +195,8 @@ the above:
    wire into the same parameter-detection path as `Context`. `UserSession` is the
    injection marker; the injected value is a `Session`.
 5. **`session_id: SessionId`** marker type: string in the schema, auto-filled
-   description, `await ctx.get_session(id)` resolver that validates the id.
+   description, standalone `await get_session(id)` resolver that validates the id
+   (works from a task worker — no foreground context needed).
 6. **`SessionProvider(Provider)`** with `create_session` (records the session) /
    `end_session` (deletes it), registered explicitly via `add_provider`. No
    enforcement that it is present — `get_session`'s validation is the guarantee.

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -92,6 +92,8 @@ bucket. Use it when a user needs more than one session.
 
 Async accessors over the server store, scoped to one `(principal, session_id)`:
 
+- `session.id` — the session's id (set for a `session_id`-resolved session; `None`
+  for an injected `UserSession`, which has no distinct id).
 - `await session.get(key, default=None)`
 - `await session.set(key, value)`
 - `await session.delete(key)`

--- a/docs/development/v4-notes/stateless-session-state.md
+++ b/docs/development/v4-notes/stateless-session-state.md
@@ -1,172 +1,176 @@
 # Stateless session state (2026-07-28)
 
-> Design proposal. Status: building.
+> Design spec. Status: building.
 
 ## Problem
 
 The `2026-07-28` era is stateless by protocol construction: each request builds a
 fresh `Connection`, `connection.session_id` is always `None`, and
-`connection.state` is a new dict that is discarded when the request returns. So
-`ctx.session_id` mints a throwaway `uuid4` per request, and `ctx.set_state` /
-`ctx.get_state` **silently never round-trip** — no error, just lost data.
+`connection.state` is a new dict discarded when the request returns. So
+`ctx.session_id` mints a throwaway `uuid4` per request and `ctx.set_state` /
+`ctx.get_state` **silently never round-trip** — no error, just lost data. A user
+who wants cross-call state (a cart, a conversation, accumulated context) has no
+safe mechanism, and the failure is invisible.
 
-Users who want cross-call state on a modern connection (a cart, a conversation,
-accumulated context) have no safe mechanism today, and the failure is invisible:
-the code reads as "works" while quietly returning the wrong thing.
+The one identifier every modern request carries that is stable and
+**non-spoofable** is the authenticated principal — `get_access_token().claims["sub"]`,
+or the `(client_id, issuer, subject)` triple. Everything else on the wire is
+client-declared and forgeable.
 
-The one thing every modern request carries that is stable and *non-spoofable* is
-the authenticated principal — `get_access_token().claims["sub"]`, or the
-`(client_id, issuer, subject)` triple. Everything else on the wire
-(`client_info`, `client_capabilities`) is client-declared and forgeable.
+## The model
 
-## Goals
+State lives **server-side** in the one `AsyncKeyValue` (py-key-value) store the
+server already holds (`session_state_store`). The framework calls `get`/`put`/
+`delete` and **never imposes a TTL** — retention is entirely the store's
+(configure it on the store you pass: a Redis TTL, a py-key-value TTL wrapper,
+whatever). There is no second store and no framework-owned TTL knob.
 
-- Offer secure, cross-request **session-scoped state** on modern connections.
-- Work with **any client** — no reliance on client-side `_meta` cooperation. The
-  session handle travels as a normal tool argument.
-- **Non-spoofable isolation** when authenticated; an **unforgeable** handle even
-  without auth.
-- Reuse what exists: the SDK's AES-GCM sealed envelope
-  (`mcp.server.request_state`) and FastMCP's `AsyncKeyValue` store abstraction.
-- Replace silent data loss with **clear errors**.
+Isolation comes from the **authenticated principal, not from the session id.**
+State is keyed by `(principal, session_id)`. A request under principal B keys
+into B's own namespace — it can never address A's keys no matter what
+`session_id` it passes. The id only organizes sessions *within* a principal. The
+handle is a bare `uuid4` string; it is **not sealed** — the principal prefix is
+the wall, and an unknown id simply resolves to an empty session in the caller's
+own namespace.
 
-## Non-goals
+## Two explicit patterns
 
-- Server→client push or notifications for session lifecycle (that is the
-  subscriptions workstream).
-- Reconstructing handshake-era session semantics on modern connections.
+A tool opts into exactly one, on purpose. There is deliberately **no** optional
+"id if given, else default" parameter — that would silently misroute a call
+whose id the agent forgot to pass into the shared per-user bucket, which is the
+invisible-degradation failure this whole feature exists to remove.
 
-## Design
-
-### One surface: scoped state
-
-Extend the existing `ctx.get_state` / `ctx.set_state` with a `scope`:
-
-```python
-ctx.get_state("cart", scope=Scope.SESSION)   # sealed session handle; many per principal
-ctx.get_state("prefs", scope=Scope.USER)     # authenticated principal; spans sessions
-ctx.get_state("scratch", scope=Scope.REQUEST) # per-request; dies with the request (today)
-```
-
-The scope selects the storage key prefix and the isolation guarantee:
-
-| Scope | Key prefix | Isolation |
-| --- | --- | --- |
-| `REQUEST` | the per-request connection | request lifetime only |
-| `SESSION` | `(principal, session_id)` | sealed + principal-bound (auth) / unforgeable (no auth) |
-| `USER` | `principal` | auth-bound; requires authentication |
-
-`USER` scope *is* the auth-tuple option; `SESSION` scope *is* the sealed token.
-`set_state`/`get_state` already exist and already key off `session_id` — this
-makes the scope **explicit** instead of implicitly-session and silently broken on
-modern.
-
-### The session handle (sealed token)
-
-A session is identified by a token minted server-side:
-
-- payload = `{session_id, principal, exp}`, AES-GCM sealed via the SDK's
-  `AESGCMRequestStateCodec` under a `RequestStateSecurity` key.
-- On use, the framework unseals, verifies expiry, and — when auth is present —
-  verifies the token's principal matches the request's authenticated principal.
-  Foreign, expired, or tampered → rejected with a clear error; the client never
-  learns why.
-
-Unlike the MRTR `request_state` seal, the session token binds **principal +
-expiry only** (it drops the SDK boundary's per-request binding), so it survives
-across *different* tool calls rather than a single round.
-
-### Transport: tool argument (decided)
-
-The handle travels as a **tool argument**, not `_meta` — `_meta` would require
-client-side cooperation, and the point is to work with any client. The framework
-may peek `_meta` first as an optimization, but the contract is argument-based. An
-annotation marks the parameter and owns the crypto:
+### Per-user state — injected
 
 ```python
-from typing import Annotated
-from fastmcp import FastMCP
-from fastmcp.server.dependencies import get_context
-from fastmcp.sessions import Session, Scope
-
-mcp = FastMCP("shop")
-
+from fastmcp.server.sessions import Session
 
 @mcp.tool
-def add_to_cart(item: str, session: Annotated[str, Session()]) -> str:
-    ctx = get_context()
-    cart = ctx.get_state("cart", scope=Scope.SESSION, default=[])
-    cart.append(item)
-    ctx.set_state("cart", cart, scope=Scope.SESSION)
-    return f"{len(cart)} items in cart"
+async def remember(fact: str, session: Session) -> str:
+    await session.set("fact", fact)
+    return "noted"
 ```
 
-The `Session()` annotation names the parameter carrying the sealed token. The
-framework unseals + verifies it once, binds the session identity to the request
-context, and the tool body reads/writes through `ctx.get_state(scope=SESSION)`.
-Authors never touch crypto or key schemes.
+`session: Session` is **dependency-injected** (like `ctx: Context`): keyed by the
+request's authenticated principal, not present in the input schema, nothing for
+the agent to pass. Requires auth — with no principal it raises a clear error. Use
+it when one bucket per user is what you want.
 
-### SessionProvider
-
-An opt-in provider that supplies the lifecycle:
-
-- Registers `create_session` and `end_session` tools. The client calls
-  `create_session`, receives an opaque sealed token, and threads it into later
-  calls.
-- Owns the backing store — an `AsyncKeyValue` (default `MemoryStore`; a Redis
-  store for multi-replica), keyed by `(principal, session_id)`.
-- Applies a TTL so abandoned sessions clear without an explicit `end_session`.
+### Distinct sessions — an argument
 
 ```python
-mcp = FastMCP("shop", session_provider=SessionProvider(store=redis_store, ttl=3600))
+from fastmcp.server.sessions import SessionId
+from fastmcp.server.dependencies import get_context
+
+@mcp.tool
+async def add_to_cart(item: str, session_id: SessionId) -> str:
+    session = get_context().session(session_id)
+    cart = await session.get("cart", default=[])
+    cart.append(item)
+    await session.set("cart", cart)
+    return f"{len(cart)} items"
 ```
 
-### Guarantee tiers
+`session_id: SessionId` is a **required string argument** — it *is* in the schema,
+the agent supplies it. `SessionId` is a marker type so the framework
+auto-populates the argument's description with the protocol:
 
-- **Authenticated:** the token binds the principal; a token echoed under a
-  different principal is rejected by the seal. Strong cross-client isolation,
-  multiple sessions per user.
-- **Unauthenticated:** no principal to bind, but the seal is still unforgeable —
-  a client cannot fabricate a valid token or guess into another session. This is
-  single-tenant-safe; there is no cross-client wall beyond unforgeability, and
-  the docs say so plainly.
+> "Session identifier. Call `create_session` to obtain one, then pass it here to
+> persist state across calls in the same session."
 
-### Fallback
+The tool becomes self-teaching — an agent reads the schema and learns the
+create-then-pass contract with no hand-prompting. `ctx.session(session_id)`
+resolves it to a `Session` keyed by `(principal, session_id)`. Use it when a user
+needs more than one session.
 
-When the transport genuinely has a session (handshake / stateful, an
-`mcp-session-id` is present), `SESSION` scope can key off it directly with no
-token round-trip. The sealed-token path is the modern/stateless story.
+## The `Session` object
 
-### Gating: no more silent loss
+Async accessors over the server store, scoped to one `(principal, session_id)`:
 
-On a modern connection with no valid handle:
+- `await session.get(key, default=None)`
+- `await session.set(key, value)`
+- `await session.delete(key)`
+- `await session.clear()`
 
-- `SESSION` access raises a clear error naming the fix ("no active session — call
-  `create_session` and pass its token").
-- `USER` access without auth raises a clear auth-required error.
-- `REQUEST` always works.
+A session's state is stored as a **single dict under one key**
+(`session:{principal}:{session_id}`). `get`/`set`/`delete` read-modify-write that
+dict; `clear` / `end_session` delete the one key. One key per session means one
+TTL per session (the store's), refreshed on write — no key index to maintain, and
+`end_session` is a single delete. (Trade-off: concurrent writes to one session
+race on the read-modify-write; session state is small and typically driven
+serially by one agent, so this is acceptable — noted, not hidden.)
 
-This replaces today's silent per-request `uuid4`.
+## `SessionProvider` — optional
 
-## Build plan
+Session ids are minted by an opt-in provider, added like any other:
 
-1. **Scoped store.** `Scope` enum; `get_state` / `set_state(scope=)` over a
-   pluggable `AsyncKeyValue`; `REQUEST` keeps current behavior; `SESSION` / `USER`
-   error-gate when unavailable.
-2. **Session codec.** Seal / unseal `{session_id, principal, exp}` via the SDK
-   AES-GCM codec; verify principal + expiry; reject foreign / expired / tampered.
-3. **SessionProvider.** `create_session` / `end_session` tools, `AsyncKeyValue`
-   store, TTL, `(principal, session_id)` key scheme.
-4. **`Session()` annotation + boundary.** Unseal / verify the token argument once,
-   bind identity to the request context; error-gate cleanly.
-5. **Docs.** The scoped-state guide, the two-tier guarantee doc, and the migration
-   note from the old `set_state`.
+```python
+from fastmcp.server.sessions import SessionProvider
 
-## Open questions
+mcp.add_provider(SessionProvider())
+```
 
-- Handle shape: inject a `SessionHandle` object vs. keep it pure
-  `ctx.get_state(scope=SESSION)`? (Proposed: context-primary; the annotation only
-  establishes identity.)
-- `USER` key: `sub` alone, or the full `(client_id, issuer, subject)` triple?
-- `create_session` return shape — the sealed token as a plain string the model
-  echoes back on later calls.
+`SessionProvider` subclasses `Provider` and contributes two tools:
+
+- `create_session()` → mints an unguessable `uuid4` and returns it as a string.
+- `end_session(session_id: SessionId)` → clears that session's state.
+
+It takes **no store** (uses the server's) and **no ttl** (the store's). It exists
+only to hand out unguessable ids. It is not required: a tool can take a
+`session_id` and the id can be anything the caller supplies — an app that already
+has its own session/user identity passes that directly (bring-your-own-key).
+`create_session` matters most without auth, where an unguessable id is the only
+defense against a caller *guessing* onto another session.
+
+## Security
+
+Keyed by `(principal, session_id)`:
+
+- **Authenticated → strong isolation.** `principal` is the validated token
+  subject, unforgeable. B keys into B's namespace; A's data is unreachable no
+  matter what id B passes. Guessing is pointless; a session id appearing in agent
+  context or logs is harmless (it is not a capability without the principal).
+  Caller-chosen ids are safe here.
+- **Unauthenticated → single-tenant-safe only.** No principal, so the key is just
+  the id in a shared namespace: the id becomes a bearer capability, and exposure
+  in logs/conversation leaks the session. `create_session`'s `uuid4` gives
+  guess-*resistance*, not isolation. Documented in bold: not a tenant boundary;
+  without auth, force minted ids and never treat sessions as a wall between
+  clients.
+- **Isolation is auth; the id is organization.** No id scheme substitutes for a
+  principal, which is why sealing the handle buys nothing load-bearing and is
+  dropped.
+- **Not FastMCP's job:** transport (use TLS), encryption at rest (the store's), a
+  malicious *authorized* client acting within its rights.
+
+## Rework plan (from the current prototype)
+
+The prototype (`sessions.py`, `context.py`, `function_tool.py`, `server.py`) built
+a `Scope` enum, a sealed `SessionCodec`, and `ctx.get_state(scope=...)`. Rework to
+the above:
+
+1. **Remove `Scope`** and the `scope=` parameter; revert `ctx.get_state`/
+   `set_state` to their original request-scoped behavior.
+2. **Remove the `SessionCodec`/sealing** — ids are bare `uuid4`.
+3. **`Session` object** with async `get`/`set`/`delete`/`clear` over the server
+   store, single-dict-per-session key scheme.
+4. **`session: Session`** injection (principal-keyed; error without auth) — wire
+   into the same parameter-detection path as `Context`.
+5. **`session_id: SessionId`** marker type: string in the schema, auto-filled
+   description, `ctx.session(id)` resolver.
+6. **`SessionProvider(Provider)`** with `create_session` / `end_session`, added via
+   `add_provider`.
+7. Rewrite the tests to cover both patterns, principal isolation, no-auth
+   behavior, and `end_session`.
+
+## Docs plan
+
+Written against the final API once the rework verifies:
+
+- A concept guide — why stateless removes the session, the two patterns, when to
+  reach for each. Why before how.
+- A security page — the two tiers, "isolation is auth, the id is organization,"
+  the bold no-multitenant-without-auth warning.
+- Fully runnable examples for both patterns (pass the doc-import guard, register
+  in `docs.json`).
+- A migration note from the old `ctx.session_id` / `set_state`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -160,6 +160,7 @@
                       "servers/dependency-injection",
                       "servers/lifespan",
                       "servers/storage-backends",
+                      "servers/sessions",
                       "servers/tasks",
                       "servers/versioning"
                     ]

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -215,7 +215,7 @@ messages = result.messages
 
 <VersionBadge version="3.0.0" />
 
-Store data that persists across multiple requests within the same MCP session. Session state is automatically keyed by the client's session, ensuring isolation between different clients.
+On a session-based (handshake-era) connection, `ctx.set_state` persists data across multiple requests within the same MCP session, automatically keyed by the client's session for isolation between clients. On the modern stateless protocol it is request-scoped instead — see the note below.
 
 <Note>
 This cross-request persistence relies on a session-based (handshake-era) connection. The modern (`2026-07-28`) protocol is stateless and has no session, so on those connections `ctx.set_state` is scoped to the single request. For state that persists across requests on any connection — keyed to the authenticated user and safe across tenants — use [Session State](/servers/sessions).

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -217,6 +217,10 @@ messages = result.messages
 
 Store data that persists across multiple requests within the same MCP session. Session state is automatically keyed by the client's session, ensuring isolation between different clients.
 
+<Note>
+This cross-request persistence relies on a session-based (handshake-era) connection. The modern (`2026-07-28`) protocol is stateless and has no session, so on those connections `ctx.set_state` is scoped to the single request. For state that persists across requests on any connection — keyed to the authenticated user and safe across tenants — use [Session State](/servers/sessions).
+</Note>
+
 ```python
 from fastmcp import FastMCP, Context
 

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -23,7 +23,7 @@ The `Context` object provides a clean interface to access MCP features within yo
 - **Prompt Access**: List and retrieve prompts registered with the server
 - **LLM Sampling**: Request the client's LLM to generate text based on provided messages
 - **User Elicitation**: Request structured input from users during tool execution
-- **Session State**: Store data that persists across requests within an MCP session
+- **Request State**: Pass values and non-serializable resources between middleware and handlers within a request (for state that persists across requests, see [Session State](/servers/sessions))
 - **Session Visibility**: [Control which components are visible](/servers/visibility#per-session-visibility) to the current session
 - **Request Information**: Access metadata about the current request
 - **Server Access**: When needed, access the underlying FastMCP server instance
@@ -71,7 +71,7 @@ async def data_analysis_request(dataset: str, ctx: Context = CurrentContext()) -
 
 - Dependency parameters are automatically excluded from the MCP schema—clients never see them.
 - Context methods are async, so your function usually needs to be async as well.
-- **Each MCP request receives a new context object.** Request-scoped values, including non-serializable state, are not available in subsequent requests. Serializable session state stored with `ctx.set_state()` persists across requests in the same MCP session.
+- **Each MCP request receives a new context object.** State set with `ctx.set_state()` is scoped to that request and is not available in subsequent ones. To persist state across requests, use [Session State](/servers/sessions).
 - Context is only available during a request; attempting to use context methods outside a request will raise errors.
 
 ### Legacy Type-Hint Injection
@@ -211,116 +211,62 @@ messages = result.messages
 - **`ctx.list_prompts() -> list[MCPPrompt]`**: Returns list of all available prompts
 - **`ctx.get_prompt(name: str, arguments: dict[str, Any] | None = None) -> GetPromptResult`**: Get a specific prompt with optional arguments
 
-### Session State
+### Request State
 
 <VersionBadge version="3.0.0" />
 
-On a session-based (handshake-era) connection, `ctx.set_state` persists data across multiple requests within the same MCP session, automatically keyed by the client's session for isolation between clients. On the modern stateless protocol it is request-scoped instead — see the note below.
+Request state carries values *within a single request*, across the middleware → handler pipeline. A request runs through any middleware you've added and then the handler — separate functions that don't share a stack frame, so a plain local variable can't pass anything between them. `ctx.set_state` / `ctx.get_state` is that channel.
 
-<Note>
-This cross-request persistence relies on a session-based (handshake-era) connection. The modern (`2026-07-28`) protocol is stateless and has no session, so on those connections `ctx.set_state` is scoped to the single request. For state that persists across requests on any connection — keyed to the authenticated user and safe across tenants — use [Session State](/servers/sessions).
-</Note>
-
-```python
-from fastmcp import FastMCP, Context
-
-mcp = FastMCP("stateful-app")
-
-@mcp.tool
-async def increment_counter(ctx: Context) -> int:
-    """Increment a counter that persists across tool calls."""
-    count = await ctx.get_state("counter") or 0
-    await ctx.set_state("counter", count + 1)
-    return count + 1
-
-@mcp.tool
-async def get_counter(ctx: Context) -> int:
-    """Get the current counter value."""
-    return await ctx.get_state("counter") or 0
-```
-
-Each client session has its own isolated state—two different clients calling `increment_counter` will each have their own counter.
-
-**Method signatures:**
-- **`await ctx.set_state(key, value, *, serializable=True)`**: Store a value in session state
-- **`await ctx.get_state(key)`**: Retrieve a value (returns None if not found)
-- **`await ctx.delete_state(key)`**: Remove a value from session state
-
-<Note>
-State methods are async and require `await`. State expires after 1 day to prevent unbounded memory growth.
-</Note>
-
-#### Non-Serializable Values
-
-By default, state values must be JSON-serializable (dicts, lists, strings, numbers, etc.) so they can be persisted across requests. For non-serializable values like HTTP clients or database connections, pass `serializable=False`:
-
-```python
-@mcp.tool
-async def my_tool(ctx: Context) -> str:
-    # This object can't be JSON-serialized
-    client = SomeHTTPClient(base_url="https://api.example.com")
-    await ctx.set_state("client", client, serializable=False)
-
-    # Retrieve it later in the same request
-    client = await ctx.get_state("client")
-    return await client.fetch("/data")
-```
-
-Values stored with `serializable=False` only live for the current MCP request (a single tool call, resource read, or prompt render). They will not be available in subsequent requests within the session.
-
-#### Custom Storage Backends
-
-By default, session state uses an in-memory store suitable for single-server deployments. For distributed or serverless deployments, provide a custom storage backend:
-
-```python
-from key_value.aio.stores.redis import RedisStore
-
-# Use Redis for distributed state
-mcp = FastMCP("distributed-app", session_state_store=RedisStore(...))
-```
-
-Any backend compatible with the [py-key-value-aio](https://github.com/strawgate/py-key-value) `AsyncKeyValue` protocol works. See [Storage Backends](/servers/storage-backends) for more options including Redis, DynamoDB, and MongoDB.
-
-#### State and Mounted Servers
-
-Each `FastMCP` instance has its own session state store. When you `mount()` a child server, state set on the parent is not visible to tools on the child, and vice versa:
+The common case is a middleware that resolves something once and every tool reads it, rather than each tool recomputing it:
 
 ```python
 from fastmcp import FastMCP, Context
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
-parent = FastMCP("Parent")
-child = FastMCP("Child")
-parent.mount(child, namespace="child")
+mcp = FastMCP("app")
 
-class Stasher(Middleware):
+
+class Enrich(Middleware):
     async def on_call_tool(self, context: MiddlewareContext, call_next):
-        await context.fastmcp_context.set_state("user", "alice")
+        await context.fastmcp_context.set_state("caller", "alice")
         return await call_next(context)
 
-parent.add_middleware(Stasher())
 
-@child.tool
+mcp.add_middleware(Enrich())
+
+
+@mcp.tool
 async def whoami(ctx: Context) -> str:
-    return await ctx.get_state("user") or "unknown"  # returns "unknown"
+    return await ctx.get_state("caller") or "unknown"
 ```
 
-To share state across the mount boundary, pass the same store to both servers:
+The state is scoped to the one request and discarded when it returns. State is also inherited by mounted children, so a value a parent middleware sets is visible to a mounted server's tools within the same request.
+
+**Method signatures:**
+
+- **`await ctx.set_state(key, value, *, serializable=True)`** — store a value
+- **`await ctx.get_state(key)`** — retrieve a value (returns `None` if not set)
+- **`await ctx.delete_state(key)`** — remove a value
+
+#### Non-serializable resources
+
+The most useful thing request state holds is objects you *can't* persist — a database connection or an HTTP client that a middleware or the [lifespan](/servers/lifespan) opens and a handler uses. Pass `serializable=False`:
 
 ```python
-from key_value.aio.stores.memory import MemoryStore
+@mcp.tool
+async def my_tool(ctx: Context) -> str:
+    client = SomeHTTPClient(base_url="https://api.example.com")
+    await ctx.set_state("client", client, serializable=False)
 
-store = MemoryStore()
-parent = FastMCP("Parent", session_state_store=store)
-child = FastMCP("Child", session_state_store=store)
-parent.mount(child, namespace="child")
+    client = await ctx.get_state("client")
+    return await client.fetch("/data")
 ```
 
-Alternatively, state set with `serializable=False` lives on the request context and is inherited by mounted children automatically — use it when the value is request-scoped and does not need to persist across tool calls.
+A `serializable=False` value lives on the request context for the current call only. It is inherently request-scoped — a live connection can't be serialized and stored — which is exactly why it belongs here rather than in a persistent store.
 
-#### State During Initialization
+#### Persisting across requests
 
-State set during `on_initialize` middleware persists to subsequent tool calls when using the same session object (STDIO, SSE, single-server HTTP). For distributed/serverless HTTP deployments where different machines handle init and tool calls, state is isolated by the `mcp-session-id` header.
+Request state does not survive from one call to the next. When you need a cart, a conversation, or any state that outlives a single request, use [Session State](/servers/sessions) — it stores server-side, keyed by the authenticated user, and works on every protocol era. (On session-based, handshake-era connections, serializable request state also persists across the session, but Session State is the deliberate, cross-era way to do it.)
 
 ### Session Visibility
 

--- a/docs/servers/sessions.mdx
+++ b/docs/servers/sessions.mdx
@@ -42,7 +42,7 @@ Sometimes one user needs more than one bucket — separate carts, parallel conve
 
 Declare a `SessionId` parameter. Unlike `UserSession`, it appears in the input schema as a string, because the agent is the one that supplies it. FastMCP fills in that argument's description for you — instructing the agent to obtain an id and pass it back — so the tool teaches the protocol on its own, with no prompting on your side.
 
-An agent obtains an id by calling `create_session`, and that tool comes from a `SessionProvider`. Register one whenever your tools take a `session_id`. The provider mints ids and ends sessions; a server whose tools declare `session_id` but registers no provider raises a clear error, naming the offending tool, before any tool can be called.
+An agent obtains an id by calling `create_session`, which comes from a `SessionProvider` — [providers](/servers/providers/overview) are how FastMCP contributes functionality like this. Register one whenever your tools take a `session_id`. Without it there is no way to mint an id, so every id is rejected and the tools cannot resolve a session — a mistake you catch the first time you run them.
 
 ```python
 from fastmcp import FastMCP

--- a/docs/servers/sessions.mdx
+++ b/docs/servers/sessions.mdx
@@ -46,8 +46,7 @@ An agent obtains an id by calling `create_session`, which comes from a `SessionP
 
 ```python
 from fastmcp import FastMCP
-from fastmcp.server.sessions import SessionId, SessionProvider
-from fastmcp.server.dependencies import get_context
+from fastmcp.server.sessions import SessionId, SessionProvider, get_session
 
 mcp = FastMCP("shop")
 mcp.add_provider(SessionProvider())
@@ -55,12 +54,14 @@ mcp.add_provider(SessionProvider())
 
 @mcp.tool
 async def add_to_cart(item: str, session_id: SessionId) -> str:
-    session = await get_context().get_session(session_id)
+    session = await get_session(session_id)
     cart = await session.get("cart", default=[])
     cart.append(item)
     await session.set("cart", cart)
     return f"{len(cart)} items in cart."
 ```
+
+`get_session` resolves and validates the id, returning a [`Session`](#the-session-object). It is a standalone function, not a context method, so it needs no foreground context and works from a [background task](/servers/tasks)'s worker as well as a normal request.
 
 A session id is real and owned: `create_session` records it under the current user, and only an id created that way resolves. Passing an id that was never created — or one created by a different user — raises rather than quietly opening a fresh bucket, so a typo or a stolen id fails loudly instead of misrouting state.
 

--- a/docs/servers/sessions.mdx
+++ b/docs/servers/sessions.mdx
@@ -70,6 +70,8 @@ When your application already mints its own identifiers — conversation ids, wo
 
 Both patterns give a tool a `Session`: an async view over one bucket of stored state. Read a value with `await session.get(key, default=None)`, write one with `await session.set(key, value)`, and remove one with `await session.delete(key)`. Values are stored as JSON, so anything JSON-serializable round-trips.
 
+The session's own identifier is available as `session.id` — the id for a session resolved from a `session_id` argument, and `None` for an injected `UserSession`, which has no distinct id because its bucket is the authenticated user.
+
 `await session.clear()` empties the session's state while keeping the session itself valid — the id still resolves, the bucket is just empty. To retire a session entirely, an agent calls `end_session`, which deletes it so the id no longer resolves at all.
 
 ## Isolation

--- a/docs/servers/sessions.mdx
+++ b/docs/servers/sessions.mdx
@@ -1,0 +1,84 @@
+---
+title: Session State
+sidebarTitle: Sessions
+description: Persist state across requests on stateless connections.
+icon: id-badge
+---
+
+import { VersionBadge } from "/snippets/version-badge.mdx"
+
+<VersionBadge version="4.0.0" />
+
+The modern MCP protocol (`2026-07-28`) is stateless. Every request stands alone: the server builds a fresh connection to handle it and discards everything when it returns. There is no session to hang state on, so a tool that wants to remember something between calls — the items in a cart, the thread of a conversation, a running total — has nowhere to keep it. Store it on the connection and it vanishes the moment the request finishes.
+
+This is a deliberate choice in the protocol. Weighing protocol-level sessions against statelessness, the MCP working group [chose statelessness](https://github.com/modelcontextprotocol/transports-wg/blob/main/docs/sessions-vs-sessionless-decision.md) and moved session semantics up to the application: the server hands the client an identifier, and the client passes it back as an argument on later calls. Their own example is a shopping cart — the server returns a `basket_id`, and the client includes it in each subsequent `add_item` and `checkout` call.
+
+FastMCP implements that pattern as **session state**, and adds the one thing the bare handle lacks: isolation. State is stored server-side and keyed to the authenticated user, so a handle is inert in anyone else's hands. You pick one of two shapes per tool, depending on whether a user has a single bucket of state or many.
+
+## Per-user state
+
+Most tools that remember things want one bucket per user — their preferences, their history, their accumulated context. Declare a `UserSession` parameter and FastMCP injects it, keyed to the authenticated user. It behaves like the request [context](/servers/context): it never appears in the tool's input schema and the caller passes nothing, because the user's identity comes from their validated credentials and selects the right bucket automatically.
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.sessions import UserSession
+
+mcp = FastMCP("assistant")
+
+
+@mcp.tool
+async def remember(fact: str, session: UserSession) -> str:
+    facts = await session.get("facts", default=[])
+    facts.append(fact)
+    await session.set("facts", facts)
+    return f"Remembered {len(facts)} facts."
+```
+
+Because the bucket is chosen from the caller's identity, `UserSession` requires [authentication](/servers/auth/authentication). On an unauthenticated request there is no user to key on, so the tool raises a clear error rather than guessing at a bucket.
+
+## Distinct sessions
+
+Sometimes one user needs more than one bucket — separate carts, parallel conversations, independent workflows. Now the caller has to say *which* session it means, so the identifier becomes a tool argument.
+
+Declare a `SessionId` parameter. Unlike `UserSession`, it appears in the input schema as a string, because the agent is the one that supplies it. FastMCP fills in that argument's description for you — instructing the agent to obtain an id and pass it back — so the tool teaches the protocol on its own, with no prompting on your side.
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.sessions import SessionId
+from fastmcp.server.dependencies import get_context
+
+mcp = FastMCP("shop")
+
+
+@mcp.tool
+async def add_to_cart(item: str, session_id: SessionId) -> str:
+    session = get_context().get_session(session_id)
+    cart = await session.get("cart", default=[])
+    cart.append(item)
+    await session.set("cart", cart)
+    return f"{len(cart)} items in cart."
+```
+
+An agent obtains an id by calling `create_session`. FastMCP registers that tool — along with `end_session` — automatically, the moment any tool on the server declares a `SessionId`. The lifecycle tools are only meaningful once a session argument exists, so wiring them by hand would be one more thing to forget; declaring the argument is the whole opt-in. When your application already mints its own identifiers — conversation ids, workflow ids — pass `auto_session_provider=False` to `FastMCP` and hand those ids in directly instead.
+
+## The session object
+
+Both patterns give a tool a `Session`: an async view over one bucket of stored state. Read a value with `await session.get(key, default=None)`, write one with `await session.set(key, value)`, remove one with `await session.delete(key)`, and empty the whole session with `await session.clear()`. Values are stored as JSON, so anything JSON-serializable round-trips.
+
+## Isolation
+
+Every session is keyed by two things, in this order: the authenticated user, then the session id. The order is the whole security model. The user is the wall; the id only organizes sessions *within* that wall.
+
+On an authenticated request the user comes from the validated token, which the caller cannot forge. Two different users can pass the very same session id and never reach each other's data, because each id is namespaced under its user's identity. This makes a session id safe to expose — it travels through the agent's context and your logs, and on its own it grants nothing. Guessing another user's id leads nowhere: it just resolves to an empty session in the guesser's own namespace.
+
+Without authentication there is no user to key on, and the guarantee changes.
+
+**An unauthenticated session is a bearer handle: whoever holds the id can read and write it.** Ids from `create_session` are unguessable, which keeps a caller from stumbling onto another session, but that is guess-resistance, not isolation — a leaked id is a leaked session. Treat unauthenticated sessions as single-tenant: sound for a personal server with one trusted client, never a boundary between tenants. Multi-tenant isolation requires authentication.
+
+## Storage and lifetime
+
+Session state lives in the server's [storage backend](/servers/storage-backends) — in-memory by default, or Redis or another shared store when a fleet of servers must see the same sessions. Because the store owns retention, it owns expiry: set a TTL on the store and sessions age out on their own, while `end_session` (or `session.clear()`) removes one immediately. FastMCP never imposes a lifetime of its own — the store you configure is the single place session data lives and expires.
+
+## Relationship to request state
+
+The request [context](/servers/context) also carries state, through `ctx.set_state` and `ctx.get_state`, and the two solve different problems. Context state is scoped to a single request — the right place for a value that a middleware sets and a handler reads within the same call. Session state is what persists *across* requests. When you need a value to survive from one tool call to the next, reach for `UserSession` or `SessionId`; when it only needs to live for the current request, keep it on the context.

--- a/docs/servers/sessions.mdx
+++ b/docs/servers/sessions.mdx
@@ -46,7 +46,8 @@ An agent obtains an id by calling `create_session`, which comes from a `SessionP
 
 ```python
 from fastmcp import FastMCP
-from fastmcp.server.sessions import SessionId, SessionProvider, get_session
+from fastmcp.server.sessions import SessionId, SessionProvider
+from fastmcp.server.dependencies import get_session
 
 mcp = FastMCP("shop")
 mcp.add_provider(SessionProvider())

--- a/docs/servers/sessions.mdx
+++ b/docs/servers/sessions.mdx
@@ -86,7 +86,19 @@ Without authentication there is no user to key on, and the guarantee changes.
 
 ## Storage and lifetime
 
-Session state lives in the server's [storage backend](/servers/storage-backends) — in-memory by default, or Redis or another shared store when a fleet of servers must see the same sessions. Because the store owns retention, it owns expiry: set a TTL on the store and sessions age out on their own, while `end_session` removes one immediately. FastMCP never imposes a lifetime of its own — the store you configure is the single place session data lives and expires.
+Session state lives in the server's [storage backend](/servers/storage-backends) — in-memory by default, or Redis or another shared store when a fleet of servers must see the same sessions. Because the store owns retention, it owns expiry: FastMCP writes session state without a TTL of its own, so the store you configure is the single place session data lives and expires. To give every session a default lifetime, wrap the store so writes without an explicit TTL get one — for example, the `key-value` library's TTL-clamp wrapper takes a `missing_ttl`:
+
+```python
+from key_value.aio.stores.redis import RedisStore
+from key_value.aio.wrappers.ttl_clamp import TTLClampWrapper
+
+store = RedisStore(url="redis://localhost:6379")
+store = TTLClampWrapper(store, min_ttl=0, max_ttl=86400, missing_ttl=3600)
+
+mcp = FastMCP("shop", session_state_store=store)
+```
+
+Now a session expires an hour after its last write, and `end_session` still removes one immediately.
 
 ## Relationship to request state
 

--- a/docs/servers/sessions.mdx
+++ b/docs/servers/sessions.mdx
@@ -42,34 +42,41 @@ Sometimes one user needs more than one bucket — separate carts, parallel conve
 
 Declare a `SessionId` parameter. Unlike `UserSession`, it appears in the input schema as a string, because the agent is the one that supplies it. FastMCP fills in that argument's description for you — instructing the agent to obtain an id and pass it back — so the tool teaches the protocol on its own, with no prompting on your side.
 
+An agent obtains an id by calling `create_session`, and that tool comes from a `SessionProvider`. Register one whenever your tools take a `session_id`. The provider mints ids and ends sessions; a server whose tools declare `session_id` but registers no provider raises a clear error, naming the offending tool, before any tool can be called.
+
 ```python
 from fastmcp import FastMCP
-from fastmcp.server.sessions import SessionId
+from fastmcp.server.sessions import SessionId, SessionProvider
 from fastmcp.server.dependencies import get_context
 
 mcp = FastMCP("shop")
+mcp.add_provider(SessionProvider())
 
 
 @mcp.tool
 async def add_to_cart(item: str, session_id: SessionId) -> str:
-    session = get_context().get_session(session_id)
+    session = await get_context().get_session(session_id)
     cart = await session.get("cart", default=[])
     cart.append(item)
     await session.set("cart", cart)
     return f"{len(cart)} items in cart."
 ```
 
-An agent obtains an id by calling `create_session`. FastMCP registers that tool — along with `end_session` — automatically, the moment any tool on the server declares a `SessionId`. The lifecycle tools are only meaningful once a session argument exists, so wiring them by hand would be one more thing to forget; declaring the argument is the whole opt-in. When your application already mints its own identifiers — conversation ids, workflow ids — pass `auto_session_provider=False` to `FastMCP` and hand those ids in directly instead.
+A session id is real and owned: `create_session` records it under the current user, and only an id created that way resolves. Passing an id that was never created — or one created by a different user — raises rather than quietly opening a fresh bucket, so a typo or a stolen id fails loudly instead of misrouting state.
+
+When your application already mints its own identifiers — conversation ids, workflow ids — take them as ordinary string arguments rather than `SessionId`, and skip the provider entirely; `SessionId` is specifically the create-then-pass contract backed by `create_session`.
 
 ## The session object
 
-Both patterns give a tool a `Session`: an async view over one bucket of stored state. Read a value with `await session.get(key, default=None)`, write one with `await session.set(key, value)`, remove one with `await session.delete(key)`, and empty the whole session with `await session.clear()`. Values are stored as JSON, so anything JSON-serializable round-trips.
+Both patterns give a tool a `Session`: an async view over one bucket of stored state. Read a value with `await session.get(key, default=None)`, write one with `await session.set(key, value)`, and remove one with `await session.delete(key)`. Values are stored as JSON, so anything JSON-serializable round-trips.
+
+`await session.clear()` empties the session's state while keeping the session itself valid — the id still resolves, the bucket is just empty. To retire a session entirely, an agent calls `end_session`, which deletes it so the id no longer resolves at all.
 
 ## Isolation
 
 Every session is keyed by two things, in this order: the authenticated user, then the session id. The order is the whole security model. The user is the wall; the id only organizes sessions *within* that wall.
 
-On an authenticated request the user comes from the validated token, which the caller cannot forge. Two different users can pass the very same session id and never reach each other's data, because each id is namespaced under its user's identity. This makes a session id safe to expose — it travels through the agent's context and your logs, and on its own it grants nothing. Guessing another user's id leads nowhere: it just resolves to an empty session in the guesser's own namespace.
+On an authenticated request the user comes from the validated token, which the caller cannot forge. Two different users can pass the very same session id and never reach each other's data, because each id is namespaced under its user's identity. This makes a session id safe to expose — it travels through the agent's context and your logs, and on its own it grants nothing. Guessing another user's id leads nowhere: it was created under *their* namespace, so in the guesser's namespace it simply does not exist and the call is rejected.
 
 Without authentication there is no user to key on, and the guarantee changes.
 
@@ -77,7 +84,7 @@ Without authentication there is no user to key on, and the guarantee changes.
 
 ## Storage and lifetime
 
-Session state lives in the server's [storage backend](/servers/storage-backends) — in-memory by default, or Redis or another shared store when a fleet of servers must see the same sessions. Because the store owns retention, it owns expiry: set a TTL on the store and sessions age out on their own, while `end_session` (or `session.clear()`) removes one immediately. FastMCP never imposes a lifetime of its own — the store you configure is the single place session data lives and expires.
+Session state lives in the server's [storage backend](/servers/storage-backends) — in-memory by default, or Redis or another shared store when a fleet of servers must see the same sessions. Because the store owns retention, it owns expiry: set a TTL on the store and sessions age out on their own, while `end_session` removes one immediately. FastMCP never imposes a lifetime of its own — the store you configure is the single place session data lives and expires.
 
 ## Relationship to request state
 

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -48,7 +48,7 @@ from fastmcp.server.sampling.run import (
     sample_step_impl,
 )
 from fastmcp.server.server import FastMCP, StateValue
-from fastmcp.server.sessions import Session, current_principal
+from fastmcp.server.sessions import Session, resolve_session
 from fastmcp.server.transforms.visibility import (
     Visibility,
 )
@@ -1429,8 +1429,8 @@ class Context:
         """Create session-prefixed key for state storage."""
         return f"{self.session_id}:{key}"
 
-    def get_session(self, session_id: str) -> Session:
-        """Resolve a `Session` for an explicit `session_id`, keyed by principal.
+    async def get_session(self, session_id: str) -> Session:
+        """Resolve and validate a `Session` for an explicit `session_id`.
 
         State is keyed by `(principal, session_id)`: the authenticated principal
         is the isolation wall and `session_id` organizes sessions within it. Two
@@ -1438,15 +1438,16 @@ class Context:
         unauthenticated request there is no principal wall — the id alone is the
         key, so sessions are not a boundary between callers.
 
+        The id must have been minted by `create_session` under the current
+        principal. An id that was never created, or created under a different
+        principal, raises `InvalidSession` rather than resolving to a fresh empty
+        bucket.
+
         Pair with a `session_id: SessionId` tool argument (the agent obtains an id
         from `create_session` and passes it back). For a single per-user bucket
         with nothing for the agent to pass, inject `session: UserSession` instead.
         """
-        return Session(
-            store=self.fastmcp._state_store,
-            principal=current_principal(),
-            session_id=session_id,
-        )
+        return await resolve_session(session_id)
 
     async def set_state(
         self, key: str, value: Any, *, serializable: bool = True

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -1440,7 +1440,7 @@ class Context:
 
         Pair with a `session_id: SessionId` tool argument (the agent obtains an id
         from `create_session` and passes it back). For a single per-user bucket
-        with nothing for the agent to pass, inject `session: Session` instead.
+        with nothing for the agent to pass, inject `session: UserSession` instead.
         """
         return Session(
             store=self.fastmcp._state_store,

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -11,6 +11,7 @@ from logging import Logger
 from typing import Any, Literal, cast, overload
 
 import mcp_types
+from key_value.aio.errors import SerializationError
 from mcp import LoggingLevel, ServerSession
 from mcp.server.context import ServerRequestContext
 from mcp_types import (
@@ -27,7 +28,11 @@ from typing_extensions import TypeVar
 from uncalled_for import SharedContext
 
 import fastmcp
-from fastmcp.exceptions import FastMCPDeprecationWarning, ToolError
+from fastmcp.exceptions import (
+    AuthorizationError,
+    FastMCPDeprecationWarning,
+    ToolError,
+)
 from fastmcp.resources.base import ResourceResult
 from fastmcp.server.dependencies import FastMCPRequestContext, fastmcp_request_ctx
 from fastmcp.server.elicitation import (
@@ -44,6 +49,14 @@ from fastmcp.server.sampling.run import (
     sample_step_impl,
 )
 from fastmcp.server.server import FastMCP, StateValue
+from fastmcp.server.sessions import (
+    NoActiveSessionError,
+    Scope,
+    current_principal,
+    get_active_session_identity,
+    session_state_key,
+    user_state_key,
+)
 from fastmcp.server.transforms.visibility import (
     Visibility,
 )
@@ -1424,39 +1437,41 @@ class Context:
         """Create session-prefixed key for state storage."""
         return f"{self.session_id}:{key}"
 
-    async def set_state(
-        self, key: str, value: Any, *, serializable: bool = True
-    ) -> None:
-        """Set a value in the state store.
+    def _scoped_state_key(self, scope: Scope, key: str) -> str:
+        """Resolve the storage key for a non-``REQUEST`` scope.
 
-        By default, values are stored in the session-scoped state store and
-        persist across requests within the same MCP session. Values must be
-        JSON-serializable (dicts, lists, strings, numbers, etc.).
-
-        For non-serializable values (e.g., HTTP clients, database connections),
-        pass ``serializable=False``. These values are stored in a request-scoped
-        dict and only live for the current MCP request (tool call, resource
-        read, or prompt render). They will not be available in subsequent
-        requests.
-
-        The key is automatically prefixed with the session identifier.
+        ``USER`` keys off the authenticated principal and raises when there is no
+        authentication; ``SESSION`` keys off ``(principal, session_id)`` from the
+        verified session handle bound onto the request and raises when no session
+        is active.
         """
-        prefixed_key = self._make_state_key(key)
-        if not serializable:
-            self._request_state[prefixed_key] = value
-            return
-        # Clear any request-scoped shadow so the session value is visible
-        self._request_state.pop(prefixed_key, None)
+        if scope is Scope.USER:
+            principal = current_principal()
+            if principal is None:
+                raise AuthorizationError(
+                    "Scope.USER state requires authentication, but no "
+                    "authenticated principal is present on this request."
+                )
+            return user_state_key(principal, key)
+        if scope is Scope.SESSION:
+            identity = get_active_session_identity()
+            if identity is None:
+                raise NoActiveSessionError
+            return session_state_key(identity, key)
+        raise ValueError(f"Unsupported scope: {scope!r}")
+
+    async def _put_state(self, prefixed_key: str, key: str, value: Any) -> None:
+        """Store a value in the shared state store, translating serialize errors."""
         try:
             await self.fastmcp._state_store.put(
                 key=prefixed_key,
                 value=StateValue(value=value),
                 ttl=self._STATE_TTL_SECONDS,
             )
-        except Exception as e:
-            # Catch serialization errors from Pydantic (ValueError) or
-            # the key_value library (SerializationError). Both contain
-            # "serialize" in the message. Other exceptions propagate as-is.
+        except (ValueError, SerializationError) as e:
+            # Pydantic raises PydanticSerializationError (a ValueError) and the
+            # key_value library raises SerializationError; both carry "serialize"
+            # in the message. Other ValueErrors propagate unchanged.
             if "serialize" in str(e).lower():
                 raise TypeError(
                     f"Value for state key {key!r} is not serializable. "
@@ -1466,27 +1481,86 @@ class Context:
                 ) from e
             raise
 
-    async def get_state(self, key: str) -> Any:
+    async def set_state(
+        self,
+        key: str,
+        value: Any,
+        *,
+        serializable: bool = True,
+        scope: Scope = Scope.REQUEST,
+    ) -> None:
+        """Set a value in the state store.
+
+        The ``scope`` selects the storage isolation (see `Scope`):
+
+        - ``Scope.REQUEST`` (default): per-request connection state, keyed by the
+          session identifier. This preserves the historical behavior — on a
+          modern (stateless) connection it lives only for the request; on a
+          stateful connection it persists across requests in the same session.
+        - ``Scope.USER``: keyed by the authenticated principal; spans sessions.
+          Raises ``AuthorizationError`` when the request is unauthenticated.
+        - ``Scope.SESSION``: keyed by ``(principal, session_id)`` from a verified
+          session handle. Raises ``NoActiveSessionError`` when no session is
+          bound to the request.
+
+        By default, values are stored in the persisted state store and must be
+        JSON-serializable (dicts, lists, strings, numbers, etc.).
+
+        For non-serializable values (e.g., HTTP clients, database connections),
+        pass ``serializable=False``. These are stored in a request-scoped dict
+        that only lives for the current MCP request and are only supported with
+        ``Scope.REQUEST``.
+        """
+        if scope is Scope.REQUEST:
+            prefixed_key = self._make_state_key(key)
+            if not serializable:
+                self._request_state[prefixed_key] = value
+                return
+            # Clear any request-scoped shadow so the persisted value is visible
+            self._request_state.pop(prefixed_key, None)
+            await self._put_state(prefixed_key, key, value)
+            return
+
+        if not serializable:
+            raise ValueError(
+                "serializable=False is only supported with Scope.REQUEST; "
+                f"{scope} state is persisted and must be serializable."
+            )
+        prefixed_key = self._scoped_state_key(scope, key)
+        await self._put_state(prefixed_key, key, value)
+
+    async def get_state(self, key: str, *, scope: Scope = Scope.REQUEST) -> Any:
         """Get a value from the state store.
 
-        Checks request-scoped state first (set with ``serializable=False``),
-        then falls back to the session-scoped state store.
+        With ``Scope.REQUEST`` (default), checks request-scoped state first (set
+        with ``serializable=False``), then falls back to the persisted store.
+        ``Scope.USER`` and ``Scope.SESSION`` read only from the persisted store
+        under their scoped key (see `set_state` for the isolation rules and the
+        errors raised when auth or a session is missing).
 
         Returns None if the key is not found.
         """
-        prefixed_key = self._make_state_key(key)
-        if prefixed_key in self._request_state:
-            return self._request_state[prefixed_key]
+        if scope is Scope.REQUEST:
+            prefixed_key = self._make_state_key(key)
+            if prefixed_key in self._request_state:
+                return self._request_state[prefixed_key]
+        else:
+            prefixed_key = self._scoped_state_key(scope, key)
         result = await self.fastmcp._state_store.get(key=prefixed_key)
         return result.value if result is not None else None
 
-    async def delete_state(self, key: str) -> None:
+    async def delete_state(self, key: str, *, scope: Scope = Scope.REQUEST) -> None:
         """Delete a value from the state store.
 
-        Removes from both request-scoped and session-scoped stores.
+        With ``Scope.REQUEST`` (default), removes from both the request-scoped and
+        persisted stores. ``Scope.USER`` and ``Scope.SESSION`` remove from the
+        persisted store under their scoped key.
         """
-        prefixed_key = self._make_state_key(key)
-        self._request_state.pop(prefixed_key, None)
+        if scope is Scope.REQUEST:
+            prefixed_key = self._make_state_key(key)
+            self._request_state.pop(prefixed_key, None)
+        else:
+            prefixed_key = self._scoped_state_key(scope, key)
         await self.fastmcp._state_store.delete(key=prefixed_key)
 
     # -------------------------------------------------------------------------

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -29,7 +29,6 @@ from uncalled_for import SharedContext
 
 import fastmcp
 from fastmcp.exceptions import (
-    AuthorizationError,
     FastMCPDeprecationWarning,
     ToolError,
 )
@@ -49,15 +48,7 @@ from fastmcp.server.sampling.run import (
     sample_step_impl,
 )
 from fastmcp.server.server import FastMCP, StateValue
-from fastmcp.server.sessions import (
-    NoActiveSessionError,
-    Scope,
-    current_principal,
-    get_active_session_identity,
-    session_index_key,
-    session_state_key,
-    user_state_key,
-)
+from fastmcp.server.sessions import Session, current_principal
 from fastmcp.server.transforms.visibility import (
     Visibility,
 )
@@ -1438,31 +1429,48 @@ class Context:
         """Create session-prefixed key for state storage."""
         return f"{self.session_id}:{key}"
 
-    def _scoped_state_key(self, scope: Scope, key: str) -> str:
-        """Resolve the storage key for a non-``REQUEST`` scope.
+    def get_session(self, session_id: str) -> Session:
+        """Resolve a `Session` for an explicit `session_id`, keyed by principal.
 
-        ``USER`` keys off the authenticated principal and raises when there is no
-        authentication; ``SESSION`` keys off ``(principal, session_id)`` from the
-        verified session handle bound onto the request and raises when no session
-        is active.
+        State is keyed by `(principal, session_id)`: the authenticated principal
+        is the isolation wall and `session_id` organizes sessions within it. Two
+        principals passing the *same* `session_id` reach different buckets. On an
+        unauthenticated request there is no principal wall — the id alone is the
+        key, so sessions are not a boundary between callers.
+
+        Pair with a `session_id: SessionId` tool argument (the agent obtains an id
+        from `create_session` and passes it back). For a single per-user bucket
+        with nothing for the agent to pass, inject `session: Session` instead.
         """
-        if scope is Scope.USER:
-            principal = current_principal()
-            if principal is None:
-                raise AuthorizationError(
-                    "Scope.USER state requires authentication, but no "
-                    "authenticated principal is present on this request."
-                )
-            return user_state_key(principal, key)
-        if scope is Scope.SESSION:
-            identity = get_active_session_identity()
-            if identity is None:
-                raise NoActiveSessionError
-            return session_state_key(identity, key)
-        raise ValueError(f"Unsupported scope: {scope!r}")
+        return Session(
+            store=self.fastmcp._state_store,
+            principal=current_principal(),
+            session_id=session_id,
+        )
 
-    async def _put_state(self, prefixed_key: str, key: str, value: Any) -> None:
-        """Store a value in the shared state store, translating serialize errors."""
+    async def set_state(
+        self, key: str, value: Any, *, serializable: bool = True
+    ) -> None:
+        """Set a value in the state store.
+
+        By default, values are stored in the session-scoped state store and
+        persist across requests within the same MCP session. Values must be
+        JSON-serializable (dicts, lists, strings, numbers, etc.).
+
+        For non-serializable values (e.g., HTTP clients, database connections),
+        pass ``serializable=False``. These values are stored in a request-scoped
+        dict and only live for the current MCP request (tool call, resource
+        read, or prompt render). They will not be available in subsequent
+        requests.
+
+        The key is automatically prefixed with the session identifier.
+        """
+        prefixed_key = self._make_state_key(key)
+        if not serializable:
+            self._request_state[prefixed_key] = value
+            return
+        # Clear any request-scoped shadow so the session value is visible
+        self._request_state.pop(prefixed_key, None)
         try:
             await self.fastmcp._state_store.put(
                 key=prefixed_key,
@@ -1482,128 +1490,27 @@ class Context:
                 ) from e
             raise
 
-    async def set_state(
-        self,
-        key: str,
-        value: Any,
-        *,
-        serializable: bool = True,
-        scope: Scope = Scope.REQUEST,
-    ) -> None:
-        """Set a value in the state store.
-
-        The ``scope`` selects the storage isolation (see `Scope`):
-
-        - ``Scope.REQUEST`` (default): per-request connection state, keyed by the
-          session identifier. This preserves the historical behavior — on a
-          modern (stateless) connection it lives only for the request; on a
-          stateful connection it persists across requests in the same session.
-        - ``Scope.USER``: keyed by the authenticated principal; spans sessions.
-          Raises ``AuthorizationError`` when the request is unauthenticated.
-        - ``Scope.SESSION``: keyed by ``(principal, session_id)`` from a verified
-          session handle. Raises ``NoActiveSessionError`` when no session is
-          bound to the request.
-
-        By default, values are stored in the persisted state store and must be
-        JSON-serializable (dicts, lists, strings, numbers, etc.).
-
-        For non-serializable values (e.g., HTTP clients, database connections),
-        pass ``serializable=False``. These are stored in a request-scoped dict
-        that only lives for the current MCP request and are only supported with
-        ``Scope.REQUEST``.
-        """
-        if scope is Scope.REQUEST:
-            prefixed_key = self._make_state_key(key)
-            if not serializable:
-                self._request_state[prefixed_key] = value
-                return
-            # Clear any request-scoped shadow so the persisted value is visible
-            self._request_state.pop(prefixed_key, None)
-            await self._put_state(prefixed_key, key, value)
-            return
-
-        if not serializable:
-            raise ValueError(
-                "serializable=False is only supported with Scope.REQUEST; "
-                f"{scope} state is persisted and must be serializable."
-            )
-        prefixed_key = self._scoped_state_key(scope, key)
-        await self._put_state(prefixed_key, key, value)
-        if scope is Scope.SESSION:
-            await self._record_session_key(key)
-
-    async def _record_session_key(self, key: str) -> None:
-        """Record a user key in the active session's index for later cleanup.
-
-        `end_session` (and `clear_session_state`) enumerate this index to delete
-        a session's state without depending on the store's optional
-        key-enumeration protocol. Best-effort: a lost update under concurrent
-        writes leaves an orphaned key that the state TTL eventually reaps.
-        """
-        identity = get_active_session_identity()
-        if identity is None:
-            return
-        index_key = session_index_key(identity)
-        result = await self.fastmcp._state_store.get(key=index_key)
-        keys: list[str] = list(result.value) if result is not None else []
-        if key in keys:
-            return
-        keys.append(key)
-        await self.fastmcp._state_store.put(
-            key=index_key,
-            value=StateValue(value=keys),
-            ttl=self._STATE_TTL_SECONDS,
-        )
-
-    async def clear_session_state(self) -> None:
-        """Delete all `Scope.SESSION` state for the session bound to this request.
-
-        Removes every key recorded in the active session's index along with the
-        index itself. Raises `NoActiveSessionError` when no verified session is
-        bound to the request.
-        """
-        identity = get_active_session_identity()
-        if identity is None:
-            raise NoActiveSessionError
-        index_key = session_index_key(identity)
-        result = await self.fastmcp._state_store.get(key=index_key)
-        keys: list[str] = list(result.value) if result is not None else []
-        for key in keys:
-            await self.fastmcp._state_store.delete(key=session_state_key(identity, key))
-        await self.fastmcp._state_store.delete(key=index_key)
-
-    async def get_state(self, key: str, *, scope: Scope = Scope.REQUEST) -> Any:
+    async def get_state(self, key: str) -> Any:
         """Get a value from the state store.
 
-        With ``Scope.REQUEST`` (default), checks request-scoped state first (set
-        with ``serializable=False``), then falls back to the persisted store.
-        ``Scope.USER`` and ``Scope.SESSION`` read only from the persisted store
-        under their scoped key (see `set_state` for the isolation rules and the
-        errors raised when auth or a session is missing).
+        Checks request-scoped state first (set with ``serializable=False``),
+        then falls back to the session-scoped state store.
 
         Returns None if the key is not found.
         """
-        if scope is Scope.REQUEST:
-            prefixed_key = self._make_state_key(key)
-            if prefixed_key in self._request_state:
-                return self._request_state[prefixed_key]
-        else:
-            prefixed_key = self._scoped_state_key(scope, key)
+        prefixed_key = self._make_state_key(key)
+        if prefixed_key in self._request_state:
+            return self._request_state[prefixed_key]
         result = await self.fastmcp._state_store.get(key=prefixed_key)
         return result.value if result is not None else None
 
-    async def delete_state(self, key: str, *, scope: Scope = Scope.REQUEST) -> None:
+    async def delete_state(self, key: str) -> None:
         """Delete a value from the state store.
 
-        With ``Scope.REQUEST`` (default), removes from both the request-scoped and
-        persisted stores. ``Scope.USER`` and ``Scope.SESSION`` remove from the
-        persisted store under their scoped key.
+        Removes from both request-scoped and session-scoped stores.
         """
-        if scope is Scope.REQUEST:
-            prefixed_key = self._make_state_key(key)
-            self._request_state.pop(prefixed_key, None)
-        else:
-            prefixed_key = self._scoped_state_key(scope, key)
+        prefixed_key = self._make_state_key(key)
+        self._request_state.pop(prefixed_key, None)
         await self.fastmcp._state_store.delete(key=prefixed_key)
 
     # -------------------------------------------------------------------------

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -48,7 +48,6 @@ from fastmcp.server.sampling.run import (
     sample_step_impl,
 )
 from fastmcp.server.server import FastMCP, StateValue
-from fastmcp.server.sessions import Session, resolve_session
 from fastmcp.server.transforms.visibility import (
     Visibility,
 )
@@ -1428,26 +1427,6 @@ class Context:
     def _make_state_key(self, key: str) -> str:
         """Create session-prefixed key for state storage."""
         return f"{self.session_id}:{key}"
-
-    async def get_session(self, session_id: str) -> Session:
-        """Resolve and validate a `Session` for an explicit `session_id`.
-
-        State is keyed by `(principal, session_id)`: the authenticated principal
-        is the isolation wall and `session_id` organizes sessions within it. Two
-        principals passing the *same* `session_id` reach different buckets. On an
-        unauthenticated request there is no principal wall — the id alone is the
-        key, so sessions are not a boundary between callers.
-
-        The id must have been minted by `create_session` under the current
-        principal. An id that was never created, or created under a different
-        principal, raises `InvalidSession` rather than resolving to a fresh empty
-        bucket.
-
-        Pair with a `session_id: SessionId` tool argument (the agent obtains an id
-        from `create_session` and passes it back). For a single per-user bucket
-        with nothing for the agent to pass, inject `session: UserSession` instead.
-        """
-        return await resolve_session(session_id)
 
     async def set_state(
         self, key: str, value: Any, *, serializable: bool = True

--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -54,6 +54,7 @@ from fastmcp.server.sessions import (
     Scope,
     current_principal,
     get_active_session_identity,
+    session_index_key,
     session_state_key,
     user_state_key,
 )
@@ -1528,6 +1529,48 @@ class Context:
             )
         prefixed_key = self._scoped_state_key(scope, key)
         await self._put_state(prefixed_key, key, value)
+        if scope is Scope.SESSION:
+            await self._record_session_key(key)
+
+    async def _record_session_key(self, key: str) -> None:
+        """Record a user key in the active session's index for later cleanup.
+
+        `end_session` (and `clear_session_state`) enumerate this index to delete
+        a session's state without depending on the store's optional
+        key-enumeration protocol. Best-effort: a lost update under concurrent
+        writes leaves an orphaned key that the state TTL eventually reaps.
+        """
+        identity = get_active_session_identity()
+        if identity is None:
+            return
+        index_key = session_index_key(identity)
+        result = await self.fastmcp._state_store.get(key=index_key)
+        keys: list[str] = list(result.value) if result is not None else []
+        if key in keys:
+            return
+        keys.append(key)
+        await self.fastmcp._state_store.put(
+            key=index_key,
+            value=StateValue(value=keys),
+            ttl=self._STATE_TTL_SECONDS,
+        )
+
+    async def clear_session_state(self) -> None:
+        """Delete all `Scope.SESSION` state for the session bound to this request.
+
+        Removes every key recorded in the active session's index along with the
+        index itself. Raises `NoActiveSessionError` when no verified session is
+        bound to the request.
+        """
+        identity = get_active_session_identity()
+        if identity is None:
+            raise NoActiveSessionError
+        index_key = session_index_key(identity)
+        result = await self.fastmcp._state_store.get(key=index_key)
+        keys: list[str] = list(result.value) if result is not None else []
+        for key in keys:
+            await self.fastmcp._state_store.delete(key=session_state_key(identity, key))
+        await self.fastmcp._state_store.delete(key=index_key)
 
     async def get_state(self, key: str, *, scope: Scope = Scope.REQUEST) -> Any:
         """Get a value from the state store.

--- a/fastmcp_slim/fastmcp/server/dependencies.py
+++ b/fastmcp_slim/fastmcp/server/dependencies.py
@@ -272,10 +272,11 @@ except ImportError:
 
 
 def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
-    """Transform ctx: Context into ctx: Context = CurrentContext().
+    """Transform injected-by-type params into Dependency-defaulted params.
 
-    Transforms ALL params typed as Context to use Docket's DI system,
-    unless they already have a Dependency-based default (like CurrentContext()).
+    Transforms ALL params typed as Context (into ``= CurrentContext()``) and as
+    Session (into ``= CurrentSession()``) to use Docket's DI system, unless they
+    already have a Dependency-based default.
 
     This unifies the legacy type annotation DI with Docket's Depends() system,
     allowing both patterns to work through a single resolution path.
@@ -291,6 +292,7 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
         Function with modified signature (same function object, updated __signature__)
     """
     from fastmcp.server.context import Context
+    from fastmcp.server.sessions import Session
 
     # Get the function's signature
     try:
@@ -307,13 +309,20 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
     # First pass: identify which params need transformation
     params_to_transform: set[str] = set()
     optional_context_params: set[str] = set()
+    session_params: set[str] = set()
     for name, param in sig.parameters.items():
         annotation = type_hints.get(name, param.annotation)
+        if isinstance(param.default, Dependency):
+            continue
         if is_class_member_of_type(annotation, Context):
-            if not isinstance(param.default, Dependency):
-                params_to_transform.add(name)
-                if param.default is None:
-                    optional_context_params.add(name)
+            params_to_transform.add(name)
+            if param.default is None:
+                optional_context_params.add(name)
+        elif is_class_member_of_type(annotation, Session):
+            # `session: Session` rides the same DI path as `ctx: Context`:
+            # injected per authenticated principal, excluded from the schema.
+            params_to_transform.add(name)
+            session_params.add(name)
 
     if not params_to_transform:
         return fn
@@ -334,12 +343,16 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
     var_keyword: list[P] = []  # **kwargs (at most one)
 
     for name, param in sig.parameters.items():
-        # Transform Context params by adding CurrentContext default
+        # Transform injected-by-type params by adding a Dependency default
         if name in params_to_transform:
             # We use CurrentContext() instead of Depends(get_context) because
             # get_context() returns the Context which is an AsyncContextManager,
             # and the DI system would try to enter it again (it's already entered)
-            if name in optional_context_params:
+            if name in session_params:
+                from fastmcp.server.sessions import CurrentSession
+
+                param = param.replace(default=CurrentSession())
+            elif name in optional_context_params:
                 param = param.replace(default=OptionalCurrentContext())
             else:
                 param = param.replace(default=CurrentContext())

--- a/fastmcp_slim/fastmcp/server/dependencies.py
+++ b/fastmcp_slim/fastmcp/server/dependencies.py
@@ -275,8 +275,8 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Transform injected-by-type params into Dependency-defaulted params.
 
     Transforms ALL params typed as Context (into ``= CurrentContext()``) and as
-    Session (into ``= CurrentSession()``) to use Docket's DI system, unless they
-    already have a Dependency-based default.
+    UserSession (into ``= CurrentSession()``) to use Docket's DI system, unless
+    they already have a Dependency-based default.
 
     This unifies the legacy type annotation DI with Docket's Depends() system,
     allowing both patterns to work through a single resolution path.
@@ -292,7 +292,7 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
         Function with modified signature (same function object, updated __signature__)
     """
     from fastmcp.server.context import Context
-    from fastmcp.server.sessions import Session
+    from fastmcp.server.sessions import UserSession
 
     # Get the function's signature
     try:
@@ -318,9 +318,11 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
             params_to_transform.add(name)
             if param.default is None:
                 optional_context_params.add(name)
-        elif is_class_member_of_type(annotation, Session):
-            # `session: Session` rides the same DI path as `ctx: Context`:
-            # injected per authenticated principal, excluded from the schema.
+        elif is_class_member_of_type(annotation, UserSession):
+            # `session: UserSession` rides the same DI path as `ctx: Context`:
+            # injected per authenticated principal, excluded from the schema. A
+            # bare `session: Session` is NOT injected — only the `UserSession`
+            # marker keys the per-user injection.
             params_to_transform.add(name)
             session_params.add(name)
 

--- a/fastmcp_slim/fastmcp/server/dependencies.py
+++ b/fastmcp_slim/fastmcp/server/dependencies.py
@@ -315,6 +315,7 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
     params_to_transform: set[str] = set()
     optional_context_params: set[str] = set()
     session_params: set[str] = set()
+    optional_session_params: set[str] = set()
     for name, param in sig.parameters.items():
         annotation = type_hints.get(name, param.annotation)
         if isinstance(param.default, Dependency):
@@ -329,7 +330,12 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
             # bare `session: Session` is NOT injected — only the `UserSession`
             # marker keys the per-user injection.
             params_to_transform.add(name)
-            session_params.add(name)
+            # A `UserSession | None = None` param opts into the unauthenticated
+            # case: inject `None` instead of raising, mirroring optional Context.
+            if param.default is None:
+                optional_session_params.add(name)
+            else:
+                session_params.add(name)
 
     if not params_to_transform:
         return fn
@@ -359,6 +365,10 @@ def transform_context_annotations(fn: Callable[..., Any]) -> Callable[..., Any]:
                 from fastmcp.server.sessions import CurrentSession
 
                 param = param.replace(default=CurrentSession())
+            elif name in optional_session_params:
+                from fastmcp.server.sessions import OptionalCurrentSession
+
+                param = param.replace(default=OptionalCurrentSession())
             elif name in optional_context_params:
                 param = param.replace(default=OptionalCurrentContext())
             else:

--- a/fastmcp_slim/fastmcp/server/dependencies.py
+++ b/fastmcp_slim/fastmcp/server/dependencies.py
@@ -40,6 +40,7 @@ from fastmcp.utilities.async_utils import (
     call_sync_fn_in_threadpool,
     is_coroutine_function,
 )
+from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import find_kwarg_by_type, is_class_member_of_type
 
 if TYPE_CHECKING:
@@ -48,6 +49,9 @@ if TYPE_CHECKING:
 
     from fastmcp.server.context import Context
     from fastmcp.server.server import FastMCP
+    from fastmcp.server.sessions import Session
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -161,6 +165,7 @@ __all__ = [
     "get_http_headers",
     "get_http_request",
     "get_server",
+    "get_session",
     "get_task_context",
     "get_task_session",
     "is_docket_available",
@@ -465,6 +470,41 @@ def get_server() -> FastMCP:
     if server is None:
         raise RuntimeError("FastMCP server instance is no longer available")
     return server
+
+
+async def get_session(session_id: str) -> Session:
+    """Resolve and validate a `Session` for an explicit `session_id`.
+
+    Pair with a `session_id: SessionId` tool argument (the agent obtains an id
+    from `create_session` and passes it back). For a single per-user bucket with
+    nothing for the agent to pass, inject `session: UserSession` instead.
+
+    State is keyed by `(principal, session_id)`: the authenticated principal is
+    the isolation wall and `session_id` organizes sessions within it. The id must
+    have been minted by `create_session` under the current principal; an id that
+    was never created, or created under a different principal, raises
+    `InvalidSession` rather than resolving to a fresh empty bucket (the specific
+    reason is logged at debug level, never returned to the caller).
+
+    Like `get_server()`, this resolves through the task-aware server, so it needs
+    no foreground context — it works from a `task=True` tool's Docket worker as
+    well as a normal request.
+    """
+    from fastmcp.server.sessions import InvalidSession, Session, current_principal
+
+    session = Session(
+        store=get_server()._state_store,
+        principal=current_principal(),
+        session_id=session_id,
+        public_id=session_id,
+    )
+    if not await session._exists():
+        logger.debug(
+            "Rejected session id %r: no record for the current principal.",
+            session_id,
+        )
+        raise InvalidSession
+    return session
 
 
 def get_http_request() -> Request:

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -80,7 +80,11 @@ from fastmcp.server.middleware.middleware import (
 from fastmcp.server.mixins import LifespanMixin, MCPOperationsMixin, TransportMixin
 from fastmcp.server.providers import LocalProvider, Provider
 from fastmcp.server.providers.aggregate import AggregateProvider
-from fastmcp.server.sessions import _ImplicitSessionProvider
+from fastmcp.server.sessions import (
+    SessionProvider,
+    SessionProviderRequiredError,
+    offending_session_id_tool,
+)
 from fastmcp.server.tasks.config import TaskConfig, TaskMeta
 from fastmcp.server.telemetry import server_span
 from fastmcp.server.transforms import (
@@ -356,7 +360,6 @@ class FastMCP(
         cache_scope: Literal["public", "private"] | None = None,
         tasks: bool | None = None,
         session_state_store: AsyncKeyValue | None = None,
-        auto_session_provider: bool = True,
         sampling_handler: SamplingHandler | None = None,
         sampling_handler_behavior: Literal["always", "fallback"] | None = None,
         client_log_level: mcp_types.LoggingLevel | None = None,
@@ -397,18 +400,6 @@ class FastMCP(
         self.add_provider(self._local_provider)
         for p in providers or []:
             self.add_provider(p)
-
-        # Auto-register the default SessionProvider when a tool declares a
-        # `session_id: SessionId` argument. The implicit provider is consulted by
-        # the server's tool listing/lookup (kept out of the public `providers`
-        # list) and only contributes its `create_session` / `end_session` tools
-        # when one is declared and no explicit SessionProvider was added. Set
-        # auto_session_provider=False to opt out (e.g. bring-your-own-key apps
-        # that supply their own session ids and never want create_session).
-        self._auto_session_provider: bool = auto_session_provider
-        self._implicit_session_provider: _ImplicitSessionProvider = (
-            _ImplicitSessionProvider(self)
-        )
 
         for t in transforms or []:
             self.add_transform(t)
@@ -763,11 +754,8 @@ class FastMCP(
             with server_span("tools/list", "tools/list", self.name, "tool", ""):
                 # Get all tools, apply session transforms, then filter enabled
                 # and model-visible (app-only tools are hidden from the model).
-                # The implicit session provider is consulted here (rather than
-                # sitting in `self.providers`) so it never perturbs the public
-                # provider list or its indices.
+                await self._require_session_provider_if_needed()
                 tools = list(await super().list_tools())
-                tools += list(await self._implicit_session_provider.list_tools())
                 tools = await apply_session_transforms(tools)
                 tools = [t for t in tools if is_enabled(t) and not _is_backend_tool(t)]
 
@@ -791,6 +779,25 @@ class FastMCP(
                     authorized.append(tool)
                 return authorized
 
+    async def _require_session_provider_if_needed(self) -> None:
+        """Fail loudly if a tool needs session ids but no `SessionProvider` exists.
+
+        A `session_id: SessionId` argument is only usable once `create_session`
+        can mint an id, so a server with such a tool must register a
+        `SessionProvider`. This check is order-independent: it re-scans the live
+        local tool set on every list/resolve rather than deciding once at
+        construction, so a `session_id` tool added after the server is built is
+        still caught. It runs on both the enumeration path (`list_tools`) and the
+        resolution path (`_get_tool`, which every tool call passes through), so a
+        tool call cannot reach a handler without the check having run.
+        """
+        if any(isinstance(p, SessionProvider) for p in self.providers):
+            return
+        local_tools = await self._local_provider._list_tools()
+        offending = offending_session_id_tool(local_tools)
+        if offending is not None:
+            raise SessionProviderRequiredError(tool_name=offending)
+
     async def _get_tool(
         self, name: str, version: VersionSpec | None = None
     ) -> Tool | None:
@@ -805,13 +812,12 @@ class FastMCP(
         Returns:
             The tool if found and authorized, None if not found or unauthorized.
         """
+        # Enforce the SessionProvider requirement before resolving anything: every
+        # tool call passes through here, so this gate cannot be bypassed.
+        await self._require_session_provider_if_needed()
+
         # Get tool from AggregateProvider (handles aggregation and namespacing)
         tool = await super()._get_tool(name, version)
-        if tool is None:
-            # Fall back to the implicit session provider (create_session /
-            # end_session), which is consulted here rather than living in
-            # `self.providers`.
-            tool = await self._implicit_session_provider.get_tool(name, version)
         if tool is None:
             return None
 

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -84,7 +84,9 @@ from fastmcp.server.providers.aggregate import AggregateProvider
 from fastmcp.server.sessions import (
     SessionProvider,
     SessionProviderRequiredError,
+    SessionProviderShadowedError,
     offending_session_id_tool,
+    shadowing_local_tool,
 )
 from fastmcp.server.tasks.config import TaskConfig, TaskMeta
 from fastmcp.server.telemetry import server_span
@@ -756,14 +758,14 @@ class FastMCP(
                 # Get all tools, apply session transforms, then filter enabled
                 # and model-visible (app-only tools are hidden from the model).
                 tools = list(await super().list_tools())
-                # Enforce the SessionProvider requirement against every tool a
-                # caller can see, not only decorator-registered ones: a
-                # provider-sourced `session_id: SessionId` tool needs the same
-                # guarantee. Checked against the full aggregated list (already in
-                # hand here), so this costs no extra provider listing.
-                self._require_session_provider(tools)
                 tools = await apply_session_transforms(tools)
                 tools = [t for t in tools if is_enabled(t) and not _is_backend_tool(t)]
+                # Enforce the SessionProvider requirement against the effective,
+                # enabled tool set a caller can actually see — not only
+                # decorator-registered ones (a provider-sourced `session_id`
+                # tool needs the same guarantee), and not tools disabled here or
+                # by a session transform, which could never be called anyway.
+                await self._require_session_provider(tools)
 
                 # Rewrite per-tool Prefab renderer URIs based on the tool's
                 # mount-point address. The walk pairs each tool with the
@@ -785,7 +787,7 @@ class FastMCP(
                     authorized.append(tool)
                 return authorized
 
-    def _require_session_provider(self, tools: Iterable[Tool]) -> None:
+    async def _require_session_provider(self, tools: Iterable[Tool]) -> None:
         """Fail loudly if any of `tools` needs session ids but no `SessionProvider` exists.
 
         A `session_id: SessionId` argument is only usable once `create_session`
@@ -795,15 +797,27 @@ class FastMCP(
         the live tool set at the moment of listing or resolving, so a
         `session_id` tool added after the server is built is still caught. It
         runs on both the enumeration path (`list_tools`, against every
-        aggregated tool) and the resolution path (`_get_tool`, against the one
-        resolved tool, which every tool call passes through), so a tool call
-        cannot reach a handler without the check having run.
+        aggregated, effectively-enabled tool) and the resolution path
+        (`_get_tool`, against the one resolved tool, which every tool call
+        passes through), so a tool call cannot reach a handler without the check
+        having run.
         """
-        if any(isinstance(p, SessionProvider) for p in self.providers):
+        if not any(isinstance(p, SessionProvider) for p in self.providers):
+            offending = offending_session_id_tool(tools)
+            if offending is not None:
+                raise SessionProviderRequiredError(tool_name=offending)
             return
-        offending = offending_session_id_tool(tools)
-        if offending is not None:
-            raise SessionProviderRequiredError(tool_name=offending)
+
+        # A SessionProvider is registered, but static, decorator-registered
+        # components always take precedence over provider-sourced ones: a local
+        # tool named `create_session` or `end_session` would permanently
+        # shadow the provider's own tool of that name, so the provider is
+        # present yet its real lifecycle tool can never run. Local listing is
+        # side-effect-free (no middleware), so this costs nothing extra.
+        local_tools = await self._local_provider._list_tools()
+        shadowed = shadowing_local_tool(local_tools)
+        if shadowed is not None:
+            raise SessionProviderShadowedError(tool_name=shadowed)
 
     async def _get_tool(
         self, name: str, version: VersionSpec | None = None
@@ -825,11 +839,14 @@ class FastMCP(
             return None
 
         # Enforce the SessionProvider requirement against the resolved tool —
-        # whichever provider it came from — before it can be called. Checking
+        # whichever provider it came from — before it can be called. Skipped for
+        # a disabled tool: it can never be called, so it should not force a
+        # provider registration the caller has no other reason to add. Checking
         # only this one tool (rather than re-listing every provider) keeps
         # resolution free of the side effects a full provider listing could
         # have (e.g. a mounted sub-server's middleware).
-        self._require_session_provider([tool])
+        if is_enabled(tool) and not _is_backend_tool(tool):
+            await self._require_session_provider([tool])
 
         # Component auth - return None if unauthorized (consistent with list filtering)
         skip_auth, token = _get_auth_context()

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -8,6 +8,7 @@ import secrets
 from collections.abc import (
     AsyncIterator,
     Callable,
+    Iterable,
     Sequence,
 )
 from contextlib import (
@@ -754,8 +755,13 @@ class FastMCP(
             with server_span("tools/list", "tools/list", self.name, "tool", ""):
                 # Get all tools, apply session transforms, then filter enabled
                 # and model-visible (app-only tools are hidden from the model).
-                await self._require_session_provider_if_needed()
                 tools = list(await super().list_tools())
+                # Enforce the SessionProvider requirement against every tool a
+                # caller can see, not only decorator-registered ones: a
+                # provider-sourced `session_id: SessionId` tool needs the same
+                # guarantee. Checked against the full aggregated list (already in
+                # hand here), so this costs no extra provider listing.
+                self._require_session_provider(tools)
                 tools = await apply_session_transforms(tools)
                 tools = [t for t in tools if is_enabled(t) and not _is_backend_tool(t)]
 
@@ -779,22 +785,23 @@ class FastMCP(
                     authorized.append(tool)
                 return authorized
 
-    async def _require_session_provider_if_needed(self) -> None:
-        """Fail loudly if a tool needs session ids but no `SessionProvider` exists.
+    def _require_session_provider(self, tools: Iterable[Tool]) -> None:
+        """Fail loudly if any of `tools` needs session ids but no `SessionProvider` exists.
 
         A `session_id: SessionId` argument is only usable once `create_session`
-        can mint an id, so a server with such a tool must register a
-        `SessionProvider`. This check is order-independent: it re-scans the live
-        local tool set on every list/resolve rather than deciding once at
-        construction, so a `session_id` tool added after the server is built is
-        still caught. It runs on both the enumeration path (`list_tools`) and the
-        resolution path (`_get_tool`, which every tool call passes through), so a
-        tool call cannot reach a handler without the check having run.
+        can mint an id, so a server exposing such a tool must register a
+        `SessionProvider` — whether the tool is decorator-registered or sourced
+        from another `Provider`. This check is order-independent: callers pass
+        the live tool set at the moment of listing or resolving, so a
+        `session_id` tool added after the server is built is still caught. It
+        runs on both the enumeration path (`list_tools`, against every
+        aggregated tool) and the resolution path (`_get_tool`, against the one
+        resolved tool, which every tool call passes through), so a tool call
+        cannot reach a handler without the check having run.
         """
         if any(isinstance(p, SessionProvider) for p in self.providers):
             return
-        local_tools = await self._local_provider._list_tools()
-        offending = offending_session_id_tool(local_tools)
+        offending = offending_session_id_tool(tools)
         if offending is not None:
             raise SessionProviderRequiredError(tool_name=offending)
 
@@ -812,14 +819,17 @@ class FastMCP(
         Returns:
             The tool if found and authorized, None if not found or unauthorized.
         """
-        # Enforce the SessionProvider requirement before resolving anything: every
-        # tool call passes through here, so this gate cannot be bypassed.
-        await self._require_session_provider_if_needed()
-
         # Get tool from AggregateProvider (handles aggregation and namespacing)
         tool = await super()._get_tool(name, version)
         if tool is None:
             return None
+
+        # Enforce the SessionProvider requirement against the resolved tool —
+        # whichever provider it came from — before it can be called. Checking
+        # only this one tool (rather than re-listing every provider) keeps
+        # resolution free of the side effects a full provider listing could
+        # have (e.g. a mounted sub-server's middleware).
+        self._require_session_provider([tool])
 
         # Component auth - return None if unauthorized (consistent with list filtering)
         skip_auth, token = _get_auth_context()

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -80,6 +80,7 @@ from fastmcp.server.middleware.middleware import (
 from fastmcp.server.mixins import LifespanMixin, MCPOperationsMixin, TransportMixin
 from fastmcp.server.providers import LocalProvider, Provider
 from fastmcp.server.providers.aggregate import AggregateProvider
+from fastmcp.server.sessions import _ImplicitSessionProvider
 from fastmcp.server.tasks.config import TaskConfig, TaskMeta
 from fastmcp.server.telemetry import server_span
 from fastmcp.server.transforms import (
@@ -355,6 +356,7 @@ class FastMCP(
         cache_scope: Literal["public", "private"] | None = None,
         tasks: bool | None = None,
         session_state_store: AsyncKeyValue | None = None,
+        auto_session_provider: bool = True,
         sampling_handler: SamplingHandler | None = None,
         sampling_handler_behavior: Literal["always", "fallback"] | None = None,
         client_log_level: mcp_types.LoggingLevel | None = None,
@@ -395,6 +397,18 @@ class FastMCP(
         self.add_provider(self._local_provider)
         for p in providers or []:
             self.add_provider(p)
+
+        # Auto-register the default SessionProvider when a tool declares a
+        # `session_id: SessionId` argument. The implicit provider is consulted by
+        # the server's tool listing/lookup (kept out of the public `providers`
+        # list) and only contributes its `create_session` / `end_session` tools
+        # when one is declared and no explicit SessionProvider was added. Set
+        # auto_session_provider=False to opt out (e.g. bring-your-own-key apps
+        # that supply their own session ids and never want create_session).
+        self._auto_session_provider: bool = auto_session_provider
+        self._implicit_session_provider: _ImplicitSessionProvider = (
+            _ImplicitSessionProvider(self)
+        )
 
         for t in transforms or []:
             self.add_transform(t)
@@ -749,7 +763,11 @@ class FastMCP(
             with server_span("tools/list", "tools/list", self.name, "tool", ""):
                 # Get all tools, apply session transforms, then filter enabled
                 # and model-visible (app-only tools are hidden from the model).
+                # The implicit session provider is consulted here (rather than
+                # sitting in `self.providers`) so it never perturbs the public
+                # provider list or its indices.
                 tools = list(await super().list_tools())
+                tools += list(await self._implicit_session_provider.list_tools())
                 tools = await apply_session_transforms(tools)
                 tools = [t for t in tools if is_enabled(t) and not _is_backend_tool(t)]
 
@@ -789,6 +807,11 @@ class FastMCP(
         """
         # Get tool from AggregateProvider (handles aggregation and namespacing)
         tool = await super()._get_tool(name, version)
+        if tool is None:
+            # Fall back to the implicit session provider (create_session /
+            # end_session), which is consulted here rather than living in
+            # `self.providers`.
+            tool = await self._implicit_session_provider.get_tool(name, version)
         if tool is None:
             return None
 

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -8,7 +8,6 @@ import secrets
 from collections.abc import (
     AsyncIterator,
     Callable,
-    Iterable,
     Sequence,
 )
 from contextlib import (
@@ -81,13 +80,6 @@ from fastmcp.server.middleware.middleware import (
 from fastmcp.server.mixins import LifespanMixin, MCPOperationsMixin, TransportMixin
 from fastmcp.server.providers import LocalProvider, Provider
 from fastmcp.server.providers.aggregate import AggregateProvider
-from fastmcp.server.sessions import (
-    SessionProvider,
-    SessionProviderRequiredError,
-    SessionProviderShadowedError,
-    offending_session_id_tool,
-    shadowing_local_tool,
-)
 from fastmcp.server.tasks.config import TaskConfig, TaskMeta
 from fastmcp.server.telemetry import server_span
 from fastmcp.server.transforms import (
@@ -760,12 +752,6 @@ class FastMCP(
                 tools = list(await super().list_tools())
                 tools = await apply_session_transforms(tools)
                 tools = [t for t in tools if is_enabled(t) and not _is_backend_tool(t)]
-                # Enforce the SessionProvider requirement against the effective,
-                # enabled tool set a caller can actually see — not only
-                # decorator-registered ones (a provider-sourced `session_id`
-                # tool needs the same guarantee), and not tools disabled here or
-                # by a session transform, which could never be called anyway.
-                await self._require_session_provider(tools)
 
                 # Rewrite per-tool Prefab renderer URIs based on the tool's
                 # mount-point address. The walk pairs each tool with the
@@ -787,38 +773,6 @@ class FastMCP(
                     authorized.append(tool)
                 return authorized
 
-    async def _require_session_provider(self, tools: Iterable[Tool]) -> None:
-        """Fail loudly if any of `tools` needs session ids but no `SessionProvider` exists.
-
-        A `session_id: SessionId` argument is only usable once `create_session`
-        can mint an id, so a server exposing such a tool must register a
-        `SessionProvider` — whether the tool is decorator-registered or sourced
-        from another `Provider`. This check is order-independent: callers pass
-        the live tool set at the moment of listing or resolving, so a
-        `session_id` tool added after the server is built is still caught. It
-        runs on both the enumeration path (`list_tools`, against every
-        aggregated, effectively-enabled tool) and the resolution path
-        (`_get_tool`, against the one resolved tool, which every tool call
-        passes through), so a tool call cannot reach a handler without the check
-        having run.
-        """
-        if not any(isinstance(p, SessionProvider) for p in self.providers):
-            offending = offending_session_id_tool(tools)
-            if offending is not None:
-                raise SessionProviderRequiredError(tool_name=offending)
-            return
-
-        # A SessionProvider is registered, but static, decorator-registered
-        # components always take precedence over provider-sourced ones: a local
-        # tool named `create_session` or `end_session` would permanently
-        # shadow the provider's own tool of that name, so the provider is
-        # present yet its real lifecycle tool can never run. Local listing is
-        # side-effect-free (no middleware), so this costs nothing extra.
-        local_tools = await self._local_provider._list_tools()
-        shadowed = shadowing_local_tool(local_tools)
-        if shadowed is not None:
-            raise SessionProviderShadowedError(tool_name=shadowed)
-
     async def _get_tool(
         self, name: str, version: VersionSpec | None = None
     ) -> Tool | None:
@@ -837,16 +791,6 @@ class FastMCP(
         tool = await super()._get_tool(name, version)
         if tool is None:
             return None
-
-        # Enforce the SessionProvider requirement against the resolved tool —
-        # whichever provider it came from — before it can be called. Skipped for
-        # a disabled tool: it can never be called, so it should not force a
-        # provider registration the caller has no other reason to add. Checking
-        # only this one tool (rather than re-listing every provider) keeps
-        # resolution free of the side effects a full provider listing could
-        # have (e.g. a mounted sub-server's middleware).
-        if is_enabled(tool) and not _is_backend_tool(tool):
-            await self._require_session_provider([tool])
 
         # Component auth - return None if unauthorized (consistent with list filtering)
         skip_auth, token = _get_auth_context()

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -80,6 +80,11 @@ from fastmcp.server.middleware.middleware import (
 from fastmcp.server.mixins import LifespanMixin, MCPOperationsMixin, TransportMixin
 from fastmcp.server.providers import LocalProvider, Provider
 from fastmcp.server.providers.aggregate import AggregateProvider
+from fastmcp.server.sessions import (
+    DEFAULT_SESSION_TTL,
+    SessionCodec,
+    SessionProvider,
+)
 from fastmcp.server.tasks.config import TaskConfig, TaskMeta
 from fastmcp.server.telemetry import server_span
 from fastmcp.server.transforms import (
@@ -355,6 +360,7 @@ class FastMCP(
         cache_scope: Literal["public", "private"] | None = None,
         tasks: bool | None = None,
         session_state_store: AsyncKeyValue | None = None,
+        session_provider: SessionProvider | None = None,
         sampling_handler: SamplingHandler | None = None,
         sampling_handler_behavior: Literal["always", "fallback"] | None = None,
         client_log_level: mcp_types.LoggingLevel | None = None,
@@ -447,6 +453,15 @@ class FastMCP(
         self._request_state_security: RequestStateSecurity | None = (
             request_state_security
         )
+
+        # Sealed-handle session state (opt-in). The codec is built lazily from the
+        # server's request-state key ring so session handles and `requestState`
+        # share one key; the provider (when present) only sets the handle TTL and
+        # registers the create/end session tools.
+        self._session_provider: SessionProvider | None = session_provider
+        self._session_codec: SessionCodec | None = None
+        if session_provider is not None:
+            session_provider.register(self)
 
         # Server-level SEP-2549 cache hints, applied uniformly to every
         # SDK-cacheable result by the low-level server's runner (raises on
@@ -566,6 +581,26 @@ class FastMCP(
             return []
         else:
             return list(self._mcp_server.icons)
+
+    @property
+    def session_codec(self) -> SessionCodec:
+        """The codec that mints and verifies this server's sealed session handles.
+
+        Built lazily from the server's `request_state_security` key ring (so
+        session handles and `requestState` share one key), or a per-process
+        ephemeral key when no policy is configured. The handle TTL comes from the
+        configured `session_provider`, or the default when none is set.
+        """
+        if self._session_codec is None:
+            ttl = (
+                self._session_provider.ttl
+                if self._session_provider is not None
+                else DEFAULT_SESSION_TTL
+            )
+            self._session_codec = SessionCodec.from_security(
+                self._request_state_security, ttl=ttl
+            )
+        return self._session_codec
 
     @property
     def local_provider(self) -> LocalProvider:

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -80,11 +80,6 @@ from fastmcp.server.middleware.middleware import (
 from fastmcp.server.mixins import LifespanMixin, MCPOperationsMixin, TransportMixin
 from fastmcp.server.providers import LocalProvider, Provider
 from fastmcp.server.providers.aggregate import AggregateProvider
-from fastmcp.server.sessions import (
-    DEFAULT_SESSION_TTL,
-    SessionCodec,
-    SessionProvider,
-)
 from fastmcp.server.tasks.config import TaskConfig, TaskMeta
 from fastmcp.server.telemetry import server_span
 from fastmcp.server.transforms import (
@@ -360,7 +355,6 @@ class FastMCP(
         cache_scope: Literal["public", "private"] | None = None,
         tasks: bool | None = None,
         session_state_store: AsyncKeyValue | None = None,
-        session_provider: SessionProvider | None = None,
         sampling_handler: SamplingHandler | None = None,
         sampling_handler_behavior: Literal["always", "fallback"] | None = None,
         client_log_level: mcp_types.LoggingLevel | None = None,
@@ -453,15 +447,6 @@ class FastMCP(
         self._request_state_security: RequestStateSecurity | None = (
             request_state_security
         )
-
-        # Sealed-handle session state (opt-in). The codec is built lazily from the
-        # server's request-state key ring so session handles and `requestState`
-        # share one key; the provider (when present) only sets the handle TTL and
-        # registers the create/end session tools.
-        self._session_provider: SessionProvider | None = session_provider
-        self._session_codec: SessionCodec | None = None
-        if session_provider is not None:
-            session_provider.register(self)
 
         # Server-level SEP-2549 cache hints, applied uniformly to every
         # SDK-cacheable result by the low-level server's runner (raises on
@@ -581,26 +566,6 @@ class FastMCP(
             return []
         else:
             return list(self._mcp_server.icons)
-
-    @property
-    def session_codec(self) -> SessionCodec:
-        """The codec that mints and verifies this server's sealed session handles.
-
-        Built lazily from the server's `request_state_security` key ring (so
-        session handles and `requestState` share one key), or a per-process
-        ephemeral key when no policy is configured. The handle TTL comes from the
-        configured `session_provider`, or the default when none is set.
-        """
-        if self._session_codec is None:
-            ttl = (
-                self._session_provider.ttl
-                if self._session_provider is not None
-                else DEFAULT_SESSION_TTL
-            )
-            self._session_codec = SessionCodec.from_security(
-                self._request_state_security, ttl=ttl
-            )
-        return self._session_codec
 
     @property
     def local_provider(self) -> LocalProvider:

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -58,7 +58,7 @@ from mcp.server.auth.provider import principal_components
 from uncalled_for import Dependency
 
 from fastmcp.exceptions import FastMCPError
-from fastmcp.server.dependencies import get_access_token, get_server
+from fastmcp.server.dependencies import get_access_token, get_server, get_session
 from fastmcp.server.providers.base import Provider
 from fastmcp.utilities.logging import get_logger
 
@@ -414,39 +414,6 @@ def CurrentSession() -> Session:
     is preferred.
     """
     return cast("Session", _CurrentSession())
-
-
-async def get_session(session_id: str) -> Session:
-    """Resolve and validate a `Session` for an explicit `session_id`.
-
-    Pair with a `session_id: SessionId` tool argument (the agent obtains an id
-    from `create_session` and passes it back). For a single per-user bucket with
-    nothing for the agent to pass, inject `session: UserSession` instead.
-
-    State is keyed by `(principal, session_id)`: the authenticated principal is
-    the isolation wall and `session_id` organizes sessions within it. The id must
-    have been minted by `create_session` under the current principal; an id that
-    was never created, or created under a different principal, raises
-    `InvalidSession` rather than resolving to a fresh empty bucket (the specific
-    reason is logged at debug level, never returned to the caller).
-
-    This is a standalone function, not a `Context` method, so it needs no
-    foreground context — it works from a `task=True` tool's Docket worker as well
-    as a normal request.
-    """
-    session = Session(
-        store=get_server()._state_store,
-        principal=current_principal(),
-        session_id=session_id,
-        public_id=session_id,
-    )
-    if not await session._exists():
-        logger.debug(
-            "Rejected session id %r: no record for the current principal.",
-            session_id,
-        )
-        raise InvalidSession
-    return session
 
 
 async def create_session() -> str:

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -7,15 +7,21 @@ calls, both backed by the server's existing state store and both isolated by the
 authenticated principal rather than by any client-declared identifier.
 
 - `Session`: async `get`/`set`/`delete`/`clear` over a single dict stored under
-  one key, scoped to a `(principal, session_id)` pair.
-- `session: Session` (injected): a per-user bucket, dependency-injected like
+  one key, scoped to a `(principal, session_id)` pair. This is the state-accessor
+  object a handler works with — the value returned by `ctx.get_session(id)` and
+  injected for a `UserSession` parameter.
+- `session: UserSession` (injected): a per-user bucket, dependency-injected like
   `ctx: Context` and keyed by the request's authenticated principal. Requires
-  auth.
+  auth. `UserSession` is the injection annotation; the injected value is a
+  `Session`.
 - `session_id: SessionId` (argument): a required string the agent supplies,
-  resolved with `ctx.session(session_id)`. Works with or without auth, but only
-  isolates between callers under auth.
-- `SessionProvider`: an opt-in `Provider` contributing `create_session` /
-  `end_session` tools.
+  resolved with `ctx.get_session(session_id)`. Works with or without auth, but
+  only isolates between callers under auth. Declaring one auto-wires the default
+  `SessionProvider` (its `create_session` / `end_session` tools) unless the
+  developer already registered one or opted out.
+- `SessionProvider`: a `Provider` contributing `create_session` / `end_session`
+  tools. Registered automatically when a tool declares `session_id: SessionId`,
+  or explicitly via `add_provider`.
 
 Isolation is the authenticated principal, not the session id. State keyed by
 `(principal, session_id)` means a request under principal B can never address
@@ -28,7 +34,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable, Sequence
+import weakref
+from collections.abc import Callable, Iterable, Sequence
 from functools import lru_cache
 from types import TracebackType
 from typing import (
@@ -53,7 +60,7 @@ from fastmcp.server.providers.base import Provider
 if TYPE_CHECKING:
     from key_value.aio.adapters.pydantic import PydanticAdapter
 
-    from fastmcp.server.server import StateValue
+    from fastmcp.server.server import FastMCP, StateValue
     from fastmcp.tools.base import Tool
 
 
@@ -67,7 +74,7 @@ SESSION_ID_DESCRIPTION: Final[str] = (
 
 
 class SessionAuthError(FastMCPError):
-    """An injected `session: Session` was requested with no authenticated principal.
+    """An injected `session: UserSession` was requested with no authenticated principal.
 
     Per-user session injection keys off the request's authenticated principal, so
     it is only meaningful under auth. A tool that needs cross-call state without
@@ -77,8 +84,8 @@ class SessionAuthError(FastMCPError):
     def __init__(
         self,
         message: str = (
-            "Injected `session: Session` requires an authenticated principal, but "
-            "this request is unauthenticated. Use a `session_id: SessionId` "
+            "Injected `session: UserSession` requires an authenticated principal, "
+            "but this request is unauthenticated. Use a `session_id: SessionId` "
             "argument for cross-call state on unauthenticated connections."
         ),
     ) -> None:
@@ -182,6 +189,34 @@ class Session:
         await self._store.delete(key=self._key)
 
 
+class UserSession(Session):
+    """Annotation marker for the injected per-user session.
+
+    A `session: UserSession` parameter is **dependency-injected** like
+    `ctx: Context`: keyed by the request's authenticated principal, excluded from
+    the input schema, and requiring auth (it raises `SessionAuthError` with no
+    principal). It is the injection *annotation* — the value a handler receives is
+    an ordinary `Session`, so `await session.get(...)`, `.set`, `.delete`, and
+    `.clear` all work exactly as on any other `Session`.
+
+    Use `UserSession` when one state bucket per user is what you want, with
+    nothing for the agent to pass. For distinct sessions the agent selects, take a
+    `session_id: SessionId` argument instead.
+
+    ```python
+    from fastmcp.server.sessions import UserSession
+
+    @mcp.tool
+    async def remember(fact: str, session: UserSession) -> str:
+        await session.set("fact", fact)
+        return "noted"
+    ```
+
+    Subclasses `Session` only so the framework's type-based injection detector can
+    key off it; it adds no behavior and is never instantiated directly.
+    """
+
+
 class _SessionIdMarker:
     """Metadata marker identifying a `SessionId`-annotated parameter."""
 
@@ -218,7 +253,7 @@ def session_id_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
 class _CurrentSession(Dependency["Session"]):
     """Dependency that injects a per-user `Session` keyed by the request principal.
 
-    Mirrors `_CurrentContext`: a bare `session: Session` parameter is rewritten to
+    Mirrors `_CurrentContext`: a `session: UserSession` parameter is rewritten to
     default to this dependency, so it is excluded from the input schema and
     resolved at call time. Raises `SessionAuthError` when the request carries no
     authenticated principal.
@@ -247,7 +282,7 @@ class _CurrentSession(Dependency["Session"]):
 def CurrentSession() -> Session:
     """Inject the per-user `Session` for the current authenticated principal.
 
-    Rarely written explicitly — a bare `session: Session` parameter is rewritten
+    Rarely written explicitly — a `session: UserSession` parameter is rewritten
     to this. Provided for parity with `CurrentContext()` when an explicit default
     is preferred.
     """
@@ -307,3 +342,55 @@ class SessionProvider(Provider):
                 Tool.from_function(end_session),
             ]
         return self._tools
+
+
+def tools_declare_session_id(tools: Iterable[Tool]) -> bool:
+    """Whether any tool in `tools` declares a `session_id: SessionId` parameter.
+
+    Checks each function-backed tool's resolved hints for the `SessionId` marker.
+    Used to decide whether the default `SessionProvider` should be auto-registered.
+    """
+    from fastmcp.tools.function_tool import FunctionTool
+
+    return any(
+        isinstance(tool, FunctionTool) and session_id_parameter_names(tool.fn)
+        for tool in tools
+    )
+
+
+class _ImplicitSessionProvider(SessionProvider):
+    """Server-owned `SessionProvider` that activates only when it is needed.
+
+    Consulted directly by the server's tool listing/lookup (it is deliberately
+    kept out of the public `providers` list so it never perturbs provider indices
+    or user introspection). It contributes its `create_session` / `end_session`
+    tools only when every condition holds:
+
+    - the server has not opted out (`FastMCP(auto_session_provider=False)`),
+    - no `SessionProvider` was registered explicitly (a manual one wins), and
+    - at least one locally registered tool declares a `session_id: SessionId`
+      argument.
+
+    Detection scans the server's own registered tools (the `LocalProvider`'s
+    decorator / `add_tool` set), which is read fresh at list time — so activation
+    is independent of the order in which tools and providers are registered (a
+    `session_id` tool added after construction still activates it) and never
+    invokes another provider's listing (a mounted sub-server wires its own
+    `SessionProvider` and is not scanned here, so its middleware is never run as a
+    side effect of this decision).
+    """
+
+    def __init__(self, server: FastMCP) -> None:
+        super().__init__()
+        self._server_ref = weakref.ref(server)
+
+    async def _list_tools(self) -> Sequence[Tool]:
+        server = self._server_ref()
+        if server is None or not server._auto_session_provider:
+            return []
+        if any(isinstance(p, SessionProvider) for p in server.providers):
+            return []
+        local_tools = await server._local_provider._list_tools()
+        if not tools_declare_session_id(local_tools):
+            return []
+        return await super()._list_tools()

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -1,41 +1,42 @@
-"""Stateless session state: the scoped-state vocabulary and the session codec.
+"""Stateless session state: server-side per-user and per-session storage.
 
-This module provides the security core for cross-request state on modern
-(stateless) MCP connections. It has two parts:
+Modern (2026-07-28) MCP connections are stateless by construction — every
+request builds a fresh connection whose in-memory state is discarded when the
+request returns. This module gives tools two explicit ways to keep state across
+calls, both backed by the server's existing state store and both isolated by the
+authenticated principal rather than by any client-declared identifier.
 
-- `Scope`: the storage-isolation vocabulary shared by `ctx.get_state` /
-  `ctx.set_state`. `REQUEST` is today's per-connection state, `USER` keys off the
-  authenticated principal, and `SESSION` keys off a sealed session handle.
-- `SessionCodec`: mints and verifies the sealed session handle. A handle binds a
-  server-minted `session_id` to the authenticated principal (when present) and an
-  expiry, sealed with the SDK's AES-GCM request-state codec. Unlike the SDK's
-  per-request `requestState` seal, a session handle binds **principal + expiry
-  only**, so it survives across different tool calls rather than a single round.
+- `Session`: async `get`/`set`/`delete`/`clear` over a single dict stored under
+  one key, scoped to a `(principal, session_id)` pair.
+- `session: Session` (injected): a per-user bucket, dependency-injected like
+  `ctx: Context` and keyed by the request's authenticated principal. Requires
+  auth.
+- `session_id: SessionId` (argument): a required string the agent supplies,
+  resolved with `ctx.session(session_id)`. Works with or without auth, but only
+  isolates between callers under auth.
+- `SessionProvider`: an opt-in `Provider` contributing `create_session` /
+  `end_session` tools.
 
-The `Session()` annotation and the request boundary that unseals the handle and
-binds it onto the request context live in a later increment. This module only
-provides the primitives and the context slot they populate.
+Isolation is the authenticated principal, not the session id. State keyed by
+`(principal, session_id)` means a request under principal B can never address
+principal A's keys, no matter what `session_id` it passes; the id only organizes
+sessions within a principal. Without auth there is no principal wall — a session
+id is a bearer capability and sessions are not a boundary between clients.
 """
 
 from __future__ import annotations
 
-import enum
 import hashlib
-import hmac
 import json
-import logging
-import math
-import time
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
-from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from collections.abc import Callable, Sequence
 from functools import lru_cache
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Annotated,
+    Any,
     Final,
-    NoReturn,
+    cast,
     get_args,
     get_origin,
     get_type_hints,
@@ -43,123 +44,45 @@ from typing import (
 from uuid import uuid4
 
 from mcp.server.auth.provider import principal_components
-from mcp.server.request_state import InvalidRequestState, RequestStateSecurity
+from uncalled_for import Dependency
 
 from fastmcp.exceptions import FastMCPError
 from fastmcp.server.dependencies import get_access_token, get_context
+from fastmcp.server.providers.base import Provider
 
 if TYPE_CHECKING:
-    from fastmcp.server.server import FastMCP
+    from key_value.aio.adapters.pydantic import PydanticAdapter
 
-logger: logging.Logger = logging.getLogger(__name__)
-
-# Default lifetime of a sealed session handle. Session handles must outlive a
-# single request (they are threaded through many tool calls), so this defaults
-# far above the SDK request-state codec's 600s per-round default. Configurable
-# per `SessionCodec`.
-DEFAULT_SESSION_TTL: Final[float] = 3600.0
-
-# Envelope version stamped into every sealed payload. The AES-GCM codec already
-# binds its own "v1." wire prefix into the seal; this is the *payload* schema
-# version, independent of the codec's token format.
-_ENVELOPE_VERSION: Final[int] = 1
+    from fastmcp.server.server import StateValue
+    from fastmcp.tools.base import Tool
 
 
-class Scope(enum.Enum):
-    """Storage isolation for `ctx.get_state` / `ctx.set_state`.
-
-    The scope selects both the storage key prefix and the isolation guarantee:
-
-    - `REQUEST`: per-request connection state. Dies with the request on a modern
-      (stateless) connection; persists across requests on a stateful one. This is
-      the historical default and the only scope that works without auth or a
-      session handle.
-    - `SESSION`: keyed by `(principal, session_id)` where `session_id` comes from
-      a verified sealed handle bound onto the request context. Sealed and
-      principal-bound when authenticated; unforgeable (but not cross-client
-      isolated) when unauthenticated.
-    - `USER`: keyed by the authenticated principal; spans every session for that
-      user. Requires authentication.
-    """
-
-    REQUEST = "request"
-    SESSION = "session"
-    USER = "user"
+# The description the framework auto-populates onto a `SessionId` argument so an
+# agent reading the tool schema learns the create-then-pass contract with no
+# hand-prompting.
+SESSION_ID_DESCRIPTION: Final[str] = (
+    "Session identifier. Call `create_session` to obtain one, then pass it here "
+    "to persist state across calls in the same session."
+)
 
 
-@dataclass(frozen=True)
-class SessionIdentity:
-    """The verified identity carried by a sealed session handle.
+class SessionAuthError(FastMCPError):
+    """An injected `session: Session` was requested with no authenticated principal.
 
-    `principal` is the authenticated `(client_id, issuer, subject)` triple encoded
-    as a compact JSON string, or `None` when the handle was minted on an
-    unauthenticated connection.
-    """
-
-    session_id: str
-    principal: str | None
-
-
-class SessionError(FastMCPError):
-    """Base class for session-state errors."""
-
-
-class InvalidSessionToken(SessionError):
-    """A sealed session handle failed verification.
-
-    Raised for foreign, expired, tampered, or malformed handles. The rejection
-    reason is captured on `.reason` and logged, never placed on the public
-    message, so a boundary that surfaces this to the wire cannot leak *why* a
-    handle was rejected (mirroring the SDK request-state boundary's stance).
-    """
-
-    def __init__(self, reason: str) -> None:
-        self.reason = reason
-        super().__init__("invalid or expired session token")
-
-
-class NoActiveSessionError(SessionError):
-    """`Scope.SESSION` state was accessed with no verified session on the request.
-
-    Modern (stateless) connections carry no protocol session, so a client must
-    obtain a sealed handle (via `create_session`) and thread it into later calls
-    for `SESSION`-scoped state to resolve.
+    Per-user session injection keys off the request's authenticated principal, so
+    it is only meaningful under auth. A tool that needs cross-call state without
+    auth should take a `session_id: SessionId` argument instead.
     """
 
     def __init__(
         self,
         message: str = (
-            "no active session — call `create_session` and pass its token as the "
-            "session argument to access Scope.SESSION state"
+            "Injected `session: Session` requires an authenticated principal, but "
+            "this request is unauthenticated. Use a `session_id: SessionId` "
+            "argument for cross-call state on unauthenticated connections."
         ),
     ) -> None:
         super().__init__(message)
-
-
-# The verified session identity for the current request. A later increment's
-# boundary sets this after unsealing the handle argument; scoped-state reads it.
-_active_session_identity: ContextVar[SessionIdentity | None] = ContextVar(
-    "fastmcp_active_session_identity", default=None
-)
-
-
-@contextmanager
-def bind_session_identity(identity: SessionIdentity) -> Iterator[SessionIdentity]:
-    """Bind a verified session identity onto the current request context.
-
-    Used by the session boundary (and tests) to make `Scope.SESSION` state
-    resolvable for the duration of a request.
-    """
-    token: Token[SessionIdentity | None] = _active_session_identity.set(identity)
-    try:
-        yield identity
-    finally:
-        _active_session_identity.reset(token)
-
-
-def get_active_session_identity() -> SessionIdentity | None:
-    """Return the verified session identity bound to the current request, if any."""
-    return _active_session_identity.get()
 
 
 def current_principal() -> str | None:
@@ -178,202 +101,104 @@ def current_principal() -> str | None:
 def _principal_segment(principal: str | None) -> str:
     """A fixed-length, delimiter-safe key segment for a principal.
 
-    Hashing keeps arbitrary principal strings from injecting the `:` key
+    Hashing keeps an arbitrary principal string from injecting the `:` key
     delimiter and bounds the key length. `None` (unauthenticated) collapses to a
-    single shared `anon` segment.
+    single shared `anon` segment — without a principal there is no isolation wall.
     """
     if principal is None:
         return "anon"
-    digest = hashlib.sha256(principal.encode("utf-8", "surrogatepass")).hexdigest()
-    return digest
+    return hashlib.sha256(principal.encode("utf-8", "surrogatepass")).hexdigest()
 
 
-def user_state_key(principal: str, key: str) -> str:
-    """Storage key for `Scope.USER` state: keyed by principal."""
-    return f"user:{_principal_segment(principal)}:{key}"
+def session_storage_key(principal: str | None, session_id: str) -> str:
+    """The single storage key holding a session's state dict.
 
-
-def session_state_key(identity: SessionIdentity, key: str) -> str:
-    """Storage key for `Scope.SESSION` state: keyed by `(principal, session_id)`."""
-    return f"session:{_principal_segment(identity.principal)}:{identity.session_id}:{key}"
-
-
-def session_index_key(identity: SessionIdentity) -> str:
-    """Storage key for a session's key index.
-
-    `Scope.SESSION` writes record their user key here so a session's state can be
-    enumerated and cleared (by `end_session`) without relying on the store's
-    optional key-enumeration protocol — the base `AsyncKeyValue` contract only
-    guarantees get/put/delete. A distinct `session-index:` prefix keeps the index
-    from ever colliding with a `session:...` state key.
+    Keyed by `(principal, session_id)`: the principal is the isolation wall, the
+    id organizes sessions within it. A session's whole state lives under this one
+    key as a dict, so one key means one store TTL per session and `clear` is a
+    single delete.
     """
-    return f"session-index:{_principal_segment(identity.principal)}:{identity.session_id}"
+    return f"session:{_principal_segment(principal)}:{session_id}"
 
 
-class _Unset:
-    """Sentinel: `unseal` should read the principal from the request context."""
+class Session:
+    """Async accessors over one `(principal, session_id)` bucket of state.
 
+    A session's state is a single dict stored under one key. `get`/`set`/`delete`
+    read-modify-write that dict; `clear` deletes the key. Writes never impose a
+    TTL — retention is entirely the server store's (configure it on the store you
+    pass to `FastMCP(session_state_store=...)`).
 
-_UNSET: Final[_Unset] = _Unset()
-
-
-class SessionCodec:
-    """Mints and verifies sealed session handles.
-
-    A handle is an opaque, URL-safe token minted server-side. Its payload —
-    `{session_id, principal, exp}` — is sealed with the SDK's AES-GCM request-state
-    codec, so a client can neither read nor forge it. On use the codec unseals it,
-    verifies it has not expired, and — when the request carries an authenticated
-    principal — verifies the handle's principal matches. Foreign, expired, or
-    tampered handles raise `InvalidSessionToken`.
-
-    Reuse the server's `request_state_security` key policy so session handles and
-    the SDK's `requestState` share one key ring; when the server sets no policy,
-    `from_security(None)` mints an ephemeral per-process key (single-process safe,
-    matching the SDK boundary's default).
+    Concurrent writes to one session race on the read-modify-write; session state
+    is small and typically driven serially by one agent, so this is acceptable.
     """
 
     def __init__(
         self,
-        security: RequestStateSecurity,
         *,
-        ttl: float = DEFAULT_SESSION_TTL,
+        store: PydanticAdapter[StateValue],
+        principal: str | None,
+        session_id: str,
     ) -> None:
-        if not (math.isfinite(ttl) and ttl > 0):
-            raise ValueError(f"session ttl must be a positive finite number, got {ttl!r}")
-        # Reuse only the raw AES-GCM codec (seal/unseal over bytes). The policy's
-        # ttl / audience / bind_principal belong to the SDK's per-request boundary
-        # and deliberately do NOT govern session handles.
-        self._codec = security.codec
-        self._ttl = ttl
+        self._store = store
+        self._principal = principal
+        self._session_id = session_id
+        self._key = session_storage_key(principal, session_id)
 
-    @classmethod
-    def from_security(
-        cls,
-        security: RequestStateSecurity | None,
-        *,
-        ttl: float = DEFAULT_SESSION_TTL,
-    ) -> SessionCodec:
-        """Build a codec from a server's request-state policy, or an ephemeral key.
+    async def _load(self) -> dict[str, Any]:
+        """Read the session's state dict, or an empty dict when unset."""
+        result = await self._store.get(key=self._key)
+        if result is None:
+            return {}
+        value = result.value
+        return dict(value) if isinstance(value, dict) else {}
 
-        Pass the server's configured `request_state_security` to bind session
-        handles to the same shared key ring. Pass `None` (no server policy) to
-        seal under a per-process ephemeral key.
-        """
-        if security is None:
-            security = RequestStateSecurity.ephemeral()
-        return cls(security, ttl=ttl)
+    async def _save(self, data: dict[str, Any]) -> None:
+        """Write the session's state dict back under its single key (no TTL)."""
+        from fastmcp.server.server import StateValue
 
-    def seal(self, session_id: str, principal: str | None) -> str:
-        """Mint a sealed handle binding `session_id` to `principal` with an expiry.
+        await self._store.put(key=self._key, value=StateValue(value=data))
 
-        `principal` is the compact-JSON principal string (see `current_principal`)
-        or `None` on an unauthenticated connection.
-        """
-        payload = {
-            "v": _ENVELOPE_VERSION,
-            "sid": session_id,
-            "p": principal,
-            "exp": time.time() + self._ttl,
-        }
-        raw = json.dumps(payload, separators=(",", ":")).encode()
-        return self._codec.seal(raw)
+    async def get(self, key: str, default: Any = None) -> Any:
+        """Return the value for `key`, or `default` when it is not set."""
+        data = await self._load()
+        return data.get(key, default)
 
-    def unseal(
-        self,
-        token: str,
-        *,
-        request_principal: str | None | _Unset = _UNSET,
-    ) -> SessionIdentity:
-        """Verify a sealed handle and return its identity.
+    async def set(self, key: str, value: Any) -> None:
+        """Store `value` under `key` in this session (read-modify-write)."""
+        data = await self._load()
+        data[key] = value
+        await self._save(data)
 
-        Checks integrity (AES-GCM), expiry, and — when the request carries an
-        authenticated principal — that the handle's principal matches it. A handle
-        minted under a principal but replayed on a request with a *different* or
-        *absent* principal is rejected, as is one minted without a principal but
-        presented under authentication (principal drift, mirroring the SDK
-        boundary).
+    async def delete(self, key: str) -> None:
+        """Remove `key` from this session, if present."""
+        data = await self._load()
+        if key in data:
+            del data[key]
+            await self._save(data)
 
-        By default the request principal is read from the current auth context;
-        tests may pass `request_principal` explicitly to exercise the match logic
-        without an auth context.
-
-        Raises:
-            InvalidSessionToken: Malformed, tampered, expired, or foreign handle.
-        """
-        if isinstance(request_principal, _Unset):
-            request_principal = current_principal()
-
-        try:
-            raw = self._codec.unseal(token)
-        except InvalidRequestState as exc:
-            self._reject(str(exc))
-
-        try:
-            claims = json.loads(raw)
-            version = claims["v"]
-            session_id = claims["sid"]
-            principal = claims["p"]
-            exp = claims["exp"]
-        except (ValueError, KeyError, TypeError):
-            self._reject("malformed")
-
-        if version != _ENVELOPE_VERSION or not isinstance(session_id, str):
-            self._reject("malformed")
-        if principal is not None and not isinstance(principal, str):
-            self._reject("malformed")
-
-        now = time.time()
-        # Stated positively so a NaN exp fails the comparison and rejects.
-        if not isinstance(exp, (int, float)) or isinstance(exp, bool) or not (now < exp):
-            self._reject("expired")
-
-        if request_principal is not None:
-            if principal is None or not hmac.compare_digest(principal, request_principal):
-                self._reject("principal mismatch")
-        elif principal is not None:
-            # Handle bound to a principal, replayed on an unauthenticated request:
-            # a downgrade that would leak a user's session. Reject.
-            self._reject("principal drift")
-
-        return SessionIdentity(session_id=session_id, principal=principal)
-
-    def _reject(self, reason: str) -> NoReturn:
-        """Log the real reason and raise a handle with a generic public message."""
-        logger.warning("session token rejected: %s", reason)
-        raise InvalidSessionToken(reason)
+    async def clear(self) -> None:
+        """Delete the entire session — its one key and all of its state."""
+        await self._store.delete(key=self._key)
 
 
-@dataclass(frozen=True)
-class Session:
-    """Marks a tool parameter as carrying a sealed session handle.
+class _SessionIdMarker:
+    """Metadata marker identifying a `SessionId`-annotated parameter."""
 
-    Use as `Annotated[str, Session()]` on a tool parameter. The parameter appears
-    in the tool's input schema as a plain string — the client supplies the token
-    it received from `create_session`. Before the tool body runs, the framework
-    unseals and verifies the token (integrity, expiry, and principal binding when
-    authenticated) and binds the resulting `SessionIdentity` onto the request, so
-    `ctx.get_state(scope=Scope.SESSION)` resolves for the duration of the call.
 
-    A missing, malformed, expired, or foreign token fails the call with
-    `InvalidSessionToken` before the body runs — session access never silently
-    degrades.
-
-    The tool body receives the raw token string in the annotated parameter. That
-    value is rarely needed: session state is read and written through
-    `ctx.get_state` / `ctx.set_state` with `Scope.SESSION`, and the annotation's
-    job is to establish identity. Declaring the parameter is enough to require a
-    valid session for the call.
-    """
+# A `session_id: SessionId` parameter is a plain required string in the input
+# schema (the agent supplies it); the marker lets the framework recognize it and
+# auto-populate its description with the create-then-pass contract.
+SessionId = Annotated[str, _SessionIdMarker()]
 
 
 @lru_cache(maxsize=5000)
-def session_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
-    """Names of a function's parameters annotated with `Session()`.
+def session_id_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
+    """Names of a function's parameters annotated with `SessionId`.
 
-    Scans the resolved type hints for `Annotated[..., Session()]` metadata.
+    Scans resolved type hints for `Annotated[str, _SessionIdMarker()]` metadata.
     Returns an empty tuple when the hints cannot be resolved (the function then
-    simply carries no session boundary).
+    simply carries no auto-populated session-id description).
     """
     try:
         hints = get_type_hints(fn, include_extras=True)
@@ -385,60 +210,100 @@ def session_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
             continue
         if get_origin(hint) is not Annotated:
             continue
-        if any(isinstance(meta, Session) for meta in get_args(hint)[1:]):
+        if any(isinstance(meta, _SessionIdMarker) for meta in get_args(hint)[1:]):
             names.append(name)
     return tuple(names)
 
 
-def create_session() -> str:
-    """Create a new session and return its opaque, sealed handle token.
+class _CurrentSession(Dependency["Session"]):
+    """Dependency that injects a per-user `Session` keyed by the request principal.
 
-    Mint a fresh `session_id`, bind it to the request's authenticated principal
-    (if any) and an expiry, and return the sealed token as a plain string. The
-    client stores this token and passes it back as the `Session()` argument on
-    later calls to access `Scope.SESSION` state.
+    Mirrors `_CurrentContext`: a bare `session: Session` parameter is rewritten to
+    default to this dependency, so it is excluded from the input schema and
+    resolved at call time. Raises `SessionAuthError` when the request carries no
+    authenticated principal.
     """
-    ctx = get_context()
-    return ctx.fastmcp.session_codec.seal(str(uuid4()), current_principal())
+
+    async def __aenter__(self) -> Session:
+        principal = current_principal()
+        if principal is None:
+            raise SessionAuthError
+        ctx = get_context()
+        return Session(
+            store=ctx.fastmcp._state_store,
+            principal=principal,
+            session_id=principal,
+        )
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
 
 
-async def end_session(session: Annotated[str, Session()]) -> str:
-    """End a session and delete all of its `Scope.SESSION` state.
+def CurrentSession() -> Session:
+    """Inject the per-user `Session` for the current authenticated principal.
 
-    The `Session()` boundary verifies the token before this body runs, so an
-    invalid or foreign token is rejected up front. All state written under this
-    session is removed; subsequent reads return their defaults.
+    Rarely written explicitly — a bare `session: Session` parameter is rewritten
+    to this. Provided for parity with `CurrentContext()` when an explicit default
+    is preferred.
     """
-    ctx = get_context()
-    await ctx.clear_session_state()
+    return cast("Session", _CurrentSession())
+
+
+async def create_session() -> str:
+    """Create a new session and return its identifier.
+
+    Mints an unguessable `uuid4` and returns it as a string. Store it and pass it
+    back as a `session_id` argument on later calls to persist state across a
+    session. State is keyed by the authenticated principal, so the id organizes
+    sessions within a user; on an unauthenticated connection the id is the only
+    thing standing between callers, which is why it is unguessable.
+    """
+    return str(uuid4())
+
+
+async def end_session(session_id: SessionId) -> str:
+    """End a session and delete all of its state."""
+    await get_context().get_session(session_id).clear()
     return "session ended"
 
 
-class SessionProvider:
-    """Opt-in lifecycle for sealed-handle session state.
+class SessionProvider(Provider):
+    """Opt-in provider contributing the session lifecycle tools.
 
-    Wire onto a server with `FastMCP(session_provider=SessionProvider(...))`. It
-    registers two tools:
+    Add it like any other provider:
 
-    - `create_session` mints a sealed handle and returns it as a plain string.
-    - `end_session` verifies a handle and clears that session's state.
+    ```python
+    from fastmcp.server.sessions import SessionProvider
 
-    The provider does not own storage: session state lives in the server's
-    configured state store (`FastMCP(session_state_store=...)`), and handles are
-    sealed with the server's `session_codec`, which reuses the server's
-    `request_state_security` key ring (or a per-process ephemeral key when none is
-    configured). `ttl` sets how long a minted handle stays valid, threaded into
-    the server's `SessionCodec`.
+    mcp.add_provider(SessionProvider())
+    ```
+
+    It registers two tools:
+
+    - `create_session()` mints an unguessable `uuid4` and returns it.
+    - `end_session(session_id)` clears that session's state.
+
+    It owns no storage (session state lives in the server's configured
+    `session_state_store`) and imposes no TTL (retention is the store's). It
+    exists only to hand out unguessable ids — a tool can take a `session_id`
+    argument and accept any caller-supplied id without it.
     """
 
-    def __init__(self, *, ttl: float = DEFAULT_SESSION_TTL) -> None:
-        if not (math.isfinite(ttl) and ttl > 0):
-            raise ValueError(
-                f"session ttl must be a positive finite number, got {ttl!r}"
-            )
-        self.ttl = ttl
+    def __init__(self) -> None:
+        super().__init__()
+        self._tools: list[Tool] | None = None
 
-    def register(self, server: FastMCP) -> None:
-        """Register the `create_session` / `end_session` tools on `server`."""
-        server.add_tool(create_session)
-        server.add_tool(end_session)
+    async def _list_tools(self) -> Sequence[Tool]:
+        if self._tools is None:
+            from fastmcp.tools.base import Tool
+
+            self._tools = [
+                Tool.from_function(create_session),
+                Tool.from_function(end_session),
+            ]
+        return self._tools

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -130,6 +130,28 @@ class SessionProviderRequiredError(FastMCPError):
         )
 
 
+class SessionProviderShadowedError(FastMCPError):
+    """A decorator-registered tool reuses a `SessionProvider` lifecycle tool's name.
+
+    Static, decorator-registered components always take precedence over
+    provider-sourced ones, so a local tool named `create_session` or
+    `end_session` silently replaces the `SessionProvider`'s own tool of that
+    name — the provider is registered, but its real lifecycle tool can never be
+    reached. Every id such a shadowed `create_session` returns is then rejected
+    by `get_session`, since it was never actually recorded. Raised at setup so
+    the misconfiguration surfaces immediately instead of as a confusing
+    `InvalidSession` on first use.
+    """
+
+    def __init__(self, *, tool_name: str) -> None:
+        super().__init__(
+            f"A local tool is registered as {tool_name!r}, which is also the name "
+            "of a SessionProvider lifecycle tool. The local tool takes precedence "
+            "and permanently shadows the provider's own tool. Rename the local "
+            "tool."
+        )
+
+
 class InvalidSession(FastMCPError):
     """A session id did not resolve to a session created under the current principal.
 
@@ -504,6 +526,30 @@ class SessionProvider(Provider):
                 Tool.from_function(end_session),
             ]
         return self._tools
+
+
+# The names `SessionProvider` registers its lifecycle tools under. Reserved:
+# a decorator-registered tool sharing one of these names always takes
+# precedence over the provider's own tool (static components beat providers),
+# permanently shadowing it.
+RESERVED_SESSION_TOOL_NAMES: Final[frozenset[str]] = frozenset(
+    {create_session.__name__, end_session.__name__}
+)
+
+
+def shadowing_local_tool(local_tools: Iterable[Tool]) -> str | None:
+    """Name of the first local tool reusing a `SessionProvider` lifecycle name.
+
+    Used to detect the case where a decorator-registered tool is named
+    `create_session` or `end_session`: because static components always take
+    precedence over providers, that local tool permanently shadows the
+    `SessionProvider`'s own tool of the same name, even though the provider is
+    registered and the requirement check passes.
+    """
+    for tool in local_tools:
+        if tool.name in RESERVED_SESSION_TOOL_NAMES:
+            return tool.name
+    return None
 
 
 def offending_session_id_tool(tools: Iterable[Tool]) -> str | None:

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -71,9 +71,14 @@ logger = get_logger(__name__)
 # The description the framework auto-populates onto a `SessionId` argument so an
 # agent reading the tool schema learns the create-then-pass contract with no
 # hand-prompting.
+# Deliberately names no specific tool. The session-creation tool can be renamed
+# by composition — mounting a server under a namespace exposes it as, e.g.,
+# `child_create_session` — so hard-coding a tool name here would point agents at
+# a tool that does not exist under that mount. Describing the capability keeps
+# the contract correct regardless of how the lifecycle tool is named.
 SESSION_ID_DESCRIPTION: Final[str] = (
-    "Session identifier. Call `create_session` to obtain one, then pass it here "
-    "to persist state across calls in the same session."
+    "Session identifier. Use a tool to create a session, then pass the resulting "
+    "id here to persist state across calls in the same session."
 )
 
 # Reserved top-level keys in a session's stored dict. User state lives under

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -34,6 +34,7 @@ id is a bearer capability and sessions are not a boundary between clients.
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 import time
@@ -56,7 +57,7 @@ from mcp.server.auth.provider import principal_components
 from uncalled_for import Dependency
 
 from fastmcp.exceptions import FastMCPError
-from fastmcp.server.dependencies import get_access_token, get_context
+from fastmcp.server.dependencies import get_access_token, get_server
 from fastmcp.server.providers.base import Provider
 from fastmcp.utilities.logging import get_logger
 
@@ -342,14 +343,27 @@ def session_id_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
     Scans resolved type hints for `Annotated[str, _SessionIdMarker()]` metadata.
     Returns an empty tuple when the hints cannot be resolved (the function then
     simply carries no auto-populated session-id description).
+
+    `functools.partial` is unwrapped first, since `get_type_hints` rejects a
+    partial object — FastMCP supports registering a partial as a tool, and its
+    schema is still built from the underlying function, so its `SessionId`
+    parameters must be detected here too. Parameters the partial has already
+    bound are dropped, matching the tool's actual argument surface.
     """
+    target: object = fn
+    bound: set[str] = set()
+    while isinstance(target, functools.partial):
+        bound.update(target.keywords or {})
+        target = target.func
+    if not callable(target):
+        return ()
     try:
-        hints = get_type_hints(fn, include_extras=True)
+        hints = get_type_hints(target, include_extras=True)
     except (TypeError, NameError):
         return ()
     names: list[str] = []
     for name, hint in hints.items():
-        if name == "return":
+        if name == "return" or name in bound:
             continue
         if get_origin(hint) is not Annotated:
             continue
@@ -371,9 +385,13 @@ class _CurrentSession(Dependency["Session"]):
         principal = current_principal()
         if principal is None:
             raise SessionAuthError
-        ctx = get_context()
+        # Resolve the store through `get_server()` rather than `get_context()`:
+        # a `task=True` tool whose only injected dependency is `UserSession` runs
+        # in a Docket worker with no foreground context, and `get_server()` is
+        # task-aware (it resolves via the task-server map in a worker).
+        server = get_server()
         return Session(
-            store=ctx.fastmcp._state_store,
+            store=server._state_store,
             principal=principal,
             session_id=_USER_SESSION_ID,
         )
@@ -406,9 +424,8 @@ async def resolve_session(session_id: str) -> Session:
     principal, raises `InvalidSession`; the specific reason is logged at debug
     level and never returned to the caller.
     """
-    ctx = get_context()
     session = Session(
-        store=ctx.fastmcp._state_store,
+        store=get_server()._state_store,
         principal=current_principal(),
         session_id=session_id,
         public_id=session_id,
@@ -434,9 +451,8 @@ async def create_session() -> str:
     is unguessable.
     """
     session_id = str(uuid4())
-    ctx = get_context()
     session = Session(
-        store=ctx.fastmcp._state_store,
+        store=get_server()._state_store,
         principal=current_principal(),
         session_id=session_id,
         public_id=session_id,

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -13,15 +13,16 @@ authenticated principal rather than by any client-declared identifier.
 - `session: UserSession` (injected): a per-user bucket, dependency-injected like
   `ctx: Context` and keyed by the request's authenticated principal. Requires
   auth. `UserSession` is the injection annotation; the injected value is a
-  `Session`.
+  `Session`. It is always available under auth — no `create_session`, no
+  provider, no validation.
 - `session_id: SessionId` (argument): a required string the agent supplies,
-  resolved with `ctx.get_session(session_id)`. Works with or without auth, but
-  only isolates between callers under auth. Declaring one auto-wires the default
-  `SessionProvider` (its `create_session` / `end_session` tools) unless the
-  developer already registered one or opted out.
+  resolved with `await ctx.get_session(session_id)`. The id must first be minted
+  by `create_session`; an id that was never created (or was created under a
+  different principal) is rejected. A server with a `session_id` tool must
+  register a `SessionProvider`.
 - `SessionProvider`: a `Provider` contributing `create_session` / `end_session`
-  tools. Registered automatically when a tool declares `session_id: SessionId`,
-  or explicitly via `add_provider`.
+  tools. Register it explicitly with `mcp.add_provider(SessionProvider())`
+  whenever a tool declares `session_id: SessionId`.
 
 Isolation is the authenticated principal, not the session id. State keyed by
 `(principal, session_id)` means a request under principal B can never address
@@ -34,7 +35,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-import weakref
+import time
 from collections.abc import Callable, Iterable, Sequence
 from functools import lru_cache
 from types import TracebackType
@@ -56,12 +57,15 @@ from uncalled_for import Dependency
 from fastmcp.exceptions import FastMCPError
 from fastmcp.server.dependencies import get_access_token, get_context
 from fastmcp.server.providers.base import Provider
+from fastmcp.utilities.logging import get_logger
 
 if TYPE_CHECKING:
     from key_value.aio.adapters.pydantic import PydanticAdapter
 
-    from fastmcp.server.server import FastMCP, StateValue
+    from fastmcp.server.server import StateValue
     from fastmcp.tools.base import Tool
+
+logger = get_logger(__name__)
 
 
 # The description the framework auto-populates onto a `SessionId` argument so an
@@ -71,6 +75,15 @@ SESSION_ID_DESCRIPTION: Final[str] = (
     "Session identifier. Call `create_session` to obtain one, then pass it here "
     "to persist state across calls in the same session."
 )
+
+# Reserved top-level keys in a session's stored dict. User state lives under
+# `_STATE_KEY` (a sub-dict), and `_MARKER_KEY` records that the session was
+# created. Keeping user state in a sub-dict means normal `set`/`delete`/`clear`
+# can never collide with or clobber the creation marker, so a created session
+# stays distinguishable from a missing one — including after `clear()`, which
+# empties the sub-dict but leaves the marker in place.
+_MARKER_KEY: Final[str] = "_created"
+_STATE_KEY: Final[str] = "state"
 
 
 class SessionAuthError(FastMCPError):
@@ -89,6 +102,37 @@ class SessionAuthError(FastMCPError):
             "argument for cross-call state on unauthenticated connections."
         ),
     ) -> None:
+        super().__init__(message)
+
+
+class SessionProviderRequiredError(FastMCPError):
+    """A tool declares `session_id: SessionId` but no `SessionProvider` is registered.
+
+    Session ids must be minted by `create_session`, so a server whose tools take a
+    `session_id: SessionId` argument has to register a `SessionProvider` to supply
+    the lifecycle tools. Raised before any tool can be called so the
+    misconfiguration surfaces loudly rather than as a runtime "unknown session".
+    """
+
+    def __init__(self, *, tool_name: str) -> None:
+        super().__init__(
+            f"Tool {tool_name!r} declares a `session_id: SessionId` parameter, but "
+            "no `SessionProvider` is registered to mint and end sessions. Register "
+            "one with `mcp.add_provider(SessionProvider())`."
+        )
+
+
+class InvalidSession(FastMCPError):
+    """A session id did not resolve to a session created under the current principal.
+
+    Raised by `ctx.get_session(session_id)` when the id was never created, or was
+    created under a different principal. The public message is deliberately
+    generic — the specific reason (which id, which principal) is logged at debug
+    level, not returned to the caller, so an attacker cannot distinguish "unknown
+    id" from "belongs to someone else".
+    """
+
+    def __init__(self, message: str = "Invalid or unknown session.") -> None:
         super().__init__(message)
 
 
@@ -122,7 +166,7 @@ def session_storage_key(principal: str | None, session_id: str) -> str:
 
     Keyed by `(principal, session_id)`: the principal is the isolation wall, the
     id organizes sessions within it. A session's whole state lives under this one
-    key as a dict, so one key means one store TTL per session and `clear` is a
+    key as a dict, so one key means one store TTL per session and `end` is a
     single delete.
     """
     return f"session:{_principal_segment(principal)}:{session_id}"
@@ -131,10 +175,13 @@ def session_storage_key(principal: str | None, session_id: str) -> str:
 class Session:
     """Async accessors over one `(principal, session_id)` bucket of state.
 
-    A session's state is a single dict stored under one key. `get`/`set`/`delete`
-    read-modify-write that dict; `clear` deletes the key. Writes never impose a
-    TTL — retention is entirely the server store's (configure it on the store you
-    pass to `FastMCP(session_state_store=...)`).
+    A session's state is a single dict stored under one key. That dict holds user
+    state in a `state` sub-dict and a small creation marker alongside it, so a
+    created-but-empty session is still distinguishable from a missing one.
+    `get`/`set`/`delete` read-modify-write the sub-dict; `clear` empties the
+    sub-dict but keeps the session valid; `end` deletes the whole key. Writes
+    never impose a TTL — retention is entirely the server store's (configure it on
+    the store you pass to `FastMCP(session_state_store=...)`).
 
     Concurrent writes to one session race on the read-modify-write; session state
     is small and typically driven serially by one agent, so this is acceptable.
@@ -152,40 +199,91 @@ class Session:
         self._session_id = session_id
         self._key = session_storage_key(principal, session_id)
 
-    async def _load(self) -> dict[str, Any]:
-        """Read the session's state dict, or an empty dict when unset."""
+    async def _load_raw(self) -> dict[str, Any] | None:
+        """Read the session's full stored dict, or `None` when the key is unset."""
         result = await self._store.get(key=self._key)
         if result is None:
-            return {}
+            return None
         value = result.value
-        return dict(value) if isinstance(value, dict) else {}
+        return dict(value) if isinstance(value, dict) else None
 
-    async def _save(self, data: dict[str, Any]) -> None:
-        """Write the session's state dict back under its single key (no TTL)."""
+    async def _save_raw(self, data: dict[str, Any]) -> None:
+        """Write the session's full dict back under its single key (no TTL)."""
         from fastmcp.server.server import StateValue
 
         await self._store.put(key=self._key, value=StateValue(value=data))
 
+    @staticmethod
+    def _state_of(raw: dict[str, Any] | None) -> dict[str, Any]:
+        """The user-state sub-dict of a raw stored dict (empty when absent)."""
+        if raw is None:
+            return {}
+        state = raw.get(_STATE_KEY)
+        return dict(state) if isinstance(state, dict) else {}
+
+    async def _exists(self) -> bool:
+        """Whether a session record exists for this `(principal, session_id)`.
+
+        True only once `create_session` has written the creation marker. A raw
+        store entry without the marker (e.g. an injected `UserSession` bucket) is
+        not a created session and does not satisfy this check.
+        """
+        raw = await self._load_raw()
+        return raw is not None and _MARKER_KEY in raw
+
+    async def _create(self) -> None:
+        """Write the initial record so the session exists (called by `create_session`)."""
+        raw = await self._load_raw() or {}
+        raw[_MARKER_KEY] = time.time()
+        raw.setdefault(_STATE_KEY, {})
+        await self._save_raw(raw)
+
     async def get(self, key: str, default: Any = None) -> Any:
         """Return the value for `key`, or `default` when it is not set."""
-        data = await self._load()
-        return data.get(key, default)
+        raw = await self._load_raw()
+        return self._state_of(raw).get(key, default)
 
     async def set(self, key: str, value: Any) -> None:
-        """Store `value` under `key` in this session (read-modify-write)."""
-        data = await self._load()
-        data[key] = value
-        await self._save(data)
+        """Store `value` under `key` in this session (read-modify-write).
+
+        Preserves the creation marker: only the user-state sub-dict is touched.
+        """
+        raw = await self._load_raw() or {}
+        state = self._state_of(raw)
+        state[key] = value
+        raw[_STATE_KEY] = state
+        await self._save_raw(raw)
 
     async def delete(self, key: str) -> None:
-        """Remove `key` from this session, if present."""
-        data = await self._load()
-        if key in data:
-            del data[key]
-            await self._save(data)
+        """Remove `key` from this session, if present (preserves the marker)."""
+        raw = await self._load_raw()
+        if raw is None:
+            return
+        state = self._state_of(raw)
+        if key in state:
+            del state[key]
+            raw[_STATE_KEY] = state
+            await self._save_raw(raw)
 
     async def clear(self) -> None:
-        """Delete the entire session — its one key and all of its state."""
+        """Empty the session's user state but keep the session valid.
+
+        The user-state sub-dict is reset to empty while the creation marker stays
+        in place, so a cleared session still resolves through `ctx.get_session`.
+        To invalidate a session entirely, use `end` (what `end_session` calls).
+        """
+        raw = await self._load_raw()
+        if raw is None:
+            return
+        raw[_STATE_KEY] = {}
+        await self._save_raw(raw)
+
+    async def end(self) -> None:
+        """Invalidate the session — delete its one key and all of its state.
+
+        After this the id no longer resolves through `ctx.get_session`. This is
+        what `end_session` calls; `clear` only empties state and keeps the session.
+        """
         await self._store.delete(key=self._key)
 
 
@@ -199,9 +297,9 @@ class UserSession(Session):
     an ordinary `Session`, so `await session.get(...)`, `.set`, `.delete`, and
     `.clear` all work exactly as on any other `Session`.
 
-    Use `UserSession` when one state bucket per user is what you want, with
-    nothing for the agent to pass. For distinct sessions the agent selects, take a
-    `session_id: SessionId` argument instead.
+    Unlike `session_id: SessionId`, the per-user bucket needs no `create_session`,
+    no `SessionProvider`, and no validation — it is always available under auth,
+    keyed directly by the caller's identity.
 
     ```python
     from fastmcp.server.sessions import UserSession
@@ -289,28 +387,67 @@ def CurrentSession() -> Session:
     return cast("Session", _CurrentSession())
 
 
+async def resolve_session(session_id: str) -> Session:
+    """Resolve and validate a session id against the current principal's store.
+
+    Reads the record for `(current_principal, session_id)` and returns a `Session`
+    only when it exists — i.e. was written by `create_session` under this same
+    principal. An id that was never created, or created under a different
+    principal, raises `InvalidSession`; the specific reason is logged at debug
+    level and never returned to the caller.
+    """
+    ctx = get_context()
+    session = Session(
+        store=ctx.fastmcp._state_store,
+        principal=current_principal(),
+        session_id=session_id,
+    )
+    if not await session._exists():
+        logger.debug(
+            "Rejected session id %r: no record for the current principal.",
+            session_id,
+        )
+        raise InvalidSession
+    return session
+
+
 async def create_session() -> str:
     """Create a new session and return its identifier.
 
-    Mints an unguessable `uuid4` and returns it as a string. Store it and pass it
-    back as a `session_id` argument on later calls to persist state across a
-    session. State is keyed by the authenticated principal, so the id organizes
-    sessions within a user; on an unauthenticated connection the id is the only
-    thing standing between callers, which is why it is unguessable.
+    Mints an unguessable `uuid4`, records an initial session owned by the current
+    principal, and returns the id as a string. Store it and pass it back as a
+    `session_id` argument on later calls to persist state across a session — only
+    an id created this way resolves. State is keyed by the authenticated
+    principal, so the id organizes sessions within a user; on an unauthenticated
+    connection the id is the only thing standing between callers, which is why it
+    is unguessable.
     """
-    return str(uuid4())
+    session_id = str(uuid4())
+    ctx = get_context()
+    session = Session(
+        store=ctx.fastmcp._state_store,
+        principal=current_principal(),
+        session_id=session_id,
+    )
+    await session._create()
+    return session_id
 
 
 async def end_session(session_id: SessionId) -> str:
-    """End a session and delete all of its state."""
-    await get_context().get_session(session_id).clear()
+    """End a session and delete all of its state.
+
+    Validates the id like any other resolution (an unknown or foreign id is
+    rejected), then deletes the session's key so the id no longer resolves.
+    """
+    session = await resolve_session(session_id)
+    await session.end()
     return "session ended"
 
 
 class SessionProvider(Provider):
-    """Opt-in provider contributing the session lifecycle tools.
+    """Provider contributing the session lifecycle tools.
 
-    Add it like any other provider:
+    Register it whenever a tool declares a `session_id: SessionId` argument:
 
     ```python
     from fastmcp.server.sessions import SessionProvider
@@ -320,13 +457,15 @@ class SessionProvider(Provider):
 
     It registers two tools:
 
-    - `create_session()` mints an unguessable `uuid4` and returns it.
-    - `end_session(session_id)` clears that session's state.
+    - `create_session()` mints an unguessable `uuid4`, records the session, and
+      returns the id.
+    - `end_session(session_id)` invalidates that session and deletes its state.
 
     It owns no storage (session state lives in the server's configured
     `session_state_store`) and imposes no TTL (retention is the store's). It
-    exists only to hand out unguessable ids — a tool can take a `session_id`
-    argument and accept any caller-supplied id without it.
+    exists to mint and end owned session ids — a server whose tools take a
+    `session_id` argument requires one, or those tools raise
+    `SessionProviderRequiredError` before they can be called.
     """
 
     def __init__(self) -> None:
@@ -344,53 +483,16 @@ class SessionProvider(Provider):
         return self._tools
 
 
-def tools_declare_session_id(tools: Iterable[Tool]) -> bool:
-    """Whether any tool in `tools` declares a `session_id: SessionId` parameter.
+def offending_session_id_tool(tools: Iterable[Tool]) -> str | None:
+    """Name of the first tool declaring `session_id: SessionId`, or `None`.
 
-    Checks each function-backed tool's resolved hints for the `SessionId` marker.
-    Used to decide whether the default `SessionProvider` should be auto-registered.
+    Used to enforce that a `SessionProvider` is registered whenever a tool
+    requires session ids. Only function-backed tools carry resolvable hints, so
+    only those are inspected.
     """
     from fastmcp.tools.function_tool import FunctionTool
 
-    return any(
-        isinstance(tool, FunctionTool) and session_id_parameter_names(tool.fn)
-        for tool in tools
-    )
-
-
-class _ImplicitSessionProvider(SessionProvider):
-    """Server-owned `SessionProvider` that activates only when it is needed.
-
-    Consulted directly by the server's tool listing/lookup (it is deliberately
-    kept out of the public `providers` list so it never perturbs provider indices
-    or user introspection). It contributes its `create_session` / `end_session`
-    tools only when every condition holds:
-
-    - the server has not opted out (`FastMCP(auto_session_provider=False)`),
-    - no `SessionProvider` was registered explicitly (a manual one wins), and
-    - at least one locally registered tool declares a `session_id: SessionId`
-      argument.
-
-    Detection scans the server's own registered tools (the `LocalProvider`'s
-    decorator / `add_tool` set), which is read fresh at list time — so activation
-    is independent of the order in which tools and providers are registered (a
-    `session_id` tool added after construction still activates it) and never
-    invokes another provider's listing (a mounted sub-server wires its own
-    `SessionProvider` and is not scanned here, so its middleware is never run as a
-    side effect of this decision).
-    """
-
-    def __init__(self, server: FastMCP) -> None:
-        super().__init__()
-        self._server_ref = weakref.ref(server)
-
-    async def _list_tools(self) -> Sequence[Tool]:
-        server = self._server_ref()
-        if server is None or not server._auto_session_provider:
-            return []
-        if any(isinstance(p, SessionProvider) for p in server.providers):
-            return []
-        local_tools = await server._local_provider._list_tools()
-        if not tools_declare_session_id(local_tools):
-            return []
-        return await super()._list_tools()
+    for tool in tools:
+        if isinstance(tool, FunctionTool) and session_id_parameter_names(tool.fn):
+            return tool.name
+    return None

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -26,17 +26,30 @@ import json
 import logging
 import math
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-from typing import Final, NoReturn
+from functools import lru_cache
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Final,
+    NoReturn,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+from uuid import uuid4
 
 from mcp.server.auth.provider import principal_components
 from mcp.server.request_state import InvalidRequestState, RequestStateSecurity
 
 from fastmcp.exceptions import FastMCPError
-from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.dependencies import get_access_token, get_context
+
+if TYPE_CHECKING:
+    from fastmcp.server.server import FastMCP
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -185,6 +198,18 @@ def session_state_key(identity: SessionIdentity, key: str) -> str:
     return f"session:{_principal_segment(identity.principal)}:{identity.session_id}:{key}"
 
 
+def session_index_key(identity: SessionIdentity) -> str:
+    """Storage key for a session's key index.
+
+    `Scope.SESSION` writes record their user key here so a session's state can be
+    enumerated and cleared (by `end_session`) without relying on the store's
+    optional key-enumeration protocol — the base `AsyncKeyValue` contract only
+    guarantees get/put/delete. A distinct `session-index:` prefix keeps the index
+    from ever colliding with a `session:...` state key.
+    """
+    return f"session-index:{_principal_segment(identity.principal)}:{identity.session_id}"
+
+
 class _Unset:
     """Sentinel: `unseal` should read the principal from the request context."""
 
@@ -317,3 +342,103 @@ class SessionCodec:
         """Log the real reason and raise a handle with a generic public message."""
         logger.warning("session token rejected: %s", reason)
         raise InvalidSessionToken(reason)
+
+
+@dataclass(frozen=True)
+class Session:
+    """Marks a tool parameter as carrying a sealed session handle.
+
+    Use as `Annotated[str, Session()]` on a tool parameter. The parameter appears
+    in the tool's input schema as a plain string — the client supplies the token
+    it received from `create_session`. Before the tool body runs, the framework
+    unseals and verifies the token (integrity, expiry, and principal binding when
+    authenticated) and binds the resulting `SessionIdentity` onto the request, so
+    `ctx.get_state(scope=Scope.SESSION)` resolves for the duration of the call.
+
+    A missing, malformed, expired, or foreign token fails the call with
+    `InvalidSessionToken` before the body runs — session access never silently
+    degrades.
+
+    The tool body receives the raw token string in the annotated parameter. That
+    value is rarely needed: session state is read and written through
+    `ctx.get_state` / `ctx.set_state` with `Scope.SESSION`, and the annotation's
+    job is to establish identity. Declaring the parameter is enough to require a
+    valid session for the call.
+    """
+
+
+@lru_cache(maxsize=5000)
+def session_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
+    """Names of a function's parameters annotated with `Session()`.
+
+    Scans the resolved type hints for `Annotated[..., Session()]` metadata.
+    Returns an empty tuple when the hints cannot be resolved (the function then
+    simply carries no session boundary).
+    """
+    try:
+        hints = get_type_hints(fn, include_extras=True)
+    except (TypeError, NameError):
+        return ()
+    names: list[str] = []
+    for name, hint in hints.items():
+        if name == "return":
+            continue
+        if get_origin(hint) is not Annotated:
+            continue
+        if any(isinstance(meta, Session) for meta in get_args(hint)[1:]):
+            names.append(name)
+    return tuple(names)
+
+
+def create_session() -> str:
+    """Create a new session and return its opaque, sealed handle token.
+
+    Mint a fresh `session_id`, bind it to the request's authenticated principal
+    (if any) and an expiry, and return the sealed token as a plain string. The
+    client stores this token and passes it back as the `Session()` argument on
+    later calls to access `Scope.SESSION` state.
+    """
+    ctx = get_context()
+    return ctx.fastmcp.session_codec.seal(str(uuid4()), current_principal())
+
+
+async def end_session(session: Annotated[str, Session()]) -> str:
+    """End a session and delete all of its `Scope.SESSION` state.
+
+    The `Session()` boundary verifies the token before this body runs, so an
+    invalid or foreign token is rejected up front. All state written under this
+    session is removed; subsequent reads return their defaults.
+    """
+    ctx = get_context()
+    await ctx.clear_session_state()
+    return "session ended"
+
+
+class SessionProvider:
+    """Opt-in lifecycle for sealed-handle session state.
+
+    Wire onto a server with `FastMCP(session_provider=SessionProvider(...))`. It
+    registers two tools:
+
+    - `create_session` mints a sealed handle and returns it as a plain string.
+    - `end_session` verifies a handle and clears that session's state.
+
+    The provider does not own storage: session state lives in the server's
+    configured state store (`FastMCP(session_state_store=...)`), and handles are
+    sealed with the server's `session_codec`, which reuses the server's
+    `request_state_security` key ring (or a per-process ephemeral key when none is
+    configured). `ttl` sets how long a minted handle stays valid, threaded into
+    the server's `SessionCodec`.
+    """
+
+    def __init__(self, *, ttl: float = DEFAULT_SESSION_TTL) -> None:
+        if not (math.isfinite(ttl) and ttl > 0):
+            raise ValueError(
+                f"session ttl must be a positive finite number, got {ttl!r}"
+            )
+        self.ttl = ttl
+
+    def register(self, server: FastMCP) -> None:
+        """Register the `create_session` / `end_session` tools on `server`."""
+        server.add_tool(create_session)
+        server.add_tool(end_session)

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -475,9 +475,9 @@ class SessionProvider(Provider):
 
     It owns no storage (session state lives in the server's configured
     `session_state_store`) and imposes no TTL (retention is the store's). It
-    exists to mint and end owned session ids — a server whose tools take a
-    `session_id` argument requires one, or those tools raise
-    `SessionProviderRequiredError` before they can be called.
+    exists to mint and end owned session ids. Registration is not enforced: with
+    no provider, no id can be created, so every `ctx.get_session(...)` rejects —
+    a `session_id` tool without a provider simply cannot resolve a session.
     """
 
     def __init__(self) -> None:

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -193,11 +193,24 @@ class Session:
         store: PydanticAdapter[StateValue],
         principal: str | None,
         session_id: str,
+        public_id: str | None = None,
     ) -> None:
         self._store = store
         self._principal = principal
         self._session_id = session_id
+        self._public_id = public_id
         self._key = session_storage_key(principal, session_id)
+
+    @property
+    def id(self) -> str | None:
+        """The session's identifier, or `None` for an injected per-user session.
+
+        For a session resolved from a `session_id` argument (or minted by
+        `create_session`) this is that id. An injected `UserSession` has no
+        distinct id — its bucket is the authenticated user — so it is `None`; the
+        internal principal-derived key is deliberately not exposed here.
+        """
+        return self._public_id
 
     async def _load_raw(self) -> dict[str, Any] | None:
         """Read the session's full stored dict, or `None` when the key is unset."""
@@ -401,6 +414,7 @@ async def resolve_session(session_id: str) -> Session:
         store=ctx.fastmcp._state_store,
         principal=current_principal(),
         session_id=session_id,
+        public_id=session_id,
     )
     if not await session._exists():
         logger.debug(
@@ -428,6 +442,7 @@ async def create_session() -> str:
         store=ctx.fastmcp._state_store,
         principal=current_principal(),
         session_id=session_id,
+        public_id=session_id,
     )
     await session._create()
     return session_id

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -85,6 +85,14 @@ SESSION_ID_DESCRIPTION: Final[str] = (
 _MARKER_KEY: Final[str] = "_created"
 _STATE_KEY: Final[str] = "state"
 
+# Fixed session-id suffix for the injected per-user bucket. The principal is
+# already hashed into the key's namespace segment (`_principal_segment`), which
+# alone makes the bucket unique per user — using the *raw* principal again as
+# the id suffix would embed unhashed identity data (issuer, client id, subject)
+# in the storage key and in any logs that record it. A reserved constant avoids
+# that while a `create_session`-minted uuid4 can never collide with it.
+_USER_SESSION_ID: Final[str] = "_user"
+
 
 class SessionAuthError(FastMCPError):
     """An injected `session: UserSession` was requested with no authenticated principal.
@@ -378,7 +386,7 @@ class _CurrentSession(Dependency["Session"]):
         return Session(
             store=ctx.fastmcp._state_store,
             principal=principal,
-            session_id=principal,
+            session_id=_USER_SESSION_ID,
         )
 
     async def __aexit__(

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import inspect
 import json
 import time
 from collections.abc import Callable, Sequence
@@ -305,9 +306,10 @@ class UserSession(Session):
     A `session: UserSession` parameter is **dependency-injected** like
     `ctx: Context`: keyed by the request's authenticated principal, excluded from
     the input schema, and requiring auth (it raises `SessionAuthError` with no
-    principal). It is the injection *annotation* — the value a handler receives is
-    an ordinary `Session`, so `await session.get(...)`, `.set`, `.delete`, and
-    `.clear` all work exactly as on any other `Session`.
+    principal). It doubles as the injection *annotation* and the injected
+    type — the value a handler receives is a `UserSession`, which subclasses
+    `Session`, so `await session.get(...)`, `.set`, `.delete`, and `.clear` all
+    work exactly as on any other `Session`.
 
     Unlike `session_id: SessionId`, the per-user bucket needs no `create_session`,
     no `SessionProvider`, and no validation — it is always available under auth,
@@ -323,7 +325,7 @@ class UserSession(Session):
     ```
 
     Subclasses `Session` only so the framework's type-based injection detector can
-    key off it; it adds no behavior and is never instantiated directly.
+    key off it; it adds no behavior of its own.
     """
 
 
@@ -349,12 +351,11 @@ def session_id_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
     partial object — FastMCP supports registering a partial as a tool, and its
     schema is still built from the underlying function, so its `SessionId`
     parameters must be detected here too. Parameters the partial has already
-    bound are dropped, matching the tool's actual argument surface.
+    bound — positionally or by keyword — are dropped, matching the tool's actual
+    argument surface (the partial's own signature already reflects this).
     """
     target: object = fn
-    bound: set[str] = set()
     while isinstance(target, functools.partial):
-        bound.update(target.keywords or {})
         target = target.func
     if not callable(target):
         return ()
@@ -362,15 +363,42 @@ def session_id_parameter_names(fn: Callable[..., object]) -> tuple[str, ...]:
         hints = get_type_hints(target, include_extras=True)
     except (TypeError, NameError):
         return ()
+    # `inspect.signature` on the (possibly partial) callable reports only the
+    # parameters still open to callers — a partial's bound positional and keyword
+    # arguments are already removed — so it is the source of truth for the tool's
+    # argument surface. Fall back to accepting every hinted name if the signature
+    # cannot be read.
+    try:
+        remaining = set(inspect.signature(fn).parameters)
+    except (TypeError, ValueError):
+        remaining = None
     names: list[str] = []
     for name, hint in hints.items():
-        if name == "return" or name in bound:
+        if name == "return" or (remaining is not None and name not in remaining):
             continue
         if get_origin(hint) is not Annotated:
             continue
         if any(isinstance(meta, _SessionIdMarker) for meta in get_args(hint)[1:]):
             names.append(name)
     return tuple(names)
+
+
+def _current_user_session() -> UserSession | None:
+    """Build the per-user session for the current principal, or `None` if unauth.
+
+    Resolves the store through `get_server()` rather than `get_context()`: a
+    `task=True` tool whose only injected dependency is `UserSession` runs in a
+    Docket worker with no foreground context, and `get_server()` is task-aware (it
+    resolves via the task-server map in a worker).
+    """
+    principal = current_principal()
+    if principal is None:
+        return None
+    return UserSession(
+        store=get_server()._state_store,
+        principal=principal,
+        session_id=_USER_SESSION_ID,
+    )
 
 
 class _CurrentSession(Dependency["Session"]):
@@ -383,19 +411,31 @@ class _CurrentSession(Dependency["Session"]):
     """
 
     async def __aenter__(self) -> Session:
-        principal = current_principal()
-        if principal is None:
+        session = _current_user_session()
+        if session is None:
             raise SessionAuthError
-        # Resolve the store through `get_server()` rather than `get_context()`:
-        # a `task=True` tool whose only injected dependency is `UserSession` runs
-        # in a Docket worker with no foreground context, and `get_server()` is
-        # task-aware (it resolves via the task-server map in a worker).
-        server = get_server()
-        return Session(
-            store=server._state_store,
-            principal=principal,
-            session_id=_USER_SESSION_ID,
-        )
+        return session
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+
+class _OptionalCurrentSession(Dependency["Session | None"]):
+    """Dependency for an *optional* per-user session (`session: UserSession | None`).
+
+    Mirrors `_OptionalCurrentContext`: when the request carries no authenticated
+    principal it injects `None` instead of raising, so a handler that declares the
+    parameter optional (default `None`) can run on unauthenticated requests and
+    branch on whether a session is available.
+    """
+
+    async def __aenter__(self) -> Session | None:
+        return _current_user_session()
 
     async def __aexit__(
         self,
@@ -414,6 +454,15 @@ def CurrentSession() -> Session:
     is preferred.
     """
     return cast("Session", _CurrentSession())
+
+
+def OptionalCurrentSession() -> Session | None:
+    """Inject the per-user `Session`, or `None` when the request is unauthenticated.
+
+    Rarely written explicitly — a `session: UserSession | None = None` parameter
+    is rewritten to this. Provided for parity with `OptionalCurrentContext()`.
+    """
+    return cast("Session | None", _OptionalCurrentSession())
 
 
 async def create_session() -> str:

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -18,11 +18,12 @@ authenticated principal rather than by any client-declared identifier.
 - `session_id: SessionId` (argument): a required string the agent supplies,
   resolved with `await ctx.get_session(session_id)`. The id must first be minted
   by `create_session`; an id that was never created (or was created under a
-  different principal) is rejected. A server with a `session_id` tool must
-  register a `SessionProvider`.
+  different principal) is rejected. This validation is the whole guarantee — an
+  unminted id never resolves, so nothing enforces provider registration.
 - `SessionProvider`: a `Provider` contributing `create_session` / `end_session`
-  tools. Register it explicitly with `mcp.add_provider(SessionProvider())`
-  whenever a tool declares `session_id: SessionId`.
+  tools. Register it with `mcp.add_provider(SessionProvider())` so a tool that
+  takes `session_id` has a way to mint ids; without it, no id can be created, so
+  those tools simply cannot resolve a session.
 
 Isolation is the authenticated principal, not the session id. State keyed by
 `(principal, session_id)` means a request under principal B can never address
@@ -36,7 +37,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Sequence
 from functools import lru_cache
 from types import TracebackType
 from typing import (
@@ -116,45 +117,6 @@ class SessionAuthError(FastMCPError):
         ),
     ) -> None:
         super().__init__(message)
-
-
-class SessionProviderRequiredError(FastMCPError):
-    """A tool declares `session_id: SessionId` but no `SessionProvider` is registered.
-
-    Session ids must be minted by `create_session`, so a server whose tools take a
-    `session_id: SessionId` argument has to register a `SessionProvider` to supply
-    the lifecycle tools. Raised before any tool can be called so the
-    misconfiguration surfaces loudly rather than as a runtime "unknown session".
-    """
-
-    def __init__(self, *, tool_name: str) -> None:
-        super().__init__(
-            f"Tool {tool_name!r} declares a `session_id: SessionId` parameter, but "
-            "no `SessionProvider` is registered to mint and end sessions. Register "
-            "one with `mcp.add_provider(SessionProvider())`."
-        )
-
-
-class SessionProviderShadowedError(FastMCPError):
-    """A decorator-registered tool reuses a `SessionProvider` lifecycle tool's name.
-
-    Static, decorator-registered components always take precedence over
-    provider-sourced ones, so a local tool named `create_session` or
-    `end_session` silently replaces the `SessionProvider`'s own tool of that
-    name — the provider is registered, but its real lifecycle tool can never be
-    reached. Every id such a shadowed `create_session` returns is then rejected
-    by `get_session`, since it was never actually recorded. Raised at setup so
-    the misconfiguration surfaces immediately instead of as a confusing
-    `InvalidSession` on first use.
-    """
-
-    def __init__(self, *, tool_name: str) -> None:
-        super().__init__(
-            f"A local tool is registered as {tool_name!r}, which is also the name "
-            "of a SessionProvider lifecycle tool. The local tool takes precedence "
-            "and permanently shadows the provider's own tool. Rename the local "
-            "tool."
-        )
 
 
 class InvalidSession(FastMCPError):
@@ -531,42 +493,3 @@ class SessionProvider(Provider):
                 Tool.from_function(end_session),
             ]
         return self._tools
-
-
-# The names `SessionProvider` registers its lifecycle tools under. Reserved:
-# a decorator-registered tool sharing one of these names always takes
-# precedence over the provider's own tool (static components beat providers),
-# permanently shadowing it.
-RESERVED_SESSION_TOOL_NAMES: Final[frozenset[str]] = frozenset(
-    {create_session.__name__, end_session.__name__}
-)
-
-
-def shadowing_local_tool(local_tools: Iterable[Tool]) -> str | None:
-    """Name of the first local tool reusing a `SessionProvider` lifecycle name.
-
-    Used to detect the case where a decorator-registered tool is named
-    `create_session` or `end_session`: because static components always take
-    precedence over providers, that local tool permanently shadows the
-    `SessionProvider`'s own tool of the same name, even though the provider is
-    registered and the requirement check passes.
-    """
-    for tool in local_tools:
-        if tool.name in RESERVED_SESSION_TOOL_NAMES:
-            return tool.name
-    return None
-
-
-def offending_session_id_tool(tools: Iterable[Tool]) -> str | None:
-    """Name of the first tool declaring `session_id: SessionId`, or `None`.
-
-    Used to enforce that a `SessionProvider` is registered whenever a tool
-    requires session ids. Only function-backed tools carry resolvable hints, so
-    only those are inspected.
-    """
-    from fastmcp.tools.function_tool import FunctionTool
-
-    for tool in tools:
-        if isinstance(tool, FunctionTool) and session_id_parameter_names(tool.fn):
-            return tool.name
-    return None

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -1,0 +1,319 @@
+"""Stateless session state: the scoped-state vocabulary and the session codec.
+
+This module provides the security core for cross-request state on modern
+(stateless) MCP connections. It has two parts:
+
+- `Scope`: the storage-isolation vocabulary shared by `ctx.get_state` /
+  `ctx.set_state`. `REQUEST` is today's per-connection state, `USER` keys off the
+  authenticated principal, and `SESSION` keys off a sealed session handle.
+- `SessionCodec`: mints and verifies the sealed session handle. A handle binds a
+  server-minted `session_id` to the authenticated principal (when present) and an
+  expiry, sealed with the SDK's AES-GCM request-state codec. Unlike the SDK's
+  per-request `requestState` seal, a session handle binds **principal + expiry
+  only**, so it survives across different tool calls rather than a single round.
+
+The `Session()` annotation and the request boundary that unseals the handle and
+binds it onto the request context live in a later increment. This module only
+provides the primitives and the context slot they populate.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import hmac
+import json
+import logging
+import math
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Final, NoReturn
+
+from mcp.server.auth.provider import principal_components
+from mcp.server.request_state import InvalidRequestState, RequestStateSecurity
+
+from fastmcp.exceptions import FastMCPError
+from fastmcp.server.dependencies import get_access_token
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Default lifetime of a sealed session handle. Session handles must outlive a
+# single request (they are threaded through many tool calls), so this defaults
+# far above the SDK request-state codec's 600s per-round default. Configurable
+# per `SessionCodec`.
+DEFAULT_SESSION_TTL: Final[float] = 3600.0
+
+# Envelope version stamped into every sealed payload. The AES-GCM codec already
+# binds its own "v1." wire prefix into the seal; this is the *payload* schema
+# version, independent of the codec's token format.
+_ENVELOPE_VERSION: Final[int] = 1
+
+
+class Scope(enum.Enum):
+    """Storage isolation for `ctx.get_state` / `ctx.set_state`.
+
+    The scope selects both the storage key prefix and the isolation guarantee:
+
+    - `REQUEST`: per-request connection state. Dies with the request on a modern
+      (stateless) connection; persists across requests on a stateful one. This is
+      the historical default and the only scope that works without auth or a
+      session handle.
+    - `SESSION`: keyed by `(principal, session_id)` where `session_id` comes from
+      a verified sealed handle bound onto the request context. Sealed and
+      principal-bound when authenticated; unforgeable (but not cross-client
+      isolated) when unauthenticated.
+    - `USER`: keyed by the authenticated principal; spans every session for that
+      user. Requires authentication.
+    """
+
+    REQUEST = "request"
+    SESSION = "session"
+    USER = "user"
+
+
+@dataclass(frozen=True)
+class SessionIdentity:
+    """The verified identity carried by a sealed session handle.
+
+    `principal` is the authenticated `(client_id, issuer, subject)` triple encoded
+    as a compact JSON string, or `None` when the handle was minted on an
+    unauthenticated connection.
+    """
+
+    session_id: str
+    principal: str | None
+
+
+class SessionError(FastMCPError):
+    """Base class for session-state errors."""
+
+
+class InvalidSessionToken(SessionError):
+    """A sealed session handle failed verification.
+
+    Raised for foreign, expired, tampered, or malformed handles. The rejection
+    reason is captured on `.reason` and logged, never placed on the public
+    message, so a boundary that surfaces this to the wire cannot leak *why* a
+    handle was rejected (mirroring the SDK request-state boundary's stance).
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__("invalid or expired session token")
+
+
+class NoActiveSessionError(SessionError):
+    """`Scope.SESSION` state was accessed with no verified session on the request.
+
+    Modern (stateless) connections carry no protocol session, so a client must
+    obtain a sealed handle (via `create_session`) and thread it into later calls
+    for `SESSION`-scoped state to resolve.
+    """
+
+    def __init__(
+        self,
+        message: str = (
+            "no active session — call `create_session` and pass its token as the "
+            "session argument to access Scope.SESSION state"
+        ),
+    ) -> None:
+        super().__init__(message)
+
+
+# The verified session identity for the current request. A later increment's
+# boundary sets this after unsealing the handle argument; scoped-state reads it.
+_active_session_identity: ContextVar[SessionIdentity | None] = ContextVar(
+    "fastmcp_active_session_identity", default=None
+)
+
+
+@contextmanager
+def bind_session_identity(identity: SessionIdentity) -> Iterator[SessionIdentity]:
+    """Bind a verified session identity onto the current request context.
+
+    Used by the session boundary (and tests) to make `Scope.SESSION` state
+    resolvable for the duration of a request.
+    """
+    token: Token[SessionIdentity | None] = _active_session_identity.set(identity)
+    try:
+        yield identity
+    finally:
+        _active_session_identity.reset(token)
+
+
+def get_active_session_identity() -> SessionIdentity | None:
+    """Return the verified session identity bound to the current request, if any."""
+    return _active_session_identity.get()
+
+
+def current_principal() -> str | None:
+    """The authenticated principal for the current request as a compact JSON string.
+
+    Returns the `(client_id, issuer, subject)` triple encoded as compact JSON, or
+    `None` on an unauthenticated request. Two users of one OAuth client are
+    distinct principals whenever the token verifier supplies a subject.
+    """
+    token = get_access_token()
+    if token is None:
+        return None
+    return json.dumps(principal_components(token), separators=(",", ":"))
+
+
+def _principal_segment(principal: str | None) -> str:
+    """A fixed-length, delimiter-safe key segment for a principal.
+
+    Hashing keeps arbitrary principal strings from injecting the `:` key
+    delimiter and bounds the key length. `None` (unauthenticated) collapses to a
+    single shared `anon` segment.
+    """
+    if principal is None:
+        return "anon"
+    digest = hashlib.sha256(principal.encode("utf-8", "surrogatepass")).hexdigest()
+    return digest
+
+
+def user_state_key(principal: str, key: str) -> str:
+    """Storage key for `Scope.USER` state: keyed by principal."""
+    return f"user:{_principal_segment(principal)}:{key}"
+
+
+def session_state_key(identity: SessionIdentity, key: str) -> str:
+    """Storage key for `Scope.SESSION` state: keyed by `(principal, session_id)`."""
+    return f"session:{_principal_segment(identity.principal)}:{identity.session_id}:{key}"
+
+
+class _Unset:
+    """Sentinel: `unseal` should read the principal from the request context."""
+
+
+_UNSET: Final[_Unset] = _Unset()
+
+
+class SessionCodec:
+    """Mints and verifies sealed session handles.
+
+    A handle is an opaque, URL-safe token minted server-side. Its payload —
+    `{session_id, principal, exp}` — is sealed with the SDK's AES-GCM request-state
+    codec, so a client can neither read nor forge it. On use the codec unseals it,
+    verifies it has not expired, and — when the request carries an authenticated
+    principal — verifies the handle's principal matches. Foreign, expired, or
+    tampered handles raise `InvalidSessionToken`.
+
+    Reuse the server's `request_state_security` key policy so session handles and
+    the SDK's `requestState` share one key ring; when the server sets no policy,
+    `from_security(None)` mints an ephemeral per-process key (single-process safe,
+    matching the SDK boundary's default).
+    """
+
+    def __init__(
+        self,
+        security: RequestStateSecurity,
+        *,
+        ttl: float = DEFAULT_SESSION_TTL,
+    ) -> None:
+        if not (math.isfinite(ttl) and ttl > 0):
+            raise ValueError(f"session ttl must be a positive finite number, got {ttl!r}")
+        # Reuse only the raw AES-GCM codec (seal/unseal over bytes). The policy's
+        # ttl / audience / bind_principal belong to the SDK's per-request boundary
+        # and deliberately do NOT govern session handles.
+        self._codec = security.codec
+        self._ttl = ttl
+
+    @classmethod
+    def from_security(
+        cls,
+        security: RequestStateSecurity | None,
+        *,
+        ttl: float = DEFAULT_SESSION_TTL,
+    ) -> SessionCodec:
+        """Build a codec from a server's request-state policy, or an ephemeral key.
+
+        Pass the server's configured `request_state_security` to bind session
+        handles to the same shared key ring. Pass `None` (no server policy) to
+        seal under a per-process ephemeral key.
+        """
+        if security is None:
+            security = RequestStateSecurity.ephemeral()
+        return cls(security, ttl=ttl)
+
+    def seal(self, session_id: str, principal: str | None) -> str:
+        """Mint a sealed handle binding `session_id` to `principal` with an expiry.
+
+        `principal` is the compact-JSON principal string (see `current_principal`)
+        or `None` on an unauthenticated connection.
+        """
+        payload = {
+            "v": _ENVELOPE_VERSION,
+            "sid": session_id,
+            "p": principal,
+            "exp": time.time() + self._ttl,
+        }
+        raw = json.dumps(payload, separators=(",", ":")).encode()
+        return self._codec.seal(raw)
+
+    def unseal(
+        self,
+        token: str,
+        *,
+        request_principal: str | None | _Unset = _UNSET,
+    ) -> SessionIdentity:
+        """Verify a sealed handle and return its identity.
+
+        Checks integrity (AES-GCM), expiry, and — when the request carries an
+        authenticated principal — that the handle's principal matches it. A handle
+        minted under a principal but replayed on a request with a *different* or
+        *absent* principal is rejected, as is one minted without a principal but
+        presented under authentication (principal drift, mirroring the SDK
+        boundary).
+
+        By default the request principal is read from the current auth context;
+        tests may pass `request_principal` explicitly to exercise the match logic
+        without an auth context.
+
+        Raises:
+            InvalidSessionToken: Malformed, tampered, expired, or foreign handle.
+        """
+        if isinstance(request_principal, _Unset):
+            request_principal = current_principal()
+
+        try:
+            raw = self._codec.unseal(token)
+        except InvalidRequestState as exc:
+            self._reject(str(exc))
+
+        try:
+            claims = json.loads(raw)
+            version = claims["v"]
+            session_id = claims["sid"]
+            principal = claims["p"]
+            exp = claims["exp"]
+        except (ValueError, KeyError, TypeError):
+            self._reject("malformed")
+
+        if version != _ENVELOPE_VERSION or not isinstance(session_id, str):
+            self._reject("malformed")
+        if principal is not None and not isinstance(principal, str):
+            self._reject("malformed")
+
+        now = time.time()
+        # Stated positively so a NaN exp fails the comparison and rejects.
+        if not isinstance(exp, (int, float)) or isinstance(exp, bool) or not (now < exp):
+            self._reject("expired")
+
+        if request_principal is not None:
+            if principal is None or not hmac.compare_digest(principal, request_principal):
+                self._reject("principal mismatch")
+        elif principal is not None:
+            # Handle bound to a principal, replayed on an unauthenticated request:
+            # a downgrade that would leak a user's session. Reject.
+            self._reject("principal drift")
+
+        return SessionIdentity(session_id=session_id, principal=principal)
+
+    def _reject(self, reason: str) -> NoReturn:
+        """Log the real reason and raise a handle with a generic public message."""
+        logger.warning("session token rejected: %s", reason)
+        raise InvalidSessionToken(reason)

--- a/fastmcp_slim/fastmcp/server/sessions.py
+++ b/fastmcp_slim/fastmcp/server/sessions.py
@@ -8,15 +8,16 @@ authenticated principal rather than by any client-declared identifier.
 
 - `Session`: async `get`/`set`/`delete`/`clear` over a single dict stored under
   one key, scoped to a `(principal, session_id)` pair. This is the state-accessor
-  object a handler works with — the value returned by `ctx.get_session(id)` and
-  injected for a `UserSession` parameter.
+  object a handler works with — the value the standalone `get_session(id)`
+  returns and the value injected for a `UserSession` parameter.
 - `session: UserSession` (injected): a per-user bucket, dependency-injected like
   `ctx: Context` and keyed by the request's authenticated principal. Requires
   auth. `UserSession` is the injection annotation; the injected value is a
   `Session`. It is always available under auth — no `create_session`, no
   provider, no validation.
 - `session_id: SessionId` (argument): a required string the agent supplies,
-  resolved with `await ctx.get_session(session_id)`. The id must first be minted
+  resolved with the standalone `await get_session(session_id)`. The id is
+  minted
   by `create_session`; an id that was never created (or was created under a
   different principal) is rejected. This validation is the whole guarantee — an
   unminted id never resolves, so nothing enforces provider registration.
@@ -123,7 +124,7 @@ class SessionAuthError(FastMCPError):
 class InvalidSession(FastMCPError):
     """A session id did not resolve to a session created under the current principal.
 
-    Raised by `ctx.get_session(session_id)` when the id was never created, or was
+    Raised by `get_session(session_id)` when the id was never created, or was
     created under a different principal. The public message is deliberately
     generic — the specific reason (which id, which principal) is logged at debug
     level, not returned to the caller, so an attacker cannot distinguish "unknown
@@ -280,7 +281,7 @@ class Session:
         """Empty the session's user state but keep the session valid.
 
         The user-state sub-dict is reset to empty while the creation marker stays
-        in place, so a cleared session still resolves through `ctx.get_session`.
+        in place, so a cleared session still resolves through `get_session`.
         To invalidate a session entirely, use `end` (what `end_session` calls).
         """
         raw = await self._load_raw()
@@ -292,7 +293,7 @@ class Session:
     async def end(self) -> None:
         """Invalidate the session — delete its one key and all of its state.
 
-        After this the id no longer resolves through `ctx.get_session`. This is
+        After this the id no longer resolves through `get_session`. This is
         what `end_session` calls; `clear` only empties state and keeps the session.
         """
         await self._store.delete(key=self._key)
@@ -415,14 +416,23 @@ def CurrentSession() -> Session:
     return cast("Session", _CurrentSession())
 
 
-async def resolve_session(session_id: str) -> Session:
-    """Resolve and validate a session id against the current principal's store.
+async def get_session(session_id: str) -> Session:
+    """Resolve and validate a `Session` for an explicit `session_id`.
 
-    Reads the record for `(current_principal, session_id)` and returns a `Session`
-    only when it exists — i.e. was written by `create_session` under this same
-    principal. An id that was never created, or created under a different
-    principal, raises `InvalidSession`; the specific reason is logged at debug
-    level and never returned to the caller.
+    Pair with a `session_id: SessionId` tool argument (the agent obtains an id
+    from `create_session` and passes it back). For a single per-user bucket with
+    nothing for the agent to pass, inject `session: UserSession` instead.
+
+    State is keyed by `(principal, session_id)`: the authenticated principal is
+    the isolation wall and `session_id` organizes sessions within it. The id must
+    have been minted by `create_session` under the current principal; an id that
+    was never created, or created under a different principal, raises
+    `InvalidSession` rather than resolving to a fresh empty bucket (the specific
+    reason is logged at debug level, never returned to the caller).
+
+    This is a standalone function, not a `Context` method, so it needs no
+    foreground context — it works from a `task=True` tool's Docket worker as well
+    as a normal request.
     """
     session = Session(
         store=get_server()._state_store,
@@ -467,7 +477,7 @@ async def end_session(session_id: SessionId) -> str:
     Validates the id like any other resolution (an unknown or foreign id is
     rejected), then deletes the session's key so the id no longer resolves.
     """
-    session = await resolve_session(session_id)
+    session = await get_session(session_id)
     await session.end()
     return "session ended"
 
@@ -492,7 +502,7 @@ class SessionProvider(Provider):
     It owns no storage (session state lives in the server's configured
     `session_state_store`) and imposes no TTL (retention is the store's). It
     exists to mint and end owned session ids. Registration is not enforced: with
-    no provider, no id can be created, so every `ctx.get_session(...)` rejects —
+    no provider, no id can be created, so every `get_session(...)` rejects —
     a `session_id` tool without a provider simply cannot resolve a session.
     """
 

--- a/fastmcp_slim/fastmcp/tools/function_parsing.py
+++ b/fastmcp_slim/fastmcp/tools/function_parsing.py
@@ -362,11 +362,12 @@ class ParsedFunction:
             if param_name not in properties:
                 continue
             existing = properties[param_name].get("description")
-            properties[param_name]["description"] = (
-                f"{existing}\n\n{SESSION_ID_DESCRIPTION}"
-                if existing
-                else SESSION_ID_DESCRIPTION
-            )
+            if not existing:
+                properties[param_name]["description"] = SESSION_ID_DESCRIPTION
+            elif SESSION_ID_DESCRIPTION not in existing:
+                properties[param_name]["description"] = (
+                    f"{existing}\n\n{SESSION_ID_DESCRIPTION}"
+                )
 
         output_schema = None
         # Get the return annotation from the signature

--- a/fastmcp_slim/fastmcp/tools/function_parsing.py
+++ b/fastmcp_slim/fastmcp/tools/function_parsing.py
@@ -349,6 +349,25 @@ class ParsedFunction:
                 ):
                     properties[param_name]["description"] = param_desc
 
+        # Auto-populate the create-then-pass contract onto `SessionId`-annotated
+        # parameters so an agent learns it straight from the schema. Append to any
+        # author-provided description rather than clobbering it.
+        from fastmcp.server.sessions import (
+            SESSION_ID_DESCRIPTION,
+            session_id_parameter_names,
+        )
+
+        properties = input_schema.get("properties", {})
+        for param_name in session_id_parameter_names(fn):
+            if param_name not in properties:
+                continue
+            existing = properties[param_name].get("description")
+            properties[param_name]["description"] = (
+                f"{existing}\n\n{SESSION_ID_DESCRIPTION}"
+                if existing
+                else SESSION_ID_DESCRIPTION
+            )
+
         output_schema = None
         # Get the return annotation from the signature
         sig = inspect.signature(fn)

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -6,6 +6,7 @@ import functools
 import inspect
 import logging
 from collections.abc import Callable
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from functools import lru_cache
 from types import MethodType
@@ -306,6 +307,14 @@ class FunctionTool(Tool):
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")
 
+        from fastmcp.server.sessions import session_parameter_names
+
+        if len(session_parameter_names(parsed_fn.fn)) > 1:
+            raise ValueError(
+                f"Tool {func_name!r}: at most one parameter may be annotated with "
+                "Session(); a tool binds a single session per call."
+            )
+
         # Inline sync execution has no cancellation checkpoints, so
         # anyio.fail_after cannot preempt the call — the timeout would be
         # silently ignored. Reject the combination so users make an
@@ -392,6 +401,62 @@ class FunctionTool(Tool):
         exec_is_async = is_coroutine_function(wrapper_fn)
         strict = _strict_input_validation()
 
+        # Unseal + verify any `Session()` handle argument and bind its identity
+        # for the duration of the call, so `ctx.get_state(scope=SESSION)`
+        # resolves. A bad handle raises `InvalidSessionToken` before the body
+        # runs. `nullcontext` for tools without a session parameter.
+        with self._session_boundary(arguments):
+            result = await self._run_body(
+                type_adapter, exec_is_async, arguments, strict=strict
+            )
+
+        # An `InputRequiredResult` is the full result of this multi-round-trip
+        # leg (SEP-2322), not tool-output data: wrap it in an
+        # `InputRequiredToolResult` so it flows through the middleware chain as
+        # an ordinary result instead of being serialized as content. The wire
+        # handler reads it back out (see `_on_call_tool`).
+        if isinstance(result, mcp_types.InputRequiredResult):
+            return InputRequiredToolResult(result)
+
+        return self.convert_result(result)
+
+    def _session_boundary(
+        self, arguments: dict[str, Any]
+    ) -> AbstractContextManager[Any]:
+        """Bind the verified session identity for a `Session()`-annotated tool.
+
+        Reads the sealed handle from the annotated argument, unseals and verifies
+        it (integrity, expiry, principal binding), and returns a context manager
+        that binds the resulting identity onto the request. Returns a
+        `nullcontext` for tools with no session parameter. Raises
+        `InvalidSessionToken` for a missing, malformed, expired, or foreign
+        handle before the body runs.
+        """
+        from fastmcp.server.dependencies import get_context
+        from fastmcp.server.sessions import (
+            InvalidSessionToken,
+            bind_session_identity,
+            session_parameter_names,
+        )
+
+        names = session_parameter_names(self.fn)
+        if not names:
+            return nullcontext()
+        token = arguments.get(names[0])
+        if not isinstance(token, str):
+            raise InvalidSessionToken("missing session token")
+        identity = get_context().fastmcp.session_codec.unseal(token)
+        return bind_session_identity(identity)
+
+    async def _run_body(
+        self,
+        type_adapter: TypeAdapter[Any],
+        exec_is_async: bool,
+        arguments: dict[str, Any],
+        *,
+        strict: bool,
+    ) -> Any:
+        """Validate arguments and execute the body, applying any timeout."""
         try:
             if self.timeout is not None:
                 try:
@@ -428,15 +493,7 @@ class FunctionTool(Tool):
             assert original is not None
             raise original from original.__cause__
 
-        # An `InputRequiredResult` is the full result of this multi-round-trip
-        # leg (SEP-2322), not tool-output data: wrap it in an
-        # `InputRequiredToolResult` so it flows through the middleware chain as
-        # an ordinary result instead of being serialized as content. The wire
-        # handler reads it back out (see `_on_call_tool`).
-        if isinstance(result, mcp_types.InputRequiredResult):
-            return InputRequiredToolResult(result)
-
-        return self.convert_result(result)
+        return result
 
     async def _execute(
         self,

--- a/fastmcp_slim/fastmcp/tools/function_tool.py
+++ b/fastmcp_slim/fastmcp/tools/function_tool.py
@@ -6,7 +6,6 @@ import functools
 import inspect
 import logging
 from collections.abc import Callable
-from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from functools import lru_cache
 from types import MethodType
@@ -307,14 +306,6 @@ class FunctionTool(Tool):
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")
 
-        from fastmcp.server.sessions import session_parameter_names
-
-        if len(session_parameter_names(parsed_fn.fn)) > 1:
-            raise ValueError(
-                f"Tool {func_name!r}: at most one parameter may be annotated with "
-                "Session(); a tool binds a single session per call."
-            )
-
         # Inline sync execution has no cancellation checkpoints, so
         # anyio.fail_after cannot preempt the call — the timeout would be
         # silently ignored. Reject the combination so users make an
@@ -401,14 +392,9 @@ class FunctionTool(Tool):
         exec_is_async = is_coroutine_function(wrapper_fn)
         strict = _strict_input_validation()
 
-        # Unseal + verify any `Session()` handle argument and bind its identity
-        # for the duration of the call, so `ctx.get_state(scope=SESSION)`
-        # resolves. A bad handle raises `InvalidSessionToken` before the body
-        # runs. `nullcontext` for tools without a session parameter.
-        with self._session_boundary(arguments):
-            result = await self._run_body(
-                type_adapter, exec_is_async, arguments, strict=strict
-            )
+        result = await self._run_body(
+            type_adapter, exec_is_async, arguments, strict=strict
+        )
 
         # An `InputRequiredResult` is the full result of this multi-round-trip
         # leg (SEP-2322), not tool-output data: wrap it in an
@@ -419,34 +405,6 @@ class FunctionTool(Tool):
             return InputRequiredToolResult(result)
 
         return self.convert_result(result)
-
-    def _session_boundary(
-        self, arguments: dict[str, Any]
-    ) -> AbstractContextManager[Any]:
-        """Bind the verified session identity for a `Session()`-annotated tool.
-
-        Reads the sealed handle from the annotated argument, unseals and verifies
-        it (integrity, expiry, principal binding), and returns a context manager
-        that binds the resulting identity onto the request. Returns a
-        `nullcontext` for tools with no session parameter. Raises
-        `InvalidSessionToken` for a missing, malformed, expired, or foreign
-        handle before the body runs.
-        """
-        from fastmcp.server.dependencies import get_context
-        from fastmcp.server.sessions import (
-            InvalidSessionToken,
-            bind_session_identity,
-            session_parameter_names,
-        )
-
-        names = session_parameter_names(self.fn)
-        if not names:
-            return nullcontext()
-        token = arguments.get(names[0])
-        if not isinstance(token, str):
-            raise InvalidSessionToken("missing session token")
-        identity = get_context().fastmcp.session_codec.unseal(token)
-        return bind_session_identity(identity)
 
     async def _run_body(
         self,

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -1,16 +1,16 @@
-"""End-to-end tests for the `SessionProvider` and the `Session()` annotation.
+"""End-to-end tests for the two session-state patterns and `SessionProvider`.
 
-Covers the lifecycle tools (`create_session` / `end_session`) and the annotation
-boundary that unseals a sealed handle, binds its identity for the call, and
-gates `Scope.SESSION` state. The happy paths run through an in-memory `Client`;
-the auth-dependent cross-principal case drives the tool boundary directly under a
-simulated authenticated principal.
+Covers the injected `session: Session` per-user pattern, the explicit
+`session_id: SessionId` argument pattern, and the `SessionProvider` lifecycle
+tools. The schema, registration, and unauthenticated paths run through an
+in-memory `Client`; the principal-isolation cases drive the tool through its full
+injection + storage path under a simulated authenticated principal.
 """
 
-import json
+import re
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Annotated
+from uuid import UUID
 
 import pytest
 from mcp.server.auth.middleware.auth_context import auth_context_var
@@ -22,11 +22,10 @@ from fastmcp.exceptions import ToolError
 from fastmcp.server.context import Context
 from fastmcp.server.dependencies import get_context
 from fastmcp.server.sessions import (
-    InvalidSessionToken,
-    Scope,
+    SESSION_ID_DESCRIPTION,
     Session,
+    SessionId,
     SessionProvider,
-    current_principal,
 )
 
 
@@ -41,8 +40,10 @@ def make_token(*, subject: str = "user-a") -> SDKAccessToken:
 
 
 @contextmanager
-def as_principal(token: SDKAccessToken) -> Iterator[None]:
-    """Set the authenticated principal for the current context."""
+def as_principal(token: SDKAccessToken | None) -> Iterator[None]:
+    if token is None:
+        yield
+        return
     reset = auth_context_var.set(AuthenticatedUser(token))
     try:
         yield
@@ -50,168 +51,225 @@ def as_principal(token: SDKAccessToken) -> Iterator[None]:
         auth_context_var.reset(reset)
 
 
-def build_shop(**provider_kwargs: float) -> FastMCP:
-    """A server with a session provider and two session-scoped cart tools."""
-    server = FastMCP("shop", session_provider=SessionProvider(**provider_kwargs))
+def build_injected_server() -> FastMCP:
+    """Server whose cart tools inject a per-user `session: Session`."""
+    server = FastMCP("shop")
 
     @server.tool
-    async def add_to_cart(item: str, session: Annotated[str, Session()]) -> int:
-        ctx = get_context()
-        cart = await ctx.get_state("cart", scope=Scope.SESSION) or []
+    async def add_to_cart(item: str, session: Session) -> int:
+        cart = await session.get("cart", default=[])
         cart.append(item)
-        await ctx.set_state("cart", cart, scope=Scope.SESSION)
+        await session.set("cart", cart)
         return len(cart)
 
     @server.tool
-    async def view_cart(session: Annotated[str, Session()]) -> list[str]:
-        ctx = get_context()
-        return await ctx.get_state("cart", scope=Scope.SESSION) or []
+    async def view_cart(session: Session) -> list[str]:
+        return await session.get("cart", default=[])
 
     return server
 
 
-class TestSessionLifecycle:
-    async def test_state_survives_across_calls(self):
-        server = build_shop()
+def build_id_server() -> FastMCP:
+    """Server whose cart tools take an explicit `session_id: SessionId`."""
+    server = FastMCP("shop")
+    server.add_provider(SessionProvider())
+
+    @server.tool
+    async def add_to_cart(item: str, session_id: SessionId) -> int:
+        session = get_context().get_session(session_id)
+        cart = await session.get("cart", default=[])
+        cart.append(item)
+        await session.set("cart", cart)
+        return len(cart)
+
+    @server.tool
+    async def view_cart(session_id: SessionId) -> list[str]:
+        return await get_context().get_session(session_id).get("cart", default=[])
+
+    return server
+
+
+# ---------------------------------------------------------------------------
+# Injected `session: Session`
+# ---------------------------------------------------------------------------
+
+
+class TestInjectedSession:
+    async def test_not_in_input_schema(self):
+        server = build_injected_server()
         async with Client(server) as client:
-            token = (await client.call_tool("create_session", {})).data
-            assert isinstance(token, str) and token
+            tools = {t.name: t for t in await client.list_tools()}
+        schema = tools["add_to_cart"].input_schema
+        assert "session" not in schema["properties"]
+        assert "item" in schema["properties"]
 
-            await client.call_tool("add_to_cart", {"item": "apple", "session": token})
-            second = await client.call_tool(
-                "add_to_cart", {"item": "banana", "session": token}
-            )
-            assert second.data == 2
-
-            view = await client.call_tool("view_cart", {"session": token})
-            assert view.data == ["apple", "banana"]
-
-    async def test_end_session_clears_state(self):
-        server = build_shop()
-        async with Client(server) as client:
-            token = (await client.call_tool("create_session", {})).data
-            await client.call_tool("add_to_cart", {"item": "apple", "session": token})
-
-            await client.call_tool("end_session", {"session": token})
-
-            view = await client.call_tool("view_cart", {"session": token})
-            assert view.data == []
-
-    async def test_distinct_sessions_are_isolated(self):
-        server = build_shop()
-        async with Client(server) as client:
-            token_a = (await client.call_tool("create_session", {})).data
-            token_b = (await client.call_tool("create_session", {})).data
-            assert token_a != token_b
-
-            await client.call_tool("add_to_cart", {"item": "apple", "session": token_a})
-
-            view_b = await client.call_tool("view_cart", {"session": token_b})
-            assert view_b.data == []
-
-
-class TestSessionAnnotationSchema:
-    async def test_lifecycle_tools_registered(self):
-        server = build_shop()
-        async with Client(server) as client:
-            names = {tool.name for tool in await client.list_tools()}
-        assert {"create_session", "end_session"} <= names
-
-    async def test_session_parameter_is_a_string_in_schema(self):
-        server = build_shop()
-        async with Client(server) as client:
-            tools = {tool.name: tool for tool in await client.list_tools()}
-        schema = tools["view_cart"].input_schema
-        assert schema["properties"]["session"]["type"] == "string"
-        assert "session" in schema["required"]
-
-    async def test_body_receives_raw_token_string(self):
-        server = FastMCP("shop", session_provider=SessionProvider())
-        observed: dict[str, str] = {}
-
-        @server.tool
-        async def echo_token(session: Annotated[str, Session()]) -> str:
-            observed["token"] = session
-            return session
-
-        async with Client(server) as client:
-            token = (await client.call_tool("create_session", {})).data
-            result = await client.call_tool("echo_token", {"session": token})
-
-        assert result.data == token
-        assert observed["token"] == token
-
-    def test_multiple_session_parameters_rejected(self):
-        server = FastMCP("shop")
-        with pytest.raises(ValueError, match="at most one"):
-
-            @server.tool
-            def two_sessions(
-                a: Annotated[str, Session()],
-                b: Annotated[str, Session()],
-            ) -> str:
-                return "nope"
-
-
-class TestInvalidHandles:
-    @pytest.mark.parametrize("bad_token", ["garbage", "v1.tampered.payload", ""])
-    async def test_invalid_token_fails_the_call(self, bad_token: str):
-        server = build_shop()
+    async def test_errors_without_auth(self):
+        server = build_injected_server()
         async with Client(server) as client:
             with pytest.raises(ToolError):
-                await client.call_tool("view_cart", {"session": bad_token})
+                await client.call_tool("view_cart", {})
 
-    async def test_foreign_key_token_fails(self):
-        """A handle sealed by a different server (different key) is rejected."""
-        minting_server = build_shop()
-        async with Client(minting_server) as client:
-            foreign_token = (await client.call_tool("create_session", {})).data
-
-        verifying_server = build_shop()
-        async with Client(verifying_server) as client:
-            with pytest.raises(ToolError):
-                await client.call_tool("view_cart", {"session": foreign_token})
-
-
-class TestCrossPrincipalIsolation:
-    async def test_token_for_a_rejected_under_b(self):
-        server = build_shop()
-        tool = await server.get_tool("view_cart")
-
-        async with Context(fastmcp=server):
-            with as_principal(make_token(subject="user-a")):
-                token = server.session_codec.seal("sess-a", current_principal())
-
-            with as_principal(make_token(subject="user-b")):
-                with pytest.raises(InvalidSessionToken):
-                    await tool.run({"session": token})
-
-    async def test_token_for_a_accepted_under_a(self):
-        server = build_shop()
+    async def test_state_survives_across_calls_per_user(self):
+        server = build_injected_server()
         add_tool = await server.get_tool("add_to_cart")
         view_tool = await server.get_tool("view_cart")
 
         async with Context(fastmcp=server):
             with as_principal(make_token(subject="user-a")):
-                token = server.session_codec.seal("sess-a", current_principal())
-                await add_tool.run({"item": "apple", "session": token})
-                result = await view_tool.run({"session": token})
+                await add_tool.run({"item": "apple"})
+                second = await add_tool.run({"item": "banana"})
+                view = await view_tool.run({})
 
-        assert json.loads(result.content[0].text) == ["apple"]
+        assert second.structured_content["result"] == 2
+        assert view.structured_content["result"] == ["apple", "banana"]
 
-
-class TestExpiry:
-    async def test_expired_token_rejected_at_boundary(self, monkeypatch):
-        import fastmcp.server.sessions as sessions_mod
-
-        server = build_shop(ttl=60)
+    async def test_two_principals_get_isolated_buckets(self):
+        server = build_injected_server()
+        add_tool = await server.get_tool("add_to_cart")
         view_tool = await server.get_tool("view_cart")
 
-        base = 1_000_000.0
-        monkeypatch.setattr(sessions_mod.time, "time", lambda: base)
-        token = server.session_codec.seal("sess-1", None)
-        monkeypatch.setattr(sessions_mod.time, "time", lambda: base + 61)
+        async with Context(fastmcp=server):
+            with as_principal(make_token(subject="user-a")):
+                await add_tool.run({"item": "apple"})
+            with as_principal(make_token(subject="user-b")):
+                view_b = await view_tool.run({})
+
+        assert view_b.structured_content["result"] == []
+
+
+# ---------------------------------------------------------------------------
+# Explicit `session_id: SessionId`
+# ---------------------------------------------------------------------------
+
+
+class TestSessionIdArgument:
+    async def test_session_id_is_a_required_string_with_contract_description(self):
+        server = build_id_server()
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        schema = tools["view_cart"].input_schema
+        prop = schema["properties"]["session_id"]
+        assert prop["type"] == "string"
+        assert "session_id" in schema["required"]
+        assert prop["description"] == SESSION_ID_DESCRIPTION
+
+    async def test_state_survives_across_calls_under_an_id(self):
+        server = build_id_server()
+        async with Client(server) as client:
+            session_id = (await client.call_tool("create_session", {})).data
+
+            await client.call_tool(
+                "add_to_cart", {"item": "apple", "session_id": session_id}
+            )
+            second = await client.call_tool(
+                "add_to_cart", {"item": "banana", "session_id": session_id}
+            )
+            assert second.data == 2
+
+            view = await client.call_tool("view_cart", {"session_id": session_id})
+            assert view.data == ["apple", "banana"]
+
+    async def test_distinct_ids_isolated(self):
+        server = build_id_server()
+        async with Client(server) as client:
+            id_a = (await client.call_tool("create_session", {})).data
+            id_b = (await client.call_tool("create_session", {})).data
+            assert id_a != id_b
+
+            await client.call_tool("add_to_cart", {"item": "apple", "session_id": id_a})
+            view_b = await client.call_tool("view_cart", {"session_id": id_b})
+            assert view_b.data == []
+
+    async def test_end_session_clears_state(self):
+        server = build_id_server()
+        async with Client(server) as client:
+            session_id = (await client.call_tool("create_session", {})).data
+            await client.call_tool(
+                "add_to_cart", {"item": "apple", "session_id": session_id}
+            )
+
+            await client.call_tool("end_session", {"session_id": session_id})
+
+            view = await client.call_tool("view_cart", {"session_id": session_id})
+            assert view.data == []
+
+    async def test_two_principals_same_id_are_isolated(self):
+        server = build_id_server()
+        add_tool = await server.get_tool("add_to_cart")
+        view_tool = await server.get_tool("view_cart")
 
         async with Context(fastmcp=server):
-            with pytest.raises(InvalidSessionToken):
-                await view_tool.run({"session": token})
+            with as_principal(make_token(subject="user-a")):
+                await add_tool.run({"item": "apple", "session_id": "shared"})
+            with as_principal(make_token(subject="user-b")):
+                view_b = await view_tool.run({"session_id": "shared"})
+                # B's own bucket under the same id is empty.
+                assert view_b.structured_content["result"] == []
+            with as_principal(make_token(subject="user-a")):
+                view_a = await view_tool.run({"session_id": "shared"})
+
+        assert view_a.structured_content["result"] == ["apple"]
+
+
+# ---------------------------------------------------------------------------
+# SessionProvider
+# ---------------------------------------------------------------------------
+
+
+class TestSessionProvider:
+    async def test_lifecycle_tools_registered_via_add_provider(self):
+        server = FastMCP("s")
+        server.add_provider(SessionProvider())
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert {"create_session", "end_session"} <= names
+
+    async def test_create_session_returns_a_uuid_string(self):
+        server = FastMCP("s")
+        server.add_provider(SessionProvider())
+        async with Client(server) as client:
+            session_id = (await client.call_tool("create_session", {})).data
+        assert isinstance(session_id, str)
+        # Parses as a uuid4 and is unguessable (not a fixed/empty value).
+        assert str(UUID(session_id)) == session_id
+
+    async def test_create_session_ids_are_distinct(self):
+        server = FastMCP("s")
+        server.add_provider(SessionProvider())
+        async with Client(server) as client:
+            first = (await client.call_tool("create_session", {})).data
+            second = (await client.call_tool("create_session", {})).data
+        assert first != second
+
+    async def test_end_session_declares_session_id_contract(self):
+        server = FastMCP("s")
+        server.add_provider(SessionProvider())
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        prop = tools["end_session"].input_schema["properties"]["session_id"]
+        assert prop["type"] == "string"
+        assert SESSION_ID_DESCRIPTION in prop["description"]
+
+
+class TestSessionIdDescriptionAppending:
+    async def test_author_description_is_preserved_and_appended(self):
+        server = FastMCP("s")
+
+        @server.tool
+        async def resume(session_id: SessionId) -> str:
+            """Resume work.
+
+            Args:
+                session_id: The handle for this workflow.
+            """
+            return session_id
+
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        desc = tools["resume"].input_schema["properties"]["session_id"]["description"]
+        assert "The handle for this workflow." in desc
+        assert SESSION_ID_DESCRIPTION in desc
+        # Author text comes first, contract appended after.
+        assert re.search(
+            r"handle for this workflow\.\s+Session identifier\.", desc
+        )

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -23,13 +23,13 @@ from mcp.server.auth.provider import AccessToken as SDKAccessToken
 from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.context import Context
-from fastmcp.server.dependencies import get_context
 from fastmcp.server.sessions import (
     SESSION_ID_DESCRIPTION,
     InvalidSession,
     SessionId,
     SessionProvider,
     UserSession,
+    get_session,
 )
 from fastmcp.tools.base import ToolResult
 
@@ -92,7 +92,7 @@ def build_id_server() -> FastMCP:
 
     @server.tool
     async def add_to_cart(item: str, session_id: SessionId) -> int:
-        session = await get_context().get_session(session_id)
+        session = await get_session(session_id)
         cart = await session.get("cart", default=[])
         cart.append(item)
         await session.set("cart", cart)
@@ -100,7 +100,7 @@ def build_id_server() -> FastMCP:
 
     @server.tool
     async def view_cart(session_id: SessionId) -> list[str]:
-        session = await get_context().get_session(session_id)
+        session = await get_session(session_id)
         return await session.get("cart", default=[])
 
     return server
@@ -244,7 +244,7 @@ class TestSessionIdArgument:
 
         @server.tool
         async def which_session(session_id: SessionId) -> str | None:
-            return (await get_context().get_session(session_id)).id
+            return (await get_session(session_id)).id
 
         async with Client(server) as client:
             session_id = (await client.call_tool("create_session", {})).data
@@ -292,7 +292,7 @@ class TestSessionIdArgument:
 
         @server.tool
         async def add_to_cart(item: str, session_id: SessionId) -> int:
-            session = await get_context().get_session(session_id)
+            session = await get_session(session_id)
             cart = await session.get("cart", default=[])
             cart.append(item)
             await session.set("cart", cart)
@@ -300,13 +300,13 @@ class TestSessionIdArgument:
 
         @server.tool
         async def clear_cart(session_id: SessionId) -> str:
-            session = await get_context().get_session(session_id)
+            session = await get_session(session_id)
             await session.clear()
             return "cleared"
 
         @server.tool
         async def view_cart(session_id: SessionId) -> list[str]:
-            session = await get_context().get_session(session_id)
+            session = await get_session(session_id)
             return await session.get("cart", default=[])
 
         async with Client(server) as client:
@@ -426,7 +426,7 @@ class TestNoProviderIsNonFatal:
 
         @server.tool
         async def add_to_cart(item: str, session_id: SessionId) -> str:
-            session = await get_context().get_session(session_id)
+            session = await get_session(session_id)
             await session.set("item", item)
             return "ok"
 

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -167,6 +167,44 @@ class TestInjectedSession:
         assert "create_session" not in names
         assert "end_session" not in names
 
+    async def test_storage_key_does_not_embed_the_raw_principal(self):
+        """The injected session is stored under the reserved per-user id, not
+        under the raw principal JSON — proven by reconstructing a `Session`
+        against the reserved id and reading back what injection wrote."""
+        from fastmcp.server.sessions import (
+            _USER_SESSION_ID,
+            Session,
+            current_principal,
+            session_storage_key,
+        )
+
+        server = build_injected_server()
+        add_tool = await server.get_tool("add_to_cart")
+        assert add_tool is not None
+
+        token = make_token(subject="user-a")
+        async with Context(fastmcp=server):
+            with as_principal(token):
+                await add_tool.run({"item": "apple"})
+                principal = current_principal()
+
+        assert principal is not None
+        assert token.subject is not None
+        # The raw principal never appears in the storage key itself.
+        key = session_storage_key(principal, _USER_SESSION_ID)
+        assert principal not in key
+        assert token.subject not in key
+        assert token.client_id not in key
+
+        # And the reserved-id reconstruction reads back what injection wrote,
+        # proving injection actually used `_USER_SESSION_ID` as the session id.
+        reconstructed = Session(
+            store=server._state_store,
+            principal=principal,
+            session_id=_USER_SESSION_ID,
+        )
+        assert await reconstructed.get("cart") == ["apple"]
+
 
 # ---------------------------------------------------------------------------
 # Explicit `session_id: SessionId` — create then validate
@@ -445,6 +483,28 @@ class TestSessionProviderRequirement:
         async with Client(server) as client:
             names = {t.name for t in await client.list_tools()}
         assert names == {"echo"}
+
+    async def test_requirement_covers_provider_sourced_tools(self):
+        """A `session_id` tool from a non-local `Provider` is covered too, not
+        only decorator-registered ones (the requirement scans the aggregated
+        tool set, not just `_local_provider`)."""
+        from fastmcp.server.providers.base import Provider
+        from fastmcp.tools.function_tool import FunctionTool
+
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        class CustomProvider(Provider):
+            async def _list_tools(self):
+                return [FunctionTool.from_function(add_to_cart)]
+
+        server = FastMCP("shop")
+        server.add_provider(CustomProvider())
+
+        with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
+            await server.list_tools()
+        with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
+            await server.get_tool("add_to_cart")
 
 
 class TestSessionIdDescriptionAppending:

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -2,8 +2,8 @@
 
 Covers the injected `session: UserSession` per-user pattern, the explicit
 `session_id: SessionId` argument pattern (with its create-then-validate
-lifecycle), and the requirement that a `SessionProvider` be registered whenever a
-tool declares `session_id`. The schema, registration, and lifecycle paths run
+lifecycle), and the `SessionProvider` that supplies the `create_session` /
+`end_session` lifecycle tools. The schema, registration, and lifecycle paths run
 through an in-memory `Client`; the principal-isolation cases drive the tool
 through its full injection + storage path under a simulated authenticated
 principal.
@@ -29,8 +29,6 @@ from fastmcp.server.sessions import (
     InvalidSession,
     SessionId,
     SessionProvider,
-    SessionProviderRequiredError,
-    SessionProviderShadowedError,
     UserSession,
 )
 from fastmcp.tools.base import ToolResult
@@ -407,48 +405,13 @@ class TestSessionProvider:
         assert SESSION_ID_DESCRIPTION in prop["description"]
 
 
-class TestSessionProviderRequirement:
-    async def test_missing_provider_raises_naming_the_tool(self):
-        """A `session_id` tool with no `SessionProvider` fails loudly, naming the
-        offending tool and the fix."""
+class TestNoProviderIsNonFatal:
+    """With the enforcement checks removed, a `session_id` tool without a
+    `SessionProvider` is not a setup error — it simply cannot resolve a session,
+    because no id can be created. The failure surfaces at use, not at listing."""
+
+    async def test_session_id_tool_lists_without_a_provider(self):
         server = FastMCP("shop")
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        with pytest.raises(SessionProviderRequiredError) as exc_info:
-            await server.list_tools()
-        message = str(exc_info.value)
-        assert "add_to_cart" in message
-        assert "add_provider(SessionProvider())" in message
-
-    async def test_missing_provider_blocks_tool_resolution(self):
-        """The requirement also gates `_get_tool`, so a call cannot slip past."""
-        server = FastMCP("shop")
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        with pytest.raises(SessionProviderRequiredError):
-            await server.get_tool("add_to_cart")
-
-    async def test_missing_provider_surfaces_over_the_wire(self):
-        """Over the client wire the misconfiguration still fails the call."""
-        server = FastMCP("shop")
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        async with Client(server) as client:
-            with pytest.raises(Exception):
-                await client.list_tools()
-
-    async def test_registering_the_provider_satisfies_the_requirement(self):
-        server = FastMCP("shop")
-        server.add_provider(SessionProvider())
 
         @server.tool
         async def add_to_cart(item: str, session_id: SessionId) -> int:
@@ -456,96 +419,23 @@ class TestSessionProviderRequirement:
 
         async with Client(server) as client:
             names = {t.name for t in await client.list_tools()}
-        assert {"create_session", "end_session"} <= names
+        assert names == {"add_to_cart"}
 
-    async def test_requirement_triggers_for_tool_added_after_construction(self):
-        """The check re-scans live, so a `session_id` tool added after the server
-        is built still triggers the requirement."""
+    async def test_any_id_is_rejected_without_a_way_to_create_one(self):
         server = FastMCP("shop")
 
-        # No session_id tool yet: listing is fine.
-        await server.list_tools()
-
         @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
+        async def add_to_cart(item: str, session_id: SessionId) -> str:
+            session = await get_context().get_session(session_id)
+            await session.set("item", item)
+            return "ok"
 
-        with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
-            await server.list_tools()
-
-    async def test_no_requirement_without_a_session_id_tool(self):
-        """A server with no `session_id` tool needs no provider and lists cleanly."""
-        server = FastMCP("plain")
-
-        @server.tool
-        async def echo(text: str) -> str:
-            return text
-
+        # No provider, so no id was ever minted: resolution rejects any id.
         async with Client(server) as client:
-            names = {t.name for t in await client.list_tools()}
-        assert names == {"echo"}
-
-    async def test_requirement_covers_provider_sourced_tools(self):
-        """A `session_id` tool from a non-local `Provider` is covered too, not
-        only decorator-registered ones (the requirement scans the aggregated
-        tool set, not just `_local_provider`)."""
-        from fastmcp.server.providers.base import Provider
-        from fastmcp.tools.function_tool import FunctionTool
-
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        class CustomProvider(Provider):
-            async def _list_tools(self):
-                return [FunctionTool.from_function(add_to_cart)]
-
-        server = FastMCP("shop")
-        server.add_provider(CustomProvider())
-
-        with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
-            await server.list_tools()
-        with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
-            await server.get_tool("add_to_cart")
-
-    async def test_disabled_session_id_tool_does_not_block_others(self):
-        """A disabled `session_id` tool can never be called, so it must not
-        force every other tool's listing or resolution to fail."""
-        server = FastMCP("shop")
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        @server.tool
-        async def echo(text: str) -> str:
-            return text
-
-        server.disable(names={"add_to_cart"}, components={"tool"})
-
-        async with Client(server) as client:
-            names = {t.name for t in await client.list_tools()}
-            result = await client.call_tool("echo", {"text": "hi"})
-        assert names == {"echo"}
-        assert result.data == "hi"
-
-    async def test_local_tool_shadowing_lifecycle_name_is_rejected(self):
-        """A local tool named `create_session` always wins over the provider's
-        own tool of that name, permanently shadowing it — rejected at setup."""
-        server = FastMCP("shop")
-        server.add_provider(SessionProvider())
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        @server.tool(name="create_session")
-        async def my_create_session() -> str:
-            return "not a real session"
-
-        with pytest.raises(SessionProviderShadowedError, match="create_session"):
-            await server.list_tools()
-        with pytest.raises(SessionProviderShadowedError, match="create_session"):
-            await server.get_tool("add_to_cart")
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "add_to_cart", {"item": "x", "session_id": "made-up"}
+                )
 
 
 class TestSessionIdDescriptionAppending:

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -157,6 +157,65 @@ class TestInjectedSession:
 
         assert result_value(view_b) == []
 
+    async def test_injected_value_is_a_user_session_instance(self):
+        """The handler receives a `UserSession`, not a bare `Session` — so
+        `isinstance(session, UserSession)` holds for code that keys off it."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def whoami(session: UserSession) -> bool:
+            return isinstance(session, UserSession)
+
+        tool = await server.get_tool("whoami")
+        assert tool is not None
+        async with Context(fastmcp=server):
+            with as_principal(make_token()):
+                result = await tool.run({})
+        assert result_value(result) is True
+
+    async def test_optional_session_is_none_without_auth(self):
+        """`session: UserSession | None = None` injects `None` on an
+        unauthenticated request instead of raising."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def maybe(session: UserSession | None = None) -> bool:
+            return session is None
+
+        tool = await server.get_tool("maybe")
+        assert tool is not None
+        async with Context(fastmcp=server):
+            result = await tool.run({})
+        assert result_value(result) is True
+
+    async def test_optional_session_is_present_with_auth(self):
+        """The same optional parameter injects a real `UserSession` when the
+        request is authenticated."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def maybe(session: UserSession | None = None) -> bool:
+            return isinstance(session, UserSession)
+
+        tool = await server.get_tool("maybe")
+        assert tool is not None
+        async with Context(fastmcp=server):
+            with as_principal(make_token()):
+                result = await tool.run({})
+        assert result_value(result) is True
+
+    async def test_optional_session_not_in_input_schema(self):
+        """An optional injected session is still excluded from the schema."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def maybe(session: UserSession | None = None) -> bool:
+            return session is None
+
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        assert "session" not in tools["maybe"].input_schema.get("properties", {})
+
     async def test_user_session_needs_no_provider(self):
         """A server using only `UserSession` requires no `SessionProvider` and
         lists no lifecycle tools."""

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -23,13 +23,13 @@ from mcp.server.auth.provider import AccessToken as SDKAccessToken
 from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.context import Context
+from fastmcp.server.dependencies import get_session
 from fastmcp.server.sessions import (
     SESSION_ID_DESCRIPTION,
     InvalidSession,
     SessionId,
     SessionProvider,
     UserSession,
-    get_session,
 )
 from fastmcp.tools.base import ToolResult
 

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -1,0 +1,217 @@
+"""End-to-end tests for the `SessionProvider` and the `Session()` annotation.
+
+Covers the lifecycle tools (`create_session` / `end_session`) and the annotation
+boundary that unseals a sealed handle, binds its identity for the call, and
+gates `Scope.SESSION` state. The happy paths run through an in-memory `Client`;
+the auth-dependent cross-principal case drives the tool boundary directly under a
+simulated authenticated principal.
+"""
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Annotated
+
+import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken as SDKAccessToken
+
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.context import Context
+from fastmcp.server.dependencies import get_context
+from fastmcp.server.sessions import (
+    InvalidSessionToken,
+    Scope,
+    Session,
+    SessionProvider,
+    current_principal,
+)
+
+
+def make_token(*, subject: str = "user-a") -> SDKAccessToken:
+    return SDKAccessToken(
+        token="opaque",
+        client_id="client-1",
+        scopes=[],
+        subject=subject,
+        claims={"iss": "https://issuer.example"},
+    )
+
+
+@contextmanager
+def as_principal(token: SDKAccessToken) -> Iterator[None]:
+    """Set the authenticated principal for the current context."""
+    reset = auth_context_var.set(AuthenticatedUser(token))
+    try:
+        yield
+    finally:
+        auth_context_var.reset(reset)
+
+
+def build_shop(**provider_kwargs: float) -> FastMCP:
+    """A server with a session provider and two session-scoped cart tools."""
+    server = FastMCP("shop", session_provider=SessionProvider(**provider_kwargs))
+
+    @server.tool
+    async def add_to_cart(item: str, session: Annotated[str, Session()]) -> int:
+        ctx = get_context()
+        cart = await ctx.get_state("cart", scope=Scope.SESSION) or []
+        cart.append(item)
+        await ctx.set_state("cart", cart, scope=Scope.SESSION)
+        return len(cart)
+
+    @server.tool
+    async def view_cart(session: Annotated[str, Session()]) -> list[str]:
+        ctx = get_context()
+        return await ctx.get_state("cart", scope=Scope.SESSION) or []
+
+    return server
+
+
+class TestSessionLifecycle:
+    async def test_state_survives_across_calls(self):
+        server = build_shop()
+        async with Client(server) as client:
+            token = (await client.call_tool("create_session", {})).data
+            assert isinstance(token, str) and token
+
+            await client.call_tool("add_to_cart", {"item": "apple", "session": token})
+            second = await client.call_tool(
+                "add_to_cart", {"item": "banana", "session": token}
+            )
+            assert second.data == 2
+
+            view = await client.call_tool("view_cart", {"session": token})
+            assert view.data == ["apple", "banana"]
+
+    async def test_end_session_clears_state(self):
+        server = build_shop()
+        async with Client(server) as client:
+            token = (await client.call_tool("create_session", {})).data
+            await client.call_tool("add_to_cart", {"item": "apple", "session": token})
+
+            await client.call_tool("end_session", {"session": token})
+
+            view = await client.call_tool("view_cart", {"session": token})
+            assert view.data == []
+
+    async def test_distinct_sessions_are_isolated(self):
+        server = build_shop()
+        async with Client(server) as client:
+            token_a = (await client.call_tool("create_session", {})).data
+            token_b = (await client.call_tool("create_session", {})).data
+            assert token_a != token_b
+
+            await client.call_tool("add_to_cart", {"item": "apple", "session": token_a})
+
+            view_b = await client.call_tool("view_cart", {"session": token_b})
+            assert view_b.data == []
+
+
+class TestSessionAnnotationSchema:
+    async def test_lifecycle_tools_registered(self):
+        server = build_shop()
+        async with Client(server) as client:
+            names = {tool.name for tool in await client.list_tools()}
+        assert {"create_session", "end_session"} <= names
+
+    async def test_session_parameter_is_a_string_in_schema(self):
+        server = build_shop()
+        async with Client(server) as client:
+            tools = {tool.name: tool for tool in await client.list_tools()}
+        schema = tools["view_cart"].input_schema
+        assert schema["properties"]["session"]["type"] == "string"
+        assert "session" in schema["required"]
+
+    async def test_body_receives_raw_token_string(self):
+        server = FastMCP("shop", session_provider=SessionProvider())
+        observed: dict[str, str] = {}
+
+        @server.tool
+        async def echo_token(session: Annotated[str, Session()]) -> str:
+            observed["token"] = session
+            return session
+
+        async with Client(server) as client:
+            token = (await client.call_tool("create_session", {})).data
+            result = await client.call_tool("echo_token", {"session": token})
+
+        assert result.data == token
+        assert observed["token"] == token
+
+    def test_multiple_session_parameters_rejected(self):
+        server = FastMCP("shop")
+        with pytest.raises(ValueError, match="at most one"):
+
+            @server.tool
+            def two_sessions(
+                a: Annotated[str, Session()],
+                b: Annotated[str, Session()],
+            ) -> str:
+                return "nope"
+
+
+class TestInvalidHandles:
+    @pytest.mark.parametrize("bad_token", ["garbage", "v1.tampered.payload", ""])
+    async def test_invalid_token_fails_the_call(self, bad_token: str):
+        server = build_shop()
+        async with Client(server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool("view_cart", {"session": bad_token})
+
+    async def test_foreign_key_token_fails(self):
+        """A handle sealed by a different server (different key) is rejected."""
+        minting_server = build_shop()
+        async with Client(minting_server) as client:
+            foreign_token = (await client.call_tool("create_session", {})).data
+
+        verifying_server = build_shop()
+        async with Client(verifying_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool("view_cart", {"session": foreign_token})
+
+
+class TestCrossPrincipalIsolation:
+    async def test_token_for_a_rejected_under_b(self):
+        server = build_shop()
+        tool = await server.get_tool("view_cart")
+
+        async with Context(fastmcp=server):
+            with as_principal(make_token(subject="user-a")):
+                token = server.session_codec.seal("sess-a", current_principal())
+
+            with as_principal(make_token(subject="user-b")):
+                with pytest.raises(InvalidSessionToken):
+                    await tool.run({"session": token})
+
+    async def test_token_for_a_accepted_under_a(self):
+        server = build_shop()
+        add_tool = await server.get_tool("add_to_cart")
+        view_tool = await server.get_tool("view_cart")
+
+        async with Context(fastmcp=server):
+            with as_principal(make_token(subject="user-a")):
+                token = server.session_codec.seal("sess-a", current_principal())
+                await add_tool.run({"item": "apple", "session": token})
+                result = await view_tool.run({"session": token})
+
+        assert json.loads(result.content[0].text) == ["apple"]
+
+
+class TestExpiry:
+    async def test_expired_token_rejected_at_boundary(self, monkeypatch):
+        import fastmcp.server.sessions as sessions_mod
+
+        server = build_shop(ttl=60)
+        view_tool = await server.get_tool("view_cart")
+
+        base = 1_000_000.0
+        monkeypatch.setattr(sessions_mod.time, "time", lambda: base)
+        token = server.session_codec.seal("sess-1", None)
+        monkeypatch.setattr(sessions_mod.time, "time", lambda: base + 61)
+
+        async with Context(fastmcp=server):
+            with pytest.raises(InvalidSessionToken):
+                await view_tool.run({"session": token})

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -1,10 +1,11 @@
 """End-to-end tests for the two session-state patterns and `SessionProvider`.
 
-Covers the injected `session: Session` per-user pattern, the explicit
+Covers the injected `session: UserSession` per-user pattern, the explicit
 `session_id: SessionId` argument pattern, and the `SessionProvider` lifecycle
-tools. The schema, registration, and unauthenticated paths run through an
-in-memory `Client`; the principal-isolation cases drive the tool through its full
-injection + storage path under a simulated authenticated principal.
+tools (registered explicitly and auto-wired). The schema, registration, and
+unauthenticated paths run through an in-memory `Client`; the principal-isolation
+cases drive the tool through its full injection + storage path under a simulated
+authenticated principal.
 """
 
 import re
@@ -23,9 +24,9 @@ from fastmcp.server.context import Context
 from fastmcp.server.dependencies import get_context
 from fastmcp.server.sessions import (
     SESSION_ID_DESCRIPTION,
-    Session,
     SessionId,
     SessionProvider,
+    UserSession,
 )
 
 
@@ -52,18 +53,18 @@ def as_principal(token: SDKAccessToken | None) -> Iterator[None]:
 
 
 def build_injected_server() -> FastMCP:
-    """Server whose cart tools inject a per-user `session: Session`."""
+    """Server whose cart tools inject a per-user `session: UserSession`."""
     server = FastMCP("shop")
 
     @server.tool
-    async def add_to_cart(item: str, session: Session) -> int:
+    async def add_to_cart(item: str, session: UserSession) -> int:
         cart = await session.get("cart", default=[])
         cart.append(item)
         await session.set("cart", cart)
         return len(cart)
 
     @server.tool
-    async def view_cart(session: Session) -> list[str]:
+    async def view_cart(session: UserSession) -> list[str]:
         return await session.get("cart", default=[])
 
     return server
@@ -90,7 +91,7 @@ def build_id_server() -> FastMCP:
 
 
 # ---------------------------------------------------------------------------
-# Injected `session: Session`
+# Injected `session: UserSession`
 # ---------------------------------------------------------------------------
 
 
@@ -251,6 +252,125 @@ class TestSessionProvider:
         assert SESSION_ID_DESCRIPTION in prop["description"]
 
 
+class TestAutoRegisteredSessionProvider:
+    async def test_session_id_tool_auto_wires_the_provider(self):
+        """Declaring `session_id: SessionId` makes create/end available with no
+        explicit add_provider call."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            session = get_context().get_session(session_id)
+            cart = await session.get("cart", default=[])
+            cart.append(item)
+            await session.set("cart", cart)
+            return len(cart)
+
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert {"create_session", "end_session"} <= names
+
+    async def test_auto_wired_lifecycle_round_trips(self):
+        server = FastMCP("shop")
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            session = get_context().get_session(session_id)
+            cart = await session.get("cart", default=[])
+            cart.append(item)
+            await session.set("cart", cart)
+            return len(cart)
+
+        async with Client(server) as client:
+            session_id = (await client.call_tool("create_session", {})).data
+            await client.call_tool(
+                "add_to_cart", {"item": "apple", "session_id": session_id}
+            )
+            await client.call_tool("end_session", {"session_id": session_id})
+
+    async def test_not_registered_without_a_session_id_tool(self):
+        """A server with no `session_id` tool gets no lifecycle tools."""
+        server = FastMCP("plain")
+
+        @server.tool
+        async def echo(text: str) -> str:
+            return text
+
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert "create_session" not in names
+        assert "end_session" not in names
+
+    async def test_injected_session_alone_does_not_auto_wire(self):
+        """The injected `UserSession` pattern needs no `create_session`, so it does
+        not trigger auto-registration."""
+        server = build_injected_server()
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert "create_session" not in names
+
+    async def test_manual_provider_is_not_doubled(self):
+        """An explicitly added SessionProvider suppresses the implicit one — only
+        one create_session / end_session is listed."""
+        server = FastMCP("shop")
+        server.add_provider(SessionProvider())
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        create = [t for t in tools if t.name == "create_session"]
+        end = [t for t in tools if t.name == "end_session"]
+        assert len(create) == 1
+        assert len(end) == 1
+
+    async def test_tool_added_after_construction_still_wires(self):
+        """Auto-registration is decided at list time, so a `session_id` tool added
+        after the server is built still activates the provider."""
+        server = FastMCP("shop")
+
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert "create_session" not in names
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert {"create_session", "end_session"} <= names
+
+    async def test_opt_out_disables_auto_registration(self):
+        """`auto_session_provider=False` (bring-your-own-key) suppresses the
+        lifecycle tools even when a `session_id` tool is declared."""
+        server = FastMCP("shop", auto_session_provider=False)
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert "create_session" not in names
+        assert "end_session" not in names
+
+    async def test_opt_out_still_allows_explicit_provider(self):
+        """Opting out of auto-registration does not block a manually added one."""
+        server = FastMCP("shop", auto_session_provider=False)
+        server.add_provider(SessionProvider())
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert {"create_session", "end_session"} <= names
+
+
 class TestSessionIdDescriptionAppending:
     async def test_author_description_is_preserved_and_appended(self):
         server = FastMCP("s")
@@ -270,6 +390,4 @@ class TestSessionIdDescriptionAppending:
         assert "The handle for this workflow." in desc
         assert SESSION_ID_DESCRIPTION in desc
         # Author text comes first, contract appended after.
-        assert re.search(
-            r"handle for this workflow\.\s+Session identifier\.", desc
-        )
+        assert re.search(r"handle for this workflow\.\s+Session identifier\.", desc)

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -1,11 +1,12 @@
 """End-to-end tests for the two session-state patterns and `SessionProvider`.
 
 Covers the injected `session: UserSession` per-user pattern, the explicit
-`session_id: SessionId` argument pattern, and the `SessionProvider` lifecycle
-tools (registered explicitly and auto-wired). The schema, registration, and
-unauthenticated paths run through an in-memory `Client`; the principal-isolation
-cases drive the tool through its full injection + storage path under a simulated
-authenticated principal.
+`session_id: SessionId` argument pattern (with its create-then-validate
+lifecycle), and the requirement that a `SessionProvider` be registered whenever a
+tool declares `session_id`. The schema, registration, and lifecycle paths run
+through an in-memory `Client`; the principal-isolation cases drive the tool
+through its full injection + storage path under a simulated authenticated
+principal.
 """
 
 import re
@@ -24,8 +25,10 @@ from fastmcp.server.context import Context
 from fastmcp.server.dependencies import get_context
 from fastmcp.server.sessions import (
     SESSION_ID_DESCRIPTION,
+    InvalidSession,
     SessionId,
     SessionProvider,
+    SessionProviderRequiredError,
     UserSession,
 )
 
@@ -77,7 +80,7 @@ def build_id_server() -> FastMCP:
 
     @server.tool
     async def add_to_cart(item: str, session_id: SessionId) -> int:
-        session = get_context().get_session(session_id)
+        session = await get_context().get_session(session_id)
         cart = await session.get("cart", default=[])
         cart.append(item)
         await session.set("cart", cart)
@@ -85,7 +88,8 @@ def build_id_server() -> FastMCP:
 
     @server.tool
     async def view_cart(session_id: SessionId) -> list[str]:
-        return await get_context().get_session(session_id).get("cart", default=[])
+        session = await get_context().get_session(session_id)
+        return await session.get("cart", default=[])
 
     return server
 
@@ -137,9 +141,18 @@ class TestInjectedSession:
 
         assert view_b.structured_content["result"] == []
 
+    async def test_user_session_needs_no_provider(self):
+        """A server using only `UserSession` requires no `SessionProvider` and
+        lists no lifecycle tools."""
+        server = build_injected_server()
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert "create_session" not in names
+        assert "end_session" not in names
+
 
 # ---------------------------------------------------------------------------
-# Explicit `session_id: SessionId`
+# Explicit `session_id: SessionId` — create then validate
 # ---------------------------------------------------------------------------
 
 
@@ -154,7 +167,7 @@ class TestSessionIdArgument:
         assert "session_id" in schema["required"]
         assert prop["description"] == SESSION_ID_DESCRIPTION
 
-    async def test_state_survives_across_calls_under_an_id(self):
+    async def test_created_id_round_trips_state_across_calls(self):
         server = build_id_server()
         async with Client(server) as client:
             session_id = (await client.call_tool("create_session", {})).data
@@ -170,7 +183,14 @@ class TestSessionIdArgument:
             view = await client.call_tool("view_cart", {"session_id": session_id})
             assert view.data == ["apple", "banana"]
 
-    async def test_distinct_ids_isolated(self):
+    async def test_uncreated_id_is_rejected(self):
+        """An id that was never handed out by `create_session` does not resolve."""
+        server = build_id_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool("view_cart", {"session_id": "never-created"})
+
+    async def test_distinct_created_ids_are_isolated(self):
         server = build_id_server()
         async with Client(server) as client:
             id_a = (await client.call_tool("create_session", {})).data
@@ -181,7 +201,8 @@ class TestSessionIdArgument:
             view_b = await client.call_tool("view_cart", {"session_id": id_b})
             assert view_b.data == []
 
-    async def test_end_session_clears_state(self):
+    async def test_end_session_invalidates_the_session(self):
+        """After `end_session` the id no longer resolves at all."""
         server = build_id_server()
         async with Client(server) as client:
             session_id = (await client.call_tool("create_session", {})).data
@@ -191,23 +212,80 @@ class TestSessionIdArgument:
 
             await client.call_tool("end_session", {"session_id": session_id})
 
+            with pytest.raises(ToolError):
+                await client.call_tool("view_cart", {"session_id": session_id})
+
+    async def test_clear_keeps_the_session_valid(self):
+        """`session.clear()` empties state but the session still resolves."""
+        server = FastMCP("shop")
+        server.add_provider(SessionProvider())
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            session = await get_context().get_session(session_id)
+            cart = await session.get("cart", default=[])
+            cart.append(item)
+            await session.set("cart", cart)
+            return len(cart)
+
+        @server.tool
+        async def clear_cart(session_id: SessionId) -> str:
+            session = await get_context().get_session(session_id)
+            await session.clear()
+            return "cleared"
+
+        @server.tool
+        async def view_cart(session_id: SessionId) -> list[str]:
+            session = await get_context().get_session(session_id)
+            return await session.get("cart", default=[])
+
+        async with Client(server) as client:
+            session_id = (await client.call_tool("create_session", {})).data
+            await client.call_tool(
+                "add_to_cart", {"item": "apple", "session_id": session_id}
+            )
+            await client.call_tool("clear_cart", {"session_id": session_id})
+
+            # Still resolves (no error), and state is empty.
             view = await client.call_tool("view_cart", {"session_id": session_id})
             assert view.data == []
 
+    async def test_created_under_one_principal_rejected_under_another(self):
+        """An id created by principal A is rejected when used by principal B."""
+        server = build_id_server()
+        create_tool = await server.get_tool("create_session")
+        view_tool = await server.get_tool("view_cart")
+
+        async with Context(fastmcp=server):
+            with as_principal(make_token(subject="user-a")):
+                created = await create_tool.run({})
+                session_id = created.structured_content["result"]
+            with as_principal(make_token(subject="user-b")):
+                with pytest.raises(InvalidSession):
+                    await view_tool.run({"session_id": session_id})
+            with as_principal(make_token(subject="user-a")):
+                # A's own session still resolves.
+                view_a = await view_tool.run({"session_id": session_id})
+
+        assert view_a.structured_content["result"] == []
+
     async def test_two_principals_same_id_are_isolated(self):
         server = build_id_server()
+        create_tool = await server.get_tool("create_session")
         add_tool = await server.get_tool("add_to_cart")
         view_tool = await server.get_tool("view_cart")
 
         async with Context(fastmcp=server):
             with as_principal(make_token(subject="user-a")):
-                await add_tool.run({"item": "apple", "session_id": "shared"})
+                id_a = (await create_tool.run({})).structured_content["result"]
+                await add_tool.run({"item": "apple", "session_id": id_a})
             with as_principal(make_token(subject="user-b")):
-                view_b = await view_tool.run({"session_id": "shared"})
-                # B's own bucket under the same id is empty.
+                id_b = (await create_tool.run({})).structured_content["result"]
+                # B's own session under its own id is empty.
+                view_b = await view_tool.run({"session_id": id_b})
                 assert view_b.structured_content["result"] == []
             with as_principal(make_token(subject="user-a")):
-                view_a = await view_tool.run({"session_id": "shared"})
+                view_a = await view_tool.run({"session_id": id_a})
 
         assert view_a.structured_content["result"] == ["apple"]
 
@@ -252,44 +330,74 @@ class TestSessionProvider:
         assert SESSION_ID_DESCRIPTION in prop["description"]
 
 
-class TestAutoRegisteredSessionProvider:
-    async def test_session_id_tool_auto_wires_the_provider(self):
-        """Declaring `session_id: SessionId` makes create/end available with no
-        explicit add_provider call."""
+class TestSessionProviderRequirement:
+    async def test_missing_provider_raises_naming_the_tool(self):
+        """A `session_id` tool with no `SessionProvider` fails loudly, naming the
+        offending tool and the fix."""
         server = FastMCP("shop")
 
         @server.tool
         async def add_to_cart(item: str, session_id: SessionId) -> int:
-            session = get_context().get_session(session_id)
-            cart = await session.get("cart", default=[])
-            cart.append(item)
-            await session.set("cart", cart)
-            return len(cart)
+            return len(item)
+
+        with pytest.raises(SessionProviderRequiredError) as exc_info:
+            await server.list_tools()
+        message = str(exc_info.value)
+        assert "add_to_cart" in message
+        assert "add_provider(SessionProvider())" in message
+
+    async def test_missing_provider_blocks_tool_resolution(self):
+        """The requirement also gates `_get_tool`, so a call cannot slip past."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        with pytest.raises(SessionProviderRequiredError):
+            await server.get_tool("add_to_cart")
+
+    async def test_missing_provider_surfaces_over_the_wire(self):
+        """Over the client wire the misconfiguration still fails the call."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        async with Client(server) as client:
+            with pytest.raises(Exception):
+                await client.list_tools()
+
+    async def test_registering_the_provider_satisfies_the_requirement(self):
+        server = FastMCP("shop")
+        server.add_provider(SessionProvider())
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
 
         async with Client(server) as client:
             names = {t.name for t in await client.list_tools()}
         assert {"create_session", "end_session"} <= names
 
-    async def test_auto_wired_lifecycle_round_trips(self):
+    async def test_requirement_triggers_for_tool_added_after_construction(self):
+        """The check re-scans live, so a `session_id` tool added after the server
+        is built still triggers the requirement."""
         server = FastMCP("shop")
+
+        # No session_id tool yet: listing is fine.
+        await server.list_tools()
 
         @server.tool
         async def add_to_cart(item: str, session_id: SessionId) -> int:
-            session = get_context().get_session(session_id)
-            cart = await session.get("cart", default=[])
-            cart.append(item)
-            await session.set("cart", cart)
-            return len(cart)
+            return len(item)
 
-        async with Client(server) as client:
-            session_id = (await client.call_tool("create_session", {})).data
-            await client.call_tool(
-                "add_to_cart", {"item": "apple", "session_id": session_id}
-            )
-            await client.call_tool("end_session", {"session_id": session_id})
+        with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
+            await server.list_tools()
 
-    async def test_not_registered_without_a_session_id_tool(self):
-        """A server with no `session_id` tool gets no lifecycle tools."""
+    async def test_no_requirement_without_a_session_id_tool(self):
+        """A server with no `session_id` tool needs no provider and lists cleanly."""
         server = FastMCP("plain")
 
         @server.tool
@@ -298,82 +406,13 @@ class TestAutoRegisteredSessionProvider:
 
         async with Client(server) as client:
             names = {t.name for t in await client.list_tools()}
-        assert "create_session" not in names
-        assert "end_session" not in names
-
-    async def test_injected_session_alone_does_not_auto_wire(self):
-        """The injected `UserSession` pattern needs no `create_session`, so it does
-        not trigger auto-registration."""
-        server = build_injected_server()
-        async with Client(server) as client:
-            names = {t.name for t in await client.list_tools()}
-        assert "create_session" not in names
-
-    async def test_manual_provider_is_not_doubled(self):
-        """An explicitly added SessionProvider suppresses the implicit one — only
-        one create_session / end_session is listed."""
-        server = FastMCP("shop")
-        server.add_provider(SessionProvider())
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        async with Client(server) as client:
-            tools = await client.list_tools()
-        create = [t for t in tools if t.name == "create_session"]
-        end = [t for t in tools if t.name == "end_session"]
-        assert len(create) == 1
-        assert len(end) == 1
-
-    async def test_tool_added_after_construction_still_wires(self):
-        """Auto-registration is decided at list time, so a `session_id` tool added
-        after the server is built still activates the provider."""
-        server = FastMCP("shop")
-
-        async with Client(server) as client:
-            names = {t.name for t in await client.list_tools()}
-        assert "create_session" not in names
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        async with Client(server) as client:
-            names = {t.name for t in await client.list_tools()}
-        assert {"create_session", "end_session"} <= names
-
-    async def test_opt_out_disables_auto_registration(self):
-        """`auto_session_provider=False` (bring-your-own-key) suppresses the
-        lifecycle tools even when a `session_id` tool is declared."""
-        server = FastMCP("shop", auto_session_provider=False)
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        async with Client(server) as client:
-            names = {t.name for t in await client.list_tools()}
-        assert "create_session" not in names
-        assert "end_session" not in names
-
-    async def test_opt_out_still_allows_explicit_provider(self):
-        """Opting out of auto-registration does not block a manually added one."""
-        server = FastMCP("shop", auto_session_provider=False)
-        server.add_provider(SessionProvider())
-
-        @server.tool
-        async def add_to_cart(item: str, session_id: SessionId) -> int:
-            return len(item)
-
-        async with Client(server) as client:
-            names = {t.name for t in await client.list_tools()}
-        assert {"create_session", "end_session"} <= names
+        assert names == {"echo"}
 
 
 class TestSessionIdDescriptionAppending:
     async def test_author_description_is_preserved_and_appended(self):
         server = FastMCP("s")
+        server.add_provider(SessionProvider())
 
         @server.tool
         async def resume(session_id: SessionId) -> str:

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -12,6 +12,7 @@ principal.
 import re
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 from uuid import UUID
 
 import pytest
@@ -31,6 +32,18 @@ from fastmcp.server.sessions import (
     SessionProviderRequiredError,
     UserSession,
 )
+from fastmcp.tools.base import ToolResult
+
+
+def result_value(result: ToolResult) -> Any:
+    """The `"result"` field of a direct `Tool.run()` call's structured content.
+
+    `structured_content` is `dict | None` on `ToolResult` (a bare function tool
+    always populates it, but the type isn't narrowed by construction), so this
+    asserts it is present before indexing.
+    """
+    assert result.structured_content is not None
+    return result.structured_content["result"]
 
 
 def make_token(*, subject: str = "user-a") -> SDKAccessToken:
@@ -118,6 +131,8 @@ class TestInjectedSession:
         server = build_injected_server()
         add_tool = await server.get_tool("add_to_cart")
         view_tool = await server.get_tool("view_cart")
+        assert add_tool is not None
+        assert view_tool is not None
 
         async with Context(fastmcp=server):
             with as_principal(make_token(subject="user-a")):
@@ -125,13 +140,15 @@ class TestInjectedSession:
                 second = await add_tool.run({"item": "banana"})
                 view = await view_tool.run({})
 
-        assert second.structured_content["result"] == 2
-        assert view.structured_content["result"] == ["apple", "banana"]
+        assert result_value(second) == 2
+        assert result_value(view) == ["apple", "banana"]
 
     async def test_two_principals_get_isolated_buckets(self):
         server = build_injected_server()
         add_tool = await server.get_tool("add_to_cart")
         view_tool = await server.get_tool("view_cart")
+        assert add_tool is not None
+        assert view_tool is not None
 
         async with Context(fastmcp=server):
             with as_principal(make_token(subject="user-a")):
@@ -139,7 +156,7 @@ class TestInjectedSession:
             with as_principal(make_token(subject="user-b")):
                 view_b = await view_tool.run({})
 
-        assert view_b.structured_content["result"] == []
+        assert result_value(view_b) == []
 
     async def test_user_session_needs_no_provider(self):
         """A server using only `UserSession` requires no `SessionProvider` and
@@ -271,11 +288,13 @@ class TestSessionIdArgument:
         server = build_id_server()
         create_tool = await server.get_tool("create_session")
         view_tool = await server.get_tool("view_cart")
+        assert create_tool is not None
+        assert view_tool is not None
 
         async with Context(fastmcp=server):
             with as_principal(make_token(subject="user-a")):
                 created = await create_tool.run({})
-                session_id = created.structured_content["result"]
+                session_id = result_value(created)
             with as_principal(make_token(subject="user-b")):
                 with pytest.raises(InvalidSession):
                     await view_tool.run({"session_id": session_id})
@@ -283,27 +302,30 @@ class TestSessionIdArgument:
                 # A's own session still resolves.
                 view_a = await view_tool.run({"session_id": session_id})
 
-        assert view_a.structured_content["result"] == []
+        assert result_value(view_a) == []
 
     async def test_two_principals_same_id_are_isolated(self):
         server = build_id_server()
         create_tool = await server.get_tool("create_session")
         add_tool = await server.get_tool("add_to_cart")
         view_tool = await server.get_tool("view_cart")
+        assert create_tool is not None
+        assert add_tool is not None
+        assert view_tool is not None
 
         async with Context(fastmcp=server):
             with as_principal(make_token(subject="user-a")):
-                id_a = (await create_tool.run({})).structured_content["result"]
+                id_a = result_value(await create_tool.run({}))
                 await add_tool.run({"item": "apple", "session_id": id_a})
             with as_principal(make_token(subject="user-b")):
-                id_b = (await create_tool.run({})).structured_content["result"]
+                id_b = result_value(await create_tool.run({}))
                 # B's own session under its own id is empty.
                 view_b = await view_tool.run({"session_id": id_b})
-                assert view_b.structured_content["result"] == []
+                assert result_value(view_b) == []
             with as_principal(make_token(subject="user-a")):
                 view_a = await view_tool.run({"session_id": id_a})
 
-        assert view_a.structured_content["result"] == ["apple"]
+        assert result_value(view_a) == ["apple"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -460,6 +460,26 @@ class TestSessionIdDescriptionAppending:
         # Author text comes first, contract appended after.
         assert re.search(r"handle for this workflow\.\s+Session identifier\.", desc)
 
+    async def test_contract_is_not_duplicated_when_author_repeats_it(self):
+        """An author who already includes the contract text doesn't get it twice."""
+        from typing import Annotated
+
+        from pydantic import Field
+
+        server = FastMCP("s")
+        server.add_provider(SessionProvider())
+
+        @server.tool
+        async def resume(
+            session_id: Annotated[SessionId, Field(description=SESSION_ID_DESCRIPTION)],
+        ) -> str:
+            return session_id
+
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        desc = tools["resume"].input_schema["properties"]["session_id"]["description"]
+        assert desc.count(SESSION_ID_DESCRIPTION) == 1
+
     async def test_description_survives_namespaced_mount(self):
         """The contract names no specific tool, so it stays correct when a mount
         renames the lifecycle tool under a namespace — the description must not

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -30,6 +30,7 @@ from fastmcp.server.sessions import (
     SessionId,
     SessionProvider,
     SessionProviderRequiredError,
+    SessionProviderShadowedError,
     UserSession,
 )
 from fastmcp.tools.base import ToolResult
@@ -504,6 +505,46 @@ class TestSessionProviderRequirement:
         with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
             await server.list_tools()
         with pytest.raises(SessionProviderRequiredError, match="add_to_cart"):
+            await server.get_tool("add_to_cart")
+
+    async def test_disabled_session_id_tool_does_not_block_others(self):
+        """A disabled `session_id` tool can never be called, so it must not
+        force every other tool's listing or resolution to fail."""
+        server = FastMCP("shop")
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        @server.tool
+        async def echo(text: str) -> str:
+            return text
+
+        server.disable(names={"add_to_cart"}, components={"tool"})
+
+        async with Client(server) as client:
+            names = {t.name for t in await client.list_tools()}
+            result = await client.call_tool("echo", {"text": "hi"})
+        assert names == {"echo"}
+        assert result.data == "hi"
+
+    async def test_local_tool_shadowing_lifecycle_name_is_rejected(self):
+        """A local tool named `create_session` always wins over the provider's
+        own tool of that name, permanently shadowing it — rejected at setup."""
+        server = FastMCP("shop")
+        server.add_provider(SessionProvider())
+
+        @server.tool
+        async def add_to_cart(item: str, session_id: SessionId) -> int:
+            return len(item)
+
+        @server.tool(name="create_session")
+        async def my_create_session() -> str:
+            return "not a real session"
+
+        with pytest.raises(SessionProviderShadowedError, match="create_session"):
+            await server.list_tools()
+        with pytest.raises(SessionProviderShadowedError, match="create_session"):
             await server.get_tool("add_to_cart")
 
 

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -183,6 +183,22 @@ class TestSessionIdArgument:
             view = await client.call_tool("view_cart", {"session_id": session_id})
             assert view.data == ["apple", "banana"]
 
+    async def test_resolved_session_exposes_its_id(self):
+        """A session resolved from a `session_id` argument carries that id."""
+        server = FastMCP("shop")
+        server.add_provider(SessionProvider())
+
+        @server.tool
+        async def which_session(session_id: SessionId) -> str | None:
+            return (await get_context().get_session(session_id)).id
+
+        async with Client(server) as client:
+            session_id = (await client.call_tool("create_session", {})).data
+            result = (
+                await client.call_tool("which_session", {"session_id": session_id})
+            ).data
+        assert result == session_id
+
     async def test_uncreated_id_is_rejected(self):
         """An id that was never handed out by `create_session` does not resolve."""
         server = build_id_server()

--- a/tests/server/test_session_provider.py
+++ b/tests/server/test_session_provider.py
@@ -569,3 +569,32 @@ class TestSessionIdDescriptionAppending:
         assert SESSION_ID_DESCRIPTION in desc
         # Author text comes first, contract appended after.
         assert re.search(r"handle for this workflow\.\s+Session identifier\.", desc)
+
+    async def test_description_survives_namespaced_mount(self):
+        """The contract names no specific tool, so it stays correct when a mount
+        renames the lifecycle tool under a namespace — the description must not
+        point agents at an unqualified `create_session` that does not exist
+        under that mount."""
+        child = FastMCP("child")
+        child.add_provider(SessionProvider())
+
+        @child.tool
+        async def workflow(session_id: SessionId) -> str:
+            return session_id
+
+        parent = FastMCP("parent")
+        parent.mount(child, namespace="child")
+
+        async with Client(parent) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+
+        # The lifecycle tool is renamed under the namespace...
+        assert "child_create_session" in tools
+        assert "create_session" not in tools
+        # ...yet the session_id contract still resolves correctly, because it
+        # describes the capability rather than naming a tool.
+        desc = tools["child_workflow"].input_schema["properties"]["session_id"][
+            "description"
+        ]
+        assert desc == SESSION_ID_DESCRIPTION
+        assert "create_session" not in desc

--- a/tests/server/test_sessions.py
+++ b/tests/server/test_sessions.py
@@ -1,54 +1,33 @@
-"""Tests for the stateless session-state primitives.
+"""Unit tests for the stateless session-state primitives.
 
-Covers the `SessionCodec` security core (seal/unseal, expiry, principal binding)
-and the scoped-state surface on `Context` (`Scope.REQUEST` / `USER` / `SESSION`).
+Covers the principal helpers, the `(principal, session_id)` key scheme, and the
+`Session` object's read-modify-write behavior against a real server store.
 """
 
 import json
 from collections.abc import Iterator
 from contextlib import contextmanager
-from unittest.mock import MagicMock
 
-import pytest
 from mcp.server.auth.middleware.auth_context import auth_context_var
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from mcp.server.auth.provider import AccessToken as SDKAccessToken
 from mcp.server.auth.provider import principal_components
-from mcp.server.request_state import RequestStateSecurity
 
-from fastmcp.exceptions import AuthorizationError
-from fastmcp.server.context import Context
 from fastmcp.server.server import FastMCP
 from fastmcp.server.sessions import (
-    DEFAULT_SESSION_TTL,
-    InvalidSessionToken,
-    NoActiveSessionError,
-    Scope,
-    SessionCodec,
-    SessionIdentity,
-    bind_session_identity,
+    Session,
     current_principal,
-    get_active_session_identity,
-    session_state_key,
-    user_state_key,
+    session_storage_key,
 )
 
-KEY_A = b"a" * 32
-KEY_B = b"b" * 32
 
-
-def make_token(
-    *,
-    client_id: str = "client-1",
-    subject: str = "user-a",
-    issuer: str = "https://issuer.example",
-) -> SDKAccessToken:
+def make_token(*, subject: str = "user-a", client_id: str = "client-1") -> SDKAccessToken:
     return SDKAccessToken(
         token="opaque",
         client_id=client_id,
         scopes=[],
         subject=subject,
-        claims={"iss": issuer},
+        claims={"iss": "https://issuer.example"},
     )
 
 
@@ -58,7 +37,6 @@ def principal_string(token: SDKAccessToken) -> str:
 
 @contextmanager
 def as_principal(token: SDKAccessToken | None) -> Iterator[None]:
-    """Set the authenticated principal for the current context."""
     if token is None:
         yield
         return
@@ -69,102 +47,10 @@ def as_principal(token: SDKAccessToken | None) -> Iterator[None]:
         auth_context_var.reset(reset)
 
 
-@pytest.fixture
-def codec() -> SessionCodec:
-    return SessionCodec(RequestStateSecurity(keys=[KEY_A]))
-
-
-class TestSessionCodecRoundTrip:
-    def test_unauthenticated_round_trip(self, codec: SessionCodec):
-        token = codec.seal("sess-1", None)
-        identity = codec.unseal(token, request_principal=None)
-        assert identity == SessionIdentity(session_id="sess-1", principal=None)
-
-    def test_authenticated_round_trip(self, codec: SessionCodec):
-        principal = principal_string(make_token())
-        token = codec.seal("sess-1", principal)
-        identity = codec.unseal(token, request_principal=principal)
-        assert identity.session_id == "sess-1"
-        assert identity.principal == principal
-
-    def test_from_security_none_uses_ephemeral_key(self):
-        codec = SessionCodec.from_security(None)
-        token = codec.seal("sess-1", None)
-        assert codec.unseal(token, request_principal=None).session_id == "sess-1"
-
-    def test_reads_principal_from_auth_context(self, codec: SessionCodec):
-        token_obj = make_token()
-        principal = principal_string(token_obj)
-        sealed = codec.seal("sess-1", principal)
-        with as_principal(token_obj):
-            identity = codec.unseal(sealed)
-        assert identity.principal == principal
-
-
-class TestSessionCodecRejection:
-    def test_tampered_token_rejected(self, codec: SessionCodec):
-        token = codec.seal("sess-1", None)
-        # Flip a character in the sealed body.
-        tampered = token[:-2] + ("A" if token[-1] != "A" else "B")
-        with pytest.raises(InvalidSessionToken):
-            codec.unseal(tampered, request_principal=None)
-
-    def test_malformed_token_rejected(self, codec: SessionCodec):
-        with pytest.raises(InvalidSessionToken):
-            codec.unseal("not-a-real-token", request_principal=None)
-
-    def test_foreign_key_rejected(self):
-        minted = SessionCodec(RequestStateSecurity(keys=[KEY_A])).seal("sess-1", None)
-        other = SessionCodec(RequestStateSecurity(keys=[KEY_B]))
-        with pytest.raises(InvalidSessionToken):
-            other.unseal(minted, request_principal=None)
-
-    def test_expired_token_rejected(self, codec: SessionCodec, monkeypatch):
-        import fastmcp.server.sessions as sessions_module
-
-        base = 1_000_000.0
-        monkeypatch.setattr(sessions_module.time, "time", lambda: base)
-        token = codec.seal("sess-1", None)
-        monkeypatch.setattr(
-            sessions_module.time, "time", lambda: base + DEFAULT_SESSION_TTL + 1
-        )
-        with pytest.raises(InvalidSessionToken):
-            codec.unseal(token, request_principal=None)
-
-    def test_principal_a_rejected_under_principal_b(self, codec: SessionCodec):
-        principal_a = principal_string(make_token(subject="user-a"))
-        principal_b = principal_string(make_token(subject="user-b"))
-        token = codec.seal("sess-1", principal_a)
-        with pytest.raises(InvalidSessionToken):
-            codec.unseal(token, request_principal=principal_b)
-
-    def test_bound_token_rejected_when_unauthenticated(self, codec: SessionCodec):
-        principal = principal_string(make_token())
-        token = codec.seal("sess-1", principal)
-        with pytest.raises(InvalidSessionToken):
-            codec.unseal(token, request_principal=None)
-
-    def test_unbound_token_rejected_under_auth(self, codec: SessionCodec):
-        principal = principal_string(make_token())
-        token = codec.seal("sess-1", None)
-        with pytest.raises(InvalidSessionToken):
-            codec.unseal(token, request_principal=principal)
-
-    def test_rejection_reason_not_on_public_message(self, codec: SessionCodec):
-        try:
-            codec.unseal("garbage", request_principal=None)
-        except InvalidSessionToken as exc:
-            assert "malformed" not in str(exc)
-            assert exc.reason == "malformed"
-        else:  # pragma: no cover
-            pytest.fail("expected InvalidSessionToken")
-
-
-class TestSessionCodecConstruction:
-    @pytest.mark.parametrize("ttl", [0, -1, float("inf"), float("nan")])
-    def test_invalid_ttl_rejected(self, ttl):
-        with pytest.raises(ValueError):
-            SessionCodec(RequestStateSecurity(keys=[KEY_A]), ttl=ttl)
+def make_session(server: FastMCP, principal: str | None, session_id: str) -> Session:
+    return Session(
+        store=server._state_store, principal=principal, session_id=session_id
+    )
 
 
 class TestPrincipalHelpers:
@@ -176,104 +62,102 @@ class TestPrincipalHelpers:
         with as_principal(token):
             assert current_principal() == principal_string(token)
 
-    def test_user_and_session_keys_are_distinct(self):
+
+class TestStorageKey:
+    def test_principal_is_the_isolation_wall(self):
+        principal_a = principal_string(make_token(subject="user-a"))
+        principal_b = principal_string(make_token(subject="user-b"))
+        # Same session id, different principals -> different keys.
+        assert session_storage_key(principal_a, "s1") != session_storage_key(
+            principal_b, "s1"
+        )
+
+    def test_id_organizes_within_a_principal(self):
         principal = principal_string(make_token())
-        identity = SessionIdentity(session_id="sess-1", principal=principal)
-        assert user_state_key(principal, "cart") != session_state_key(identity, "cart")
-        # The principal is hashed, not embedded verbatim.
-        assert principal not in user_state_key(principal, "cart")
+        assert session_storage_key(principal, "s1") != session_storage_key(
+            principal, "s2"
+        )
+
+    def test_unauthenticated_collapses_to_shared_namespace(self):
+        assert session_storage_key(None, "s1").startswith("session:anon:")
+
+    def test_principal_not_embedded_verbatim(self):
+        principal = principal_string(make_token())
+        # The principal is hashed into a fixed segment, never embedded raw.
+        assert principal not in session_storage_key(principal, "s1")
 
 
-class TestBindSessionIdentity:
-    def test_bind_and_read(self):
-        assert get_active_session_identity() is None
-        identity = SessionIdentity(session_id="sess-1", principal=None)
-        with bind_session_identity(identity):
-            assert get_active_session_identity() is identity
-        assert get_active_session_identity() is None
-
-
-class TestScopedStateRequest:
-    async def test_default_scope_is_request(self):
+class TestSessionRoundTrip:
+    async def test_set_get_delete(self):
         server = FastMCP("test")
-        async with Context(fastmcp=server, session=MagicMock()) as ctx:
-            await ctx.set_state("k", "v")
-            assert await ctx.get_state("k") == "v"
-            # Explicit REQUEST scope resolves to the same key.
-            assert await ctx.get_state("k", scope=Scope.REQUEST) == "v"
+        session = make_session(server, None, "s1")
+        assert await session.get("missing") is None
+        assert await session.get("missing", default=[]) == []
 
-    async def test_serializable_false_still_works_for_request(self):
+        await session.set("cart", ["apple"])
+        assert await session.get("cart") == ["apple"]
+
+        await session.delete("cart")
+        assert await session.get("cart") is None
+
+    async def test_multiple_keys_share_one_dict(self):
         server = FastMCP("test")
-        async with Context(fastmcp=server, session=MagicMock()) as ctx:
-            sentinel = object()
-            await ctx.set_state("obj", sentinel, serializable=False)
-            assert await ctx.get_state("obj") is sentinel
+        session = make_session(server, None, "s1")
+        await session.set("a", 1)
+        await session.set("b", 2)
+        assert await session.get("a") == 1
+        assert await session.get("b") == 2
 
-    async def test_delete_request_scope(self):
+    async def test_clear_removes_everything(self):
         server = FastMCP("test")
-        async with Context(fastmcp=server, session=MagicMock()) as ctx:
-            await ctx.set_state("k", "v")
-            await ctx.delete_state("k")
-            assert await ctx.get_state("k") is None
+        session = make_session(server, None, "s1")
+        await session.set("a", 1)
+        await session.set("b", 2)
+        await session.clear()
+        assert await session.get("a") is None
+        assert await session.get("b") is None
 
-
-class TestScopedStateUser:
-    async def test_user_scope_requires_auth(self):
+    async def test_delete_missing_key_is_a_noop(self):
         server = FastMCP("test")
-        async with Context(fastmcp=server) as ctx:
-            with pytest.raises(AuthorizationError):
-                await ctx.get_state("prefs", scope=Scope.USER)
-            with pytest.raises(AuthorizationError):
-                await ctx.set_state("prefs", "x", scope=Scope.USER)
+        session = make_session(server, None, "s1")
+        await session.delete("nope")  # does not raise
+        assert await session.get("nope") is None
 
-    async def test_user_scope_round_trip_under_auth(self):
+
+class TestSessionIsolation:
+    async def test_distinct_ids_are_isolated(self):
         server = FastMCP("test")
-        async with Context(fastmcp=server) as ctx:
-            with as_principal(make_token(subject="user-a")):
-                await ctx.set_state("prefs", {"theme": "dark"}, scope=Scope.USER)
-                assert await ctx.get_state("prefs", scope=Scope.USER) == {
-                    "theme": "dark"
-                }
+        principal = principal_string(make_token())
+        await make_session(server, principal, "s1").set("cart", ["apple"])
+        assert await make_session(server, principal, "s2").get("cart") is None
 
-    async def test_user_scope_isolates_principals(self):
+    async def test_same_id_different_principals_are_isolated(self):
         server = FastMCP("test")
-        async with Context(fastmcp=server) as ctx:
-            with as_principal(make_token(subject="user-a")):
-                await ctx.set_state("prefs", "a-value", scope=Scope.USER)
-            with as_principal(make_token(subject="user-b")):
-                assert await ctx.get_state("prefs", scope=Scope.USER) is None
+        principal_a = principal_string(make_token(subject="user-a"))
+        principal_b = principal_string(make_token(subject="user-b"))
+        await make_session(server, principal_a, "shared-id").set("cart", ["a-item"])
+        # B passes the *same* session id but reaches its own empty bucket.
+        assert await make_session(server, principal_b, "shared-id").get("cart") is None
+        # A still sees its own data.
+        assert await make_session(server, principal_a, "shared-id").get("cart") == [
+            "a-item"
+        ]
 
-    async def test_user_scope_rejects_serializable_false(self):
+
+class TestSharedStore:
+    async def test_sessions_share_the_one_server_store(self):
+        """A second Session for the same key sees the first's writes."""
         server = FastMCP("test")
-        async with Context(fastmcp=server) as ctx:
-            with as_principal(make_token()):
-                with pytest.raises(ValueError):
-                    await ctx.set_state(
-                        "prefs", "x", scope=Scope.USER, serializable=False
-                    )
+        await make_session(server, None, "s1").set("x", 42)
+        # A freshly constructed handle for the same (principal, id) reads it back.
+        assert await make_session(server, None, "s1").get("x") == 42
 
 
-class TestScopedStateSession:
-    async def test_session_scope_without_session_errors(self):
+class TestFalsyValues:
+    async def test_stored_falsy_value_is_not_treated_as_missing(self):
         server = FastMCP("test")
-        async with Context(fastmcp=server) as ctx:
-            with pytest.raises(NoActiveSessionError):
-                await ctx.get_state("cart", scope=Scope.SESSION)
-            with pytest.raises(NoActiveSessionError):
-                await ctx.set_state("cart", [], scope=Scope.SESSION)
-
-    async def test_session_scope_round_trip_when_bound(self):
-        server = FastMCP("test")
-        identity = SessionIdentity(session_id="sess-1", principal=None)
-        async with Context(fastmcp=server) as ctx:
-            with bind_session_identity(identity):
-                await ctx.set_state("cart", ["apple"], scope=Scope.SESSION)
-                assert await ctx.get_state("cart", scope=Scope.SESSION) == ["apple"]
-
-    async def test_session_scope_isolated_by_session_id(self):
-        server = FastMCP("test")
-        async with Context(fastmcp=server) as ctx:
-            with bind_session_identity(SessionIdentity("sess-1", None)):
-                await ctx.set_state("cart", ["apple"], scope=Scope.SESSION)
-            with bind_session_identity(SessionIdentity("sess-2", None)):
-                assert await ctx.get_state("cart", scope=Scope.SESSION) is None
+        session = make_session(server, None, "s1")
+        await session.set("count", 0)
+        await session.set("flag", False)
+        assert await session.get("count", default=99) == 0
+        assert await session.get("flag", default=True) is False

--- a/tests/server/test_sessions.py
+++ b/tests/server/test_sessions.py
@@ -126,6 +126,23 @@ class TestSessionRoundTrip:
         assert await session.get("nope") is None
 
 
+class TestSessionIdProperty:
+    def test_id_is_none_without_a_public_id(self):
+        # An injected `UserSession` is built this way — no distinct public id.
+        server = FastMCP("test")
+        assert make_session(server, None, "s1").id is None
+
+    def test_id_returns_the_public_id(self):
+        server = FastMCP("test")
+        session = Session(
+            store=server._state_store,
+            principal=None,
+            session_id="s1",
+            public_id="s1",
+        )
+        assert session.id == "s1"
+
+
 class TestSessionIsolation:
     async def test_distinct_ids_are_isolated(self):
         server = FastMCP("test")

--- a/tests/server/test_sessions.py
+++ b/tests/server/test_sessions.py
@@ -21,7 +21,9 @@ from fastmcp.server.sessions import (
 )
 
 
-def make_token(*, subject: str = "user-a", client_id: str = "client-1") -> SDKAccessToken:
+def make_token(
+    *, subject: str = "user-a", client_id: str = "client-1"
+) -> SDKAccessToken:
     return SDKAccessToken(
         token="opaque",
         client_id=client_id,
@@ -161,3 +163,46 @@ class TestFalsyValues:
         await session.set("flag", False)
         assert await session.get("count", default=99) == 0
         assert await session.get("flag", default=True) is False
+
+
+class TestLifecycleMarker:
+    async def test_uncreated_session_does_not_exist(self):
+        server = FastMCP("test")
+        session = make_session(server, None, "s1")
+        assert await session._exists() is False
+
+    async def test_created_session_exists(self):
+        server = FastMCP("test")
+        session = make_session(server, None, "s1")
+        await session._create()
+        assert await session._exists() is True
+
+    async def test_writing_state_does_not_clobber_the_marker(self):
+        server = FastMCP("test")
+        session = make_session(server, None, "s1")
+        await session._create()
+        # A user key literally named like the marker cannot collide with it,
+        # because user state lives in a namespaced sub-dict.
+        await session.set("_created", "user-value")
+        await session.set("cart", ["apple"])
+        await session.delete("cart")
+        assert await session._exists() is True
+        assert await session.get("_created") == "user-value"
+
+    async def test_clear_keeps_the_session_but_empties_state(self):
+        server = FastMCP("test")
+        session = make_session(server, None, "s1")
+        await session._create()
+        await session.set("cart", ["apple"])
+        await session.clear()
+        assert await session._exists() is True
+        assert await session.get("cart") is None
+
+    async def test_end_removes_the_session_entirely(self):
+        server = FastMCP("test")
+        session = make_session(server, None, "s1")
+        await session._create()
+        await session.set("cart", ["apple"])
+        await session.end()
+        assert await session._exists() is False
+        assert await session.get("cart") is None

--- a/tests/server/test_sessions.py
+++ b/tests/server/test_sessions.py
@@ -1,0 +1,279 @@
+"""Tests for the stateless session-state primitives.
+
+Covers the `SessionCodec` security core (seal/unseal, expiry, principal binding)
+and the scoped-state surface on `Context` (`Scope.REQUEST` / `USER` / `SESSION`).
+"""
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken as SDKAccessToken
+from mcp.server.auth.provider import principal_components
+from mcp.server.request_state import RequestStateSecurity
+
+from fastmcp.exceptions import AuthorizationError
+from fastmcp.server.context import Context
+from fastmcp.server.server import FastMCP
+from fastmcp.server.sessions import (
+    DEFAULT_SESSION_TTL,
+    InvalidSessionToken,
+    NoActiveSessionError,
+    Scope,
+    SessionCodec,
+    SessionIdentity,
+    bind_session_identity,
+    current_principal,
+    get_active_session_identity,
+    session_state_key,
+    user_state_key,
+)
+
+KEY_A = b"a" * 32
+KEY_B = b"b" * 32
+
+
+def make_token(
+    *,
+    client_id: str = "client-1",
+    subject: str = "user-a",
+    issuer: str = "https://issuer.example",
+) -> SDKAccessToken:
+    return SDKAccessToken(
+        token="opaque",
+        client_id=client_id,
+        scopes=[],
+        subject=subject,
+        claims={"iss": issuer},
+    )
+
+
+def principal_string(token: SDKAccessToken) -> str:
+    return json.dumps(principal_components(token), separators=(",", ":"))
+
+
+@contextmanager
+def as_principal(token: SDKAccessToken | None) -> Iterator[None]:
+    """Set the authenticated principal for the current context."""
+    if token is None:
+        yield
+        return
+    reset = auth_context_var.set(AuthenticatedUser(token))
+    try:
+        yield
+    finally:
+        auth_context_var.reset(reset)
+
+
+@pytest.fixture
+def codec() -> SessionCodec:
+    return SessionCodec(RequestStateSecurity(keys=[KEY_A]))
+
+
+class TestSessionCodecRoundTrip:
+    def test_unauthenticated_round_trip(self, codec: SessionCodec):
+        token = codec.seal("sess-1", None)
+        identity = codec.unseal(token, request_principal=None)
+        assert identity == SessionIdentity(session_id="sess-1", principal=None)
+
+    def test_authenticated_round_trip(self, codec: SessionCodec):
+        principal = principal_string(make_token())
+        token = codec.seal("sess-1", principal)
+        identity = codec.unseal(token, request_principal=principal)
+        assert identity.session_id == "sess-1"
+        assert identity.principal == principal
+
+    def test_from_security_none_uses_ephemeral_key(self):
+        codec = SessionCodec.from_security(None)
+        token = codec.seal("sess-1", None)
+        assert codec.unseal(token, request_principal=None).session_id == "sess-1"
+
+    def test_reads_principal_from_auth_context(self, codec: SessionCodec):
+        token_obj = make_token()
+        principal = principal_string(token_obj)
+        sealed = codec.seal("sess-1", principal)
+        with as_principal(token_obj):
+            identity = codec.unseal(sealed)
+        assert identity.principal == principal
+
+
+class TestSessionCodecRejection:
+    def test_tampered_token_rejected(self, codec: SessionCodec):
+        token = codec.seal("sess-1", None)
+        # Flip a character in the sealed body.
+        tampered = token[:-2] + ("A" if token[-1] != "A" else "B")
+        with pytest.raises(InvalidSessionToken):
+            codec.unseal(tampered, request_principal=None)
+
+    def test_malformed_token_rejected(self, codec: SessionCodec):
+        with pytest.raises(InvalidSessionToken):
+            codec.unseal("not-a-real-token", request_principal=None)
+
+    def test_foreign_key_rejected(self):
+        minted = SessionCodec(RequestStateSecurity(keys=[KEY_A])).seal("sess-1", None)
+        other = SessionCodec(RequestStateSecurity(keys=[KEY_B]))
+        with pytest.raises(InvalidSessionToken):
+            other.unseal(minted, request_principal=None)
+
+    def test_expired_token_rejected(self, codec: SessionCodec, monkeypatch):
+        import fastmcp.server.sessions as sessions_module
+
+        base = 1_000_000.0
+        monkeypatch.setattr(sessions_module.time, "time", lambda: base)
+        token = codec.seal("sess-1", None)
+        monkeypatch.setattr(
+            sessions_module.time, "time", lambda: base + DEFAULT_SESSION_TTL + 1
+        )
+        with pytest.raises(InvalidSessionToken):
+            codec.unseal(token, request_principal=None)
+
+    def test_principal_a_rejected_under_principal_b(self, codec: SessionCodec):
+        principal_a = principal_string(make_token(subject="user-a"))
+        principal_b = principal_string(make_token(subject="user-b"))
+        token = codec.seal("sess-1", principal_a)
+        with pytest.raises(InvalidSessionToken):
+            codec.unseal(token, request_principal=principal_b)
+
+    def test_bound_token_rejected_when_unauthenticated(self, codec: SessionCodec):
+        principal = principal_string(make_token())
+        token = codec.seal("sess-1", principal)
+        with pytest.raises(InvalidSessionToken):
+            codec.unseal(token, request_principal=None)
+
+    def test_unbound_token_rejected_under_auth(self, codec: SessionCodec):
+        principal = principal_string(make_token())
+        token = codec.seal("sess-1", None)
+        with pytest.raises(InvalidSessionToken):
+            codec.unseal(token, request_principal=principal)
+
+    def test_rejection_reason_not_on_public_message(self, codec: SessionCodec):
+        try:
+            codec.unseal("garbage", request_principal=None)
+        except InvalidSessionToken as exc:
+            assert "malformed" not in str(exc)
+            assert exc.reason == "malformed"
+        else:  # pragma: no cover
+            pytest.fail("expected InvalidSessionToken")
+
+
+class TestSessionCodecConstruction:
+    @pytest.mark.parametrize("ttl", [0, -1, float("inf"), float("nan")])
+    def test_invalid_ttl_rejected(self, ttl):
+        with pytest.raises(ValueError):
+            SessionCodec(RequestStateSecurity(keys=[KEY_A]), ttl=ttl)
+
+
+class TestPrincipalHelpers:
+    def test_current_principal_none_without_auth(self):
+        assert current_principal() is None
+
+    def test_current_principal_encodes_triple(self):
+        token = make_token()
+        with as_principal(token):
+            assert current_principal() == principal_string(token)
+
+    def test_user_and_session_keys_are_distinct(self):
+        principal = principal_string(make_token())
+        identity = SessionIdentity(session_id="sess-1", principal=principal)
+        assert user_state_key(principal, "cart") != session_state_key(identity, "cart")
+        # The principal is hashed, not embedded verbatim.
+        assert principal not in user_state_key(principal, "cart")
+
+
+class TestBindSessionIdentity:
+    def test_bind_and_read(self):
+        assert get_active_session_identity() is None
+        identity = SessionIdentity(session_id="sess-1", principal=None)
+        with bind_session_identity(identity):
+            assert get_active_session_identity() is identity
+        assert get_active_session_identity() is None
+
+
+class TestScopedStateRequest:
+    async def test_default_scope_is_request(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server, session=MagicMock()) as ctx:
+            await ctx.set_state("k", "v")
+            assert await ctx.get_state("k") == "v"
+            # Explicit REQUEST scope resolves to the same key.
+            assert await ctx.get_state("k", scope=Scope.REQUEST) == "v"
+
+    async def test_serializable_false_still_works_for_request(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server, session=MagicMock()) as ctx:
+            sentinel = object()
+            await ctx.set_state("obj", sentinel, serializable=False)
+            assert await ctx.get_state("obj") is sentinel
+
+    async def test_delete_request_scope(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server, session=MagicMock()) as ctx:
+            await ctx.set_state("k", "v")
+            await ctx.delete_state("k")
+            assert await ctx.get_state("k") is None
+
+
+class TestScopedStateUser:
+    async def test_user_scope_requires_auth(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server) as ctx:
+            with pytest.raises(AuthorizationError):
+                await ctx.get_state("prefs", scope=Scope.USER)
+            with pytest.raises(AuthorizationError):
+                await ctx.set_state("prefs", "x", scope=Scope.USER)
+
+    async def test_user_scope_round_trip_under_auth(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server) as ctx:
+            with as_principal(make_token(subject="user-a")):
+                await ctx.set_state("prefs", {"theme": "dark"}, scope=Scope.USER)
+                assert await ctx.get_state("prefs", scope=Scope.USER) == {
+                    "theme": "dark"
+                }
+
+    async def test_user_scope_isolates_principals(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server) as ctx:
+            with as_principal(make_token(subject="user-a")):
+                await ctx.set_state("prefs", "a-value", scope=Scope.USER)
+            with as_principal(make_token(subject="user-b")):
+                assert await ctx.get_state("prefs", scope=Scope.USER) is None
+
+    async def test_user_scope_rejects_serializable_false(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server) as ctx:
+            with as_principal(make_token()):
+                with pytest.raises(ValueError):
+                    await ctx.set_state(
+                        "prefs", "x", scope=Scope.USER, serializable=False
+                    )
+
+
+class TestScopedStateSession:
+    async def test_session_scope_without_session_errors(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server) as ctx:
+            with pytest.raises(NoActiveSessionError):
+                await ctx.get_state("cart", scope=Scope.SESSION)
+            with pytest.raises(NoActiveSessionError):
+                await ctx.set_state("cart", [], scope=Scope.SESSION)
+
+    async def test_session_scope_round_trip_when_bound(self):
+        server = FastMCP("test")
+        identity = SessionIdentity(session_id="sess-1", principal=None)
+        async with Context(fastmcp=server) as ctx:
+            with bind_session_identity(identity):
+                await ctx.set_state("cart", ["apple"], scope=Scope.SESSION)
+                assert await ctx.get_state("cart", scope=Scope.SESSION) == ["apple"]
+
+    async def test_session_scope_isolated_by_session_id(self):
+        server = FastMCP("test")
+        async with Context(fastmcp=server) as ctx:
+            with bind_session_identity(SessionIdentity("sess-1", None)):
+                await ctx.set_state("cart", ["apple"], scope=Scope.SESSION)
+            with bind_session_identity(SessionIdentity("sess-2", None)):
+                assert await ctx.get_state("cart", scope=Scope.SESSION) is None

--- a/tests/server/test_sessions.py
+++ b/tests/server/test_sessions.py
@@ -4,6 +4,7 @@ Covers the principal helpers, the `(principal, session_id)` key scheme, and the
 `Session` object's read-modify-write behavior against a real server store.
 """
 
+import functools
 import json
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -16,7 +17,9 @@ from mcp.server.auth.provider import principal_components
 from fastmcp.server.server import FastMCP
 from fastmcp.server.sessions import (
     Session,
+    SessionId,
     current_principal,
+    session_id_parameter_names,
     session_storage_key,
 )
 
@@ -223,3 +226,38 @@ class TestLifecycleMarker:
         await session.end()
         assert await session._exists() is False
         assert await session.get("cart") is None
+
+
+class TestSessionIdParameterNames:
+    def test_detects_plain_parameter(self):
+        def tool(item: str, session_id: SessionId) -> None: ...
+
+        assert session_id_parameter_names(tool) == ("session_id",)
+
+    def test_none_when_absent(self):
+        def tool(item: str) -> None: ...
+
+        assert session_id_parameter_names(tool) == ()
+
+    def test_partial_positional_binding_is_dropped(self):
+        # A positionally bound leading argument is no longer part of the tool's
+        # argument surface; the `session_id` that remains is still detected.
+        def tool(item: str, session_id: SessionId) -> None: ...
+
+        bound = functools.partial(tool, "apple")
+        assert session_id_parameter_names(bound) == ("session_id",)
+
+    def test_partial_binding_the_session_id_positionally_drops_it(self):
+        def tool(session_id: SessionId, item: str) -> None: ...
+
+        bound = functools.partial(tool, "s1")
+        assert session_id_parameter_names(bound) == ()
+
+    def test_partial_keyword_binding_stays_detected(self):
+        # A keyword-bound partial argument remains overridable by the caller, so
+        # it is still in the tool's input schema — detection tracks the schema
+        # and keeps populating its description.
+        def tool(item: str, session_id: SessionId) -> None: ...
+
+        bound = functools.partial(tool, session_id="s1")
+        assert session_id_parameter_names(bound) == ("session_id",)


### PR DESCRIPTION
The modern MCP protocol (`2026-07-28`) is stateless: every request builds a fresh connection and discards it on return, so a tool that wants to remember anything across calls — a cart, a conversation, a running total — has nowhere to put it. Today `ctx.set_state` on a modern connection silently loses everything, which is the worst kind of broken. This introduces the base primitives for a real, documented answer.

The design follows the MCP working group's own decision. They [rejected protocol-level sessions](https://github.com/modelcontextprotocol/transports-wg/blob/main/docs/sessions-vs-sessionless-decision.md) (SEP-1359/1364) in favor of statelessness and "explicit state handles" (SEP-2567): the server hands out an identifier, and the client passes it back as a tool argument — their canonical example is a shopping cart with a `basket_id`. FastMCP implements exactly that pattern and adds the one thing the bare handle lacks: isolation. State lives server-side in the existing storage backend, keyed by the authenticated principal, so a handle is inert in anyone else's hands.

There are two shapes, picked per tool by one question — does a user have one bucket of state, or many?

```python
from fastmcp import FastMCP
from fastmcp.server.sessions import UserSession, SessionId, SessionProvider
from fastmcp.server.dependencies import get_context

mcp = FastMCP("shop")
mcp.add_provider(SessionProvider())


# Per-user: injected like Context, keyed by the authenticated user, nothing to pass.
@mcp.tool
async def remember(fact: str, session: UserSession) -> int:
    facts = await session.get("facts", default=[])
    facts.append(fact)
    await session.set("facts", facts)
    return len(facts)


# Distinct sessions: an explicit id the agent creates with `create_session` and carries.
@mcp.tool
async def add_to_cart(item: str, session_id: SessionId) -> int:
    session = await get_context().get_session(session_id)
    cart = await session.get("cart", default=[])
    cart.append(item)
    await session.set("cart", cart)
    return len(cart)
```

Isolation is the authenticated principal, not the id: because state is keyed `(principal, session_id)`, a request under one user can never address another's data, whatever id it passes — the developer never handles the prefix, so cross-user access is structurally impossible rather than a rule to remember. A `SessionId` session is a real, owned thing: `create_session` records it, and an id that was never created (or was created by a different user) is rejected rather than lazily conjuring a bucket. That create-then-validate check is the whole guarantee, which is why the primitives stay small — there is no setup-time enforcement layer reaching into the tool pipeline; a server with no way to mint ids simply can't resolve a session, a mistake caught the first time the tools run. Without authentication there is no principal wall, so a session id is a bearer capability and sessions are single-tenant-safe only — stated plainly in the docs. Lifetime belongs to the storage backend: configure a TTL on the store and sessions age out on their own.

`SessionProvider` is a normal [provider](https://gofastmcp.com/servers/providers/overview) — the idiomatic way to contribute the `create_session` / `end_session` tools — so composition (mounting, namespacing) works without special-casing. The [Session State](https://gofastmcp.com/servers/sessions) docs lead with the working-group rationale and give the security model its own section.

Label: features.
