### PR TITLE
feat: Add AuthPlaneAuthProvider for AuthPlane OAuth 2.1 integration

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/__init__.py
+++ b/fastmcp_slim/fastmcp/server/auth/__init__.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING
 
+__all__ = [
+    "AuthPlaneAuthProvider",
+]
 from .auth import (
     OAuthProvider,
     TokenVerifier,

--- a/fastmcp_slim/fastmcp/server/auth/providers/__init__.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/__init__.py
@@ -1,0 +1,7 @@
+"""Authentication providers for FastMCP."""
+
+from fastmcp.server.auth.providers.authplane import AuthPlaneAuthProvider
+
+__all__ = [
+    "AuthPlaneAuthProvider",
+]

--- a/fastmcp_slim/fastmcp/server/auth/providers/authplane.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/authplane.py
@@ -1,0 +1,76 @@
+"""AuthPlane authentication provider for FastMCP."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from pydantic import AnyHttpUrl
+
+from fastmcp.server.auth import RemoteAuthProvider, TokenVerifier
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.utilities.auth import parse_scopes
+from fastmcp.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class AuthPlaneAuthProvider(RemoteAuthProvider):
+    """AuthPlane authentication provider using JWT verification.
+
+    This provider integrates AuthPlane (https://github.com/AuthPlane/authserver),
+    an open-source, self-hosted OAuth 2.1 authorization server for MCP.
+
+    Example:
+        ```python
+        from fastmcp import FastMCP
+        from fastmcp.server.auth.providers.authplane import AuthPlaneAuthProvider
+
+        auth = AuthPlaneAuthProvider(
+            server_url="https://auth.example.com",
+            base_url="https://my-mcp-server.example.com",
+        )
+
+        mcp = FastMCP("My App", auth=auth)
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        server_url: AnyHttpUrl | str,
+        base_url: AnyHttpUrl | str,
+        required_scopes: list[str] | str | None = None,
+        audience: str | list[str] | None = None,
+        token_verifier: TokenVerifier | None = None,
+    ):
+        """Initialize the AuthPlane auth provider.
+
+        Args:
+            server_url: AuthPlane server URL (e.g., "https://auth.example.com")
+            base_url: Public URL of this FastMCP server
+            required_scopes: Scopes to require on incoming tokens. Defaults to
+                ["openid"], which ensures the `sub` claim (user identifier) is
+                present in the access token. Override to require additional scopes.
+            audience: Optional audience(s) for JWT validation. Recommended for production.
+            token_verifier: Optional custom token verifier. Defaults to a JWTVerifier
+                configured for AuthPlane's JWKS endpoint and issuer.
+        """
+        self.server_url = str(server_url).rstrip("/")
+        parsed_scopes = (
+            parse_scopes(required_scopes) if required_scopes is not None else ["openid"]
+        )
+
+        if token_verifier is None:
+            # AuthPlane follows standard OAuth 2.1, JWKS at /.well-known/jwks.json
+            token_verifier = JWTVerifier(
+                jwks_uri=f"{self.server_url}/.well-known/jwks.json",
+                issuer=self.server_url,
+                algorithm="RS256",
+                required_scopes=parsed_scopes,
+                audience=audience,
+            )
+
+        super().__init__(
+            token_verifier=token_verifier,
+            authorization_servers=[AnyHttpUrl(self.server_url)],
+            base_url=AnyHttpUrl(str(base_url).rstrip("/")),
+        )

--- a/tests/server/auth/providers/test_authplane.py
+++ b/tests/server/auth/providers/test_authplane.py
@@ -1,0 +1,20 @@
+import pytest
+
+from fastmcp.server.auth.providers.authplane import AuthPlaneAuthProvider
+
+
+def test_authplane_basic_init():
+    auth = AuthPlaneAuthProvider(
+        server_url="https://auth.example.com",
+        base_url="http://localhost:8000",
+    )
+    assert auth is not None
+
+
+def test_authplane_jwks_uri():
+    auth = AuthPlaneAuthProvider(
+        server_url="https://auth.example.com/",
+        base_url="http://localhost:8000",
+    )
+    verifier = auth.token_verifier
+    assert verifier.jwks_uri == "https://auth.example.com/.well-known/jwks.json"


### PR DESCRIPTION
- Implements AuthPlaneAuthProvider as a RemoteAuthProvider wrapper
- uses JWTVerifier with standard OAuth 2.1 JWKS endpoint
- follows the same pattern as KeycloakAuthProvider
- includes basic tests for instantiation and JWKS URI construction

#4667
## Summary
This PR adds an `AuthPlaneAuthProvider` to FastMCP's built-in authentication providers, as requested in #4667.

## Changes
- Added `AuthPlaneAuthProvider` class in `fastmcp_slim/fastmcp/server/auth/providers/authplane.py`
- Implemented as a `RemoteAuthProvider` wrapper using `JWTVerifier`
- Follows the same pattern as `KeycloakAuthProvider` (#1937)
- Uses standard OAuth 2.1 JWKS endpoint at `/.well-known/jwks.json`
- Added basic tests for provider instantiation and JWKS URI construction
- No new dependencies required

## Example Usage
```python
from fastmcp import FastMCP
from fastmcp.server.auth.providers.authplane import AuthPlaneAuthProvider

auth = AuthPlaneAuthProvider(
    server_url="https://auth.example.com",
    base_url="https://my-mcp-server.example.com",
    required_scopes=["mcp:access"],
)

mcp = FastMCP("My Protected Server", auth=auth)
```

## Related
- Closes #4667
- AuthPlane: https://github.com/AuthPlane/authserver
- AuthPlane FastMCP adapter: https://github.com/AuthPlane/python-sdk/tree/main/authplane-fastmcp

## Testing
- Unit tests pass: `pytest tests/server/auth/providers/test_authplane.py`
- Follows the same pattern as existing providers (Keycloak, WorkOS, etc.)