### PR TITLE
Backport CIMD assertion audience fix to v3

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -699,6 +699,19 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             )
         return self._jwt_issuer
 
+    @property
+    def token_endpoint_url(self) -> str:
+        """The token endpoint URL, as advertised in the authorization server metadata.
+
+        A CIMD `private_key_jwt` assertion is bound to this URL as its `aud`, so
+        it must match the advertised `token_endpoint` byte-for-byte. The SDK's
+        `build_metadata` builds that URL by stripping any trailing slash from
+        `base_url` first, so this does too: pydantic renders a bare-authority
+        `base_url` with a trailing slash, which would otherwise expect an `aud`
+        of `https://example.com//token`.
+        """
+        return f"{str(self.base_url).rstrip('/')}/token"
+
     # -------------------------------------------------------------------------
     # Upstream OAuth Client
     # -------------------------------------------------------------------------
@@ -2058,7 +2071,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             ):
                 # Replace the token endpoint authenticator with one that supports
                 # private_key_jwt for CIMD clients
-                token_endpoint_url = f"{self.base_url}/token"
+                token_endpoint_url = self.token_endpoint_url
                 cimd_authenticator = PrivateKeyJWTClientAuthenticator(
                     provider=self,
                     cimd_manager=self._cimd_manager,

--- a/tests/server/auth/oauth_proxy/test_oauth_proxy.py
+++ b/tests/server/auth/oauth_proxy/test_oauth_proxy.py
@@ -1,6 +1,7 @@
 """Tests for OAuth proxy initialization and configuration."""
 
 import time
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -10,6 +11,7 @@ from key_value.aio.stores.memory import MemoryStore
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
+from fastmcp.server.auth.auth import PrivateKeyJWTClientAuthenticator
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.oauth_proxy.models import OAuthTransaction
 
@@ -443,8 +445,14 @@ class TestCIMDTokenEndpointAudience:
             client_storage=MemoryStore(),
         )
 
-        app = Starlette(routes=proxy.get_routes(mcp_path="/mcp"))
+        with patch(
+            "fastmcp.server.auth.oauth_proxy.proxy.PrivateKeyJWTClientAuthenticator",
+            wraps=PrivateKeyJWTClientAuthenticator,
+        ) as authenticator:
+            app = Starlette(routes=proxy.get_routes(mcp_path="/mcp"))
+
         with TestClient(app) as client:
             metadata = client.get("/.well-known/oauth-authorization-server").json()
 
-        assert proxy.token_endpoint_url == metadata["token_endpoint"]
+        expected_audience = authenticator.call_args.kwargs["token_endpoint_url"]
+        assert expected_audience == metadata["token_endpoint"]

--- a/tests/server/auth/oauth_proxy/test_oauth_proxy.py
+++ b/tests/server/auth/oauth_proxy/test_oauth_proxy.py
@@ -1,7 +1,6 @@
 """Tests for OAuth proxy initialization and configuration."""
 
 import time
-from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -11,7 +10,6 @@ from key_value.aio.stores.memory import MemoryStore
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
-from fastmcp.server.auth.auth import PrivateKeyJWTClientAuthenticator
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.oauth_proxy.models import OAuthTransaction
 
@@ -445,14 +443,8 @@ class TestCIMDTokenEndpointAudience:
             client_storage=MemoryStore(),
         )
 
-        with patch(
-            "fastmcp.server.auth.oauth_proxy.proxy.PrivateKeyJWTClientAuthenticator",
-            wraps=PrivateKeyJWTClientAuthenticator,
-        ) as authenticator:
-            app = Starlette(routes=proxy.get_routes(mcp_path="/mcp"))
-
+        app = Starlette(routes=proxy.get_routes(mcp_path="/mcp"))
         with TestClient(app) as client:
             metadata = client.get("/.well-known/oauth-authorization-server").json()
 
-        expected_audience = authenticator.call_args.kwargs["token_endpoint_url"]
-        assert expected_audience == metadata["token_endpoint"]
+        assert proxy.token_endpoint_url == metadata["token_endpoint"]

--- a/tests/server/auth/oauth_proxy/test_oauth_proxy.py
+++ b/tests/server/auth/oauth_proxy/test_oauth_proxy.py
@@ -8,6 +8,7 @@ import pytest
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from key_value.aio.stores.memory import MemoryStore
 from starlette.applications import Starlette
+from starlette.testclient import TestClient
 
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.oauth_proxy.models import OAuthTransaction
@@ -412,3 +413,38 @@ class TestIdpCallbackErrorForwarding:
             )
 
         assert response.status_code == 400
+
+
+class TestCIMDTokenEndpointAudience:
+    """The `aud` expected on a CIMD assertion matches the advertised token endpoint."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["https://api.example.com", "https://api.example.com/api"],
+    )
+    def test_token_endpoint_url_matches_advertised_metadata(
+        self, jwt_verifier, base_url: str
+    ):
+        """A bare-authority base_url must not expect `aud` of `https://host//token`.
+
+        CIMD is enabled by default, and a spec-following client binds its
+        private_key_jwt assertion to the `token_endpoint` the metadata
+        advertises. If the proxy expects a different string, every such client
+        is rejected with invalid_client.
+        """
+        proxy = OAuthProxy(
+            upstream_authorization_endpoint="https://auth.example.com/authorize",
+            upstream_token_endpoint="https://auth.example.com/token",
+            upstream_client_id="client-123",
+            upstream_client_secret="secret-456",
+            token_verifier=jwt_verifier,
+            base_url=base_url,
+            jwt_signing_key="test-secret",
+            client_storage=MemoryStore(),
+        )
+
+        app = Starlette(routes=proxy.get_routes(mcp_path="/mcp"))
+        with TestClient(app) as client:
+            metadata = client.get("/.well-known/oauth-authorization-server").json()
+
+        assert proxy.token_endpoint_url == metadata["token_endpoint"]


### PR DESCRIPTION
This backports #4659 to `release/3.x`. `OAuthProxy` advertises a token endpoint like `https://example.com/token`, but the stable branch currently validates CIMD `private_key_jwt` assertions against `https://example.com//token` because Pydantic adds a trailing slash to a bare-origin `base_url`. Spec-following clients therefore fail authentication with `invalid_client`.

The expected audience now comes from the same normalized token endpoint URL advertised in metadata, while preserving path-mounted deployments:

```python
proxy = OAuthProxy(base_url="https://example.com", ...)
proxy.token_endpoint_url  # "https://example.com/token"
```

Fixes #4789
