### PR TITLE
fix: cache empty component lists

### DIFF
--- a/fastmcp_slim/fastmcp/server/middleware/caching.py
+++ b/fastmcp_slim/fastmcp/server/middleware/caching.py
@@ -354,7 +354,8 @@ class ResponseCachingMiddleware(Middleware):
 
         cache_key: str = _get_auth_partition_key()
 
-        if cached_value := await self._list_tools_cache.get(key=cache_key):
+        cached_value = await self._list_tools_cache.get(key=cache_key)
+        if cached_value is not None:
             return cached_value
 
         tools: Sequence[Tool] = await call_next(context)
@@ -383,7 +384,8 @@ class ResponseCachingMiddleware(Middleware):
 
         cache_key: str = _get_auth_partition_key()
 
-        if cached_value := await self._list_resources_cache.get(key=cache_key):
+        cached_value = await self._list_resources_cache.get(key=cache_key)
+        if cached_value is not None:
             return cached_value
 
         resources: Sequence[Resource] = await call_next(context)
@@ -414,7 +416,8 @@ class ResponseCachingMiddleware(Middleware):
 
         cache_key: str = _get_auth_partition_key()
 
-        if cached_value := await self._list_prompts_cache.get(key=cache_key):
+        cached_value = await self._list_prompts_cache.get(key=cache_key)
+        if cached_value is not None:
             return cached_value
 
         prompts: Sequence[Prompt] = await call_next(context)

--- a/tests/server/middleware/test_caching.py
+++ b/tests/server/middleware/test_caching.py
@@ -249,6 +249,36 @@ class TestResponseCachingMiddleware:
             ),
         )
 
+    async def test_empty_tool_list_is_cached(self):
+        middleware = ResponseCachingMiddleware()
+        context = MagicMock()
+        call_next = AsyncMock(return_value=[])
+
+        assert await middleware.on_list_tools(context, call_next) == []
+        assert await middleware.on_list_tools(context, call_next) == []
+
+        call_next.assert_awaited_once()
+
+    async def test_empty_resource_list_is_cached(self):
+        middleware = ResponseCachingMiddleware()
+        context = MagicMock()
+        call_next = AsyncMock(return_value=[])
+
+        assert await middleware.on_list_resources(context, call_next) == []
+        assert await middleware.on_list_resources(context, call_next) == []
+
+        call_next.assert_awaited_once()
+
+    async def test_empty_prompt_list_is_cached(self):
+        middleware = ResponseCachingMiddleware()
+        context = MagicMock()
+        call_next = AsyncMock(return_value=[])
+
+        assert await middleware.on_list_prompts(context, call_next) == []
+        assert await middleware.on_list_prompts(context, call_next) == []
+
+        call_next.assert_awaited_once()
+
     @pytest.mark.parametrize(
         ("tool_name", "included_tools", "excluded_tools", "result"),
         [


### PR DESCRIPTION
Empty tools, resources, and prompts list responses were stored but then treated as cache misses because retrieval used list truthiness. This made empty or fully filtered servers recompute every list request.

This change treats only `None` as a cache miss and adds focused regressions for all three list methods. Fixes #4733.

Assisted-by: GPT-5 Codex
