### PR TITLE
fix: use Python field name for structured task results

### DIFF
--- a/tests/tasks/server/test_task_return_types.py
+++ b/tests/tasks/server/test_task_return_types.py
@@ -50,7 +50,7 @@ def _sync_result_to_wire(result: ToolResult) -> dict[str, Any]:
         content, structured_content = mcp_result
         call_tool_result = mcp_types.CallToolResult(
             content=content,
-            structuredContent=structured_content,
+            structured_content=structured_content,
         )
     else:
         call_tool_result = mcp_types.CallToolResult(content=mcp_result)


### PR DESCRIPTION
## Description

FastMCP's upgrade check fails under `ty 0.0.60` because the task result test constructs `CallToolResult` with the MCP wire alias `structuredContent`. Pydantic accepts that alias at runtime, but the upgraded checker treats it as a discarded extra argument and blocks `main`.

Use the Python field name in the fixture while preserving the serialized MCP field through the existing `model_dump(by_alias=True)` call:

```python
mcp_types.CallToolResult(
    content=content,
    structured_content=structured_content,
)
```

Fixes #4616

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

🤖 Generated with OpenAI Codex on behalf of @gnanirahulnutakki.