### PR TITLE
Fix prompt string coercion for annotated and optional str

### DIFF
--- a/fastmcp_slim/fastmcp/prompts/function_prompt.py
+++ b/fastmcp_slim/fastmcp/prompts/function_prompt.py
@@ -32,7 +32,7 @@ from fastmcp.utilities.authorization import AuthCheck
 from fastmcp.utilities.docstring_parsing import ParsedDocstring, parse_docstring
 from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.logging import get_logger
-from fastmcp.utilities.types import get_cached_typeadapter
+from fastmcp.utilities.types import get_cached_typeadapter, is_class_member_of_type
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -263,10 +263,10 @@ class FunctionPrompt(Prompt):
             if param_name in sig.parameters:
                 param = sig.parameters[param_name]
 
-                # If parameter has no annotation or annotation is str, pass as-is
+                # If parameter has no annotation or resolves to str, pass as-is
                 if (
                     param.annotation == inspect.Parameter.empty
-                    or param.annotation is str
+                    or is_class_member_of_type(param.annotation, str)
                 ) or not isinstance(param_value, str):
                     converted_kwargs[param_name] = param_value
                 else:

--- a/tests/prompts/test_prompt.py
+++ b/tests/prompts/test_prompt.py
@@ -313,6 +313,41 @@ class TestPromptTypeConversion:
 
         assert result.messages == [Message("Hello world (repeated 3 times)")]
 
+    async def test_annotated_str_not_json_coerced(self):
+        """Test that Annotated[str] params pass strings through without JSON coercion."""
+        from typing import Annotated
+
+        from pydantic import Field
+
+        def annotated_str_prompt(
+            value: Annotated[str, Field(description="A string")],
+        ) -> str:
+            return f"value={value}"
+
+        prompt = Prompt.from_function(annotated_str_prompt)
+        result = await prompt.render(arguments={"value": '"hello"'})
+        assert result.messages == [Message('value="hello"')]
+
+    async def test_optional_str_not_json_coerced(self):
+        """Test that Optional[str] params pass strings through without JSON coercion."""
+
+        def optional_str_prompt(value: str | None = None) -> str:
+            return f"value={value}"
+
+        prompt = Prompt.from_function(optional_str_prompt)
+        result = await prompt.render(arguments={"value": "null"})
+        assert result.messages == [Message("value=null")]
+
+    async def test_union_str_none_not_json_coerced(self):
+        """Test that str | None params pass strings through without JSON coercion."""
+
+        def union_str_prompt(value: str | None = None) -> str:
+            return f"value={value}"
+
+        prompt = Prompt.from_function(union_str_prompt)
+        result = await prompt.render(arguments={"value": "null"})
+        assert result.messages == [Message("value=null")]
+
 
 class TestPromptArgumentDescriptions:
     def test_enhanced_descriptions_for_non_string_types(self):


### PR DESCRIPTION
## Description

`_convert_string_arguments` uses `is str` to decide whether to skip JSON coercion. This misses `Annotated[str, ...]`, `Optional[str]`, and `str | None`. The guard falls through to `validate_json`, which parses strings like `'"hello"'` → `hello` and `"null"` → `None`.

Replace the identity check with `is_class_member_of_type`, which already exists in `utilities/types` and correctly unwraps `Annotated`, `Union`, and `UnionType`.

`Any` parameters are left unchanged, they continue to pass through as before.

Closes #4724

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)