### PR TITLE
Fix the ty failure blocking upgrade checks on main

### DIFF
--- a/tests/tasks/server/test_task_return_types.py
+++ b/tests/tasks/server/test_task_return_types.py
@@ -50,7 +50,7 @@ def _sync_result_to_wire(result: ToolResult) -> dict[str, Any]:
         content, structured_content = mcp_result
         call_tool_result = mcp_types.CallToolResult(
             content=content,
-            structuredContent=structured_content,
+            structured_content=structured_content,
         )
     else:
         call_tool_result = mcp_types.CallToolResult(content=mcp_result)


### PR DESCRIPTION
The upgrade-checks workflow has been red on `main` since 2026-07-24 (#4616). A newer `ty` added the `pydantic-discarded-extra-argument` rule, which flags `mcp_types.CallToolResult(content=..., structuredContent=...)` in the task return-type test — the last camelCase keyword argument left anywhere in the suite, a straggler from the SDK v1→v2 rename.

The alias means both spellings populate the field at runtime, so nothing was actually broken; `structured_content` is simply the canonical v2 spelling and the one the rest of the codebase uses. Renaming it clears the diagnostic and closes the last inconsistency of its kind.

Worth noting for whoever picks up the next `ty` bump: **`ty` 0.0.63 (newer than what CI currently resolves) reports three further diagnostics on `main`** that this PR deliberately leaves alone, because none is a straightforward fix:

- `examples/screenshot.py` — `pyautogui` is unresolved despite being listed in `replace-imports-with-any`, so the config's behavior appears to have shifted.
- `fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py:1236` — a `# ty:ignore[invalid-argument-type]` that 0.0.63 considers unused. Removing it would break the currently pinned 0.0.59, which still needs it, so this one cannot be satisfied for both versions at once.
- `fastmcp_slim/fastmcp/mcp_config.py:224,291` — `_TransformingMCPServerMixin.to_transport` returns `ClientTransport` while `StdioMCPServer.to_transport` returns the narrower `StdioTransport`. A real variance problem that wants a design decision rather than a quick annotation.

Closes #4616

Label: bug
