### PR TITLE
Clarify review of closed contributor PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ When modifying MCP functionality, changes typically need to be applied across al
 
 **Read `CONTRIBUTING.md` before opening issues or PRs.** It describes when PRs are appropriate, what we expect from enhancement proposals, and what we'll close without review.
 
+**Review closed contributor PRs.** When reviewing an issue, inspect every associated non-maintainer PR, including closed PRs. External PRs may be closed as part of the issue-link and assignment workflow, so closure alone is not a negative signal. Read `CONTRIBUTING.md` and the PR timeline and comments to understand its status before evaluating it.
+
 ### Git & CI
 
 - Prek hooks are required (run automatically on commits)


### PR DESCRIPTION
Closed contributor PRs can be part of FastMCP's issue-link and assignment workflow, but `CLAUDE.md` did not tell review agents how to interpret that state. This could cause a closed PR to be skipped or treated as negative evidence during issue review.

This adds explicit guidance to inspect every associated non-maintainer PR, treat closure as neutral until its cause is understood, and consult `CONTRIBUTING.md` plus the PR timeline and comments before evaluating it.
