### PR TITLE
fix(server): warn on visibility keys with misplaced @ delimiter

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/visibility.py
+++ b/fastmcp_slim/fastmcp/server/transforms/visibility.py
@@ -37,6 +37,38 @@ _FASTMCP_KEY = "fastmcp"
 _INTERNAL_KEY = "_internal"
 
 
+def _visibility_key_is_malformed(key: str) -> bool:
+    """Return True when a visibility key can never match a real component key.
+
+    Component keys always include ``@`` as the version delimiter. Unversioned
+    keys end with a bare ``@``; versioned keys end with ``@<version>``. URIs
+    may contain ``@``, so a key that omits the trailing delimiter can satisfy
+    ``"@" in key`` while still matching nothing.
+    """
+    if "@" not in key:
+        return True
+
+    if key.endswith("@"):
+        return False
+
+    key_suffix = key
+    for prefix in ("tool", "resource", "template", "prompt"):
+        head = f"{prefix}:"
+        if key.startswith(head):
+            key_suffix = key[len(head) :]
+            break
+    else:
+        if ":" in key:
+            _, key_suffix = key.split(":", 1)
+
+    _name, version = key_suffix.rsplit("@", 1)
+
+    if not version:
+        return True
+
+    return "/" in version or ":" in version
+
+
 class Visibility(Transform):
     """Sets visibility state on matching components.
 
@@ -83,7 +115,7 @@ class Visibility(Transform):
             match_all: If True, matches all components regardless of other criteria.
         """
         if keys:
-            malformed = sorted(key for key in keys if "@" not in key)
+            malformed = sorted(key for key in keys if _visibility_key_is_malformed(key))
             if malformed:
                 warnings.warn(
                     f"Component keys are missing the '@' version delimiter and will "

--- a/tests/server/transforms/test_visibility.py
+++ b/tests/server/transforms/test_visibility.py
@@ -284,6 +284,7 @@ class TestMalformedKeyWarning:
             "tool:my_tool",
             "resource:data://config",
             "prompt:analyze",
+            "resource:data://user@example.com/profile",
         ],
     )
     def test_warns_on_key_without_delimiter(self, key: str):
@@ -298,6 +299,8 @@ class TestMalformedKeyWarning:
             "tool:my_tool@v1",
             "resource:data://config@",
             "resource:data://user@example.com/profile@",
+            "resource:data://user@example.com/profile@v1",
+            "resource:file://x@v1",
         ],
     )
     def test_no_warning_on_well_formed_key(self, key: str, recwarn):
@@ -320,3 +323,32 @@ class TestMalformedKeyWarning:
         Visibility(False, tags={"internal"})
         Visibility(False, match_all=True)
         assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+
+
+class TestMalformedKeyIntegration:
+    """End-to-end: malformed keys with '@' in the URI must warn and not hide."""
+
+    @pytest.mark.asyncio
+    async def test_disable_key_missing_trailing_at_on_uri_with_at(self):
+        import warnings
+
+        from fastmcp import Client, FastMCP
+
+        uri = "data://user@example.com/profile"
+        mcp = FastMCP("demo")
+
+        @mcp.resource(uri)
+        def profile() -> str:
+            return "SECRET"
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mcp.disable(keys={f"resource:{uri}"})
+
+        assert any(
+            "missing the '@' version delimiter" in str(w.message) for w in caught
+        )
+
+        async with Client(mcp) as client:
+            resources = await client.list_resources()
+            assert [str(r.uri) for r in resources] == [uri]


### PR DESCRIPTION
## Summary

Extend malformed visibility `keys` validation so resource URIs that contain `@` but omit the trailing version delimiter trigger the existing `UserWarning`, instead of silently matching nothing.

## Motivation

`Visibility(keys=...)` warned only when `"@" not in key`. A key like `resource:data://user@example.com/profile` (missing trailing `@`) passes that check because the URI contains `@`, but it never matches the real component key `resource:data://user@example.com/profile@`. Disable/enable then appears to succeed while the resource stays visible (#4819).

## Changes

- Add `_visibility_key_is_malformed()` to parse keys using the component-type prefix and the last `@` delimiter.
- Warn when the parsed version segment is empty or looks like a URI fragment (`/` or `:` in the version slot).
- Add regression tests, including an integration test with `FastMCP` + `Client`.

## Tests

```bash
uv run pytest tests/server/transforms/test_visibility.py -v
```

41 passed.

```bash
uv run prek run --files fastmcp_slim/fastmcp/server/transforms/visibility.py tests/server/transforms/test_visibility.py
```

ruff, ty, format: passed.

## Notes

Versioned resource keys with `@` in the URI (e.g. `resource:data://user@example.com/profile@v1`) remain valid. Some edge cases without path segments in the misparsed version (e.g. `resource:data://user@example.com`) may still slip through; the issue repro includes `/profile` which is covered.

Fixes #4819