### PR TITLE
fix(cli): preserve valid MCP servers during discovery

### DIFF
--- a/fastmcp_slim/fastmcp/cli/discovery.py
+++ b/fastmcp_slim/fastmcp/cli/discovery.py
@@ -97,24 +97,29 @@ def _parse_mcp_servers(
     if not servers_dict:
         return []
 
-    normalized = {
-        name: _normalize_server_entry(entry)
-        for name, entry in servers_dict.items()
-        if isinstance(entry, dict)
-    }
+    discovered: list[DiscoveredServer] = []
+    for name, entry in servers_dict.items():
+        if not isinstance(entry, dict):
+            continue
 
-    try:
-        config = MCPConfig.from_dict({"mcpServers": normalized})
-    except Exception as exc:
-        logger.warning("Could not parse MCP servers from %s: %s", config_path, exc)
-        return []
+        normalized = _normalize_server_entry(entry)
+        try:
+            config = MCPConfig.from_dict({"mcpServers": {name: normalized}})
+        except Exception as exc:
+            logger.warning(
+                "Could not parse MCP server %r from %s: %s", name, config_path, exc
+            )
+            continue
 
-    return [
-        DiscoveredServer(
-            name=name, source=source, config=server, config_path=config_path
-        )
-        for name, server in config.mcpServers.items()
-    ]
+        server = config.mcpServers.get(name)
+        if server is not None:
+            discovered.append(
+                DiscoveredServer(
+                    name=name, source=source, config=server, config_path=config_path
+                )
+            )
+
+    return discovered
 
 
 def _parse_mcp_config(path: Path, source: str) -> list[DiscoveredServer]:

--- a/tests/cli/test_discovery.py
+++ b/tests/cli/test_discovery.py
@@ -117,6 +117,22 @@ class TestParseMcpConfig:
         assert all(s.source == "test-source" for s in servers)
         assert all(s.config_path == path for s in servers)
 
+    def test_invalid_server_does_not_hide_valid_servers(self, tmp_path: Path):
+        path = tmp_path / "config.json"
+        _write_config(
+            path,
+            {
+                "mcpServers": {
+                    "working": {"command": "python", "args": ["server.py"]},
+                    "broken": {"args": ["missing-command.py"]},
+                }
+            },
+        )
+
+        servers = _parse_mcp_config(path, "project")
+
+        assert [server.name for server in servers] == ["working"]
+
     def test_missing_file(self, tmp_path: Path):
         path = tmp_path / "nonexistent.json"
         servers = _parse_mcp_config(path, "test")


### PR DESCRIPTION
When CLI discovery parsed the full mcpServers mapping at once, one malformed entry caused every valid server to be dropped. This change parses each entry independently, preserving valid servers while logging and skipping malformed entries. The regression test covers a config with one valid command server and one malformed entry.

Validation: `compileall`, Ruff lint, Ruff format, and `git diff --check` pass. The focused pytest command could not collect in this checkout because `mcp_types` is not installed.

🤖 Generated with Claude Code
