### PR TITLE
Cover require_roles in the v4 highlights

### DIFF
--- a/docs/getting-started/whats-new.mdx
+++ b/docs/getting-started/whats-new.mdx
@@ -86,7 +86,7 @@ mcp = FastMCP("Internal API", auth=auth)
 
 The asserted subject flows into the normal auth context, so tools read it through `get_access_token()` like any other identity. See [Identity Assertion](/servers/auth/oauth-proxy#identity-assertion-sep-990).
 
-Authorizing that identity is the next step, and it is where providers diverge. Scopes are standardized, so `require_scopes` behaves the same everywhere, but roles and groups are not part of OIDC and every provider files them under a different claim. `require_roles` handles the comparison and takes an `extract` callable naming where to look, so Keycloak's `realm_access.roles`, Cognito's `cognito:groups`, and Auth0's per-tenant namespaced claims all work without FastMCP guessing.
+Authorizing a caller by role is a related, provider-agnostic need. Scopes are standardized, so `require_scopes` behaves the same everywhere, but roles and groups are not part of OIDC and every provider files them under a different claim. `require_roles` handles the comparison and takes an `extract` callable naming where to look, so Keycloak's `realm_access.roles`, Cognito's `cognito:groups`, and Auth0's per-tenant namespaced claims all work without FastMCP guessing.
 
 ```python
 from fastmcp import FastMCP
@@ -100,7 +100,7 @@ def rotate_credentials() -> str:
     return "Rotated"
 ```
 
-See [Authorization](/servers/authorization#require_roles).
+This illustrates the check in isolation — enforcing it for real needs an HTTP-transport server with a token-validating `auth` provider configured (a `JWTVerifier`, a `RemoteAuthProvider`, or a provider built on one, such as `KeycloakAuthProvider`, all expose claims directly), since STDIO has no OAuth concept and skips every check. See [Authorization](/servers/authorization#require_roles) for the full picture.
 
 ## Faster and safer
 

--- a/docs/getting-started/whats-new.mdx
+++ b/docs/getting-started/whats-new.mdx
@@ -86,6 +86,22 @@ mcp = FastMCP("Internal API", auth=auth)
 
 The asserted subject flows into the normal auth context, so tools read it through `get_access_token()` like any other identity. See [Identity Assertion](/servers/auth/oauth-proxy#identity-assertion-sep-990).
 
+Authorizing that identity is the next step, and it is where providers diverge. Scopes are standardized, so `require_scopes` behaves the same everywhere, but roles and groups are not part of OIDC and every provider files them under a different claim. `require_roles` handles the comparison and takes an `extract` callable naming where to look, so Keycloak's `realm_access.roles`, Cognito's `cognito:groups`, and Auth0's per-tenant namespaced claims all work without FastMCP guessing.
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.auth import require_roles
+
+mcp = FastMCP("Internal API")
+
+@mcp.tool(auth=require_roles("admin", extract=lambda c: c["realm_access"]["roles"]))
+def rotate_credentials() -> str:
+    """Only callable by a caller holding the 'admin' role."""
+    return "Rotated"
+```
+
+See [Authorization](/servers/authorization#require_roles).
+
 ## Faster and safer
 
 Two more capabilities arrive by default. Response caching (SEP-2549) lets a server stamp freshness hints on its results that a caching [client](/clients/client#response-caching) reuses without a round trip, and a distributed `KeyValueResponseCacheStore` backs that cache with Redis or any key-value store, so a fleet of clients or proxy replicas shares fills.


### PR DESCRIPTION
`require_roles` shipped in #4656 with a `4.0.0` version badge but no mention in the v4 highlights, so the only way to find it is to already be reading the authorization page. That is the wrong discovery path for it: the people who need role-based gating are the ones who just finished wiring up enterprise SSO, and they are reading "Enterprise identity."

This extends that section rather than adding a new one. It already ends by explaining that an asserted subject flows into the normal auth context; authorizing that subject is the natural next beat, and it motivates why the API takes an `extract` callable instead of guessing the claim per provider.

```python
from fastmcp import FastMCP
from fastmcp.server.auth import require_roles

mcp = FastMCP("Internal API")

@mcp.tool(auth=require_roles("admin", extract=lambda c: c["realm_access"]["roles"]))
def rotate_credentials() -> str:
    """Only callable by a caller holding the 'admin' role."""
    return "Rotated"
```

The appropriate label is `enhancements`.
