### PR TITLE
Fix self-referential connection error causes

### DIFF
--- a/fastmcp_slim/fastmcp/client/client.py
+++ b/fastmcp_slim/fastmcp/client/client.py
@@ -1022,7 +1022,10 @@ class Client(
                         raise RuntimeError(
                             "Session task completed without exception but connection failed"
                         )
-                    raise _connection_failure(exception) from exception
+                    failure = _connection_failure(exception)
+                    if failure is exception:
+                        raise exception
+                    raise failure from exception
 
             self._session_state.nesting_counter += 1
 

--- a/tests/client/auth/test_oauth_client.py
+++ b/tests/client/auth/test_oauth_client.py
@@ -96,9 +96,11 @@ async def test_unauthorized(client_unauthorized: Client):
     SDK v2 surfaces the server's 401 as an MCPError ("Server returned an error
     response") rather than re-raising the raw httpx2.HTTPStatusError.
     """
-    with pytest.raises(MCPError, match="error response"):
+    with pytest.raises(MCPError, match="error response") as exc_info:
         async with client_unauthorized:
             pass
+
+    assert exc_info.value.__cause__ is not exc_info.value
 
 
 async def test_ping(streamable_http_server: str):

--- a/tests/client/client/test_session.py
+++ b/tests/client/client/test_session.py
@@ -1,16 +1,31 @@
 """Client session and task error propagation tests."""
 
 import asyncio
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
+import httpx2
 import pytest
-from mcp import ClientSession
-from mcp_types import TextContent
+from mcp import ClientSession, MCPError
+from mcp_types import INTERNAL_ERROR, TextContent
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
-from fastmcp.client.transports import PythonStdioTransport
+from fastmcp.client.transports import ClientTransport, PythonStdioTransport
 from fastmcp.client.transports.base import TransportOptions
+
+
+class _FailingTransport(ClientTransport):
+    def __init__(self, exception: Exception) -> None:
+        self._exception = exception
+
+    @asynccontextmanager
+    async def connect_session(
+        self, **session_kwargs: Any
+    ) -> AsyncIterator[ClientSession]:
+        raise self._exception
+        yield
 
 
 class TestSessionTaskErrorPropagation:
@@ -141,6 +156,40 @@ class TestSessionTaskErrorPropagation:
 
             # Restore for cleanup
             client._session_state.session_task = original_task
+
+
+class TestConnectionFailurePropagation:
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            MCPError(code=INTERNAL_ERROR, message="upstream failed"),
+            httpx2.HTTPStatusError(
+                "upstream unavailable",
+                request=httpx2.Request("GET", "https://example.com"),
+                response=httpx2.Response(503),
+            ),
+        ],
+        ids=["mcp-error", "http-status-error"],
+    )
+    async def test_preserves_passthrough_exception(self, failure: Exception):
+        client = Client(transport=_FailingTransport(failure))
+
+        with pytest.raises(type(failure)) as exc_info:
+            async with client:
+                pass
+
+        assert exc_info.value is failure
+        assert exc_info.value.__cause__ is not failure
+
+    async def test_wraps_other_failures_with_cause(self):
+        failure = OSError("connection refused")
+        client = Client(transport=_FailingTransport(failure))
+
+        with pytest.raises(RuntimeError, match="Client failed to connect") as exc_info:
+            async with client:
+                pass
+
+        assert exc_info.value.__cause__ is failure
 
 
 class TestCustomSessionClass:


### PR DESCRIPTION
`Client._connect()` unconditionally chained normalized connection failures, causing pass-through `MCPError` and `HTTPStatusError` instances to become their own `__cause__`. Cause-chain traversal could therefore loop indefinitely after an upstream HTTP failure.

Preserved exceptions are now raised directly, while newly created `RuntimeError` wrappers retain the original failure as their cause:

```python
failure = _connection_failure(exception)
if failure is exception:
    raise exception
raise failure from exception
```

🤖 Generated with OpenAI Codex
