### PR TITLE
fix(#4814): reuse CSRF token on repeated GET consent fetches

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/consent.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/consent.py
@@ -370,8 +370,16 @@ class ConsentMixin:
                 )
 
         # Need consent: issue CSRF token and show HTML
-        csrf_token = secrets.token_urlsafe(32)
-        csrf_expires_at = time.time() + 15 * 60
+        if (
+            txn_model.csrf_token
+            and txn_model.csrf_expires_at
+            and time.time() < txn_model.csrf_expires_at
+        ):
+            csrf_token = txn_model.csrf_token
+            csrf_expires_at = txn_model.csrf_expires_at
+        else:
+            csrf_token = secrets.token_urlsafe(32)
+            csrf_expires_at = time.time() + 15 * 60
 
         # Update transaction with CSRF token
         txn_model.csrf_token = csrf_token

--- a/tests/server/auth/test_oauth_consent_flow.py
+++ b/tests/server/auth/test_oauth_consent_flow.py
@@ -537,6 +537,89 @@ class TestCSRFDoubleSubmit:
             assert response.status_code == 403
 
 
+class TestConsentPageDoubleFetch:
+    """Regression tests for double-fetch CSRF invalidation.
+
+    Some browser extensions and built-in prefetch mechanisms re-fetch the
+    consent page URL immediately after the browser receives it (same IP/UA,
+    0.2-1.2 s apart).  Before the fix, each GET issued a *fresh* one-time
+    CSRF token and overwrote the transaction's stored token, so the first
+    page's token became invalid and the user's POST returned 400.
+
+    The fix: reuse ``csrf_token`` / ``csrf_expires_at`` already stored in
+    the transaction as long as they have not expired.
+    """
+
+    async def test_double_get_returns_same_csrf_token(self, oauth_proxy_with_storage):
+        """A second GET to /consent within the 15-minute window must return the
+        same CSRF token as the first — not a freshly generated one."""
+        txn_id, _ = await _start_flow(
+            oauth_proxy_with_storage,
+            "double-fetch-client-a",
+            "http://localhost:9091/callback",
+        )
+        app = Starlette(routes=oauth_proxy_with_storage.get_routes())
+        with TestClient(app) as c:
+            first = c.get(f"/consent?txn_id={txn_id}")
+            second = c.get(f"/consent?txn_id={txn_id}")
+
+            assert first.status_code == 200
+            assert second.status_code == 200
+
+            csrf1 = _extract_csrf(first.text)
+            csrf2 = _extract_csrf(second.text)
+
+            assert csrf1 is not None, "first page must contain csrf_token"
+            assert csrf2 is not None, "second page must contain csrf_token"
+            assert csrf1 == csrf2, (
+                "second fetch must reuse the existing CSRF token; "
+                "a new token would invalidate the page the user is looking at"
+            )
+
+    async def test_consent_submittable_after_page_double_fetch(
+        self, oauth_proxy_with_storage
+    ):
+        """After a browser double-fetches the consent page, the user's POST
+        (using the CSRF token from the *first* page) must still succeed (302).
+
+        Reproduces the production failure described in the issue:
+        users whose browser extension re-fetches the URL could never complete
+        authorization because the second GET rotated the stored token.
+        """
+        txn_id, _ = await _start_flow(
+            oauth_proxy_with_storage,
+            "double-fetch-client-b",
+            "http://localhost:9092/callback",
+        )
+        app = Starlette(routes=oauth_proxy_with_storage.get_routes())
+        with TestClient(app) as c:
+            # First GET — the page the user actually sees.
+            first_response = c.get(f"/consent?txn_id={txn_id}")
+            assert first_response.status_code == 200
+
+            # Seed the CSRF cookies from the first response.
+            for k, v in first_response.cookies.items():
+                c.cookies.set(k, v)
+
+            csrf = _extract_csrf(first_response.text)
+            assert csrf, "CSRF token must be present in the consent page"
+
+            # Second GET — simulates a browser extension or prefetch re-fetch.
+            second_response = c.get(f"/consent?txn_id={txn_id}")
+            assert second_response.status_code == 200
+
+            # User clicks Allow on the *first* page they saw.
+            submit = c.post(
+                "/consent",
+                data={"action": "approve", "txn_id": txn_id, "csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert submit.status_code in (302, 303), (
+                f"Expected redirect after approve, got {submit.status_code}; "
+                f"body: {submit.content}"
+            )
+
+
 class TestStoragePersistence:
     """Tests for state persistence across storage backends."""
 


### PR DESCRIPTION
## Description

Fixes a bug where first-time users could not complete OAuth authorization when their browser double-fetched the consent page.

Closes #4814

**What happened:** Every `GET /consent` unconditionally generated a fresh CSRF token and overwrote the one stored in the transaction. Browser extensions and prefetch mechanisms re-fetch the visited URL 0.2–1.2 s after load (same IP/UA), so the second GET invalidated the token embedded in the page the user was actually looking at. Their `POST /consent` then hit the stored-token check and returned `400 Invalid or expired consent token`. Only first-time users are affected — users with remembered consent skip the screen entirely — which made the failure look like a per-user mystery.

**Fix:** Before generating a new token, check whether `csrf_token` and `csrf_expires_at` are already present in the transaction and still within the 15-minute window. If so, reuse them. A fresh token is issued only on the first `GET` or after expiry.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
