### PR TITLE
fix: use yaml.BaseLoader for skills frontmatter parsing (fixes #4416)

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/skills/_common.py
+++ b/fastmcp_slim/fastmcp/server/providers/skills/_common.py
@@ -52,7 +52,18 @@ def parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     frontmatter_text = content[3 : 3 + end_match.start()]
     remaining = content[3 + end_match.end() :]
 
-    # Parse YAML (simple key: value parsing, no complex types)
+    # Try parsing with yaml.BaseLoader first.
+    # BaseLoader supports block scalars (|, >) without implicit type coercion
+    # (no yes->True, no 1.10->1.1), making it safe for untrusted frontmatter.
+    try:
+        import yaml
+        parsed = yaml.load(frontmatter_text, Loader=yaml.BaseLoader)
+        if isinstance(parsed, dict):
+            return parsed, remaining
+    except Exception:
+        pass
+
+    # Fall back to simple line-by-line parsing for malformed YAML
     frontmatter: dict[str, Any] = {}
     for line in frontmatter_text.strip().split("\n"):
         if ":" in line:

--- a/tests/server/providers/test_skills_common.py
+++ b/tests/server/providers/test_skills_common.py
@@ -1,0 +1,66 @@
+"""Tests for skills frontmatter parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp.server.providers.skills._common import parse_frontmatter
+
+
+class TestParseFrontmatter:
+    def test_single_line_description(self):
+        content = "---\ndescription: A simple description\n---\n# Body"
+        frontmatter, remaining = parse_frontmatter(content)
+        assert frontmatter["description"] == "A simple description"
+        assert "# Body" in remaining
+
+    def test_multiline_description_pipe(self):
+        content = "---\ndescription: |\n  First line.\n  Second line.\n---\n# Body"
+        frontmatter, remaining = parse_frontmatter(content)
+        assert "First line." in frontmatter["description"]
+        assert "Second line." in frontmatter["description"]
+
+    def test_multiline_description_folded(self):
+        content = "---\ndescription: >\n  First line.\n  Second line.\n---\n# Body"
+        frontmatter, remaining = parse_frontmatter(content)
+        assert frontmatter["description"] != ""
+
+    def test_no_type_coercion_yes(self):
+        content = "---\ndescription: yes\n---\n"
+        frontmatter, _ = parse_frontmatter(content)
+        assert frontmatter["description"] == "yes"
+        assert isinstance(frontmatter["description"], str)
+
+    def test_no_type_coercion_true(self):
+        content = "---\ndescription: true\n---\n"
+        frontmatter, _ = parse_frontmatter(content)
+        assert frontmatter["description"] == "true"
+        assert isinstance(frontmatter["description"], str)
+
+    def test_no_type_coercion_float(self):
+        content = "---\nversion: 1.10\n---\n"
+        frontmatter, _ = parse_frontmatter(content)
+        assert frontmatter["version"] == "1.10"
+        assert isinstance(frontmatter["version"], str)
+
+    def test_other_keys_preserved(self):
+        content = "---\nname: my-skill\nauthor: sai\n---\n"
+        frontmatter, _ = parse_frontmatter(content)
+        assert frontmatter["name"] == "my-skill"
+        assert frontmatter["author"] == "sai"
+
+    def test_malformed_yaml_falls_back(self):
+        content = "---\ndescription: value: with: colons\n---\n"
+        frontmatter, _ = parse_frontmatter(content)
+        assert "description" in frontmatter
+
+    def test_no_frontmatter_returns_empty(self):
+        content = "# Just markdown\nNo frontmatter here."
+        frontmatter, remaining = parse_frontmatter(content)
+        assert frontmatter == {}
+        assert remaining == content
+
+    def test_empty_frontmatter_returns_empty_dict(self):
+        content = "---\n---\n# Body"
+        frontmatter, remaining = parse_frontmatter(content)
+        assert frontmatter == {}


### PR DESCRIPTION
Fixes #4416

## Description

The `parse_frontmatter` function in `fastmcp/server/providers/skills/_common.py` used simple line-by-line key:value parsing which broke multiline YAML block scalars (`|`, `>`). A `description: |` block stored the literal string `|` and silently dropped all continuation lines.

This PR replaces the line parser with `yaml.BaseLoader` which supports block scalars without implicit type coercion. It directly addresses the maintainer feedback on #4701 which specifically requested `yaml.BaseLoader` over `yaml.safe_load`.

Closes #4416

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)

## Checklist

- [x] I have read the contributing guidelines
- [x] Tests added for multiline `|` and `>` block scalars
- [x] Tests added for no type coercion (`yes`, `true`, `1.10` preserved as strings)
- [x] Tests added for malformed YAML fallback to line parser
- [x] All 10 tests pass locally