### PR TITLE
Reconnect `StdioTransport` when reused on a different event loop

### DIFF
--- a/docs/clients/transports.mdx
+++ b/docs/clients/transports.mdx
@@ -98,6 +98,8 @@ For complete isolation between connections, disable session persistence:
 transport = StdioTransport(command="python", args=["server.py"], keep_alive=False)
 ```
 
+A persisted session belongs to the event loop that created it, so reuse from a different loop transparently starts a fresh subprocess instead. Sharing one transport between loops still works, but only reuses the subprocess within a single loop — and it raises if two loops try to hold overlapping sessions on the same transport, which needs one transport per loop.
+
 ## HTTP Transport
 
 <VersionBadge version="2.3.0" />

--- a/fastmcp_slim/fastmcp/client/transports/stdio.py
+++ b/fastmcp_slim/fastmcp/client/transports/stdio.py
@@ -105,6 +105,24 @@ class StdioTransport(ClientTransport):
         # Serialized so concurrent callers can't each decide to replace the
         # session and race to spawn competing subprocesses.
         async with self._connect_lock:
+            # The connection task and the session's streams belong to the event
+            # loop that created them. A session reused from another loop never
+            # sees its responses, so the initialize handshake hangs forever.
+            # Rebuild on this loop instead; refuse when another client is still
+            # using the old connection, since tearing it down would break them.
+            if self._connect_task is not None and (
+                self._connect_task.get_loop() is not asyncio.get_running_loop()
+            ):
+                if self._active_sessions:
+                    raise RuntimeError(
+                        "This stdio transport has a live session bound to a "
+                        "different event loop and another client is still using "
+                        "it. Sharing one transport across event loops with "
+                        "overlapping sessions is not supported; give each loop "
+                        "its own transport."
+                    )
+                await self.disconnect()
+
             # A kept-alive session was built for one client's options; handing it
             # to a client that wants different ones would silently give it the
             # first client's behavior. Rebuild it when it's idle; refuse when
@@ -170,13 +188,26 @@ class StdioTransport(ClientTransport):
         if self._connect_task is None:
             return
 
+        connect_task = self._connect_task
+        owning_loop = connect_task.get_loop()
+
+        # The task can only be signalled and awaited from the loop that owns
+        # it. From any other loop, hand the stop signal over and drop our
+        # references; that loop tears the subprocess down on its own. If it is
+        # already gone there is nothing left to signal.
+        if owning_loop is not asyncio.get_running_loop():
+            stop_event = self._stop_event
+            self._reset()
+            with contextlib.suppress(RuntimeError):
+                owning_loop.call_soon_threadsafe(stop_event.set)
+            return
+
         # signal the connection task to stop
         self._stop_event.set()
 
         # Wait without propagating the connection task's cancellation into
         # this caller. Cancellation of this wait therefore still belongs to
         # the caller and must propagate normally.
-        connect_task = self._connect_task
         await asyncio.wait({connect_task})
         try:
             _ = connect_task.result()
@@ -188,7 +219,10 @@ class StdioTransport(ClientTransport):
                 exc_info=True,
             )
 
-        # reset variables and events for potential future reconnects
+        self._reset()
+
+    def _reset(self) -> None:
+        """Clear connection state and events so a future connect starts fresh."""
         self._connect_task = None
         self._session = None
         self._session_options = None

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -311,6 +311,43 @@ class TestKeepAlive:
 
         assert pid1 != pid2
 
+    # https://github.com/PrefectHQ/fastmcp/issues/4471
+    @pytest.mark.timeout(30)
+    async def test_keep_alive_reconnects_on_a_different_event_loop(self, stdio_script):
+        """A kept-alive connection belongs to the loop that created it.
+
+        Reusing the transport from a second, concurrently-alive loop has to
+        spawn a fresh subprocess: the first loop's session never sees its
+        responses on the second loop, so reusing it would hang the initialize
+        handshake instead of connecting.
+        """
+        client = Client(transport=PythonStdioTransport(script_path=stdio_script))
+
+        async with client:
+            result1 = await client.call_tool("pid")
+            pid1: int = result1.data
+
+        async def reuse() -> int:
+            async with client:
+                result = await client.call_tool("pid")
+            return int(result.data)
+
+        def reuse_on_new_loop() -> int:
+            # Bounded so a reused foreign-loop session fails as a timeout here
+            # rather than hanging the suite.
+            return asyncio.run(asyncio.wait_for(reuse(), timeout=10))
+
+        # Off-thread, so this test's loop stays running while the second one
+        # connects: only the owning loop can tear the old connection down.
+        pid2 = await asyncio.to_thread(reuse_on_new_loop)
+
+        assert pid2 != pid1
+        await wait_for_process_exit(pid1)
+
+        # The second loop is closed by now; closing from this one must still
+        # succeed rather than fail on a task it cannot await.
+        await client.close()
+
     async def test_keep_alive_starts_new_session_if_manually_closed(self, stdio_script):
         client = Client(transport=PythonStdioTransport(script_path=stdio_script))
         assert client.transport.keep_alive is True


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

> Note: David has **not** reviewed this change yet — flagging honestly for the maintainers.

Closes #4471.

## Problem

A `Client(StdioTransport(...))` with the default `keep_alive=True` cannot be reused on a second, concurrently-alive event loop. The persisted subprocess connection — the connect task and its anyio streams — is bound to the loop of first connect. On reuse from a different running loop, the MCP `initialize` handshake never receives its response on the new loop and hangs. `keep_alive=False` avoids it, but forfeits connection reuse entirely.

This bites any app that shares one `Client`/transport across event loops: ASGI apps with a background loop, worker pools, and durable-execution frameworks (DBOS/Temporal) that recover or fork a run onto a different loop.

The reuse check (`_is_session_dead`) only inspects stream closure, not loop identity, so a foreign-loop-bound session gets reused.

> Note on the issue's framing: #4471 (filed against 3.4.2) reports the handshake raises after `init_timeout`. On current `main` (fastmcp 4.0 / mcp 2.0) it is **no longer bounded by `init_timeout`** — the reused-loop handshake hangs indefinitely; in the repro it only ended at an outer test guard.

## Fix

In `StdioTransport` (`fastmcp_slim/fastmcp/client/transports/stdio.py`):

- `connect_session` now compares the connect task's loop to the running loop under the existing connect lock. On a loop change it `disconnect()`s and rebuilds on the current loop. If another loop still holds a live session (`_active_sessions`), it raises a clear `RuntimeError` rather than tearing down a connection another client is using.
- `disconnect` is made loop-aware: a task can only be signalled/awaited from the loop that owns it, so from a foreign loop it hands `stop_event.set` over via `call_soon_threadsafe` and drops its references instead of awaiting a task it cannot. Shared reset logic is extracted to `_reset()`.

Other transports (StreamableHttp/SSE) are untouched — they don't persist a loop-bound subprocess connection this way.

## Test

`tests/client/test_stdio.py::TestKeepAlive::test_keep_alive_reconnects_on_a_different_event_loop` reuses the transport from a second loop off-thread (keeping the first loop alive), and asserts a fresh subprocess pid, that the first subprocess is reaped, and that `close()` from a loop whose owner is gone doesn't raise.

Verified both directions: **fails (times out) on `main`, passes with the fix.** `tests/client` and `tests/server/providers/proxy` are green; the docs note under *Session Persistence* documents the new per-loop reuse behavior and the overlapping-sessions error.
