### PR TITLE
docs: fix ProxyProvider docstring example calling nonexistent with_namespace()

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -695,8 +695,8 @@ class ProxyProvider(Provider):
         mcp = FastMCP("Proxy Server")
         mcp.add_provider(proxy)
 
-        # Can also add with namespace
-        mcp.add_provider(proxy.with_namespace("remote"))
+        # Can also add with a namespace
+        mcp.add_provider(proxy, namespace="remote")
         ```
     """
 


### PR DESCRIPTION
## Description

The `ProxyProvider` class docstring's `Example` block calls a method that does not exist:

```python
# Can also add with namespace
mcp.add_provider(proxy.with_namespace("remote"))
```

`with_namespace` is defined nowhere in the repository — `def with_namespace` returns zero matches, and the only occurrence of the name in the package is this docstring. Running the example raises `AttributeError: 'ProxyProvider' object has no attribute 'with_namespace'`.

This changes the example to the supported keyword argument on `add_provider`:

```python
# Can also add with a namespace
mcp.add_provider(proxy, namespace="remote")
```

which matches the actual signature, `add_provider(self, provider: Provider, *, namespace: str = "") -> None`, and the naming already used by the existing test `test_works_with_namespace_on_provider`.

Present in `3.4.4` and on `main` at `fastmcp_slim/fastmcp/server/providers/proxy.py:699`. Docstring text only — no behavior change.

Closes #4634

## Contribution type

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [x] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes — not applicable, the change is docstring prose with no reachable behavior
- [ ] I have run `uv run prek run --all-files` and all checks pass — see note below
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

I did not run the full `prek` suite. Instead I verified the touched file directly: `ruff format --diff` reports "1 file already formatted", and `ruff check --select E,F` returns the same 7 pre-existing `E501` findings before and after the change, so the diff introduces nothing new. Happy to run the full suite if you'd like it on the record.
