### PR TITLE
Docs: mirror v3.4.6 changelog entries

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,22 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v3.4.6" description="2026-08-05">
+
+**[v3.4.6: Trust, but Proxy](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.6)**
+
+FastMCP 3.4.6 backports trusted-proxy support for SSRF-protected OAuth metadata and JWKS fetches. Deployments can now route these requests through a mandated corporate proxy while preserving custom CA certificates; FastMCP refuses the fetch when no proxy is configured instead of risking an unprotected direct request.
+
+### Fixes 🐞
+* Backport #4412 to 3.x: support trusted SSRF proxies by [@jlowin](https://github.com/jlowin) in [#4755](https://github.com/PrefectHQ/fastmcp/pull/4755)
+
+### Docs 📚
+* Docs: add v3.4.6 changelog entries by [@jlowin](https://github.com/jlowin) in [#4761](https://github.com/PrefectHQ/fastmcp/pull/4761)
+
+**Full Changelog**: [v3.4.5...v3.4.6](https://github.com/PrefectHQ/fastmcp/compare/v3.4.5...v3.4.6)
+
+</Update>
+
 <Update label="v4.0.0b1" description="2026-07-28">
 
 **[v4.0.0b1: Fourgone Conclusion](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b1)**

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,16 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 3.4.6" description="August 5, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v3.4.6: Trust, but Proxy"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.6"
+cta="Read the release notes"
+>
+FastMCP 3.4.6 adds trusted-proxy support for SSRF-protected OAuth metadata and JWKS fetches on the 3.x line. Deployments can route these requests through a mandated corporate proxy while preserving custom CA certificates, and FastMCP refuses the fetch when no proxy is configured instead of risking an unprotected direct request.
+</Card>
+</Update>
+
 <Update label="FastMCP 4.0.0b1" description="July 28, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v4.0.0b1: Fourgone Conclusion"


### PR DESCRIPTION
FastMCP 3.4.6 is releasing from the maintenance branch, but the default-branch docs also need to retain the complete release history. This mirrors the approved title, notes, categorized PR list, and release-feed card from `release/3.x` onto `main`.