### PR TITLE
Docs: add v3.4.5 changelog entries to main

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,7 +9,7 @@ tag: NEW
 
 **[v3.4.5: Key Change](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.5)**
 
-FastMCP 3.4.5 is a maintenance release for the 3.x line. `JWTVerifier` no longer rejects every token when an authorization server publishes a key type it does not recognize — a single Ed25519 entry in a JWKS, which Rauthy, Ory Hydra, and some Keycloak configurations publish by default, previously poisoned the entire key cache. Azure token exchange now applies the same scope fallback the authorize URL already did, so clients that omit `scope` no longer fail with AADSTS70011. Alongside those, OpenAPI `deepObject` query parameters serialize to the bracketed form their specs describe, `compress_schema` no longer mutates the schema it was handed or drops definitions referenced deep inside one, and transformed tools emit a stable `required` order across processes.
+FastMCP 3.4.5 collects five fixes for the 3.x line, led by `JWTVerifier` no longer rejecting every token when an authorization server publishes an unrecognized key type such as Ed25519.
 
 ### Fixes 🐞
 * Backport #4517 to release/3.x: skip unsupported JWKS keys (#4515) by [@kakiii](https://github.com/kakiii) in [#4631](https://github.com/PrefectHQ/fastmcp/pull/4631)

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,26 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v3.4.5" description="2026-07-27">
+
+**[v3.4.5: Key Change](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.5)**
+
+FastMCP 3.4.5 is a maintenance release for the 3.x line. `JWTVerifier` no longer rejects every token when an authorization server publishes a key type it does not recognize — a single Ed25519 entry in a JWKS, which Rauthy, Ory Hydra, and some Keycloak configurations publish by default, previously poisoned the entire key cache. Azure token exchange now applies the same scope fallback the authorize URL already did, so clients that omit `scope` no longer fail with AADSTS70011. Alongside those, OpenAPI `deepObject` query parameters serialize to the bracketed form their specs describe, `compress_schema` no longer mutates the schema it was handed or drops definitions referenced deep inside one, and transformed tools emit a stable `required` order across processes.
+
+### Fixes 🐞
+* Backport #4517 to release/3.x: skip unsupported JWKS keys (#4515) by [@kakiii](https://github.com/kakiii) in [#4631](https://github.com/PrefectHQ/fastmcp/pull/4631)
+* Backport #4469 to release/3.x: fix Azure scope fallback by [@jlowin](https://github.com/jlowin) in [#4662](https://github.com/PrefectHQ/fastmcp/pull/4662)
+* Backport #4523 to release/3.x: serialize deep object query parameters by [@jlowin](https://github.com/jlowin) in [#4664](https://github.com/PrefectHQ/fastmcp/pull/4664)
+* Backport #4564 to release/3.x: make transformed tool required order deterministic by [@jlowin](https://github.com/jlowin) in [#4665](https://github.com/PrefectHQ/fastmcp/pull/4665)
+* Backport #4492 to release/3.x: don't mutate the caller's schema in compress_schema by [@jlowin](https://github.com/jlowin) in [#4663](https://github.com/PrefectHQ/fastmcp/pull/4663)
+
+## New Contributors
+* @kakiii made their first contribution in [#4631](https://github.com/PrefectHQ/fastmcp/pull/4631)
+
+**Full Changelog**: [v3.4.4...v3.4.5](https://github.com/PrefectHQ/fastmcp/compare/v3.4.4...v3.4.5)
+
+</Update>
+
 <Update label="v3.4.4" description="2026-07-08">
 
 **[v3.4.4: Host in Translation](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.4)**

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,24 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 3.4.5" description="July 27, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v3.4.5: Key Change"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.5"
+cta="Read the release notes"
+>
+A maintenance release for the 3.x line, led by a JWKS fix for deployments whose identity provider publishes an unrecognized key type. Four other fixes cover Azure scopes, OpenAPI query serialization, schema compression, and transformed tool schemas.
+
+🔑 **Unsupported JWKS keys are skipped** — one Ed25519 key no longer poisons the whole key cache, so tokens signed by supported keys in the same set still verify.
+
+🔐 **Azure scope fallback** — clients that omit `scope` now exchange and refresh against the configured API scope instead of failing with AADSTS70011.
+
+🔗 **OpenAPI `deepObject` parameters** — nested query objects serialize to the bracketed form the spec describes rather than as unrelated top-level keys.
+
+🧬 **Schema compression is non-destructive** — `compress_schema` leaves the caller's schema untouched and keeps definitions referenced below its traversal depth.
+</Card>
+</Update>
+
 <Update label="FastMCP 3.4.4" description="July 8, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v3.4.4: Host in Translation"

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -11,15 +11,7 @@ title="FastMCP v3.4.5: Key Change"
 href="https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.5"
 cta="Read the release notes"
 >
-A maintenance release for the 3.x line, led by a JWKS fix for deployments whose identity provider publishes an unrecognized key type. Four other fixes cover Azure scopes, OpenAPI query serialization, schema compression, and transformed tool schemas.
-
-🔑 **Unsupported JWKS keys are skipped** — one Ed25519 key no longer poisons the whole key cache, so tokens signed by supported keys in the same set still verify.
-
-🔐 **Azure scope fallback** — clients that omit `scope` now exchange and refresh against the configured API scope instead of failing with AADSTS70011.
-
-🔗 **OpenAPI `deepObject` parameters** — nested query objects serialize to the bracketed form the spec describes rather than as unrelated top-level keys.
-
-🧬 **Schema compression is non-destructive** — `compress_schema` leaves the caller's schema untouched and keeps definitions referenced below its traversal depth.
+A maintenance release for the 3.x line. A single unrecognized JWKS key — Ed25519, which Rauthy and Ory Hydra publish by default — no longer poisons the entire key cache, alongside fixes for Azure scope fallback, OpenAPI `deepObject` query serialization, schema compression, and transformed tool `required` ordering.
 </Card>
 </Update>
 


### PR DESCRIPTION
Mirrors #4673 onto `main`, which carries the documentation that actually reaches gofastmcp.com.

The 3.4.5 entries have to exist on both branches for different reasons. On `release/3.x` they need to be in the commit being tagged, since the maintenance release publishes from there. On `main` they need to be present so the next default-branch stable release force-pushes `published-docs` forward with 3.4.5 already in the changelog, rather than skipping over it.

The added entries are byte-identical to #4673. The two branches' changelogs differ only in a pair of older typo corrections that already exist on `main`.
