### PR TITLE
fix: accept callable roots handlers (bound methods, partials)

### DIFF
--- a/fastmcp_slim/fastmcp/client/roots.py
+++ b/fastmcp_slim/fastmcp/client/roots.py
@@ -37,7 +37,7 @@ def create_roots_callback(
     if isinstance(handler, list):
         # TODO(ty): remove when ty supports isinstance union narrowing
         return _create_roots_callback_from_roots(handler)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
-    elif inspect.isfunction(handler):
+    elif callable(handler):
         return _create_roots_callback_from_fn(handler)
     else:
         raise ValueError(f"Invalid roots handler: {handler}")

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1314,12 +1314,7 @@ def _restore_request_context(
 
 
 def _make_restoring_handler(handler: Callable, rc_ref: list[Any]) -> Callable:
-    """Wrap a proxy handler to restore request_ctx before delegating.
-
-    The wrapper is a plain ``async def`` so it passes
-    ``inspect.isfunction()`` checks in handler registration paths
-    (e.g., ``create_roots_callback``).
-    """
+    """Wrap a proxy handler to restore request_ctx before delegating."""
 
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         _restore_request_context(rc_ref)

--- a/tests/client/test_roots.py
+++ b/tests/client/test_roots.py
@@ -1,6 +1,10 @@
+import functools
+
+import mcp_types
 import pytest
 
 from fastmcp import Client, Context, FastMCP
+from fastmcp.client.roots import create_roots_callback, convert_roots_list
 
 
 @pytest.fixture
@@ -43,3 +47,85 @@ class TestClientRoots:
                 "file://x/y/z",
                 "file://x/y/z",
             ]
+
+
+class TestRootsHandlerCallable:
+    """Regression tests for issue #4638: callable roots handlers.
+
+    Bound methods, functools.partial, and other callables should be accepted
+    as roots handlers, not just plain functions.
+    """
+
+    async def test_bound_method_accepted(self, fastmcp_server: FastMCP):
+        class RootsProvider:
+            async def get_roots(self, _context):
+                return ["file:///bound-method"]
+
+        handler = RootsProvider().get_roots
+        async with Client(fastmcp_server, mode="legacy", roots=handler) as client:
+            result = await client.call_tool("list_roots", {})
+            assert result.data == ["file:///bound-method"]
+
+    async def test_partial_accepted(self, fastmcp_server: FastMCP):
+        async def get_roots(prefix, _context):
+            return [f"file:///{prefix}"]
+
+        handler = functools.partial(get_roots, "partial-root")
+        async with Client(fastmcp_server, mode="legacy", roots=handler) as client:
+            result = await client.call_tool("list_roots", {})
+            assert result.data == ["file:///partial-root"]
+
+    async def test_lambda_accepted(self, fastmcp_server: FastMCP):
+        handler = lambda _context: ["file:///lambda-root"]
+        async with Client(fastmcp_server, mode="legacy", roots=handler) as client:
+            result = await client.call_tool("list_roots", {})
+            assert result.data == ["file:///lambda-root"]
+
+    async def test_callable_object_accepted(self, fastmcp_server: FastMCP):
+        class CallableRoots:
+            async def __call__(self, _context):
+                return ["file:///callable-object"]
+
+        async with Client(fastmcp_server, mode="legacy", roots=CallableRoots()) as client:
+            result = await client.call_tool("list_roots", {})
+            assert result.data == ["file:///callable-object"]
+
+    async def test_non_callable_rejected(self, fastmcp_server: FastMCP):
+        with pytest.raises(ValueError, match="Invalid roots handler"):
+            Client(fastmcp_server, roots="not-a-handler")
+
+    async def test_sync_function_accepted(self, fastmcp_server: FastMCP):
+        def sync_handler(_context):
+            return ["file:///sync-root"]
+
+        async with Client(fastmcp_server, mode="legacy", roots=sync_handler) as client:
+            result = await client.call_tool("list_roots", {})
+            assert result.data == ["file:///sync-root"]
+
+    def test_create_roots_callback_rejects_non_callable(self):
+        with pytest.raises(ValueError, match="Invalid roots handler"):
+            create_roots_callback(42)
+
+
+class TestRootsErrorHandling:
+    """Test error paths in roots callback and conversion."""
+
+    async def test_handler_exception_returns_error(self, fastmcp_server: FastMCP):
+        async def failing_handler(_context):
+            raise RuntimeError("roots handler failed")
+
+        from fastmcp.exceptions import ToolError
+
+        async with Client(fastmcp_server, mode="legacy", roots=failing_handler) as client:
+            with pytest.raises(ToolError, match="roots handler failed"):
+                await client.call_tool("list_roots", {})
+
+    async def test_roots_list_with_root_objects(self, fastmcp_server: FastMCP):
+        roots = [mcp_types.Root(uri="file:///from-root-obj", name="my-root")]
+        async with Client(fastmcp_server, mode="legacy", roots=roots) as client:
+            result = await client.call_tool("list_roots", {})
+            assert result.data == ["file:///from-root-obj"]
+
+    def test_convert_roots_list_rejects_invalid_element(self):
+        with pytest.raises(ValueError, match="Invalid root"):
+            convert_roots_list([42])  # type: ignore[list-item]


### PR DESCRIPTION
## Description

create_roots_callback() rejected bound methods, unctools.partial, lambdas, and callable class instances because it validated handlers with inspect.isfunction(), which only matches bare 	ypes.FunctionType. This is inconsistent with the RootsHandler type alias (Callable[...]) and with how sampling and elicitation handlers work — those perform no type check at all.

Replace inspect.isfunction(handler) with callable(handler) in astmcp_slim/fastmcp/client/roots.py. One-line change. Also removed a stale docstring in proxy.py that referenced the old inspect.isfunction() check.

Closes #4638

## Contribution type
- [x] Bug fix

## Checklist
- [x] This PR addresses an existing issue
- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes
- [x] I have run validation and all checks pass
- [x] I have self-reviewed my changes