### PR TITLE
Backport #4659 to release/3.x: bind CIMD assertion audience to the advertised token endpoint

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -699,6 +699,19 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             )
         return self._jwt_issuer
 
+    @property
+    def token_endpoint_url(self) -> str:
+        """The token endpoint URL, as advertised in the authorization server metadata.
+
+        A CIMD `private_key_jwt` assertion is bound to this URL as its `aud`, so
+        it must match the advertised `token_endpoint` byte-for-byte. The SDK's
+        `build_metadata` builds that URL by stripping any trailing slash from
+        `base_url` first, so this does too: pydantic renders a bare-authority
+        `base_url` with a trailing slash, which would otherwise expect an `aud`
+        of `https://example.com//token`.
+        """
+        return f"{str(self.base_url).rstrip('/')}/token"
+
     # -------------------------------------------------------------------------
     # Upstream OAuth Client
     # -------------------------------------------------------------------------
@@ -2058,7 +2071,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             ):
                 # Replace the token endpoint authenticator with one that supports
                 # private_key_jwt for CIMD clients
-                token_endpoint_url = f"{self.base_url}/token"
+                token_endpoint_url = self.token_endpoint_url
                 cimd_authenticator = PrivateKeyJWTClientAuthenticator(
                     provider=self,
                     cimd_manager=self._cimd_manager,

--- a/tests/server/auth/oauth_proxy/test_oauth_proxy.py
+++ b/tests/server/auth/oauth_proxy/test_oauth_proxy.py
@@ -8,6 +8,7 @@ import pytest
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from key_value.aio.stores.memory import MemoryStore
 from starlette.applications import Starlette
+from starlette.testclient import TestClient
 
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.oauth_proxy.models import OAuthTransaction
@@ -412,3 +413,38 @@ class TestIdpCallbackErrorForwarding:
             )
 
         assert response.status_code == 400
