### PR TITLE
fix: accept callable roots handlers

### DIFF
--- a/fastmcp_slim/fastmcp/client/roots.py
+++ b/fastmcp_slim/fastmcp/client/roots.py
@@ -37,7 +37,7 @@ def create_roots_callback(
     if isinstance(handler, list):
         # TODO(ty): remove when ty supports isinstance union narrowing
         return _create_roots_callback_from_roots(handler)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
-    elif inspect.isfunction(handler):
+    elif callable(handler):
         return _create_roots_callback_from_fn(handler)
     else:
         raise ValueError(f"Invalid roots handler: {handler}")

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1314,12 +1314,7 @@ def _restore_request_context(
 
 
 def _make_restoring_handler(handler: Callable, rc_ref: list[Any]) -> Callable:
-    """Wrap a proxy handler to restore request_ctx before delegating.
-
-    The wrapper is a plain ``async def`` so it passes
-    ``inspect.isfunction()`` checks in handler registration paths
-    (e.g., ``create_roots_callback``).
-    """
+    """Wrap a proxy handler to restore request_ctx before delegating."""
 
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         _restore_request_context(rc_ref)

--- a/tests/client/test_roots.py
+++ b/tests/client/test_roots.py
@@ -70,3 +70,15 @@ class TestClientRoots:
             result = await client.call_tool("list_roots", {})
 
         assert result.data == ["file:///partial"]
+
+    async def test_callable_object_roots_handler(self, fastmcp_server: FastMCP):
+        class RootsProvider:
+            async def __call__(self, _context: object) -> list[str]:
+                return ["file:///callable-object"]
+
+        async with Client(
+            fastmcp_server, mode="legacy", roots=RootsProvider()
+        ) as client:
+            result = await client.call_tool("list_roots", {})
+
+        assert result.data == ["file:///callable-object"]

--- a/tests/client/test_roots.py
+++ b/tests/client/test_roots.py
@@ -1,3 +1,5 @@
+import functools
+
 import pytest
 
 from fastmcp import Client, Context, FastMCP
@@ -43,3 +45,28 @@ class TestClientRoots:
                 "file://x/y/z",
                 "file://x/y/z",
             ]
+
+    async def test_bound_method_roots_handler(self, fastmcp_server: FastMCP):
+        class RootsProvider:
+            async def get_roots(self, _context: object) -> list[str]:
+                return ["file:///bound-method"]
+
+        provider = RootsProvider()
+
+        async with Client(
+            fastmcp_server, mode="legacy", roots=provider.get_roots
+        ) as client:
+            result = await client.call_tool("list_roots", {})
+
+        assert result.data == ["file:///bound-method"]
+
+    async def test_partial_roots_handler(self, fastmcp_server: FastMCP):
+        async def get_roots(prefix: str, _context: object) -> list[str]:
+            return [f"file:///{prefix}"]
+
+        handler = functools.partial(get_roots, "partial")
+
+        async with Client(fastmcp_server, mode="legacy", roots=handler) as client:
+            result = await client.call_tool("list_roots", {})
+
+        assert result.data == ["file:///partial"]


### PR DESCRIPTION
`RootsHandler` is typed as a `Callable`, but `create_roots_callback()` gated dynamic handlers with `inspect.isfunction()`. That rejected valid callable objects such as bound methods and `functools.partial` before the existing callback adapter could invoke them.

This uses Python's `callable()` predicate at the dispatch boundary and adds public `Client` regression coverage for both cases. Static roots lists and the existing sync/async callback handling remain unchanged.

```python
async with Client(server, mode="legacy", roots=provider.get_roots):
    ...
```

Fixes #4638