### PR TITLE
Pin burner-redis below the Windows-crashing 0.1.7 release

### DIFF
--- a/fastmcp_tasks/pyproject.toml
+++ b/fastmcp_tasks/pyproject.toml
@@ -54,4 +54,13 @@ fallback-version = "0.0.0"
 dependencies = [
     "fastmcp-slim[server]=={{ version }}",
     "pydocket>=0.20.0",
+    # burner-redis 0.1.7's Windows build crashes the interpreter (native fault,
+    # no Python traceback) running the memory:// backend under pytest-xdist —
+    # reproduced on GitHub Actions windows-latest, confirmed absent on
+    # macOS/Linux with the same versions. pydocket only floors it at >=0.1.6, so
+    # capping pydocket alone is not enough: a resolver is free to pick the
+    # newest burner-redis satisfying that floor regardless. Pin burner-redis
+    # directly (which in turn caps pydocket to <0.20.2, the last release that
+    # doesn't itself require burner-redis>=0.1.7) until upstream ships a fix.
+    "burner-redis<0.1.7",
 ]

--- a/fastmcp_tasks/pyproject.toml
+++ b/fastmcp_tasks/pyproject.toml
@@ -57,10 +57,12 @@ dependencies = [
     # burner-redis 0.1.7's Windows build crashes the interpreter (native fault,
     # no Python traceback) running the memory:// backend under pytest-xdist —
     # reproduced on GitHub Actions windows-latest, confirmed absent on
-    # macOS/Linux with the same versions. pydocket only floors it at >=0.1.6, so
+    # macOS/Linux with the same versions (full suite green there under the
+    # identical upgraded dependencies). pydocket only floors it at >=0.1.6, so
     # capping pydocket alone is not enough: a resolver is free to pick the
     # newest burner-redis satisfying that floor regardless. Pin burner-redis
-    # directly (which in turn caps pydocket to <0.20.2, the last release that
-    # doesn't itself require burner-redis>=0.1.7) until upstream ships a fix.
-    "burner-redis<0.1.7",
+    # directly on Windows only (which in turn caps pydocket to <0.20.2 there,
+    # the last release that doesn't itself require burner-redis>=0.1.7) until
+    # upstream ships a fix — other platforms are unaffected and stay unpinned.
+    "burner-redis<0.1.7; sys_platform == 'win32'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-17T00:28:52.816998Z"
+exclude-newer = "2026-07-17T00:42:32.518243Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -1087,14 +1087,14 @@ provides-extras = ["anthropic", "apps", "azure", "client", "code-mode", "gemini"
 name = "fastmcp-tasks"
 source = { editable = "fastmcp_tasks" }
 dependencies = [
-    { name = "burner-redis" },
+    { name = "burner-redis", marker = "sys_platform == 'win32'" },
     { name = "fastmcp-slim", extra = ["server"] },
     { name = "pydocket" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "burner-redis", specifier = "<0.1.7" },
+    { name = "burner-redis", marker = "sys_platform == 'win32'", specifier = "<0.1.7" },
     { name = "fastmcp-slim", extras = ["server"], editable = "fastmcp_slim" },
     { name = "pydocket", specifier = ">=0.20.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-17T00:06:59.485533Z"
+exclude-newer = "2026-07-17T00:28:52.816998Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -1087,12 +1087,14 @@ provides-extras = ["anthropic", "apps", "azure", "client", "code-mode", "gemini"
 name = "fastmcp-tasks"
 source = { editable = "fastmcp_tasks" }
 dependencies = [
+    { name = "burner-redis" },
     { name = "fastmcp-slim", extra = ["server"] },
     { name = "pydocket" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "burner-redis", specifier = "<0.1.7" },
     { name = "fastmcp-slim", extras = ["server"], editable = "fastmcp_slim" },
     { name = "pydocket", specifier = ">=0.20.0" },
 ]


### PR DESCRIPTION
`fastmcp-tasks` pinned `pydocket>=0.20.0` with no upper bound. `pydocket` itself only floors its `burner-redis` dependency at `>=0.1.6`, so a fresh `pip install "fastmcp[tasks]"` can resolve the newest `burner-redis` release regardless of which `pydocket` version it lands on. `burner-redis==0.1.7` crashes the interpreter (a native fault, no Python traceback) running the `memory://` task backend on Windows — reproduced via `pytest-xdist` worker crashes on GitHub Actions' `windows-latest`, and confirmed absent on macOS/Linux with the identical dependency versions. Since `memory://` is the zero-setup default backend, this was reachable by any Windows user installing the package today.

Capping `pydocket` alone isn't sufficient: a resolver stays free to pick the newest `burner-redis` that satisfies pydocket's `>=0.1.6` floor. Pinning `burner-redis<0.1.7` directly fixes that, and transitively caps `pydocket` to `<0.20.2` (the last release that doesn't itself require `burner-redis>=0.1.7`). Verified the pin holds under both locked and `--upgrade` (highest) resolution before landing it.
