### PR TITLE
fix: project resource links through namespaces

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -1489,7 +1489,8 @@ class FastMCP(
                     raise NotFoundError(f"Unknown tool: {name!r}")
                 span.set_attributes(tool.get_span_attributes())
                 try:
-                    return await tool._run(arguments or {})
+                    result = await tool._run(arguments or {})
+                    return tool._apply_result_transforms(result)
                 except ValidationError as e:
                     # Argument-validation failure (a bad call). FunctionTool
                     # converts pydantic's call-validation error into fastmcp's

--- a/fastmcp_slim/fastmcp/server/transforms/namespace.py
+++ b/fastmcp_slim/fastmcp/server/transforms/namespace.py
@@ -6,6 +6,8 @@ import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+import mcp_types
+
 from fastmcp.server.transforms import (
     GetPromptNext,
     GetResourceNext,
@@ -13,6 +15,7 @@ from fastmcp.server.transforms import (
     GetToolNext,
     Transform,
 )
+from fastmcp.tools.base import InputRequiredToolResult, ToolResult
 from fastmcp.utilities.versions import VersionSpec
 
 if TYPE_CHECKING:
@@ -20,6 +23,7 @@ if TYPE_CHECKING:
     from fastmcp.resources.base import Resource
     from fastmcp.resources.template import ResourceTemplate
     from fastmcp.tools.base import Tool
+
 
 # Pattern for matching URIs: protocol://path
 _URI_PATTERN = re.compile(r"^([^:]+://)(.*?)$")
@@ -90,6 +94,32 @@ class Namespace(Transform):
             return None
         return None
 
+    def _transform_tool_result(self, result: ToolResult) -> ToolResult:
+        """Project resource links returned by a tool into this namespace."""
+        if isinstance(result, InputRequiredToolResult):
+            return result
+
+        content = [
+            mcp_types.ResourceLink.model_validate(
+                {
+                    **block.model_dump(mode="python", by_alias=True),
+                    "uri": self._transform_uri(str(block.uri)),
+                }
+            )
+            if isinstance(block, mcp_types.ResourceLink)
+            else block
+            for block in result.content
+        ]
+        if content == result.content:
+            return result
+
+        return ToolResult(
+            content=content,
+            structured_content=result.structured_content,
+            meta=result.meta,
+            is_error=result.is_error,
+        )
+
     # -------------------------------------------------------------------------
     # Tools
     # -------------------------------------------------------------------------
@@ -97,7 +127,10 @@ class Namespace(Transform):
     async def list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
         """Prefix tool names with namespace."""
         return [
-            t.model_copy(update={"name": self._transform_name(t.name)}) for t in tools
+            t.model_copy(
+                update={"name": self._transform_name(t.name)}
+            )._with_result_transform(self._transform_tool_result)
+            for t in tools
         ]
 
     async def get_tool(
@@ -109,7 +142,9 @@ class Namespace(Transform):
             return None
         tool = await call_next(original, version=version)
         if tool:
-            return tool.model_copy(update={"name": name})
+            return tool.model_copy(update={"name": name})._with_result_transform(
+                self._transform_tool_result
+            )
         return None
 
     # -------------------------------------------------------------------------

--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -232,6 +232,9 @@ class Tool(FastMCPComponent):
     """Internal tool registration info."""
 
     KEY_PREFIX: ClassVar[str] = "tool"
+    _result_transforms: tuple[Callable[[ToolResult], ToolResult], ...] = PrivateAttr(
+        default=()
+    )
 
     return_type: Annotated[SkipJsonSchema[Any], Field(exclude=True)] = None
     parameters: Annotated[
@@ -438,6 +441,20 @@ class Tool(FastMCPComponent):
         overrides this to delegate to child-server middleware.
         """
         return await self.run(arguments)
+
+    def _with_result_transform(
+        self, transform: Callable[[ToolResult], ToolResult]
+    ) -> Tool:
+        """Copy this tool and append a result transform."""
+        tool = self.model_copy()
+        tool._result_transforms = (*self._result_transforms, transform)
+        return tool
+
+    def _apply_result_transforms(self, result: ToolResult) -> ToolResult:
+        """Apply result transforms in the same order as component transforms."""
+        for transform in self._result_transforms:
+            result = transform(result)
+        return result
 
     @classmethod
     def from_tool(

--- a/fastmcp_slim/fastmcp/tools/tool_transform.py
+++ b/fastmcp_slim/fastmcp/tools/tool_transform.py
@@ -620,6 +620,7 @@ class TransformedTool(Tool):
             transform_args=transform_args,
             auth=tool.auth,
         )
+        transformed_tool._result_transforms = tool._result_transforms
 
         return transformed_tool
 

--- a/fastmcp_tasks/fastmcp_tasks/handlers.py
+++ b/fastmcp_tasks/fastmcp_tasks/handlers.py
@@ -228,9 +228,10 @@ def _inline_result(tool: Tool, raw_value: Any) -> dict[str, Any]:
     # (end-and-reenter G2); use it directly so isError round-trips. A normal
     # return is converted through the tool's own result coercion.
     if isinstance(raw_value, ToolResult):
-        mcp_result = raw_value.to_mcp_result()
+        tool_result = raw_value
     else:
-        mcp_result = tool.convert_result(raw_value).to_mcp_result()
+        tool_result = tool.convert_result(raw_value)
+    mcp_result = tool._apply_result_transforms(tool_result).to_mcp_result()
     if isinstance(mcp_result, mcp_types.CallToolResult):
         call_tool_result = mcp_result
     elif isinstance(mcp_result, tuple):

--- a/tests/server/providers/test_transforming_provider.py
+++ b/tests/server/providers/test_transforming_provider.py
@@ -1,11 +1,14 @@
 """Tests for Namespace and ToolTransform."""
 
+import mcp_types
 import pytest
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
+from fastmcp.server import create_proxy
 from fastmcp.server.providers import FastMCPProvider
 from fastmcp.server.transforms import Namespace, ToolTransform
+from fastmcp.tools.base import ToolResult
 from fastmcp.tools.tool_transform import ToolTransformConfig
 
 
@@ -80,6 +83,50 @@ class TestNamespaceTransform:
 
         assert len(transformed_templates) == 1
         assert transformed_templates[0].uri_template == "resource://ns/{name}/data"
+
+    async def test_namespace_rewrites_resource_links_in_tool_results(self):
+        """Resource links returned by namespaced tools use the public URI."""
+        upstream = FastMCP("Upstream")
+
+        @upstream.resource("resource://data")
+        def data() -> str:
+            return "resource"
+
+        @upstream.tool
+        def get_link() -> ToolResult:
+            return ToolResult(
+                content=[
+                    mcp_types.TextContent(type="text", text="resource"),
+                    mcp_types.ResourceLink(
+                        name="data",
+                        uri="resource://data",
+                        mime_type="text/plain",
+                    ),
+                ],
+                structured_content={"source": "upstream"},
+                meta={"request_id": "123"},
+                is_error=True,
+            )
+
+        proxy = create_proxy(upstream)
+        proxy.add_transform(Namespace("ns"))
+
+        result = await proxy.call_tool("ns_get_link")
+        resources = await proxy.list_resources()
+
+        assert str(resources[0].uri) == "resource://ns/data"
+        assert result.content[0] == mcp_types.TextContent(type="text", text="resource")
+        resource_link = result.content[1]
+        assert resource_link == mcp_types.ResourceLink(
+            name="data",
+            uri="resource://ns/data",
+            mime_type="text/plain",
+        )
+        assert isinstance(resource_link, mcp_types.ResourceLink)
+        assert isinstance(resource_link.uri, str)
+        assert result.structured_content == {"source": "upstream"}
+        assert result.meta == {"request_id": "123"}
+        assert result.is_error
 
 
 class TestToolTransformRenames:
@@ -242,8 +289,8 @@ class TestTransformStacking:
         sub = FastMCP("Sub")
 
         @sub.tool
-        def my_tool() -> str:
-            return "success"
+        def my_tool() -> mcp_types.ResourceLink:
+            return mcp_types.ResourceLink(name="data", uri="resource://data")
 
         main = FastMCP("Main")
         provider = FastMCPProvider(sub)
@@ -256,7 +303,9 @@ class TestTransformStacking:
 
         async with Client(main) as client:
             result = await client.call_tool("short", {})
-            assert result.data == "success"
+            assert result.content[0] == mcp_types.ResourceLink(
+                name="data", uri="resource://ns/data"
+            )
 
 
 class TestNoTransformation:

--- a/tests/tasks/server/test_task_mount.py
+++ b/tests/tasks/server/test_task_mount.py
@@ -122,6 +122,26 @@ class TestMountedToolTasks:
             assert not hasattr(result, "task_id")
             assert "child sync: hi" in result.content[0].text
 
+    async def test_namespaced_task_rewrites_resource_link_results(self):
+        child = FastMCP("child")
+
+        @child.tool(task=True)
+        async def linked_resource() -> mt.ResourceLink:
+            return mt.ResourceLink(name="data", uri="resource://data")
+
+        parent = FastMCP("parent")
+        parent.add_extension(TasksExtension())
+        parent.mount(child, namespace="child")
+
+        async with running_task_server(parent):
+            final = await wait_for_task(
+                parent,
+                (await submit_task(parent, "child_linked_resource", {})).task_id,
+            )
+
+        assert final.result is not None
+        assert final.result["content"][0]["uri"] == "resource://child/data"
+
 
 class TestRemoteWorkerServerResolution:
     """A separate worker process re-resolves the owning child from the root.


### PR DESCRIPTION
Closes #4154

`Namespace` currently rewrites resource catalogs and read routes but leaves `ResourceLink` content returned from `tools/call` unchanged. This adds a reusable, copy-preserving tool-result transform so URI projection runs after the original tool completes, without replacing its concrete type or bypassing mounted-server execution, task registration, middleware, or spans. The same transform is applied when task results are inlined and is preserved through `ToolTransform`; unrelated content, structured output, metadata, error state, and input-required results remain unchanged.

```python
proxy.add_transform(Namespace("api"))
# resource://item -> resource://api/item in both resources/list and ResourceLink results
```

🤖 Generated with OpenAI Codex.