### PR TITLE
Unbreak Marvin triage: pin Claude Code below the 2.1.216 sandbox regression

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -19,6 +19,13 @@ jobs:
       issues: write
       id-token: write
 
+    # TEMPORARY PIN — see the matching note in marvin-label-triage.yml.
+    # Claude Code 2.1.216 broke every Bash call under the action's subprocess
+    # isolation, which this workflow needs for all of its `gh` searching.
+    # https://github.com/anthropics/claude-code/issues/79997
+    env:
+      PINNED_CLAUDE_CODE_VERSION: "2.1.215"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -91,9 +98,17 @@ jobs:
       - name: Clean up stale Claude locks
         run: rm -rf ~/.claude/.locks ~/.local/state/claude/locks || true
 
+      - name: Install pinned Claude Code
+        id: pin-claude
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash -s -- "$PINNED_CLAUDE_CODE_VERSION"
+          echo "path=$HOME/.local/bin/claude" >> "$GITHUB_OUTPUT"
+          "$HOME/.local/bin/claude" --version
+
       - name: Run Marvin dedupe command
         uses: anthropics/claude-code-action@v1
         with:
+          path_to_claude_code_executable: ${{ steps.pin-claude.outputs.path }}
           github_token: ${{ steps.marvin-token.outputs.token }}
           bot_name: "Marvin Context Protocol"
           prompt: ${{ steps.dedupe-prompt.outputs.PROMPT }}

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -27,6 +27,22 @@ jobs:
       issues: write
       pull-requests: write
 
+    # TEMPORARY PIN — remove once upstream ships a fix.
+    #
+    # Claude Code 2.1.216 regressed the sandbox that claude-code-action wraps
+    # every Bash call in when `allowed_non_write_users` is set: the mountpoint
+    # walk fails closed, so every command — down to `true` — dies with
+    # `bwrap: Can't create file at /home/.mcp.json: Permission denied`.
+    # Marvin still reads the issue and picks correct labels, then cannot run
+    # the helper that applies them, so triage silently applied zero labels
+    # from 2026-07-20 onward while every run reported success.
+    #
+    # 2.1.215 is the last release without the regression.
+    # https://github.com/anthropics/claude-code/issues/79997
+    # https://github.com/anthropics/claude-code-action/issues/1547
+    env:
+      PINNED_CLAUDE_CODE_VERSION: "2.1.215"
+
     steps:
       - name: Checkout base repository
         uses: actions/checkout@v7
@@ -142,10 +158,21 @@ jobs:
       - name: Clean up stale Claude locks
         run: rm -rf ~/.claude/.locks ~/.local/state/claude/locks || true
 
+      # Mirrors how the action installs Claude Code itself, minus the version
+      # it hardcodes. Passing path_to_claude_code_executable makes the action
+      # skip its own install and use this build.
+      - name: Install pinned Claude Code
+        id: pin-claude
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash -s -- "$PINNED_CLAUDE_CODE_VERSION"
+          echo "path=$HOME/.local/bin/claude" >> "$GITHUB_OUTPUT"
+          "$HOME/.local/bin/claude" --version
+
       - name: Run Marvin for Issue Triage
         id: marvin
         uses: anthropics/claude-code-action@v1
         with:
+          path_to_claude_code_executable: ${{ steps.pin-claude.outputs.path }}
           github_token: ${{ steps.marvin-token.outputs.token }}
           bot_name: "Marvin Context Protocol"
           prompt: ${{ steps.triage-prompt.outputs.PROMPT }}
@@ -173,7 +200,7 @@ jobs:
       # agent reaching for something never on the allowlist (falling back to
       # `gh issue view` when the API is down, say) is behaving normally, and
       # failing on that would cry wolf during every GitHub incident.
-      - name: Fail if an allowlisted tool was denied
+      - name: Fail if Marvin could not run its tools
         if: always() && steps.marvin.conclusion != 'skipped'
         env:
           EXECUTION_FILE: ${{ steps.marvin.outputs.execution_file }}
