### PR TITLE
Docs: mirror v3.4.7 release notes

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,22 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v3.4.7" description="2026-08-10">
+
+**[v3.4.7: Know Your Audience](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.7)**
+
+FastMCP 3.4.7 fixes CIMD `private_key_jwt` authentication on bare-origin OAuth proxy deployments by validating client assertions against the exact token endpoint advertised in OAuth metadata.
+
+### Security 🔒
+* Backport CIMD assertion audience fix to v3 by [@jlowin](https://github.com/jlowin) in [#4799](https://github.com/PrefectHQ/fastmcp/pull/4799)
+
+### Docs 📚
+* Docs: add v3.4.7 changelog entries by [@jlowin](https://github.com/jlowin) in [#4810](https://github.com/PrefectHQ/fastmcp/pull/4810)
+
+**Full Changelog**: [v3.4.6...v3.4.7](https://github.com/PrefectHQ/fastmcp/compare/v3.4.6...v3.4.7)
+
+</Update>
+
 <Update label="v3.4.6" description="2026-08-05">
 
 **[v3.4.6: Trust, but Proxy](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.6)**

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,16 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 3.4.7" description="August 10, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v3.4.7: Know Your Audience"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.7"
+cta="Read the release notes"
+>
+FastMCP 3.4.7 restores CIMD `private_key_jwt` authentication for bare-origin OAuth proxy deployments by validating client assertions against the exact token endpoint advertised to clients.
+</Card>
+</Update>
+
 <Update label="FastMCP 3.4.6" description="August 5, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v3.4.6: Trust, but Proxy"


### PR DESCRIPTION
Mirrors #4810 onto `main`, preserving the `v3.4.7: Know Your Audience` entry in the full changelog and release feed. The release branch carries these notes in the maintenance tag; `main` needs the same entry so a future main-line docs publication does not drop the 3.x release from the public history.
