### PR TITLE
Serialize_by_alias=False ignored for nested Pydantic models

### DIFF
--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -83,6 +83,19 @@ def resolve_serialize_by_alias(value: Any) -> bool:
     return True if configured is None else configured
 
 
+def _dump_nested_models(value: Any, fallback: Callable[[Any], Any] | None) -> Any:
+    """Serialize models found in *value*, each with its own alias setting."""
+    if isinstance(value, dict):
+        return {key: _dump_nested_models(item, fallback) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_dump_nested_models(item, fallback) for item in value]
+    if isinstance(value, BaseModel):
+        return pydantic_core.to_jsonable_python(
+            value, by_alias=resolve_serialize_by_alias(value), fallback=fallback
+        )
+    return value
+
+
 def to_jsonable_by_alias(
     value: Any, *, fallback: Callable[[Any], Any] | None = None
 ) -> Any:
@@ -90,18 +103,11 @@ def to_jsonable_by_alias(
 
     ``by_alias`` applies to an entire payload, so a model nested in a dict or
     list would be serialized with the container's setting rather than its own
-    ``serialize_by_alias`` config. Recursing through plain containers lets every
-    model resolve its own setting.
+    ``serialize_by_alias`` config. Dumping those models first lets each one
+    resolve its own setting.
     """
-    if isinstance(value, dict):
-        return {
-            key: to_jsonable_by_alias(item, fallback=fallback)
-            for key, item in value.items()
-        }
-    if isinstance(value, list | tuple):
-        return [to_jsonable_by_alias(item, fallback=fallback) for item in value]
     return pydantic_core.to_jsonable_python(
-        value, by_alias=resolve_serialize_by_alias(value), fallback=fallback
+        _dump_nested_models(value, fallback), fallback=fallback
     )
 
 

--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -83,9 +83,31 @@ def resolve_serialize_by_alias(value: Any) -> bool:
     return True if configured is None else configured
 
 
+def to_jsonable_by_alias(
+    value: Any, *, fallback: Callable[[Any], Any] | None = None
+) -> Any:
+    """Convert *value* to JSON-compatible types, honoring alias configuration.
+
+    ``by_alias`` applies to an entire payload, so a model nested in a dict or
+    list would be serialized with the container's setting rather than its own
+    ``serialize_by_alias`` config. Recursing through plain containers lets every
+    model resolve its own setting.
+    """
+    if isinstance(value, dict):
+        return {
+            key: to_jsonable_by_alias(item, fallback=fallback)
+            for key, item in value.items()
+        }
+    if isinstance(value, list | tuple):
+        return [to_jsonable_by_alias(item, fallback=fallback) for item in value]
+    return pydantic_core.to_jsonable_python(
+        value, by_alias=resolve_serialize_by_alias(value), fallback=fallback
+    )
+
+
 def default_serializer(data: Any) -> str:
     return pydantic_core.to_json(
-        data, fallback=str, by_alias=resolve_serialize_by_alias(data)
+        to_jsonable_by_alias(data, fallback=str), fallback=str
     ).decode()
 
 
@@ -133,10 +155,7 @@ class ToolResult(BaseModel):
                 )
 
             try:
-                structured_content = pydantic_core.to_jsonable_python(
-                    value=structured_content,
-                    by_alias=resolve_serialize_by_alias(structured_content),
-                )
+                structured_content = to_jsonable_by_alias(structured_content)
             except pydantic_core.PydanticSerializationError as e:
                 logger.error(
                     f"Could not serialize structured content. If this is unexpected, set your tool's output_schema to None to disable automatic serialization: {e}"
@@ -404,9 +423,7 @@ class Tool(FastMCPComponent):
             return ToolResult(content=content)
 
         try:
-            structured = pydantic_core.to_jsonable_python(
-                raw_value, by_alias=resolve_serialize_by_alias(raw_value)
-            )
+            structured = to_jsonable_by_alias(raw_value)
         except (pydantic_core.PydanticSerializationError, UnicodeDecodeError):
             return ToolResult(content=content)
 

--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -84,10 +84,15 @@ def resolve_serialize_by_alias(value: Any) -> bool:
 
 
 def _dump_nested_models(value: Any, fallback: Callable[[Any], Any] | None) -> Any:
-    """Serialize models found in *value*, each with its own alias setting."""
+    """Serialize models found in *value*, each with its own alias setting.
+
+    Recurses through the same containers ``_resolve_output_by_alias`` unwraps.
+    If the two disagree, the output schema describes one alias mode while the
+    result emits the other and clients reject the structured content.
+    """
     if isinstance(value, dict):
         return {key: _dump_nested_models(item, fallback) for key, item in value.items()}
-    if isinstance(value, list | tuple):
+    if isinstance(value, list | tuple | set | frozenset):
         return [_dump_nested_models(item, fallback) for item in value]
     if isinstance(value, BaseModel):
         return pydantic_core.to_jsonable_python(
@@ -101,8 +106,8 @@ def to_jsonable_by_alias(
 ) -> Any:
     """Convert *value* to JSON-compatible types, honoring alias configuration.
 
-    ``by_alias`` applies to an entire payload, so a model nested in a dict or
-    list would be serialized with the container's setting rather than its own
+    ``by_alias`` applies to an entire payload, so a model nested in a container
+    would be serialized with the container's setting rather than its own
     ``serialize_by_alias`` config. Dumping those models first lets each one
     resolve its own setting.
     """

--- a/fastmcp_slim/fastmcp/tools/function_parsing.py
+++ b/fastmcp_slim/fastmcp/tools/function_parsing.py
@@ -147,7 +147,13 @@ def _strip_input_required(tp: Any) -> Any:
 
 
 def _unwrap_model(tp: Any) -> type[BaseModel] | None:
-    """Unwrap ``Annotated``, unions and containers to find a Pydantic model."""
+    """Unwrap ``Annotated``, unions and containers to find a Pydantic model.
+
+    Only the annotated type of an ``Annotated`` is searched, so metadata that
+    happens to be a model class is not mistaken for the returned value.
+    """
+    if get_origin(tp) is Annotated:
+        return _unwrap_model(get_args(tp)[0])
     if args := get_args(tp):
         for arg in args:
             model = _unwrap_model(arg)

--- a/fastmcp_slim/fastmcp/tools/function_parsing.py
+++ b/fastmcp_slim/fastmcp/tools/function_parsing.py
@@ -147,9 +147,13 @@ def _strip_input_required(tp: Any) -> Any:
 
 
 def _unwrap_model(tp: Any) -> type[BaseModel] | None:
-    """Unwrap ``Annotated`` and return the underlying Pydantic model, if any."""
-    if get_origin(tp) is Annotated:
-        return _unwrap_model(get_args(tp)[0])
+    """Unwrap ``Annotated``, unions and containers to find a Pydantic model."""
+    if args := get_args(tp):
+        for arg in args:
+            model = _unwrap_model(arg)
+            if model is not None:
+                return model
+        return None
     if isinstance(tp, type) and issubclass(tp, BaseModel):
         return tp
     return None
@@ -158,39 +162,23 @@ def _unwrap_model(tp: Any) -> type[BaseModel] | None:
 def _resolve_output_by_alias(tp: Any) -> bool:
     """Resolve ``by_alias`` for the output schema of return type *tp*.
 
-    Unwraps ``Annotated`` and ``Optional``/``Union`` wrappers to find the
-    underlying Pydantic model so the generated schema honors the model's
+    Unwraps ``Annotated``, ``Optional``/``Union`` and container wrappers to find
+    the underlying Pydantic model so the generated schema honors the model's
     ``serialize_by_alias`` config — keeping it consistent with how the runtime
-    result is serialized. Containers (``list[Model]`` etc.) are not unwrapped:
-    their schema keeps the default, matching the runtime path which only
-    special-cases a directly-returned model.
+    result is serialized.
 
     Known limitation: a single schema is generated with one ``by_alias`` value,
-    while the runtime resolves the alias mode per returned value. They cannot
-    diverge for a plain single-model return, but a union return can produce more
-    than one runtime alias mode that no single schema can describe:
+    while the runtime resolves the alias mode per serialized model. Distinct
+    models with *conflicting* ``serialize_by_alias`` (e.g. ``A | B`` where ``A``
+    opts out but ``B`` opts in) produce more than one runtime alias mode that no
+    single schema can describe.
 
-    - distinct models with *conflicting* ``serialize_by_alias`` (e.g. ``A | B``
-      where ``A`` opts out but ``B`` opts in), and
-    - a model arm alongside a container arm (e.g. ``Model | list[Model]``):
-      a directly-returned model honors its config, but a returned ``list`` is
-      serialized with the default alias mode, so the two variants disagree.
-
-    Pydantic's schema generator does not consult per-model ``serialize_by_alias``
-    and the runtime does not recurse into containers, so honoring every variant
-    would require per-arm schema assembly. This is an accepted edge; single-model
-    returns and unions whose arms all resolve to the same mode are consistent.
+    Pydantic's schema generator does not consult per-model ``serialize_by_alias``,
+    so honoring every variant would require per-arm schema assembly. This is an
+    accepted edge; returns whose models all resolve to the same mode agree.
     """
-    origin = get_origin(tp)
-    if origin is Annotated:
-        return _resolve_output_by_alias(get_args(tp)[0])
-    if origin is Union or origin is types.UnionType:
-        for arg in get_args(tp):
-            model = _unwrap_model(arg)
-            if model is not None:
-                return resolve_serialize_by_alias(model)
-        return True
-    return resolve_serialize_by_alias(tp)
+    model = _unwrap_model(tp)
+    return True if model is None else resolve_serialize_by_alias(model)
 
 
 T = TypeVarExt("T", default=Any)

--- a/fastmcp_slim/fastmcp/tools/tool_transform.py
+++ b/fastmcp_slim/fastmcp/tools/tool_transform.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Literal, cast
 
 import mcp_types
-import pydantic_core
 from mcp_types import ToolAnnotations
 from pydantic import ConfigDict
 from pydantic.fields import Field
@@ -20,7 +19,7 @@ from fastmcp.tools.base import (
     Tool,
     ToolResult,
     _convert_to_content,
-    resolve_serialize_by_alias,
+    to_jsonable_by_alias,
 )
 from fastmcp.tools.function_parsing import ParsedFunction
 from fastmcp.utilities.async_utils import (
@@ -405,20 +404,14 @@ class TransformedTool(Tool):
                     # Schema says wrap - serialize the inner result first (so its
                     # serialize_by_alias config is honored) before nesting, since
                     # wrapping in a dict would otherwise mask the model's config.
-                    structured_output = {
-                        "result": pydantic_core.to_jsonable_python(
-                            result, by_alias=resolve_serialize_by_alias(result)
-                        )
-                    }
+                    structured_output = {"result": to_jsonable_by_alias(result)}
                 else:
                     structured_output = result
             # If no output schema, try to serialize the result. If it is a dict, use
             # it as structured content. If it is not a dict, ignore it.
             if structured_output is None:
                 try:
-                    structured_output = pydantic_core.to_jsonable_python(
-                        result, by_alias=resolve_serialize_by_alias(result)
-                    )
+                    structured_output = to_jsonable_by_alias(result)
                     if not isinstance(structured_output, dict):
                         structured_output = None
                 except Exception:

--- a/tests/tools/tool/test_results.py
+++ b/tests/tools/tool/test_results.py
@@ -378,6 +378,60 @@ class TestSerializeByAlias:
 
         assert result.structured_content == {"id": "1", "inner": {"inner_id": "2"}}
 
+    async def test_model_in_returned_dict_respects_config(self):
+        """A model nested in a returned dict honors its own config.
+
+        Regression: by_alias applies to the whole payload, so a model inside a
+        container was serialized with the container's default of emitting
+        aliases instead of its own serialize_by_alias config.
+        """
+
+        class Biofile(BaseModel):
+            model_config = ConfigDict(serialize_by_alias=False)
+            id: str = Field(alias="_id")
+
+        class Aliased(BaseModel):
+            id: str = Field(alias="_id")
+
+        mcp = FastMCP()
+
+        @mcp.tool
+        def get_biofile() -> dict:
+            return {"biofile": Biofile(_id="1"), "aliased": Aliased(_id="2")}
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("get_biofile", {})
+
+        assert result.structured_content == {
+            "biofile": {"id": "1"},
+            "aliased": {"_id": "2"},
+        }
+        assert json.loads(result.content[0].text) == result.structured_content  # type: ignore[union-attr]
+
+    async def test_list_return_stays_consistent(self):
+        """A list[Model] return serializes and describes itself the same way."""
+
+        class Biofile(BaseModel):
+            model_config = ConfigDict(serialize_by_alias=False)
+            id: str = Field(alias="_id")
+
+        mcp = FastMCP()
+
+        @mcp.tool
+        def get_biofiles() -> list[Biofile]:
+            return [Biofile(_id="1")]
+
+        async with Client(mcp) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+            # client-side validation raises if the schema and content disagree
+            result = await client.call_tool("get_biofiles", {})
+
+        item_schema = tools["get_biofiles"].output_schema["properties"]["result"][
+            "items"
+        ]  # type: ignore[index]
+        assert set(item_schema["properties"]) == {"id"}
+        assert result.structured_content == {"result": [{"id": "1"}]}
+
     async def test_annotated_optional_return_stays_consistent(self):
         """Annotated[Model, ...] | None resolves the model inside the union arm.
 

--- a/tests/tools/tool/test_results.py
+++ b/tests/tools/tool/test_results.py
@@ -432,6 +432,30 @@ class TestSerializeByAlias:
         assert set(item_schema["properties"]) == {"id"}
         assert result.structured_content == {"result": [{"id": "1"}]}
 
+    async def test_set_return_stays_consistent(self):
+        """A set[Model] return serializes and describes itself the same way."""
+
+        class Biofile(BaseModel):
+            model_config = ConfigDict(serialize_by_alias=False, frozen=True)
+            id: str = Field(alias="_id")
+
+        mcp = FastMCP()
+
+        @mcp.tool
+        def get_biofiles() -> set[Biofile]:
+            return {Biofile(_id="1")}
+
+        async with Client(mcp) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+            # client-side validation raises if the schema and content disagree
+            result = await client.call_tool("get_biofiles", {})
+
+        item_schema = tools["get_biofiles"].output_schema["properties"]["result"][
+            "items"
+        ]  # type: ignore[index]
+        assert set(item_schema["properties"]) == {"id"}
+        assert result.structured_content == {"result": [{"id": "1"}]}
+
     async def test_annotated_optional_return_stays_consistent(self):
         """Annotated[Model, ...] | None resolves the model inside the union arm.
 


### PR DESCRIPTION
`by_alias` applies to a whole payload, so tool result serialization resolved it once from the outermost value. A model returned on its own honored its `serialize_by_alias` config, but the moment it was nested in a dict or list the container's default won and the model was serialized with aliases anyway. Serialization now recurses through plain containers and resolves the setting per model, so each one is dumped the way it asked to be.

The output schema is derived from the return annotation, so it has to agree with that: schema resolution now unwraps container types to find the model whose config it should honor. Both sides recognize the same containers — dicts, lists, tuples, sets, and frozensets — so a `list[Model]` or `set[Model]` return still validates against the schema clients check it with.

```python
class Biofile(BaseModel):
    model_config = ConfigDict(serialize_by_alias=False)
    id: str = Field(alias="_id")


@mcp.tool
def get_biofiles() -> dict[str, Biofile]:
    return {"a": Biofile(_id="1")}


# before: {"a": {"_id": "1"}}
# after:  {"a": {"id": "1"}}
```

Fixes #4744