@@ -220,6 +247,38 @@ jobs:
           fi
           if [[ "$total" -gt 0 ]]; then
             echo "::notice::Marvin was denied $total call(s), none of them to tools this workflow grants. That is expected when it probes for a tool we deliberately withhold; the allowlist is intact."
+          fi
+
+          # A granted tool can also fail *after* the permission check, which the
+          # denial count above cannot see. Claude Code 2.1.216 did exactly that:
+          # the sandbox refused to build and every Bash call — including the
+          # labeling helper — exited 1 with `bwrap: ...`, while the run stayed
+          # green. Correlate results back to their Bash tool_use rather than
+          # grepping the whole log, so an issue body quoting a sandbox error
+          # cannot fail an otherwise healthy run.
+          if ! sandbox=$(jq -sr '
+                [ .[] | if type == "array" then .[] else . end ]
+                | map(select(type == "object" and (.type == "assistant" or .type == "user")))
+                | map(.message.content // []) | flatten
+                | map(select(type == "object"))
+                | . as $blocks
+                | ( $blocks
+                    | map(select(.type == "tool_use" and .name == "Bash"))
+                    | map(.id) ) as $bash
+                | $blocks
+                | map(select(.type == "tool_result" and (.tool_use_id as $i | $bash | index($i))))
+                | map(.content | tostring)
+                | map(select(test("bwrap:|Failed to (start|create) sandbox")))
+                | "\(length)\t\(.[0] // "" | gsub("[\t\n]"; " ") | .[0:200])"
+              ' "$file"); then
+            echo "::error::Could not scan Marvin execution log for sandbox failures ($file)."
+            exit 1
+          fi
+          IFS=$'\t' read -r sandbox_failures sandbox_sample <<<"$sandbox"
+
+          if [[ "$sandbox_failures" -gt 0 ]]; then
+            echo "::error::Marvin's Bash tool failed $sandbox_failures time(s) inside the action's subprocess sandbox, so it could not apply labels: ${sandbox_sample}. This is an environment failure, not a prompt or allowlist problem — check whether the pinned Claude Code version (${PINNED_CLAUDE_CODE_VERSION}) still avoids the upstream sandbox regression."
+            exit 1
           fi
 
       - name: Upload Marvin execution log


### PR DESCRIPTION
Marvin has applied zero labels since 2026-07-20, and every run reported success. Claude Code 2.1.216 regressed the bubblewrap sandbox that `claude-code-action` wraps Bash in whenever `allowed_non_write_users` is set, so every command — down to `true` — dies before running:

```
Exit code 1
bwrap: Can't create file at /home/.mcp.json: Permission denied
```

Marvin still reads the issue and picks correct labels, then can't run the helper that applies them. The last run gave up with "a session-level environment failure, not something caused by the specific command." Bisecting the workflow artifacts puts the boundary at 2.1.216, and the action bump that crossed it (`af0559e...b76a077`) contains exactly one commit — the version bump — so this is the CLI, not the action.

This pins the two workflows that opt into the sandbox to 2.1.215, the last release without the regression, by installing it ourselves and passing `path_to_claude_code_executable` so the action skips its own hardcoded install. Upstream: anthropics/claude-code#79997, anthropics/claude-code-action#1547. Both open; remove the pin when either lands.

The guard added in #4555 structurally could not catch this — it only inspects `permission_denials`, and these were *granted* tools failing after the permission check. Triage now also fails on sandbox errors, correlating `tool_result` blocks back to their `Bash` `tool_use` id rather than grepping the log, so an issue body quoting a sandbox error can't fail a healthy run:

```
run 30189690466 (2.1.220)  ->  fires, 9 hits
run 29958716584 (2.1.217)  ->  fires, 9 hits
run 29848064054 (2.1.216)  ->  fires, 10 hits
run 29776506678 (2.1.215)  ->  silent
```

`marvin-test-failure.yml` and the `run-claude` composite never set `allowed_non_write_users`, so they're never sandboxed and are untouched.

One residual risk worth naming: the action bumps the CLI and Agent SDK in lockstep, so pinning the CLI to 2.1.215 leaves it driven by SDK 0.3.220. That only shows up on a real run.

Label: `enhancement`, `tests`
