### PR TITLE
Use mcp.types directly instead of aliasing to mcp_types in docs

### DIFF
--- a/docs/clients/notifications.mdx
+++ b/docs/clients/notifications.mdx
@@ -47,23 +47,23 @@ For fine-grained targeting, subclass `MessageHandler` to use specific hooks:
 ```python
 from fastmcp import Client
 from fastmcp.client.messages import MessageHandler
-import mcp.types as mcp_types
+import mcp.types
 
 class MyMessageHandler(MessageHandler):
     async def on_tool_list_changed(
-        self, notification: mcp_types.ToolListChangedNotification
+        self, notification: mcp.types.ToolListChangedNotification
     ) -> None:
         """Handle tool list changes."""
         print("Tool list changed - refreshing available tools")
 
     async def on_resource_list_changed(
-        self, notification: mcp_types.ResourceListChangedNotification
+        self, notification: mcp.types.ResourceListChangedNotification
     ) -> None:
         """Handle resource list changes."""
         print("Resource list changed")
 
     async def on_prompt_list_changed(
-        self, notification: mcp_types.PromptListChangedNotification
+        self, notification: mcp.types.PromptListChangedNotification
     ) -> None:
         """Handle prompt list changes."""
         print("Prompt list changed")
@@ -78,7 +78,7 @@ client = Client(
 
 ```python
 from fastmcp.client.messages import MessageHandler
-import mcp.types as mcp_types
+import mcp.types
 
 class MyMessageHandler(MessageHandler):
     async def on_message(self, message) -> None:
@@ -86,49 +86,49 @@ class MyMessageHandler(MessageHandler):
         pass
 
     async def on_notification(
-        self, notification: mcp_types.ServerNotification
+        self, notification: mcp.types.ServerNotification
     ) -> None:
         """Called for notifications (fire-and-forget)."""
         pass
 
     async def on_tool_list_changed(
-        self, notification: mcp_types.ToolListChangedNotification
+        self, notification: mcp.types.ToolListChangedNotification
     ) -> None:
         """Called when the server's tool list changes."""
         pass
 
     async def on_resource_list_changed(
-        self, notification: mcp_types.ResourceListChangedNotification
+        self, notification: mcp.types.ResourceListChangedNotification
     ) -> None:
         """Called when the server's resource list changes."""
         pass
 
     async def on_prompt_list_changed(
-        self, notification: mcp_types.PromptListChangedNotification
+        self, notification: mcp.types.PromptListChangedNotification
     ) -> None:
         """Called when the server's prompt list changes."""
         pass
 
     async def on_progress(
-        self, notification: mcp_types.ProgressNotification
+        self, notification: mcp.types.ProgressNotification
     ) -> None:
         """Called for progress updates during long-running operations."""
         pass
 
     async def on_resource_updated(
-        self, notification: mcp_types.ResourceUpdatedNotification
+        self, notification: mcp.types.ResourceUpdatedNotification
     ) -> None:
         """Called when a specific resource changes."""
         pass
 
     async def on_cancelled(
-        self, notification: mcp_types.CancelledNotification
+        self, notification: mcp.types.CancelledNotification
     ) -> None:
         """Called when a request is cancelled."""
         pass
 
     async def on_logging_message(
-        self, notification: mcp_types.LoggingMessageNotification
+        self, notification: mcp.types.LoggingMessageNotification
     ) -> None:
         """Called for log messages from the server."""
         pass
@@ -141,14 +141,14 @@ A practical example of maintaining a tool cache that refreshes when tools change
 ```python
 from fastmcp import Client
 from fastmcp.client.messages import MessageHandler
-import mcp.types as mcp_types
+import mcp.types
 
 class ToolCacheHandler(MessageHandler):
     def __init__(self):
         self.cached_tools = []
 
     async def on_tool_list_changed(
-        self, notification: mcp_types.ToolListChangedNotification
+        self, notification: mcp.types.ToolListChangedNotification
     ) -> None:
         """Clear tool cache when tools change."""
         print("Tools changed - clearing cache")

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -271,14 +271,18 @@ Tools can customize which components are visible to their current session using 
 FastMCP automatically sends list change notifications when components (such as tools, resources, or prompts) are added, removed, enabled, or disabled. In rare cases where you need to manually trigger these notifications, you can use the context's notification methods:
 
 ```python
-import mcp.types
+from mcp.types import (
+    PromptListChangedNotification,
+    ResourceListChangedNotification,
+    ToolListChangedNotification,
+)
 
 @mcp.tool
 async def custom_tool_management(ctx: Context) -> str:
     """Example of manual notification after custom tool changes."""
-    await ctx.send_notification(mcp.types.ToolListChangedNotification())
-    await ctx.send_notification(mcp.types.ResourceListChangedNotification())
-    await ctx.send_notification(mcp.types.PromptListChangedNotification())
+    await ctx.send_notification(ToolListChangedNotification())
+    await ctx.send_notification(ResourceListChangedNotification())
+    await ctx.send_notification(PromptListChangedNotification())
     return "Notifications sent"
 ```
 

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -179,7 +179,7 @@ content = resource_result.contents[0].content
 ```
 
 **Method signatures:**
-- **`ctx.list_resources() -> list[mcp_types.Resource]`**: <VersionBadge version="2.13.0" /> Returns list of all available resources
+- **`ctx.list_resources() -> list[mcp.types.Resource]`**: <VersionBadge version="2.13.0" /> Returns list of all available resources
 - **`ctx.read_resource(uri: str | AnyUrl) -> ResourceResult`**: Returns a `ResourceResult` whose `.contents` list contains the resource content parts
 
 ### Prompt Access
