### PR TITLE
fix(context): move elicit overload docs inside the stubs so mypy sees the chain

### DIFF
--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -962,9 +962,8 @@ class Context:
         *,
         response_title: str | None = None,
         response_description: str | None = None,
-    ) -> AcceptedElicitation[T] | DeclinedElicitation | CancelledElicitation: ...
-
-    """The accepted elicitation will contain the response data"""
+    ) -> AcceptedElicitation[T] | DeclinedElicitation | CancelledElicitation:
+        """The accepted elicitation will contain the response data"""
 
     @overload
     async def elicit(
@@ -974,10 +973,9 @@ class Context:
         *,
         response_title: str | None = None,
         response_description: str | None = None,
-    ) -> AcceptedElicitation[str] | DeclinedElicitation | CancelledElicitation: ...
-
-    """When response_type is a list of strings, the accepted elicitation will
-    contain the selected string response"""
+    ) -> AcceptedElicitation[str] | DeclinedElicitation | CancelledElicitation:
+        """When response_type is a list of strings, the accepted elicitation will
+        contain the selected string response"""
 
     @overload
     async def elicit(
@@ -987,10 +985,9 @@ class Context:
         *,
         response_title: str | None = None,
         response_description: str | None = None,
-    ) -> AcceptedElicitation[str] | DeclinedElicitation | CancelledElicitation: ...
-
-    """When response_type is a dict mapping keys to title dicts, the accepted
-    elicitation will contain the selected key"""
+    ) -> AcceptedElicitation[str] | DeclinedElicitation | CancelledElicitation:
+        """When response_type is a dict mapping keys to title dicts, the accepted
+        elicitation will contain the selected key"""
 
     @overload
     async def elicit(
@@ -1000,12 +997,9 @@ class Context:
         *,
         response_title: str | None = None,
         response_description: str | None = None,
-    ) -> (
-        AcceptedElicitation[list[str]] | DeclinedElicitation | CancelledElicitation
-    ): ...
-
-    """When response_type is a list containing a list of strings (multi-select),
-    the accepted elicitation will contain a list of selected strings"""
+    ) -> AcceptedElicitation[list[str]] | DeclinedElicitation | CancelledElicitation:
+        """When response_type is a list containing a list of strings (multi-select),
+        the accepted elicitation will contain a list of selected strings"""
 
     @overload
     async def elicit(
@@ -1015,13 +1009,10 @@ class Context:
         *,
         response_title: str | None = None,
         response_description: str | None = None,
-    ) -> (
-        AcceptedElicitation[list[str]] | DeclinedElicitation | CancelledElicitation
-    ): ...
-
-    """When response_type is a list containing a dict mapping keys to title dicts
-    (multi-select with titles), the accepted elicitation will contain a list of
-    selected keys"""
+    ) -> AcceptedElicitation[list[str]] | DeclinedElicitation | CancelledElicitation:
+        """When response_type is a list containing a dict mapping keys to title dicts
+        (multi-select with titles), the accepted elicitation will contain a list of
+        selected keys"""
 
     async def elicit(
         self,


### PR DESCRIPTION
Fixes #4773

## What

The explanatory string literals for `Context.elicit`'s `@overload` stubs sit *between* the stubs rather than inside them. Each stub's body is `...`, and the prose follows it as a bare class-body expression statement. A statement between overloads terminates the overload series for mypy, so mypy only ever registers the first stub and rejects every other documented `response_type` at the call site.

This moves each literal into its stub's body, where it reads as that stub's docstring.

## Why it is worth fixing

pyright and ty both tolerate the interleaved statements and see all six overloads, so the repo's own `ty check` hook stays green and this never surfaces in CI here. It only reproduces for downstream users running mypy, where a documented call fails:

```python
CHOICES: Final[list[str]] = ["CANCEL", "CONFIRM"]
await ctx.elicit("Confirm?", response_type=CHOICES)
```

```
error: Argument "response_type" to "elicit" of "Context" has incompatible type
       "list[str]"; expected "None"  [arg-type]
```

There is no call-site workaround. With only the first stub visible, every value that is not that stub's type is rejected. On the 3.x line the first stub is `response_type: None`, which is the form the implementation's own docstring marks as deprecated, so mypy users are pushed toward the one shape the library is retiring.

## Verification

Checked a consumer calling three documented overloads (`list[str]`, `list[list[str]]`, `dict[str, dict[str, str]]`):

| | before | after |
|---|---|---|
| `mypy --strict` | 3 errors | `Success: no issues found` |
| `pyright` | 0 errors | 0 errors |
| `ruff check` @ v0.14.10 | 3 pre-existing | same 3, none added |
| `ruff format --check` | formatted | formatted |
| `prek run` on the file | n/a | ruff-check, ruff-format, ty, loq, codespell all pass |

No runtime or API change. The implementation function is untouched: I hashed its source segment before and after and it is byte-identical (`eead596a94d925ff`). The overload stub count is unchanged at 5. The literals being moved were dead expression statements, evaluated and discarded at class-definition time, so `Context.elicit.__doc__` and dispatch behaviour are unaffected.

## Note on the diff size

The deletions outnumber the insertions because dropping ` ...` from the stub terminator frees enough width for `ruff format` to collapse two previously multi-line return annotations onto one line. That reformatting is `ruff format`'s output, not a hand edit.

I did not add a placeholder `...` after the docstrings: ruff flags that as PIE790 `unnecessary-placeholder`, and a docstring is a sufficient stub body.
