### PR TITLE
Search transform proxy tools (call_read_tool, call_write_tool, etc.) missing 'title' field

### DIFF
--- a/docs/servers/transforms/tool-search.mdx
+++ b/docs/servers/transforms/tool-search.mdx
@@ -139,6 +139,8 @@ mcp.add_transform(RegexSearchTransform(
 ))
 ```
 
+Both tools also carry an MCP `title` derived from their name — `find_tools` becomes "Find Tools" — since some clients drop tools that have no title.
+
 ## The `call_tool` Proxy
 
 The `call_tool` proxy forwards calls to the real tool. When a client calls `call_tool(name="search_database", arguments={...})`, the proxy resolves `search_database` through the server's normal tool pipeline — including transforms and middleware — and executes it.

--- a/docs/v3/servers/transforms/tool-search.mdx
+++ b/docs/v3/servers/transforms/tool-search.mdx
@@ -139,6 +139,8 @@ mcp.add_transform(RegexSearchTransform(
 ))
 ```
 
+Both tools also carry an MCP `title` derived from their name — `find_tools` becomes "Find Tools" — since some clients drop tools that have no title.
+
 ## The `call_tool` Proxy
 
 The `call_tool` proxy forwards calls to the real tool. When a client calls `call_tool(name="search_database", arguments={...})`, the proxy resolves `search_database` through the server's normal tool pipeline — including transforms and middleware — and executes it.

--- a/fastmcp_slim/fastmcp/server/transforms/search/base.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/base.py
@@ -112,6 +112,17 @@ def _schema_type(schema: Any) -> str:
     return "object" if "properties" in schema else "any"
 
 
+def _synthetic_tool_title(name: str) -> str:
+    """Derive a display title for a synthetic tool from its name.
+
+    Some clients (notably ChatGPT) drop tools that have no `title`, so the
+    generated search/call tools always carry one. Deriving it from the
+    configured name keeps the title correct when the tools are renamed:
+    `call_read_tool` becomes "Call Read Tool".
+    """
+    return name.replace("_", " ").title()
+
+
 def _schema_section(schema: dict[str, Any] | None, title: str) -> list[str]:
     lines = [f"**{title}**"]
     if not isinstance(schema, dict):
@@ -242,7 +253,11 @@ class BaseSearchTransform(CatalogTransform):
                 )
             return await ctx.fastmcp.call_tool(name, arguments)
 
-        return Tool.from_function(fn=call_tool, name=self._call_tool_name)
+        return Tool.from_function(
+            fn=call_tool,
+            name=self._call_tool_name,
+            title=_synthetic_tool_title(self._call_tool_name),
+        )
 
     # ------------------------------------------------------------------
     # Serialization

--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -11,6 +11,7 @@ from fastmcp.server.transforms.search.base import (
     BaseSearchTransform,
     SearchResultSerializer,
     _extract_searchable_text,
+    _synthetic_tool_title,
 )
 from fastmcp.tools.base import Tool
 
@@ -126,7 +127,11 @@ class BM25SearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, query)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=_synthetic_tool_title(self._search_tool_name),
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         current_hash = _catalog_hash(tools)

--- a/fastmcp_slim/fastmcp/server/transforms/search/regex.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/regex.py
@@ -8,6 +8,7 @@ from fastmcp.server.context import Context
 from fastmcp.server.transforms.search.base import (
     BaseSearchTransform,
     _extract_searchable_text,
+    _synthetic_tool_title,
 )
 from fastmcp.tools.base import Tool
 
@@ -37,7 +38,11 @@ class RegexSearchTransform(BaseSearchTransform):
             results = await transform._search(hidden, pattern)
             return await transform._render_results(results)
 
-        return Tool.from_function(fn=search_tools, name=self._search_tool_name)
+        return Tool.from_function(
+            fn=search_tools,
+            name=self._search_tool_name,
+            title=_synthetic_tool_title(self._search_tool_name),
+        )
 
     async def _search(self, tools: Sequence[Tool], query: str) -> Sequence[Tool]:
         try:

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -137,6 +137,36 @@ class TestBaseTransformBehavior:
         assert await mcp.get_tool("find_tools") is not None
         assert await mcp.get_tool("run_tool") is not None
 
+    @pytest.mark.parametrize(
+        "transform_cls", [RegexSearchTransform, BM25SearchTransform]
+    )
+    async def test_synthetic_tools_have_titles(self, transform_cls):
+        """Some clients require `title` to register a tool."""
+        mcp = _make_server_with_tools()
+        mcp.add_transform(transform_cls())
+        tools = await mcp.list_tools()
+        titles = {t.name: t.to_mcp_tool().title for t in tools}
+        assert titles == {"search_tools": "Search Tools", "call_tool": "Call Tool"}
+
+    @pytest.mark.parametrize(
+        "transform_cls", [RegexSearchTransform, BM25SearchTransform]
+    )
+    async def test_titles_follow_custom_tool_names(self, transform_cls):
+        """Renaming the synthetic tools renames their titles too."""
+        mcp = _make_server_with_tools()
+        mcp.add_transform(
+            transform_cls(
+                search_tool_name="find_tools",
+                call_tool_name="call_read_tool",
+            )
+        )
+        tools = await mcp.list_tools()
+        titles = {t.name: t.to_mcp_tool().title for t in tools}
+        assert titles == {
+            "find_tools": "Find Tools",
+            "call_read_tool": "Call Read Tool",
+        }
+
     async def test_search_respects_visibility_filtering(self):
         """Tools disabled via Visibility transform should not appear in search."""
         mcp = _make_server_with_tools()


### PR DESCRIPTION
The search transforms now set the MCP `title` on their synthetic `search_tools` and `call_tool` proxies, derived from each tool's configured name by a single private helper (`_synthetic_tool_title`) in `search/base.py`. No public constructor parameters were added, so the fix is confined to giving the generated tools a title that clients like ChatGPT require, and renamed tools (`call_read_tool` → "Call Read Tool") get correct titles automatically.

Fixes #4414

### Testing
[targeted] $ /Users/m2/Documents/PW/github-bot/work/PrefectHQ__fastmcp/4414/.contrib-venv/bin/python -m pytest -x -q --no-header tests/server/transforms/test_search.py

### Notes for reviewers
The source edits land under `fastmcp_slim/fastmcp/server/transforms/search/` while the tests import plain `fastmcp` and live under `tests/` — from the diff alone I cannot tell whether `fastmcp_slim/` is the real package root or a vendored/generated copy, which means I can't confirm the passing tests are exercising the changed code. Also verify `Tool.from_function` actually accepts and propagates `title` through to `to_mcp_tool()`. The two `.mdx` files are byte-identical edits; confirm `docs/v3/` isn't generated from `docs/`. Finally, both new tests assert exact dict equality over `await mcp.list_tools()`, which will break the moment the transform emits any additional tool — assert on the synthetic tools' titles specifically instead.

