### PR TITLE
Advertise only supported token endpoint auth methods in OAuthProxy metadata

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -919,6 +919,17 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             value=proxy_client,
         )
 
+        # The SDK's RegistrationHandler serializes this same `client_info` object
+        # into the DCR response after we return. Left untouched it would echo the
+        # SDK's default `client_secret_post` (or a requested `client_secret_basic`)
+        # and a generated secret — a confidential method the proxy never enforces
+        # and does not advertise in server metadata. Normalize it to the public
+        # client we actually store so the registration response, stored client, and
+        # advertised `token_endpoint_auth_methods_supported` all agree.
+        client_info.token_endpoint_auth_method = "none"
+        client_info.client_secret = None
+        client_info.client_secret_expires_at = None
+
         # Log redirect URIs to help users discover what patterns they might need
         if client_info.redirect_uris:
             for uri in client_info.redirect_uris:

--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -2312,26 +2312,18 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 # always be overridden to advertise support — not just when
                 # CIMD or identity assertion is also enabled.
                 metadata.authorization_response_iss_parameter_supported = True
+                # Every client the proxy authenticates at the token endpoint is
+                # public: DCR-registered and synthesized clients are stored with
+                # `token_endpoint_auth_method="none"`, and CIMD clients use
+                # `private_key_jwt`. The SDK's default advertisement of
+                # `client_secret_basic`/`client_secret_post` is misleading — the
+                # proxy never enforces a downstream client secret — so we override
+                # it to reflect the methods actually supported.
+                auth_methods = ["none"]
                 if self._cimd_manager is not None:
                     metadata.client_id_metadata_document_supported = True
-                    existing = metadata.token_endpoint_auth_methods_supported or []
-                    metadata.token_endpoint_auth_methods_supported = [
-                        *existing,
-                        "private_key_jwt",
-                        "none",
-                    ]
-                if self._identity_assertion is not None:
-                    # DCR clients are public (`token_endpoint_auth_method="none"`),
-                    # so a metadata consumer must see `none` advertised to use the
-                    # jwt-bearer grant — even when CIMD (which also adds it) is off.
-                    methods_supported = (
-                        metadata.token_endpoint_auth_methods_supported or []
-                    )
-                    if "none" not in methods_supported:
-                        metadata.token_endpoint_auth_methods_supported = [
-                            *methods_supported,
-                            "none",
-                        ]
+                    auth_methods.append("private_key_jwt")
+                metadata.token_endpoint_auth_methods_supported = auth_methods
                 handler = MetadataHandler(metadata)
                 methods = route.methods or ["GET", "OPTIONS"]
 

--- a/tests/server/auth/oauth_proxy/test_client_registration.py
+++ b/tests/server/auth/oauth_proxy/test_client_registration.py
@@ -197,6 +197,35 @@ class TestOAuthProxyClientRegistration:
         assert registered_client is not None
         assert registered_client.scope == "read write calendar"
 
+    @pytest.mark.parametrize(
+        "requested_auth_method",
+        [None, "client_secret_post", "client_secret_basic"],
+    )
+    async def test_dcr_response_is_public_client(
+        self, oauth_proxy, requested_auth_method
+    ):
+        """The DCR response must describe the public client the proxy actually
+        stores — never a confidential method / secret the proxy does not enforce
+        and does not advertise in server metadata.
+        """
+        registration = {"redirect_uris": ["https://client.example.com/callback"]}
+        if requested_auth_method is not None:
+            registration["token_endpoint_auth_method"] = requested_auth_method
+
+        app = Starlette(routes=oauth_proxy.get_routes())
+        transport = httpx2.ASGITransport(app=app)
+
+        async with httpx2.AsyncClient(
+            transport=transport,
+            base_url="https://myserver.com",
+        ) as client:
+            response = await client.post("/register", json=registration)
+
+        assert response.status_code == 201
+        client_info = response.json()
+        assert client_info["token_endpoint_auth_method"] == "none"
+        assert client_info.get("client_secret") is None
+
 
 class TestUpstreamClientIdFallback:
     """Tests for clients that skip DCR and use the upstream client_id directly."""

--- a/tests/server/auth/oauth_proxy/test_oauth_proxy.py
+++ b/tests/server/auth/oauth_proxy/test_oauth_proxy.py
@@ -235,11 +235,37 @@ class TestOAuthProxyInitialization:
         metadata = response.json()
         assert metadata.get("client_id_metadata_document_supported") is True
         assert set(metadata.get("token_endpoint_auth_methods_supported")) == {
-            "client_secret_post",
-            "client_secret_basic",
             "private_key_jwt",
             "none",
         }
+
+    async def test_metadata_advertises_only_public_client_auth(self, jwt_verifier):
+        """The proxy authenticates every client as public, so metadata must
+        advertise `none` and must not claim secret-based methods it never enforces.
+        """
+        proxy = OAuthProxy(
+            upstream_authorization_endpoint="https://auth.example.com/authorize",
+            upstream_token_endpoint="https://auth.example.com/token",
+            upstream_client_id="client-123",
+            upstream_client_secret="secret-456",
+            token_verifier=jwt_verifier,
+            base_url="https://api.example.com",
+            jwt_signing_key="test-secret",
+            client_storage=MemoryStore(),
+            enable_cimd=False,
+        )
+
+        app = Starlette(routes=proxy.get_routes())
+        transport = httpx2.ASGITransport(app=app)
+
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="https://api.example.com"
+        ) as client:
+            response = await client.get("/.well-known/oauth-authorization-server")
+
+        assert response.status_code == 200
+        metadata = response.json()
+        assert set(metadata.get("token_endpoint_auth_methods_supported")) == {"none"}
 
     async def test_metadata_advertises_authorization_response_issuer_parameter(
         self, jwt_verifier


### PR DESCRIPTION
`OAuthProxy` advertised `token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"]` (the MCP SDK's `build_metadata` default), but it never enforces a downstream client secret. Every client the proxy authenticates at `/token` is public: DCR-registered and synthesized clients are stored with `token_endpoint_auth_method="none"`, and CIMD clients use `private_key_jwt`. A client that trusted the advertisement and made a standards-compliant `client_secret_basic` token request (credentials in the `Authorization` header, no `client_id` in the form body) got `invalid_client` / `Missing client_id` back — the server claimed to support a method it can't actually complete.

The proxy already patched `none`/`private_key_jwt` into the advertised set, but only when CIMD or identity assertion happened to be enabled. This makes the override unconditional and sets the advertised methods to exactly what the proxy supports — `none`, plus `private_key_jwt` when CIMD is on — so discovery no longer promises secret-based auth the proxy doesn't perform.

```python
# /.well-known/oauth-authorization-server now advertises:
{"token_endpoint_auth_methods_supported": ["none"]}              # base proxy
{"token_endpoint_auth_methods_supported": ["none", "private_key_jwt"]}  # with CIMD
```

This is deliberately scoped to metadata honesty. The proxy's public-client design is intentional (it holds the upstream credentials and secures downstream clients with PKCE), so this does not add downstream secret-based authentication. Closes #4600.

Suggested label: bugs