+
+
+class TestCIMDTokenEndpointAudience:
+    """The `aud` expected on a CIMD assertion matches the advertised token endpoint."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["https://api.example.com", "https://api.example.com/api"],
+    )
+    def test_token_endpoint_url_matches_advertised_metadata(
+        self, jwt_verifier, base_url: str
+    ):
+        """A bare-authority base_url must not expect `aud` of `https://host//token`.
+
+        CIMD is enabled by default, and a spec-following client binds its
+        private_key_jwt assertion to the `token_endpoint` the metadata
+        advertises. If the proxy expects a different string, every such client
+        is rejected with invalid_client.
+        """
+        proxy = OAuthProxy(
+            upstream_authorization_endpoint="https://auth.example.com/authorize",
+            upstream_token_endpoint="https://auth.example.com/token",
+            upstream_client_id="client-123",
+            upstream_client_secret="secret-456",
+            token_verifier=jwt_verifier,
+            base_url=base_url,
+            jwt_signing_key="test-secret",
+            client_storage=MemoryStore(),
+        )
+
+        app = Starlette(routes=proxy.get_routes(mcp_path="/mcp"))
+        with TestClient(app) as client:
+            metadata = client.get("/.well-known/oauth-authorization-server").json()
+
+        assert proxy.token_endpoint_url == metadata["token_endpoint"]


### PR DESCRIPTION
# Backport #4659 to release/3.x: bind CIMD assertion audience to the advertised token endpoint

## Summary

On `release/3.x`, an `OAuthProxy` whose `base_url` is a bare origin expects a
`private_key_jwt` client assertion whose `aud` is `https://host//token` (doubled
slash), while the authorization server metadata advertises `https://host/token`.
Every RFC 7523 `private_key_jwt` client is therefore rejected with
`invalid_client`.

This is a straight backport of #4659, which fixed the same defect on `main` and
shipped in `v4.0.0b1`. It has never been released on the v3 line: the fix landed
2026-07-27, `v3.4.5` was tagged ~3.5 hours later from `release/3.x` and did not
include it, and `v3.4.6` (2026-08-05) still carries the original line. Since
`pip install fastmcp` resolves to `v3.4.6` (the v4 betas are pre-releases and
excluded by default), every stable installation is still affected.

## Root cause

`fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py:2061` (as of `v3.4.6`):

```python
token_endpoint_url = f"{self.base_url}/token"
```

`self.base_url` is a pydantic `AnyHttpUrl`. Pydantic normalises a bare authority
to a trailing slash:

```python
>>> str(AnyHttpUrl("https://example.com"))
'https://example.com/'
```

The repository already asserts this behaviour in
`tests/server/auth/oauth_proxy/test_oauth_proxy.py:41`
(`assert str(proxy.base_url) == "https://api.example.com/"`).

So for a bare-origin `base_url` the f-string yields `https://example.com//token`.

That string flows to the JWT audience check:

- `proxy.py:2062-2065` -> `PrivateKeyJWTClientAuthenticator(token_endpoint_url=...)`
- `auth.py:196` -> `CIMDClientManager.validate_private_key_jwt(token_endpoint=...)`
- `cimd.py:802` -> `CIMDAssertionValidator.validate_assertion(...)`
- `cimd.py:540` / `cimd.py:553` -> `JWTVerifier(audience=token_endpoint)`

Meanwhile the advertised `token_endpoint` comes from the MCP SDK's
`build_metadata`, which strips the trailing slash first:

```python
token_url = AnyHttpUrl(str(issuer_url).rstrip("/") + TOKEN_PATH)
```

A spec-following client signs its assertion with `aud` set to the advertised
value, so the two never match. The failure surfaces as
`ValueError("Invalid JWT assertion")` (`cimd.py:563`), wrapped into
`AuthenticationError("Invalid client assertion: ...")` (`auth.py:199`), and
returned as HTTP 401 `invalid_client`.

Note that two other call sites in the same file already used the correct form —
`proxy.py:1006` (`consent_url`) and `proxy.py:2268` (the redirect URI) both use
`str(self.base_url).rstrip('/')`. Line 2061 was the outlier.

## Why this is silent for `none`-auth clients

`auth.py:178` gates the whole private_key_jwt path:

```python
if client.token_endpoint_auth_method == "private_key_jwt":
```

A CIMD document declaring `"token_endpoint_auth_method": "none"` skips this
branch entirely and falls through to `super().authenticate_request(request)` at
`auth.py:204`, so `_token_endpoint_url` is never consulted and the bug is
invisible.

This makes the bug look client-specific and is easy to misdiagnose: clients
whose Client ID Metadata Document declares `private_key_jwt` fail 100% of the
time against a bare-origin deployment, while `none`-auth clients on the same
server authenticate normally. Only the auth method differs, not the server
configuration.

## The fix

Introduce a `token_endpoint_url` property that mirrors `build_metadata`'s
construction byte-for-byte, and use it at the call site.

```python
@property
def token_endpoint_url(self) -> str:
    return f"{str(self.base_url).rstrip('/')}/token"
```

Deliberately *not* `urllib.parse.urljoin`: `urljoin` resolves a relative
reference against the base and drops the final path segment, which silently
breaks path-mounted deployments.

| `base_url` | `rstrip('/')` (this fix) | `urljoin(base, "token")` |
| --- | --- | --- |
| `https://example.com` | `https://example.com/token` | `https://example.com/token` |
| `https://example.com/api` | `https://example.com/api/token` | `https://example.com/token` (wrong) |
| `https://example.com/a/b` | `https://example.com/a/b/token` | `https://example.com/a/token` (wrong) |

The correctness criterion here is not "canonical URL join" but "identical to the
string the metadata advertises", and the metadata is built with
`str(...).rstrip("/") + PATH`. Ports, userinfo and IPv6 literals are carried
through unchanged (`https://user:pw@example.com:9443/token`,
`http://[::1]:8000/token`).

## Test

`TestCIMDTokenEndpointAudience::test_token_endpoint_url_matches_advertised_metadata`
asserts that `proxy.token_endpoint_url` equals the `token_endpoint` served at
`/.well-known/oauth-authorization-server`, parametrized over a bare-origin and a
path-mounted `base_url`.

Substituting the pre-fix expression back into the property body fails only the
bare-origin case, which isolates the defect:

```
E   AssertionError: assert 'https://api....le.com//token' == 'https://api....ple.com/token'
E     - https://api.example.com/token
E     + https://api.example.com//token
E     ?                         +
FAILED ...::test_token_endpoint_url_matches_advertised_metadata[https://api.example.com]
==================== 1 failed, 1 passed, 1 warning in 0.08s ====================
```

With the fix, both parameters pass, and the full `tests/server/auth` suite is
green (995 passed).

## Minimal reproduction

Against `fastmcp==3.4.6`:

```python
from unittest.mock import Mock

from key_value.aio.stores.memory import MemoryStore
from starlette.applications import Starlette
from starlette.testclient import TestClient

from fastmcp.server.auth.oauth_proxy import OAuthProxy
from fastmcp.server.auth.providers.jwt import JWTVerifier

verifier = Mock(spec=JWTVerifier)
verifier.required_scopes = []

proxy = OAuthProxy(
    upstream_authorization_endpoint="https://auth.example.com/authorize",
    upstream_token_endpoint="https://auth.example.com/token",
    upstream_client_id="client-123",
    upstream_client_secret="secret-456",
    token_verifier=verifier,
    base_url="https://api.example.com",  # bare origin -- the common case
    jwt_signing_key="test-secret-value",
    client_storage=MemoryStore(),
)

app = Starlette(routes=proxy.get_routes(mcp_path="/mcp"))
with TestClient(app) as c:
    advertised = c.get("/.well-known/oauth-authorization-server").json()["token_endpoint"]

expected_aud = f"{proxy.base_url}/token"  # the expression v3.4.6 uses internally

print("advertised token_endpoint :", advertised)
print("aud the proxy expects     :", expected_aud)
assert advertised == expected_aud
```

Output on `v3.4.6`:

```
advertised token_endpoint : https://api.example.com/token
aud the proxy expects     : https://api.example.com//token
AssertionError
```

Setting `base_url="https://api.example.com/api"` makes the assertion pass,
confirming the defect is specific to bare-origin `base_url` values.

## Confirmed real-world impact

We hit this in production today. Every ChatGPT MCP connector login to our server failed with a generic connection error while Claude kept working, which made it look client-specific for hours.

The asymmetry is entirely explained by the two clients' Client ID Metadata Documents (both fetched directly today):

| client | `token_endpoint_auth_method` | affected |
|---|---|---|
| ChatGPT (`https://chatgpt.com/oauth/<id>/client.json`) | **`private_key_jwt`** (RS256, with `jwks_uri`) | yes — 100% of logins |
| Claude (`https://claude.ai/oauth/mcp-oauth-client-metadata`) | `none` | no — never reaches the assertion path |

Probing our live `/token` with a bogus code separates client auth from grant validation, since the SDK returns 401 only for client-authentication failure and 400 for everything else:

- ChatGPT's `client_id` → `401 invalid_client` — `Invalid client assertion: Invalid JWT assertion`
- Claude's `client_id` → gets **past** client auth → `invalid_grant` (only the bogus code failed)

Because clients using `none` are unaffected, this failure is silent for the most common deployment and easy to misattribute to the client. That is the main argument for backporting rather than waiting for v4.

