### PR TITLE
docs: clarify server-level list notifications

### DIFF
--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -291,7 +291,7 @@ Tools can customize which components are visible to their current session using 
 
 <VersionBadge version="3.0.0" />
 
-FastMCP automatically sends list change notifications when components (such as tools, resources, or prompts) are added, removed, enabled, or disabled. In rare cases where you need to manually trigger these notifications, you can use the context's notification methods:
+Per-session visibility changes made with `ctx.enable_components()`, `ctx.disable_components()`, or `ctx.reset_visibility()` automatically send list change notifications to the current client. Server-level component changes do not send notifications automatically because they are not associated with a client session. When making a server-level change inside an active request, use the context's notification method explicitly:
 
 ```python
 import mcp.types
@@ -305,7 +305,7 @@ async def custom_tool_management(ctx: Context) -> str:
     return "Notifications sent"
 ```
 
-These methods are primarily used internally by FastMCP's automatic notification system and most users will not need to invoke them directly.
+Operations performed outside an active request, such as during server initialization, have no client session to notify.
 
 ### FastMCP Server
 
@@ -440,4 +440,3 @@ def send_email(to: str, subject: str, body: str, ctx: Context) -> str:
 <Warning>
 The MCP request is part of the low-level MCP SDK and intended for advanced use cases. Most users will not need to use it directly.
 </Warning>
-

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -964,21 +964,19 @@ Client-specific behavior:
 
 <VersionBadge version="2.9.1" />
 
-FastMCP automatically sends `notifications/tools/list_changed` notifications to connected clients when tools are added, removed, enabled, or disabled. This allows clients to stay up-to-date with the current tool set without manually polling for changes.
+Per-session visibility changes made with `ctx.enable_components()` or `ctx.disable_components()` automatically send `notifications/tools/list_changed` to the current client. Server-level changes made with `mcp.add_tool()`, `mcp.enable()`, `mcp.disable()`, or `mcp.local_provider.remove_tool()` do not send notifications automatically because they are not associated with a client session.
 
 ```python
-@mcp.tool
-def example_tool() -> str:
-    return "Hello!"
+import mcp.types
 
-# These operations trigger notifications:
-mcp.add_tool(example_tool)              # Sends tools/list_changed notification
-mcp.disable(keys={"tool:example_tool"}) # Sends tools/list_changed notification
-mcp.enable(keys={"tool:example_tool"})  # Sends tools/list_changed notification
-mcp.local_provider.remove_tool("example_tool")  # Sends tools/list_changed notification
+@mcp.tool
+async def disable_example(ctx: Context) -> str:
+    mcp.disable(keys={"tool:example_tool"})
+    await ctx.send_notification(mcp.types.ToolListChangedNotification())
+    return "Disabled example_tool"
 ```
 
-Notifications are only sent when these operations occur within an active MCP request context (e.g., when called from within a tool or other MCP operation). Operations performed during server initialization do not trigger notifications.
+Explicit notifications require an active MCP request context and notify that request's client. Operations performed during server initialization have no client session to notify.
 
 Clients can handle these notifications using a [message handler](/clients/notifications) to automatically refresh their tool lists or update their interfaces.
 

--- a/docs/servers/visibility.mdx
+++ b/docs/servers/visibility.mdx
@@ -409,16 +409,19 @@ Sessions start seeing only the activation tools. Calling `activate_finance` reve
 
 ## Client Notifications
 
-When visibility state changes, FastMCP automatically notifies connected clients. Clients supporting the MCP notification protocol receive `list_changed` events and can refresh their component lists.
-
-This happens automatically. You don't need to trigger notifications manually.
+Per-session visibility changes made with `ctx.enable_components()`, `ctx.disable_components()`, or `ctx.reset_visibility()` automatically notify the current client. Server-level changes made with `mcp.enable()` or `mcp.disable()` do not automatically broadcast notifications because they are not associated with a client session.
 
 ```python
-# This automatically notifies clients
-mcp.disable(tags={"maintenance"})
+import mcp.types
 
-# Clients receive: tools/list_changed, resources/list_changed, etc.
+@mcp.tool
+async def start_maintenance(ctx: Context) -> str:
+    mcp.disable(tags={"maintenance"})
+    await ctx.send_notification(mcp.types.ToolListChangedNotification())
+    return "Maintenance tools disabled"
 ```
+
+Explicit notifications require an active MCP request context and notify that request's client. Operations performed during server initialization have no client session to notify.
 
 ## Filtering Logic
 


### PR DESCRIPTION
## Description

Clarifies that per-session visibility changes notify the current client automatically, while server-level component changes have no associated client session and therefore do not broadcast list-change notifications. The docs now show how to send an explicit notification when a server-level change is made inside an active request.

Closes #4788.

AI disclosure: Documentation wording was prepared with OpenAI Codex and reviewed against the current implementation and the design history in #2915.

**Contributors Checklist**

- [x] My change closes #4788
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests (documentation-only change; no code test was needed)
- [x] I have performed all required documentation updates

Validation:

- `uv run prek run --files docs/servers/context.mdx docs/servers/tools.mdx docs/servers/visibility.mdx`
- `npx --yes mint@latest broken-links`

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
