### PR TITLE
Fix generic typing for proxy cache entries

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -14,7 +14,7 @@ import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
 import anyio
 import httpx2
@@ -77,6 +77,7 @@ logger = get_logger(__name__)
 # Type alias for client factory functions
 ClientFactoryT = Callable[[], Client] | Callable[[], Awaitable[Client]]
 ProxyIdentity = Literal["proxy", "upstream"]
+_CacheT = TypeVar("_CacheT")
 
 
 class _ForwardingClientSession(ClientSession):
@@ -819,12 +820,12 @@ class ProxyPrompt(Prompt):
 # -----------------------------------------------------------------------------
 
 
-class _CacheEntry:
+class _CacheEntry(Generic[_CacheT]):
     """A cached sequence of components with a monotonic timestamp."""
 
     __slots__ = ("items", "timestamp")
 
-    def __init__(self, items: Sequence[Any], timestamp: float):
+    def __init__(self, items: Sequence[_CacheT], timestamp: float):
         self.items = items
         self.timestamp = timestamp
 


### PR DESCRIPTION
## Description

Make `_CacheEntry` generic and preserve its item type so current `ty` releases accept the typed proxy cache annotations. This restores the scheduled upgrade check without changing runtime behavior.

Closes #4812

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (the failing static check is the regression; existing proxy cache tests pass)
- [ ] I have run `uv run prek run --all-files` and all checks pass (Windows run passes all hooks except the existing POSIX-only `fcntl` diagnostics)
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

Validation: `ty check fastmcp_slim/fastmcp/server/providers/proxy.py`; proxy cache tests (7 passed).