### PR TITLE
fix(auth): forward CIMD setting to OIDC providers

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
@@ -104,6 +104,7 @@ class Auth0Provider(OIDCProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        enable_cimd: bool = True,
     ) -> None:
         """Initialize Auth0 OAuth provider.
 
@@ -148,6 +149,8 @@ class Auth0Provider(OIDCProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            enable_cimd: Whether to enable CIMD (Client ID Metadata Document) client support.
+                Defaults to True.
         """
         # Parse scopes if provided as string
         auth0_required_scopes = (
@@ -174,6 +177,7 @@ class Auth0Provider(OIDCProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            enable_cimd=enable_cimd,
         )
 
         logger.debug(

--- a/fastmcp_slim/fastmcp/server/auth/providers/aws.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/aws.py
@@ -144,6 +144,7 @@ class AWSCognitoProvider(OIDCProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        enable_cimd: bool = True,
     ):
         """Initialize AWS Cognito OAuth provider.
 
@@ -188,6 +189,8 @@ class AWSCognitoProvider(OIDCProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            enable_cimd: Whether to enable CIMD (Client ID Metadata Document) client support.
+                Defaults to True.
         """
         # Parse scopes if provided as string
         required_scopes_final = (
@@ -223,6 +226,7 @@ class AWSCognitoProvider(OIDCProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            enable_cimd=enable_cimd,
         )
 
         logger.debug(

--- a/fastmcp_slim/fastmcp/server/auth/providers/oci.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/oci.py
@@ -141,6 +141,7 @@ class OCIProvider(OIDCProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        enable_cimd: bool = True,
     ) -> None:
         """Initialize OCI OIDC provider.
 
@@ -174,6 +175,8 @@ class OCIProvider(OIDCProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            enable_cimd: Whether to enable CIMD (Client ID Metadata Document) client support.
+                Defaults to True.
         """
         # Parse scopes if provided as string
         oci_required_scopes = (
@@ -200,6 +203,7 @@ class OCIProvider(OIDCProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            enable_cimd=enable_cimd,
         )
 
         logger.debug(

--- a/tests/server/auth/providers/test_auth0.py
+++ b/tests/server/auth/providers/test_auth0.py
@@ -34,6 +34,27 @@ def valid_oidc_configuration_dict():
 class TestAuth0Provider:
     """Test Auth0Provider initialization."""
 
+    def test_cimd_can_be_disabled(self, valid_oidc_configuration_dict):
+        """The provider forwards the CIMD opt-out to OIDCProxy."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            mock_get.return_value = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+
+            provider = Auth0Provider(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                audience=TEST_AUDIENCE,
+                base_url=TEST_BASE_URL,
+                jwt_signing_key="test-secret",
+                enable_cimd=False,
+            )
+
+            assert provider._cimd_manager is None
+
     def test_init_with_explicit_params(self, valid_oidc_configuration_dict):
         """Test initialization with explicit parameters."""
         with patch(
@@ -97,3 +118,4 @@ class TestAuth0Provider:
             assert str(provider.base_url) == TEST_BASE_URL
             assert provider._redirect_path == "/auth/callback"
             assert provider._token_validator.required_scopes == ["openid"]
+            assert provider._cimd_manager is not None

--- a/tests/server/auth/providers/test_aws.py
+++ b/tests/server/auth/providers/test_aws.py
@@ -37,6 +37,20 @@ def mock_cognito_oidc_discovery():
 class TestAWSCognitoProvider:
     """Test AWSCognitoProvider initialization."""
 
+    def test_cimd_can_be_disabled(self):
+        """The provider forwards the CIMD opt-out to OIDCProxy."""
+        with mock_cognito_oidc_discovery():
+            provider = AWSCognitoProvider(
+                user_pool_id="us-east-1_XXXXXXXXX",
+                client_id="test_client",
+                client_secret="test_secret",
+                base_url="https://example.com",
+                jwt_signing_key="test-secret",
+                enable_cimd=False,
+            )
+
+            assert provider._cimd_manager is None
+
     def test_init_with_explicit_params(self):
         """Test initialization with explicit parameters."""
         with mock_cognito_oidc_discovery():
@@ -85,6 +99,7 @@ class TestAWSCognitoProvider:
             assert provider._redirect_path == "/auth/callback"
             assert provider._token_validator.required_scopes == ["openid"]
             assert provider.aws_region == "eu-central-1"
+            assert provider._cimd_manager is not None
 
     def test_oidc_discovery_integration(self):
         """Test that OIDC discovery endpoints are used correctly."""

--- a/tests/server/auth/providers/test_oci.py
+++ b/tests/server/auth/providers/test_oci.py
@@ -36,6 +36,28 @@ def valid_oidc_configuration_dict():
 class TestOCIProvider:
     """Test OCIProvider initialization."""
 
+    def test_cimd_can_be_disabled(self, valid_oidc_configuration_dict):
+        """The provider forwards the CIMD opt-out to OIDCProxy."""
+        with patch(
+            "fastmcp.server.auth.oidc_proxy.OIDCConfiguration.get_oidc_configuration"
+        ) as mock_get:
+            mock_get.return_value = OIDCConfiguration.model_validate(
+                valid_oidc_configuration_dict
+            )
+
+            provider = OCIProvider(
+                config_url=TEST_CONFIG_URL,
+                client_id=TEST_CLIENT_ID,
+                client_secret=TEST_CLIENT_SECRET,
+                audience=TEST_AUDIENCE,
+                base_url=TEST_BASE_URL,
+                client_storage=MemoryStore(),
+                jwt_signing_key="test-secret-key",
+                enable_cimd=False,
+            )
+
+            assert provider._cimd_manager is None
+
     def test_init_with_explicit_params(self, valid_oidc_configuration_dict):
         """Test initialization with explicit parameters."""
         with patch(
@@ -85,3 +107,4 @@ class TestOCIProvider:
             assert str(provider.base_url) == TEST_BASE_URL
             assert provider._redirect_path == TEST_REDIRECT_PATH
             assert provider._token_validator.required_scopes == TEST_REQUIRED_SCOPES
+            assert provider._cimd_manager is not None


### PR DESCRIPTION
Auth0Provider, AWSCognitoProvider, and OCIProvider now expose the existing OIDCProxy `enable_cimd` option and forward it to the base class. The default remains enabled, while callers can pass `enable_cimd=False` to disable CIMD for providers that do not want client metadata document support. Provider-level regression tests cover both the opt-out and the unchanged default.

Validation: `compileall`, Ruff lint, Ruff format, and `git diff --check` pass. The focused pytest command could not collect in this checkout because `mcp_types` is not installed.

🤖 Generated with Claude Code
