### PR TITLE
Declare run-claude extra allowed tools input

### DIFF
--- a/.github/actions/run-claude/action.yml
+++ b/.github/actions/run-claude/action.yml
@@ -37,6 +37,11 @@ inputs:
     required: false
     default: ""
 
+  extra-allowed-tools:
+    description: "Additional comma-separated tools to append to allowed-tools"
+    required: false
+    default: ""
+
   model:
     description: "Model to use for Claude"
     required: false


### PR DESCRIPTION
The shared `run-claude` action already reads `extra-allowed-tools` when composing `--allowedTools`, but the input is not declared. GitHub therefore rejects it as unexpected and silently drops the additional tools.

Declare the optional input with an empty default so the existing composition logic works without changing current callers. This is the bottom layer of the workflow-hardening stack tracked in #4570.
