### PR TITLE
Write downloaded skill text as UTF-8

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/skills.py
+++ b/fastmcp_slim/fastmcp/utilities/skills.py
@@ -205,7 +205,7 @@ async def download_skill(
 
         # Write content
         if isinstance(content, mcp_types.TextResourceContents):
-            file_path.write_text(content.text)
+            file_path.write_text(content.text, encoding="utf-8")
         elif isinstance(content, mcp_types.BlobResourceContents):
             file_path.write_bytes(base64.b64decode(content.blob))
         else:

--- a/tests/utilities/test_skills.py
+++ b/tests/utilities/test_skills.py
@@ -269,6 +269,53 @@ class TestDownloadSkill:
         downloaded = (result / "SKILL.md").read_text()
         assert downloaded == original
 
+    async def test_writes_text_resources_as_utf8(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        content = "Use the tool — then stop."
+        manifest = {
+            "skill": "unicode",
+            "files": [
+                {
+                    "path": "SKILL.md",
+                    "size": len(content.encode("utf-8")),
+                    "hash": "sha256:unicode",
+                }
+            ],
+        }
+        client = FakeResourceReader(
+            {
+                "skill://unicode/_manifest": [
+                    text_resource("skill://unicode/_manifest", json.dumps(manifest))
+                ],
+                "skill://unicode/SKILL.md": [
+                    text_resource("skill://unicode/SKILL.md", content)
+                ],
+            }
+        )
+        original_write_text = Path.write_text
+
+        def locale_sensitive_write_text(
+            path: Path,
+            data: str,
+            encoding: str | None = None,
+            errors: str | None = None,
+            newline: str | None = None,
+        ) -> int:
+            return original_write_text(
+                path,
+                data,
+                encoding=encoding or "ascii",
+                errors=errors,
+                newline=newline,
+            )
+
+        monkeypatch.setattr(Path, "write_text", locale_sensitive_write_text)
+
+        result = await download_skill(cast(Client, client), "unicode", tmp_path)
+
+        assert (result / "SKILL.md").read_text(encoding="utf-8") == content
+
     async def test_raises_if_exists_without_overwrite(
         self, skills_server: FastMCP, tmp_path: Path
     ):


### PR DESCRIPTION
`download_skill()` currently lets `Path.write_text()` choose the operating system's locale encoding. On Windows systems using a non-UTF-8 code page, downloaded skill text can either raise `UnicodeEncodeError` or produce files that `SkillProvider` cannot read back as UTF-8.

Write text resources explicitly as UTF-8 at the download boundary, matching the encoding used by the skill readers. The regression test simulates a non-UTF-8 locale and verifies that Unicode content still round-trips:

```python
file_path.write_text(content.text, encoding="utf-8")
```

Fixes #4708.

Generated with OpenAI Codex
