### PR TITLE
Quote run-claude allowed tools argument

### DIFF
--- a/.github/actions/run-claude/action.yml
+++ b/.github/actions/run-claude/action.yml
@@ -93,7 +93,7 @@ runs:
         track_progress: ${{ inputs.track-progress }}
         prompt: ${{ inputs.prompt }}
         claude_args: |
-          ${{ (inputs.allowed-tools != '' || inputs.extra-allowed-tools != '') && format('--allowedTools {0}{1}', inputs.allowed-tools, inputs.extra-allowed-tools != '' && format(',{0}', inputs.extra-allowed-tools) || '') || '' }}
+          ${{ (inputs.allowed-tools != '' || inputs.extra-allowed-tools != '') && format('--allowedTools ''{0}{1}''', inputs.allowed-tools, inputs.extra-allowed-tools != '' && format(',{0}', inputs.extra-allowed-tools) || '') || '' }}
           ${{ inputs.mcp-servers != '' && format('--mcp-config ''{0}''', inputs.mcp-servers) || '' }}
           --model ${{ inputs.model }}
         settings: |


### PR DESCRIPTION
The shared action passes its composed allowlist through `claude_args`, which is parsed with shell quoting. Without quoting the value, a pattern such as `Bash(npm test)` is split and no longer reaches Claude's permission matcher intact.

Quote the complete comma-separated allowlist as one argument. This is the second layer of the #4570 workflow-hardening stack and builds on #4740's declared extension input.
