### PR TITLE
Update v4 install instructions for the stable SDK pins

### DIFF
--- a/dev-docs/v4-notes/index.md
+++ b/dev-docs/v4-notes/index.md
@@ -22,7 +22,7 @@ FastMCP v4.0 is an engine swap. Three forces drive the major version:
 
 The migration merges to `main` and development continues there with subsequent PRs. Releases follow the SDK's own beta timeline:
 
-- **`main` carries the beta pins.** While the SDK is on `mcp==2.0.0b1` / `mcp-types==2.0.0b1`, `main` cuts **pre-releases** (`4.0.0b1`, `4.0.0b2`, …). No stable PyPI release goes out until `mcp 2.0.0` reaches GA — at which point the pins swap to the stable SDK and `4.0.0` ships. The pin-swap is a tracked checklist item on the [Known Gaps](known-gaps.md) page.
+- **`main` cuts pre-releases.** While the SDK was on exact beta pins, `main` cut the `4.0.0a*` alphas. When `mcp 2.0.0` reaches GA the pins move to stable ranges (`>=2.0.0,<3.0.0`) and the line continues through `4.0.0b1` before `4.0.0` ships — the stable SDK is what a beta needs, not a reason to skip straight to GA. The pin-swap is a tracked checklist item on the [Known Gaps](known-gaps.md) page.
 - **`release/3.x` is the maintenance line.** A `release/3.x` branch is cut from pre-merge `main`. It stays on the SDK v1 line, receives upstream security patches, and serves users who cannot move to the SDK v2 beta yet.
 
 ### Release codenames

--- a/dev-docs/v4-notes/known-gaps.md
+++ b/dev-docs/v4-notes/known-gaps.md
@@ -80,6 +80,6 @@ Separately, the [SDK delegation round two](feature-program.md#sdk-delegation-rou
 
 The beta-to-stable transition is a small set of tracked steps:
 
-- **Swap the pins.** When `mcp 2.0.0` reaches GA, change `mcp-types==2.0.0b1` (core) and the `mcp` pin (the `[mcp]` extra) in `fastmcp_slim/pyproject.toml` from the beta to the stable release, and cut `4.0.0` instead of another pre-release.
+- **Swap the pins.** When `mcp 2.0.0` reaches GA, change the exact `mcp-types` pin (core) and the `mcp` pin (the `[mcp]` extra) in `fastmcp_slim/pyproject.toml` from the beta to a stable range (`>=2.0.0,<3.0.0`), then regenerate `uv.lock` and confirm the suite and conformance run green against the stable SDK. The published install snippet in the upgrade guide pins these too, so it has to change in the same commit — a `2.0.0b2` constraint does not satisfy `>=2.0.0` and would break the very resolution it is meant to enable. FastMCP still ships a beta on the stable SDK before `4.0.0`.
 - **Re-run the xfail suite against the GA SDK.** Any strict xfail that starts passing means a gap closed — remove the marker and, where applicable, the corresponding shim.
 - **Confirm `release/3.x`** is cut from pre-merge `main` and receiving upstream security patches for users who stay on the SDK v1 line.

--- a/docs/getting-started/upgrading/from-fastmcp-3.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-3.mdx
@@ -11,21 +11,23 @@ FastMCP 4 absorbs almost all of this for you. Field access is bridged so your ex
 
 ## Install the v4 prerelease
 
-While FastMCP 4 is in prerelease, pin the beta and its prerelease protocol dependencies explicitly. For a uv project, add the following to `pyproject.toml`:
+While FastMCP 4 is in prerelease, pin the beta explicitly. The `fastmcp` package is a thin wrapper that depends on `fastmcp-slim` at the same version, so asking for a prerelease of one means asking for a prerelease of the other. pip infers that on its own:
+
+```bash
+pip install "fastmcp==4.0.0b1"
+```
+
+uv is stricter: it allows prereleases only for packages you name, and `fastmcp-slim` arrives transitively. Constrain it alongside the requirement in `pyproject.toml`:
 
 ```toml
 [project]
 dependencies = ["fastmcp==4.0.0b1"]
 
 [tool.uv]
-constraint-dependencies = [
-    "fastmcp-slim==4.0.0b1",
-    "mcp==2.0.0b2",
-    "mcp-types==2.0.0b2",
-]
+constraint-dependencies = ["fastmcp-slim==4.0.0b1"]
 ```
 
-Then run `uv lock` or `uv sync` normally. The constraints opt only these transitive packages into their prerelease versions; you do not need `--prerelease allow`, which permits prereleases throughout the dependency graph.
+Then run `uv lock` or `uv sync` normally. Naming the one package keeps the rest of your graph on stable releases, where `--prerelease allow` would opt every dependency into prereleases.
 
 ## Environment requirements
 


### PR DESCRIPTION
**Draft until #4655 merges.** Merging this before the SDK is stable would publish install instructions that don't work yet; merging #4655 without this would publish instructions that actively fail. They need to land together.

The published install snippet in the upgrade guide constrains `mcp==2.0.0b2` and `mcp-types==2.0.0b2`. Once #4655 moves FastMCP's own pins to `mcp>=2.0.0,<3.0.0`, those user-facing constraints become unsatisfiable — under PEP 440 a prerelease does not satisfy a `>=` bound on the same release, so `2.0.0b2` is excluded by `>=2.0.0` and `uv lock` fails on the exact command the section exists to make work.

With a stable SDK the constraint list also gets shorter, because `mcp` and `mcp-types` are no longer prereleases at all. The only prerelease left in the graph is `fastmcp-slim`, which arrives transitively from the `fastmcp` wrapper:

```toml
[project]
dependencies = ["fastmcp==4.0.0b1"]

[tool.uv]
constraint-dependencies = ["fastmcp-slim==4.0.0b1"]
```

The section now also states the pip path (`pip install "fastmcp==4.0.0b1"`, no `--pre` needed) and explains *why* uv needs the extra line, rather than leaving the reader to infer it from a block of pins.

Also corrects the internal release checklist in `dev-docs/v4-notes/`, which still said to cut `4.0.0` directly at SDK GA and referenced the older `2.0.0b1` pins. It now records that a beta ships on the stable SDK first, and flags that the published snippet has to change in the same commit as the pins.

Suggested label: `documentation`.
