### PR TITLE
Bump MCP conformance to 0.2.0-alpha.10

### DIFF
--- a/tests/conformance/expected-failures.yml
+++ b/tests/conformance/expected-failures.yml
@@ -21,3 +21,10 @@ server:
   # need the tool to declare which one it wants, which is an unmade API
   # decision rather than a bug.
   - tasks-mrtr-composition
+
+  # Upstream SDK Bug: The mcp-python SDK strictly validates that `clientInfo` is
+  # present in the request `_meta`, rejecting the request with -32602 Invalid params
+  # if it is missing. The MCP protocol (SEP-2575) designates `clientInfo` as an
+  # optional SHOULD requirement. FastMCP relies on the upstream SDK's
+  # `classify_inbound_request` logic which incorrectly enforces this as a MUST.
+  - server-stateless

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -28,7 +28,7 @@ EXPECTED_FAILURES = CONFORMANCE_DIR / "expected-failures.yml"
 HOST = "127.0.0.1"
 
 #: Pinned version of `@modelcontextprotocol/conformance`. Bump deliberately.
-CONFORMANCE_VERSION = "0.2.0-alpha.9"
+CONFORMANCE_VERSION = "0.2.0-alpha.10"
 
 
 def _get_free_port() -> int:


### PR DESCRIPTION
## Summary

Fixes #4651
This PR updates the pinned MCP conformance suite to `0.2.0-alpha.10`.

### Changes

- Bump `CONFORMANCE_VERSION` from `0.2.0-alpha.9` to `0.2.0-alpha.10`.
- Add `server-stateless` to `tests/conformance/expected-failures.yml` with a note describing the current upstream SDK behavior.

### Context

The updated conformance suite introduces a new `server-stateless` scenario. The observed failure occurs before FastMCP request handling, where the underlying `mcp-python` parser rejects requests whose `_meta` omits `clientInfo`. This behavior is documented in the expected failures baseline.

The existing expected failures for:

- `resources-subscribe`
- `resources-unsubscribe`
- `tasks-mrtr-composition`

remain unchanged.

### Testing

- Updated the conformance version pin.
- Reviewed the conformance failures introduced by the new suite.
- Verified that the new expected failure matches the observed behavior.