### PR TITLE
fix: use canonical structured content field in task tests

### DIFF
--- a/tests/tasks/server/test_task_return_types.py
+++ b/tests/tasks/server/test_task_return_types.py
@@ -50,7 +50,7 @@ def _sync_result_to_wire(result: ToolResult) -> dict[str, Any]:
         content, structured_content = mcp_result
         call_tool_result = mcp_types.CallToolResult(
             content=content,
-            structuredContent=structured_content,
+            structured_content=structured_content,
         )
     else:
         call_tool_result = mcp_types.CallToolResult(content=mcp_result)


### PR DESCRIPTION
Fixes #4616

The upgrade check installs `mcp-types 2.0.0b2`, where `CallToolResult.structured_content` is the Python field and `structuredContent` is its serialization alias. `ty 0.0.60` therefore reports the alias constructor argument as discarded.

Use the canonical Python field name. The existing `model_dump(by_alias=True)` keeps the wire key unchanged.

Validation:
- `.venv/bin/ty check`
- `.venv/bin/pytest tests/tasks/server/test_task_return_types.py -q` (31 passed)
- `.venv/bin/ruff check tests/tasks/server/test_task_return_types.py`
- `.venv/bin/ruff format --check tests/tasks/server/test_task_return_types.py`