### PR TITLE
Validate tool results against declared output_schema

### DIFF
--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -43,6 +43,13 @@ try:
 except ImportError:
     _HAS_PREFAB = False
 
+try:
+    import jsonschema as _jsonschema
+
+    _HAS_JSONSCHEMA = True
+except ImportError:
+    _HAS_JSONSCHEMA = False
+
 if TYPE_CHECKING:
     from fastmcp.tools.function_tool import FunctionTool
     from fastmcp.tools.tool_transform import ArgTransform, TransformedTool
@@ -80,6 +87,31 @@ def default_serializer(data: Any) -> str:
     return pydantic_core.to_json(
         data, fallback=str, by_alias=resolve_serialize_by_alias(data)
     ).decode()
+
+
+def _validate_against_output_schema(
+    structured_content: dict[str, Any], output_schema: dict[str, Any]
+) -> None:
+    """Validate structured_content against the declared output_schema.
+
+    Skips validation silently when jsonschema is not installed (it is a
+    transitive dependency, not a direct one).  Raises ``ValueError`` if the
+    content does not conform to the schema.
+    """
+    if not _HAS_JSONSCHEMA:
+        return
+    # Strip FastMCP-internal extension keys so they do not confuse validators
+    # that operate in strict mode.  Standard validators ignore unknown keywords,
+    # but stripping is cheap and future-proofs against stricter validators.
+    schema_for_validation = {
+        k: v for k, v in output_schema.items() if k != "x-fastmcp-wrap-result"
+    }
+    try:
+        _jsonschema.validate(structured_content, schema_for_validation)
+    except _jsonschema.ValidationError as exc:
+        raise ValueError(
+            f"Tool result does not conform to the declared output_schema: {exc.message}"
+        ) from exc
 
 
 class ToolResult(BaseModel):
@@ -406,9 +438,11 @@ class Tool(FastMCPComponent):
 
         # Has output_schema - wrap if x-fastmcp-wrap-result is set
         wrap_result = self.output_schema.get("x-fastmcp-wrap-result")
+        structured_content = {"result": structured} if wrap_result else structured
+        _validate_against_output_schema(structured_content, self.output_schema)
         return ToolResult(
             content=content,
-            structured_content={"result": structured} if wrap_result else structured,
+            structured_content=structured_content,
             meta={"fastmcp": {"wrap_result": True}} if wrap_result else None,
         )
 

--- a/tests/tools/tool/test_output_schema.py
+++ b/tests/tools/tool/test_output_schema.py
@@ -441,8 +441,8 @@ class TestToolFromFunctionOutputSchema:
         }
         tool = Tool.from_function(func, output_schema=explicit_schema)
 
-        # Should fail because int is not dict-compatible with object schema
-        with pytest.raises(ValueError, match="structured_content must be a dict"):
+        # Should fail because 42 does not conform to the object schema
+        with pytest.raises(ValueError, match="output_schema"):
             await tool.run({})
 
     async def test_object_output_schema_not_wrapped(self):
@@ -619,3 +619,104 @@ class TestWrapResultMeta:
         result = await tool.run({})
         assert result.structured_content == {"key": "val"}
         assert result.meta is None
+
+
+class TestOutputSchemaValidation:
+    """Tests that tool results are validated against the declared output_schema."""
+
+    async def test_valid_result_passes_validation(self):
+        """A conforming result should not raise."""
+
+        def func() -> dict[str, int]:
+            return {"value": 42}
+
+        tool = Tool.from_function(func)
+        result = await tool.run({})
+        assert result.structured_content == {"value": 42}
+
+    async def test_invalid_result_raises_value_error(self):
+        """A result that violates the schema should raise ValueError."""
+
+        def func() -> dict[str, int]:
+            # Return a value that breaks the inferred schema: str instead of int
+            return {"value": "not-an-int"}  # type: ignore[return-value]
+
+        tool = Tool.from_function(func)
+        with pytest.raises(ValueError, match="output_schema"):
+            await tool.run({})
+
+    async def test_explicit_schema_invalid_result_raises(self):
+        """An explicit output_schema violation should raise ValueError."""
+
+        explicit_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+        }
+
+        def func() -> dict[str, Any]:
+            return {"name": "Alice", "age": "thirty"}  # age should be integer
+
+        tool = Tool.from_function(func, output_schema=explicit_schema)
+        with pytest.raises(ValueError, match="output_schema"):
+            await tool.run({})
+
+    async def test_explicit_schema_valid_result_passes(self):
+        """A result that conforms to an explicit schema should not raise."""
+
+        explicit_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+        }
+
+        def func() -> dict[str, Any]:
+            return {"name": "Alice", "age": 30}
+
+        tool = Tool.from_function(func, output_schema=explicit_schema)
+        result = await tool.run({})
+        assert result.structured_content == {"name": "Alice", "age": 30}
+
+    async def test_wrapped_primitive_validated_against_schema(self):
+        """Wrapped primitive results are validated against the wrapping schema."""
+
+        def func() -> int:
+            return 42
+
+        tool = Tool.from_function(func)
+        # Inferred schema wraps int as {"result": <int>}, so result is valid
+        result = await tool.run({})
+        assert result.structured_content == {"result": 42}
+
+    async def test_no_schema_skips_validation(self):
+        """When output_schema is None, no validation is performed."""
+
+        def func() -> dict[str, Any]:
+            return {"anything": "goes", "no": "schema"}
+
+        tool = Tool.from_function(func, output_schema=None)
+        result = await tool.run({})
+        # No schema means no validation, dict still gets structured_content
+        assert result.structured_content == {"anything": "goes", "no": "schema"}
+
+    async def test_missing_required_field_raises(self):
+        """Missing required fields are caught by schema validation."""
+
+        explicit_schema = {
+            "type": "object",
+            "properties": {"required_field": {"type": "string"}},
+            "required": ["required_field"],
+        }
+
+        def func() -> dict[str, Any]:
+            return {}  # missing required_field
+
+        tool = Tool.from_function(func, output_schema=explicit_schema)
+        with pytest.raises(ValueError, match="output_schema"):
+            await tool.run({})


### PR DESCRIPTION
## Summary

When a tool declares an `output_schema`, the structured content produced at runtime was never validated against it. A tool could return the wrong shape and the error would only surface later (or not at all), making debugging harder.

This PR adds validation of the `structured_content` value against the declared `output_schema` inside `Tool.convert_result`. If the result does not conform, a `ValueError` is raised with a clear message before the `ToolResult` is constructed.

- Validation uses `jsonschema.validate`, which is already a transitive runtime dependency (via `mcp`). An `ImportError` guard skips validation silently when the library is absent.
- The FastMCP-internal `x-fastmcp-wrap-result` extension key is stripped from the schema before validation so it does not interfere with strict validators.
- An existing test whose assertion was tied to the old code path (a dict-type check in `ToolResult.__init__`) is updated to match the new, earlier and more descriptive error.

Fixes #1689

## Test plan

- [x] `tests/tools/tool/test_output_schema.py` -- all 64 tests pass, including 7 new tests in `TestOutputSchemaValidation`
- [x] `tests/server/providers/local_provider_tools/test_output_schema.py` -- all 28 tests pass
- [x] Full `tests/tools/` suite -- 355 passed, 1 skipped