### PR TITLE
Give parallel Windows CI more timeout headroom

### DIFF
--- a/.github/actions/run-pytest/action.yml
+++ b/.github/actions/run-pytest/action.yml
@@ -46,6 +46,16 @@ runs:
           PARALLEL_FLAGS="--numprocesses auto --maxprocesses $MAX_PROCS --dist worksteal"
         fi
 
+        # pytest-timeout has no signal-based method on Windows, so it falls back
+        # to the thread method, which dumps stacks and os._exit()s the process.
+        # Under a contended runner that turns a single slow test into a dead
+        # xdist worker, failing whichever unrelated test that worker happened to
+        # be running. Give parallel Windows runs more headroom so ordinary
+        # scheduling jitter does not take a worker down.
+        if [ "$RUNNER_OS" == "Windows" ] && [ "$MAX_PROCS" != "0" ]; then
+          TIMEOUT=$((TIMEOUT * 4))
+        fi
+
         uv run --no-sync pytest \
           --inline-snapshot=disable \
           --timeout=$TIMEOUT \


### PR DESCRIPTION
Parallel Windows unit tests regularly run close to the repository's 5-second per-test timeout. On Windows, `pytest-timeout` uses its thread method, which terminates the entire process on timeout; under xdist, one slow test therefore kills its worker and GitHub reports an unrelated test as `node down: Not properly terminated`.

This has occurred in three independent Windows jobs with different victim tests: [PR #4677](https://github.com/PrefectHQ/fastmcp/actions/runs/30300707463/job/90092641917), [`main`](https://github.com/PrefectHQ/fastmcp/actions/runs/30297215586), and [PR #4684](https://github.com/PrefectHQ/fastmcp/actions/runs/30320638138/job/90155580453). The latest run explicitly reports the 5-second thread timeout, then loses `gw1`, while neighboring tests take 4.04-4.05 seconds.

This gives the parallel Windows unit step a 20-second timeout:

```text
Windows + parallel unit tests: 5s -> 20s
Serial, conformance, and non-Windows tests: unchanged
```

The [rebased validation job](https://github.com/PrefectHQ/fastmcp/actions/runs/30464547737/job/90618890632) confirms the split: 6,931 parallel unit tests passed with `timeout: 20.0s`, then all 16 serial subprocess tests passed with `timeout: 5.0s`.

The Windows unit step normally completes in roughly 2.5 minutes inside a 10-minute job limit, so the added per-test headroom does not weaken the job-level hang bound.