@@ -271,14 +271,14 @@ Tools can customize which components are visible to their current session using 
 FastMCP automatically sends list change notifications when components (such as tools, resources, or prompts) are added, removed, enabled, or disabled. In rare cases where you need to manually trigger these notifications, you can use the context's notification methods:
 
 ```python
-import mcp.types as mcp_types
+import mcp.types
 
 @mcp.tool
 async def custom_tool_management(ctx: Context) -> str:
     """Example of manual notification after custom tool changes."""
-    await ctx.send_notification(mcp_types.ToolListChangedNotification())
-    await ctx.send_notification(mcp_types.ResourceListChangedNotification())
-    await ctx.send_notification(mcp_types.PromptListChangedNotification())
+    await ctx.send_notification(mcp.types.ToolListChangedNotification())
+    await ctx.send_notification(mcp.types.ResourceListChangedNotification())
+    await ctx.send_notification(mcp.types.PromptListChangedNotification())
     return "Notifications sent"
 ```
 

--- a/docs/servers/tasks.mdx
+++ b/docs/servers/tasks.mdx
@@ -225,30 +225,30 @@ A tool can ask the client a question partway through — the same [guard pattern
 ```python
 from fastmcp import Context, FastMCP
 from fastmcp_tasks import TasksExtension
-import mcp.types as mcp_types
+import mcp.types
 
 mcp = FastMCP("MyServer")
 mcp.add_extension(TasksExtension())
 
 @mcp.tool(task=True)
-async def plan_dinner(ctx: Context) -> str | mcp_types.InputRequiredResult:
+async def plan_dinner(ctx: Context) -> str | mcp.types.InputRequiredResult:
     responses = ctx.input_responses
     if responses is None:
         # First leg: ask a question and end here.
-        request = mcp_types.ElicitRequest(
-            params=mcp_types.ElicitRequestFormParams(
+        request = mcp.types.ElicitRequest(
+            params=mcp.types.ElicitRequestFormParams(
                 message="What are you in the mood for?",
                 requested_schema={"type": "object", "properties": {"cuisine": {"type": "string"}}},
             )
         )
-        return mcp_types.InputRequiredResult(
+        return mcp.types.InputRequiredResult(
             result_type="input_required",
             input_requests={"prefs": request},
         )
 
     # Re-entered leg: the client's answer is on ctx.input_responses.
     answer = responses["prefs"]
-    assert isinstance(answer, mcp_types.ElicitResult)
+    assert isinstance(answer, mcp.types.ElicitResult)
     return f"Tonight: {answer.content['cuisine']}!"
 ```
 

--- a/docs/servers/tasks.mdx
+++ b/docs/servers/tasks.mdx
@@ -225,30 +225,35 @@ A tool can ask the client a question partway through — the same [guard pattern
 ```python
 from fastmcp import Context, FastMCP
 from fastmcp_tasks import TasksExtension
-import mcp.types
+from mcp.types import (
+    ElicitRequest,
+    ElicitRequestFormParams,
+    ElicitResult,
+    InputRequiredResult,
+)
 
 mcp = FastMCP("MyServer")
 mcp.add_extension(TasksExtension())
 
 @mcp.tool(task=True)
-async def plan_dinner(ctx: Context) -> str | mcp.types.InputRequiredResult:
+async def plan_dinner(ctx: Context) -> str | InputRequiredResult:
     responses = ctx.input_responses
     if responses is None:
         # First leg: ask a question and end here.
-        request = mcp.types.ElicitRequest(
-            params=mcp.types.ElicitRequestFormParams(
+        request = ElicitRequest(
+            params=ElicitRequestFormParams(
                 message="What are you in the mood for?",
                 requested_schema={"type": "object", "properties": {"cuisine": {"type": "string"}}},
             )
         )
-        return mcp.types.InputRequiredResult(
+        return InputRequiredResult(
             result_type="input_required",
             input_requests={"prefs": request},
         )
 
     # Re-entered leg: the client's answer is on ctx.input_responses.
     answer = responses["prefs"]
-    assert isinstance(answer, mcp.types.ElicitResult)
+    assert isinstance(answer, ElicitResult)
     return f"Tonight: {answer.content['cuisine']}!"
 ```
 


### PR DESCRIPTION
Some docs pages imported `mcp.types` under the alias `mcp_types` (e.g. `import mcp.types as mcp_types`), then referenced it as `mcp_types.ToolListChangedNotification`. Since `mcp.types` is a stable, permanent alias in the SDK, there's no reason for docs to invent a second name for it — especially when other pages already reference `mcp.types` directly.

Client-side examples now use the qualified form, which reads cleanly because nothing else binds `mcp`:

```python
import mcp.types

async def on_tool_list_changed(
    self, notification: mcp.types.ToolListChangedNotification
) -> None:
    ...
```

Server examples can't use that form: `import mcp.types` binds the name `mcp`, which every server page immediately rebinds with `mcp = FastMCP(...)`. The eagerly-evaluated annotation then resolves `mcp.types` against the server instance and raises `AttributeError` at decoration time. Those examples import the symbols directly instead:

```python
from mcp.types import ElicitRequest, InputRequiredResult

mcp = FastMCP("MyServer")

@mcp.tool(task=True)
async def plan_dinner(ctx: Context) -> str | InputRequiredResult:
    ...
```
