### PR TITLE
Scope Marvin App token to each job's declared permissions

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           app-id: ${{ secrets.MARVIN_APP_ID }}
           private-key: ${{ secrets.MARVIN_APP_PRIVATE_KEY }}
+          # Match the job's `permissions:` block above. Unscoped, the token
+          # inherits the App installation's full set — which includes
+          # contents: write and actions: write, neither of which this job
+          # declares and both of which end up in the model's shell as GH_TOKEN.
+          permission-contents: read
+          permission-issues: write
 
       - name: Set dedupe prompt
         id: dedupe-prompt
@@ -114,8 +120,12 @@ jobs:
           prompt: ${{ steps.dedupe-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
           allowed_non_write_users: "*"
+          # No `Bash(gh api:*)`: it reaches every endpoint the token can, which
+          # is the reason marvin-label-triage routes its one write through
+          # .github/scripts/triage-label.sh instead. Dedupe searches, reads and
+          # comments — the four verbs below cover that.
           claude_args: |
-            --allowedTools "Bash(gh issue view:*)","Bash(gh search:*)","Bash(gh issue list:*)","Bash(gh api:*)","Bash(gh issue comment:*)",Task
+            --allowedTools "Bash(gh issue view:*)","Bash(gh search:*)","Bash(gh issue list:*)","Bash(gh issue comment:*)",Task
           settings: |
             {
               "model": "claude-sonnet-5",

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -56,7 +56,14 @@ jobs:
         with:
           app-id: ${{ secrets.MARVIN_APP_ID }}
           private-key: ${{ secrets.MARVIN_APP_PRIVATE_KEY }}
-          owner: PrefectHQ
+          # No `owner:` — with it set and `repositories:` empty the token is
+          # scoped to every repo in the PrefectHQ installation. Triage only
+          # ever touches this one. The permissions below match the job's
+          # `permissions:` block; unscoped the token would also carry
+          # contents: write and actions: write from the App installation.
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Set triage prompt
         id: triage-prompt


### PR DESCRIPTION
Both Marvin workflows that run on issues from any GitHub account mint their App token without scoping it. The token inherits the App installation's full permission set. That set is wider than the `permissions:` block each job declares, and the token reaches the model as `GH_TOKEN`. Someone reading the workflow cannot see what the agent actually holds.

Each mint now names the same permissions its job declares:

```yaml
- name: Generate Marvin App token
  uses: actions/create-github-app-token@v3
  with:
    app-id: ${{ secrets.MARVIN_APP_ID }}
    private-key: ${{ secrets.MARVIN_APP_PRIVATE_KEY }}
    permission-contents: read
    permission-issues: write
```

`create-github-app-token` can only narrow an installation's permissions. It fails the step when you name a permission the App does not have, so this cannot grant more than the token carries today.

Label triage also drops `owner: PrefectHQ`. With `owner` set and `repositories` empty, the action scopes the token to every repository in the installation. Triage only ever touches this one.

Dedupe drops `Bash(gh api:*)` from its tool list. That pattern reaches every endpoint the token can. The helper at `.github/scripts/triage-label.sh` already records this reasoning for label triage. Dedupe searches issues, reads them, and posts at most one comment, so the four remaining `gh` verbs cover its prompt.

Neither workflow should behave differently. If the agent reaches for `gh api` as an unlisted fallback, the dedupe run log shows a denial rather than a failed job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
