### PR TITLE
Clarify auto-closed PR message

### DIFF
--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -379,9 +379,6 @@ jobs:
             async function enforceFailure(kind) {
               await addLabel();
 
-              const reason = kind === 'no-link'
-                ? "it doesn't reference a tracked issue assigned to you"
-                : "you aren't assigned to the issue it references";
               const steps = kind === 'no-link'
                 ? [
                     `1. Find or [open an issue](https://github.com/${owner}/${repo}/issues/new/choose) describing the change — if you open it, you have first claim on it.`,
@@ -393,9 +390,9 @@ jobs:
 
               const commentBody = [
                 MARKER,
-                "**Don't open a new pull request — this one reopens on its own.** It's closed for " +
-                  `now because ${reason}, but the moment that's fixed it reopens automatically. Keep this ` +
-                  'PR and edit it; opening a fresh duplicate just starts you over and creates more to triage.',
+                '**This pull request was closed because it must link to an issue assigned to you.** ' +
+                  'Once this PR links to an issue and a maintainer assigns that issue to you, it will ' +
+                  'reopen automatically. Please update this PR rather than opening a new one.',
                 '',
                 `Per [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md), an external PR must reference an issue that's assigned to its author. To get there:`,
                 '',


### PR DESCRIPTION
The auto-close comment currently leads with a warning not to open another pull request before explaining what happened. That makes the first thing a contributor sees feel disconnected from the closure itself.

This puts the reason first, then explains the exact path back to an open PR:

> **This pull request was closed because it must link to an issue assigned to you.** Once this PR links to an issue and a maintainer assigns that issue to you, it will reopen automatically. Please update this PR rather than opening a new one.
