### PR TITLE
fix(server): warn on unmatched visibility keys

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/visibility.py
+++ b/fastmcp_slim/fastmcp/server/transforms/visibility.py
@@ -102,6 +102,39 @@ class Visibility(Transform):
         self.tags = tags  # e.g., {"internal", "deprecated"}
         self.components = components  # e.g., {"tool", "prompt"}
         self.match_all = match_all
+        self._warned_unmatched_keys = {key for key in keys or () if "@" not in key}
+
+    def _warn_for_unmatched_keys(
+        self,
+        components: Sequence[FastMCPComponent],
+        component_type: Literal["tool", "resource", "template", "prompt"],
+    ) -> None:
+        """Warn when a key cannot match any component in a list operation.
+
+        The version delimiter cannot be validated from the key string alone:
+        resource URIs may contain ``@`` themselves. Compare keys with the
+        components after transforms have produced the current list instead.
+        """
+        if not self.keys or self.match_all:
+            return
+        if self.components is not None and component_type not in self.components:
+            return
+
+        prefix = f"{component_type}:"
+        keys = {key for key in self.keys if "@" in key and key.startswith(prefix)}
+        unmatched = sorted(keys - {component.key for component in components})
+        unmatched = [key for key in unmatched if key not in self._warned_unmatched_keys]
+        if not unmatched:
+            return
+
+        self._warned_unmatched_keys.update(unmatched)
+        warnings.warn(
+            f"Component keys do not match any component and will match nothing: "
+            f"{unmatched}. Read the value from `component.key`, or filter by "
+            f"`names` instead.",
+            UserWarning,
+            stacklevel=3,
+        )
 
     def __repr__(self) -> str:
         action = "enable" if self._enabled else "disable"
@@ -209,6 +242,7 @@ class Visibility(Transform):
 
     async def list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
         """Mark tools by visibility state."""
+        self._warn_for_unmatched_keys(tools, "tool")
         return [self._mark_component(t) for t in tools]
 
     async def get_tool(
@@ -226,6 +260,7 @@ class Visibility(Transform):
 
     async def list_resources(self, resources: Sequence[Resource]) -> Sequence[Resource]:
         """Mark resources by visibility state."""
+        self._warn_for_unmatched_keys(resources, "resource")
         return [self._mark_component(r) for r in resources]
 
     async def get_resource(
@@ -249,6 +284,7 @@ class Visibility(Transform):
         self, templates: Sequence[ResourceTemplate]
     ) -> Sequence[ResourceTemplate]:
         """Mark resource templates by visibility state."""
+        self._warn_for_unmatched_keys(templates, "template")
         return [self._mark_component(t) for t in templates]
 
     async def get_resource_template(
@@ -270,6 +306,7 @@ class Visibility(Transform):
 
     async def list_prompts(self, prompts: Sequence[Prompt]) -> Sequence[Prompt]:
         """Mark prompts by visibility state."""
+        self._warn_for_unmatched_keys(prompts, "prompt")
         return [self._mark_component(p) for p in prompts]
 
     async def get_prompt(

--- a/tests/server/transforms/test_visibility.py
+++ b/tests/server/transforms/test_visibility.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from fastmcp.resources.base import Resource
 from fastmcp.server.transforms.visibility import Visibility, is_enabled
 from fastmcp.tools.base import Tool
 from fastmcp.utilities.versions import VersionSpec
@@ -313,6 +314,29 @@ class TestMalformedKeyWarning:
         message = str(record[0].message)
         assert "tool:bad" in message
         assert "tool:good@" not in message
+
+    async def test_warns_when_resource_uri_at_sign_hides_missing_delimiter(self):
+        """A missing delimiter is ambiguous when the resource URI contains '@'."""
+        resource = Resource(uri="data://user@example.com/profile")
+        visibility = Visibility(
+            False,
+            keys={"resource:data://user@example.com/profile"},
+        )
+
+        with pytest.warns(UserWarning, match="do not match any component"):
+            await visibility.list_resources([resource])
+
+    async def test_resource_uri_at_sign_with_delimiter_matches_without_warning(
+        self, recwarn
+    ):
+        """A canonical resource key remains valid when its URI contains '@'."""
+        resource = Resource(uri="data://user@example.com/profile")
+        visibility = Visibility(False, keys={resource.key})
+
+        result = await visibility.list_resources([resource])
+
+        assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+        assert is_enabled(result[0]) is False
 
     def test_other_filters_do_not_warn(self, recwarn):
         """Only `keys` is subject to this validation."""


### PR DESCRIPTION
Fixes #4819

`Visibility` currently treats any key containing `@` as well-formed. That misses malformed keys when the resource URI itself contains `@`, so a rule such as `resource:data://user@example.com/profile` silently matches nothing and leaves the resource visible. This change compares configured keys with canonical component keys during list operations and warns when a key matches no component, while preserving the existing warning for keys that omit `@` and the valid behavior for canonical resource keys.

For example, disabling `resource:data://user@example.com/profile` now warns that the key matches no component and points callers to `component.key`.

🤖 Prepared with Codex; reviewed and tested locally.
