### PR TITLE
Scalekit issuer updates backward compatibility

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/providers/scalekit.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/scalekit.py
@@ -125,15 +125,22 @@ class ScalekitProvider(RemoteAuthProvider):
 
         # Create default JWT verifier if none provided
         if token_verifier is None:
+            # Scalekit is migrating the `iss` claim from the bare environment URL
+            # to a resource-scoped issuer. Accept both forms so tokens minted
+            # before and after the migration validate against the same provider.
+            expected_issuers = [
+                self.environment_url,
+                f"{self.environment_url}/resources/{self.resource_id}",
+            ]
             logger.debug(
                 "Creating default JWTVerifier for Scalekit: jwks_uri=%s issuer=%s required_scopes=%s",
                 f"{self.environment_url}/keys",
-                self.environment_url,
+                expected_issuers,
                 self.required_scopes,
             )
             token_verifier = JWTVerifier(
                 jwks_uri=f"{self.environment_url}/keys",
-                issuer=self.environment_url,
+                issuer=expected_issuers,
                 algorithm="RS256",
                 audience=self.resource_id,
                 required_scopes=self.required_scopes or None,

--- a/tests/server/auth/providers/test_scalekit.py
+++ b/tests/server/auth/providers/test_scalekit.py
@@ -6,7 +6,7 @@ from mcp import MCPError
 
 from fastmcp import Client, FastMCP
 from fastmcp.client.transports import StreamableHttpTransport
-from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.auth.providers.jwt import JWTVerifier, RSAKeyPair
 from fastmcp.server.auth.providers.scalekit import ScalekitProvider
 from fastmcp.utilities.tests import HeadlessOAuth, run_server_async
 
@@ -91,10 +91,15 @@ class TestScalekitProvider:
             base_url="https://myserver.com/",
         )
 
-        # Check that JWT verifier uses the correct endpoints
+        # Check that JWT verifier uses the correct endpoints. Both the bare
+        # environment URL and the resource-scoped issuer are accepted so tokens
+        # from before and after Scalekit's issuer migration validate.
         assert isinstance(provider.token_verifier, JWTVerifier)
         assert provider.token_verifier.jwks_uri == "https://my-env.scalekit.com/keys"
-        assert provider.token_verifier.issuer == "https://my-env.scalekit.com"
+        assert provider.token_verifier.issuer == [
+            "https://my-env.scalekit.com",
+            "https://my-env.scalekit.com/resources/sk_resource_456",
+        ]
         assert provider.token_verifier.audience == "sk_resource_456"
 
     def test_required_scopes_hooks_into_verifier(self):
@@ -122,6 +127,61 @@ class TestScalekitProvider:
             str(provider.authorization_servers[0])
             == "https://my-env.scalekit.com/resources/sk_resource_456"
         )
+
+
+class TestScalekitIssuerMigration:
+    """Scalekit is migrating the `iss` claim from the bare environment URL to a
+    resource-scoped issuer. Tokens minted before and after the migration must
+    both validate against the same provider.
+    """
+
+    ENV_URL = "https://my-env.scalekit.com"
+    RESOURCE_ID = "sk_resource_456"
+
+    @pytest.fixture
+    def key_pair(self) -> RSAKeyPair:
+        return RSAKeyPair.generate()
+
+    def _provider(self, key_pair: RSAKeyPair) -> ScalekitProvider:
+        provider = ScalekitProvider(
+            environment_url=self.ENV_URL,
+            resource_id=self.RESOURCE_ID,
+            base_url="https://myserver.com/",
+        )
+        # Verify against the test key instead of Scalekit's live JWKS endpoint.
+        assert isinstance(provider.token_verifier, JWTVerifier)
+        provider.token_verifier.public_key = key_pair.public_key
+        return provider
+
+    async def test_pre_migration_issuer_accepted(self, key_pair: RSAKeyPair):
+        """The bare environment URL issuer (pre-migration) validates."""
+        provider = self._provider(key_pair)
+        token = key_pair.create_token(
+            issuer=self.ENV_URL,
+            audience=self.RESOURCE_ID,
+        )
+
+        assert await provider.token_verifier.verify_token(token) is not None
+
+    async def test_post_migration_issuer_accepted(self, key_pair: RSAKeyPair):
+        """The resource-scoped issuer (post-migration) validates."""
+        provider = self._provider(key_pair)
+        token = key_pair.create_token(
+            issuer=f"{self.ENV_URL}/resources/{self.RESOURCE_ID}",
+            audience=self.RESOURCE_ID,
+        )
+
+        assert await provider.token_verifier.verify_token(token) is not None
+
+    async def test_unknown_issuer_rejected(self, key_pair: RSAKeyPair):
+        """An issuer outside the accepted set is still rejected."""
+        provider = self._provider(key_pair)
+        token = key_pair.create_token(
+            issuer="https://evil.example.com",
+            audience=self.RESOURCE_ID,
+        )
+
+        assert await provider.token_verifier.verify_token(token) is None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Scalekit is migrating the issuer (`iss`) claim on its access tokens to align with the July 2026 MCP spec: alongside the existing environment-level issuer (`https://<env>.scalekit.com`), tokens begin carrying a resource-scoped issuer (`https://<env>.scalekit.com/resources/<resource_id>`). Because the rollout is gradual, both forms are valid at the same time. `ScalekitProvider` previously configured its default `JWTVerifier` with a single expected issuer, so the moment the auth server started emitting the resource-scoped `iss`, legitimate tokens will start getting rejected.

This PR sets the verifier in ScalekitProvider to accept either issuer form for the duration of the migration. `JWTVerifier` already validates `iss` by membership when given a list, so the provider now passes both forms — tokens signed before and after the migration validate against the same provider, with no public API change and no effect on callers that supply their own `token_verifier`.

```python
# Before — only the legacy issuer was accepted
issuer=self.environment_url

# After — both forms accepted during the migration
issuer=[
    self.environment_url,                                    # existing
    f"{self.environment_url}/resources/{self.resource_id}",  # resource-scoped (July 2026 spec)
]
```

Closes #4797 

## Contribution type

<!-- Check the one that applies. If you're unsure whether your change is welcome, please open an issue first — see CONTRIBUTING.md. -->

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
