### PR TITLE
Fix non-canonical MIME types for Audio(format=...)

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/types.py
+++ b/fastmcp_slim/fastmcp/utilities/types.py
@@ -312,6 +312,18 @@ class Image:
         return f"data:{mime_type or self._mime_type};base64,{data}"
 
 
+# Canonical MIME types keyed by (dotless) format / file extension. Both the
+# `format=` and `path=` construction paths consult this so they agree — e.g.
+# `Audio(format="mp3")` and `Audio(path="x.mp3")` both resolve to `audio/mpeg`.
+_AUDIO_MIME_TYPES = {
+    "wav": "audio/wav",
+    "mp3": "audio/mpeg",
+    "ogg": "audio/ogg",
+    "m4a": "audio/mp4",
+    "flac": "audio/flac",
+}
+
+
 class Audio:
     """Helper class for returning audio from tools."""
 
@@ -336,17 +348,12 @@ class Audio:
     def _get_mime_type(self) -> str:
         """Get MIME type from format or guess from file extension."""
         if self._format:
-            return f"audio/{self._format.lower()}"
+            fmt = self._format.lower()
+            return _AUDIO_MIME_TYPES.get(fmt, f"audio/{fmt}")
 
         if self.path:
-            suffix = self.path.suffix.lower()
-            return {
-                ".wav": "audio/wav",
-                ".mp3": "audio/mpeg",
-                ".ogg": "audio/ogg",
-                ".m4a": "audio/mp4",
-                ".flac": "audio/flac",
-            }.get(suffix, "application/octet-stream")
+            suffix = self.path.suffix.lower().lstrip(".")
+            return _AUDIO_MIME_TYPES.get(suffix, "application/octet-stream")
         return "audio/wav"  # default for raw binary data
 
     def to_audio_content(

--- a/tests/utilities/test_types.py
+++ b/tests/utilities/test_types.py
@@ -285,7 +285,39 @@ class TestAudio:
     def test_audio_initialization_with_format(self):
         """Test audio initialization with a specific format."""
         audio = Audio(data=b"test", format="mp3")
-        assert audio._mime_type == "audio/mp3"
+        assert audio._mime_type == "audio/mpeg"
+
+    def test_audio_initialization_with_unmapped_format(self):
+        """Formats without a canonical mapping fall back to `audio/<format>`."""
+        audio = Audio(data=b"test", format="aac")
+        assert audio._mime_type == "audio/aac"
+
+    @pytest.mark.parametrize(
+        "fmt,expected",
+        [
+            ("wav", "audio/wav"),
+            ("mp3", "audio/mpeg"),
+            ("ogg", "audio/ogg"),
+            ("m4a", "audio/mp4"),
+            ("flac", "audio/flac"),
+        ],
+    )
+    def test_format_matches_path_mime_type(self, tmp_path, fmt, expected):
+        """`format=` and `path=` must resolve to the same canonical MIME type.
+
+        Regression test for #4627: `Audio(format="mp3")` previously produced the
+        non-canonical `audio/mp3` while `Audio(path="x.mp3")` produced
+        `audio/mpeg`.
+        """
+        from_format = Audio(data=b"test", format=fmt)
+
+        path = tmp_path / f"test.{fmt}"
+        path.write_bytes(b"fake audio data")
+        from_path = Audio(path=path)
+
+        assert from_format._mime_type == expected
+        assert from_path._mime_type == expected
+        assert from_format._mime_type == from_path._mime_type
 
     def test_missing_data_and_path_raises_error(self):
         """Test that error is raised when neither path nor data is provided."""
@@ -335,7 +367,7 @@ class TestAudio:
         content = audio.to_audio_content()
 
         assert content.type == "audio"
-        assert content.mime_type == "audio/mp3"
+        assert content.mime_type == "audio/mpeg"
         assert content.data == base64.b64encode(test_data).decode()
 
     def test_to_audio_content_error(self, monkeypatch):


### PR DESCRIPTION
`Audio(format="mp3")` produced `audio/mp3` while `Audio(path="x.mp3")` produced the
canonical `audio/mpeg` — the two construction paths disagreed because only the path branch
consulted a canonical extension→MIME map; the `format=` branch just concatenated
`audio/<format>`. The same split gave `audio/m4a` vs `audio/mp4`. Any consumer keying off
the MIME type saw two different values for identical audio.

This unifies both branches on a single canonical `_AUDIO_MIME_TYPES` map, so `format=` and
`path=` always agree. Unmapped formats keep the previous `audio/<format>` fallback, so
nothing that worked before regresses.

```python
from fastmcp.utilities.types import Audio
Audio(data=b"...", format="mp3").to_audio_content().mime_type  # now "audio/mpeg"
Audio(path="clip.mp3")._mime_type                              # "audio/mpeg" (unchanged)
```

Fixes #4627.

---

_Disclosure (per this repo's CLAUDE.md): this contribution was prepared with AI assistance. It is submitted by Cognis Digital, who is not affiliated with and is not acting on behalf of the maintainer._
