### PR TITLE
Make response cache keys insensitive to argument order

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/caching.py
+++ b/fastmcp_slim/fastmcp/server/middleware/caching.py
@@ -1,6 +1,7 @@
 """A middleware for response caching."""
 
 import hashlib
+import json
 from collections.abc import Sequence
 from logging import Logger
 from typing import Any, TypedDict
@@ -593,13 +594,23 @@ class ResponseCachingMiddleware(Middleware):
 
 
 def _get_arguments_str(arguments: dict[str, Any] | None) -> str:
-    """Get a string representation of the arguments."""
+    """Get a canonical string representation of the arguments.
+
+    Keys are sorted at every level so that arguments that differ only in the order the
+    client sent them produce the same string, and therefore the same cache key. JSON
+    object member order carries no meaning, and arguments are frequently model-generated,
+    so the same logical call can arrive with its keys in any order.
+    """
 
     if arguments is None:
         return "null"
 
     try:
-        return pydantic_core.to_json(value=arguments, fallback=str).decode()
+        return json.dumps(
+            pydantic_core.to_jsonable_python(arguments, fallback=str),
+            sort_keys=True,
+            default=str,
+        )
 
     except TypeError:
         return repr(arguments)

--- a/tests/server/middleware/test_caching.py
+++ b/tests/server/middleware/test_caching.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import warnings
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import mcp_types
@@ -284,6 +285,56 @@ class TestResponseCachingMiddleware:
         )
         assert middleware1._matches_tool_cache_settings(tool_name=tool_name) is result
 
+    @pytest.mark.parametrize(
+        ("first", "second"),
+        [
+            ({"a": 5, "b": 3}, {"b": 3, "a": 5}),
+            ({"q": {"x": 1, "y": 2}}, {"q": {"y": 2, "x": 1}}),
+            ({"l": [{"x": 1, "y": 2}]}, {"l": [{"y": 2, "x": 1}]}),
+        ],
+        ids=["top level", "nested dict", "dict inside a list"],
+    )
+    def test_cache_keys_ignore_argument_order(
+        self, first: dict[str, Any], second: dict[str, Any]
+    ):
+        """Arguments that differ only in key order share a cache key.
+
+        JSON object member order carries no meaning and arguments are often
+        model-generated, so the same logical call can arrive in any order. Nesting is
+        covered too: normalizing only the top level would still miss.
+        """
+        assert first == second
+
+        assert _make_call_tool_cache_key(
+            mcp_types.CallToolRequestParams(name="tool", arguments=first)
+        ) == _make_call_tool_cache_key(
+            mcp_types.CallToolRequestParams(name="tool", arguments=second)
+        )
+
+    def test_get_prompt_cache_key_ignores_argument_order(self):
+        """`prompts/get` shares the same key builder helper, so it behaves the same.
+
+        Prompt arguments are string-valued, hence the separate case.
+        """
+        assert _make_get_prompt_cache_key(
+            mcp_types.GetPromptRequestParams(
+                name="prompt", arguments={"a": "5", "b": "3"}
+            )
+        ) == _make_get_prompt_cache_key(
+            mcp_types.GetPromptRequestParams(
+                name="prompt", arguments={"b": "3", "a": "5"}
+            )
+        )
+
+    def test_cache_keys_still_distinguish_different_arguments(self):
+        """Order-insensitivity must not collapse genuinely different arguments."""
+        swapped_values = _make_call_tool_cache_key(
+            mcp_types.CallToolRequestParams(name="tool", arguments={"a": 5, "b": 3})
+        ) != _make_call_tool_cache_key(
+            mcp_types.CallToolRequestParams(name="tool", arguments={"a": 3, "b": 5})
+        )
+        assert swapped_values
+
 
 @pytest.mark.skipif(
     sys.platform == "win32",
@@ -423,6 +474,24 @@ class TestResponseCachingMiddlewareIntegration:
                 "add", {"a": 5, "b": 3}
             )
             assert call_tool_result_one == call_tool_result_two
+
+    async def test_call_tool_with_reordered_arguments_hits_the_cache(
+        self,
+        caching_server: FastMCP,
+        tracking_calculator: TrackingCalculator,
+    ):
+        """The same arguments sent in a different key order are one cache entry."""
+        tracking_calculator.add_tools(fastmcp=caching_server)
+
+        async with Client[FastMCPTransport](transport=caching_server) as client:
+            first: CallToolResult = await client.call_tool("add", {"a": 5, "b": 3})
+            assert tracking_calculator.add_calls == 1
+
+            second: CallToolResult = await client.call_tool("add", {"b": 3, "a": 5})
+            assert tracking_calculator.add_calls == 1, (
+                "reordered arguments re-executed the tool instead of hitting the cache"
+            )
+            assert first == second
 
     async def test_call_tool_very_large_value(
         self,


### PR DESCRIPTION
Fixes #4735

`_get_arguments_str` serialized arguments with `pydantic_core.to_json`, which preserves dict insertion order. Both `_make_call_tool_cache_key` and `_make_get_prompt_cache_key` hash that string, so `{"a": 5, "b": 3}` and `{"b": 3, "a": 5}` produced different keys and the tool ran twice. `resources/read` is keyed on the URI and was unaffected.

The fix sorts keys while serializing, in the one helper both key builders share, so the two call sites stay identical by construction:

```python
return json.dumps(
    pydantic_core.to_jsonable_python(arguments, fallback=str),
    sort_keys=True,
    default=str,
)
```

`to_jsonable_python` keeps the existing `fallback=str` coercion of non-JSON values, and the `except TypeError: return repr(arguments)` guard is unchanged.

Sorting is recursive rather than top-level-only: normalizing just the outer mapping would still miss on `{"q": {"x": 1, "y": 2}}` vs `{"q": {"y": 2, "x": 1}}`, and on dicts nested inside lists. All three are covered by parametrized cases.

### Tests

`test_cache_keys_ignore_argument_order` (3 cases: top level, nested dict, dict inside a list) and `test_get_prompt_cache_key_ignores_argument_order` fail on `main` and pass here. `prompts/get` is a separate case because its arguments are string-valued.

`test_cache_keys_still_distinguish_different_arguments` guards the other direction — `{"a": 5, "b": 3}` and `{"a": 3, "b": 5}` must stay distinct — and passes both before and after, so it isn't load-bearing on the change.

`test_call_tool_with_reordered_arguments_hits_the_cache` covers it end to end through a real server, asserting the tool executed once.

`tests/server` is green (3267 passed) apart from one pre-existing environment failure unrelated to this change (`test_manifest_ignores_symlink_target_outside_skill`, `WinError 1314` — no symlink privilege — fails identically on `022547a`). `ruff check`, `ruff format --check`, and `ty check` are clean.

Note: the integration test lands in `TestResponseCachingMiddlewareIntegration`, which is skipped on win32, so I verified it locally by temporarily disabling that skip (passes for both the `memory` and `filetree` fixture params) before restoring the decorator.
