### PR TITLE
Let maintenance releases publish without fastmcp-tasks

### DIFF
--- a/.github/workflows/publish-fastmcp-tasks.yml
+++ b/.github/workflows/publish-fastmcp-tasks.yml
@@ -23,13 +23,29 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # Maintenance branches predate the standalone fastmcp-tasks package and
+      # resolve the `tasks` extra through fastmcp-slim instead. This workflow
+      # runs from the default branch for every fastmcp-slim release, including
+      # those tags, so detect the package rather than assume it is there.
+      - name: Check whether this ref builds fastmcp-tasks
+        id: package_present
+        run: |
+          if [ -d fastmcp_tasks ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "This ref has no fastmcp_tasks package; nothing to publish."
+          fi
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
       - name: Build fastmcp-tasks
+        if: steps.package_present.outputs.present == 'true'
         run: uv build --package fastmcp-tasks
 
       - name: Verify matching fastmcp-slim is published
+        if: steps.package_present.outputs.present == 'true'
         run: |
           SLIM_VERSION=$(python - <<'PY'
           import email.parser
@@ -84,4 +100,5 @@ jobs:
           exit 1
 
       - name: Publish fastmcp-tasks to PyPI
+        if: steps.package_present.outputs.present == 'true'
         run: uv publish -v dist/fastmcp_tasks-*.tar.gz dist/fastmcp_tasks-*.whl

--- a/.github/workflows/publish-fastmcp.yml
+++ b/.github/workflows/publish-fastmcp.yml
@@ -134,16 +134,23 @@ jobs:
           # fastmcp-tasks is pinned via the optional `tasks` extra, so its
           # Requires-Dist entry carries an `extra == "tasks"` marker — unlike the
           # base slim dependency, do not skip marked entries here.
+          #
+          # Print nothing when there is no such pin. Release lines that resolve
+          # the `tasks` extra through fastmcp-slim instead of a standalone
+          # fastmcp-tasks package have nothing here to verify.
           for value in metadata.get_all("Requires-Dist", []):
               requirement, _, _marker = value.partition(";")
               match = re.fullmatch(r"fastmcp-tasks==([^;\s]+)", requirement.strip())
               if match:
                   print(match.group(1))
                   break
-          else:
-              raise RuntimeError("Could not find the fastmcp-tasks extra dependency")
           PY
           )
+
+          if [ -z "$TASKS_VERSION" ]; then
+            echo "This build does not pin fastmcp-tasks; the [tasks] extra cannot be uninstallable, so there is nothing to verify."
+            exit 0
+          fi
 
           for attempt in {1..12}; do
             if python - "$TASKS_VERSION" <<'PY'


### PR DESCRIPTION
Cutting v3.4.5 published `fastmcp-slim` and `fastmcp-remote` but not `fastmcp` itself, leaving `pip install fastmcp==3.4.5` broken until the root package was published by hand. Two jobs failed the same way: they run from the default branch for every `fastmcp-slim` release, including tags on maintenance branches, and both assume the standalone `fastmcp-tasks` package that only exists on `main`. On `release/3.x` the `tasks` extra resolves through `fastmcp-slim`, so `publish-fastmcp` aborted on `Could not find the fastmcp-tasks extra dependency` and `publish-fastmcp-tasks` had nothing to build. The guard was added on 2026-07-23, after 3.4.4 shipped — which is why this is the first release it broke.

The gate itself is worth keeping: publishing `fastmcp` while `fastmcp-tasks` is missing from PyPI leaves an uninstallable `[tasks]` extra. So rather than exempting maintenance branches by name — a test that needs updating for every new release line and fails open on the next one — both jobs now decide from what is actually in front of them. `publish-fastmcp` verifies `fastmcp-tasks` when the built wheel pins it and skips when nothing pins it, since an extra that never references the package cannot be uninstallable. `publish-fastmcp-tasks` checks for the package in the checked-out tree and no-ops when it is absent.

Confirmed against both published wheels:

```
fastmcp-3.4.5   Requires-Dist: fastmcp-slim[tasks]==3.4.5  -> no pin, guard skips
fastmcp-4.0.0a2 Requires-Dist: fastmcp-tasks==4.0.0a2      -> pinned, guard runs and still blocks
```
