### PR TITLE
fix: cache OIDC discovery for identical configuration

### DIFF
--- a/docs/servers/auth/oidc-proxy.mdx
+++ b/docs/servers/auth/oidc-proxy.mdx
@@ -220,6 +220,12 @@ auth = OIDCProxy(
 </ParamField>
 </Card>
 
+### Discovery Caching
+
+The proxy fetches your provider's discovery document when it is constructed. Successful responses are cached in-process per `config_url` for five minutes, so building several proxies for the same issuer — or rebuilding a server at runtime — issues a single request instead of one per provider. Providers such as Auth0 throttle their discovery endpoint, and this keeps a busy server well below those limits.
+
+Failed requests are never cached, so a provider that is briefly unreachable is retried on the next attempt. Once the entry expires the document is fetched again, which means metadata changes (a rotated `jwks_uri`, for instance) are picked up without restarting the process.
+
 ### Using Built-in Providers
 
 FastMCP includes pre-configured OIDC providers for common services:

--- a/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
@@ -9,7 +9,10 @@ This implementation is based on:
     OAuth 2.0 Authorization Server Metadata - https://datatracker.ietf.org/doc/html/rfc8414
 """
 
+import threading
+import time
 from collections.abc import Sequence
+from copy import deepcopy
 from typing import Any, Literal
 
 import httpx2
@@ -31,6 +34,54 @@ logger = get_logger(__name__)
 #: unreachable issuer metadata endpoint. Pass ``timeout_seconds=None`` to fall
 #: back to the HTTP client's own default timeout instead.
 DEFAULT_OIDC_DISCOVERY_TIMEOUT_SECONDS = 10
+
+#: How long, in seconds, a discovery document is reused before the issuer's
+#: metadata endpoint is queried again. Discovery for the same issuer happens
+#: repeatedly in practice (several providers sharing an issuer, servers rebuilt
+#: at runtime, tests), and some issuers throttle it aggressively.
+OIDC_DISCOVERY_CACHE_TTL_SECONDS = 300
+
+#: Maximum number of discovery documents held in the process-local cache.
+OIDC_DISCOVERY_CACHE_MAX_SIZE = 128
+
+_discovery_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+_discovery_cache_lock = threading.Lock()
+
+
+def _get_cached_discovery_document(config_url: str) -> dict[str, Any] | None:
+    """Return a copy of the cached discovery document, if one is still valid."""
+    with _discovery_cache_lock:
+        entry = _discovery_cache.get(config_url)
+        if entry is None:
+            return None
+
+        expires_at, document = entry
+        if expires_at <= time.monotonic():
+            del _discovery_cache[config_url]
+            return None
+
+        return deepcopy(document)
+
+
+def _cache_discovery_document(config_url: str, document: dict[str, Any]) -> None:
+    """Cache a discovery document that was fetched and validated successfully."""
+    with _discovery_cache_lock:
+        if (
+            config_url not in _discovery_cache
+            and len(_discovery_cache) >= OIDC_DISCOVERY_CACHE_MAX_SIZE
+        ):
+            del _discovery_cache[next(iter(_discovery_cache))]
+
+        _discovery_cache[config_url] = (
+            time.monotonic() + OIDC_DISCOVERY_CACHE_TTL_SECONDS,
+            deepcopy(document),
+        )
+
+
+def clear_oidc_discovery_cache() -> None:
+    """Drop every cached OIDC discovery document."""
+    with _discovery_cache_lock:
+        _discovery_cache.clear()
 
 
 class OIDCConfiguration(BaseModel):
@@ -153,6 +204,12 @@ class OIDCConfiguration(BaseModel):
     ) -> Self:
         """Get the OIDC configuration for the specified config URL.
 
+        Discovery documents are cached per config URL for
+        `OIDC_DISCOVERY_CACHE_TTL_SECONDS` so that repeated calls for the same
+        issuer reuse a single request. The raw document is cached rather than the
+        validated model, so each caller gets its own configuration instance and
+        `strict` is applied per call.
+
         Args:
             config_url: The OIDC config URL
             strict: The strict flag for the configuration
@@ -162,20 +219,31 @@ class OIDCConfiguration(BaseModel):
         if timeout_seconds is not None:
             get_kwargs["timeout"] = timeout_seconds
 
-        try:
-            response = httpx2.get(str(config_url), **get_kwargs)
-            response.raise_for_status()
+        document = _get_cached_discovery_document(str(config_url))
+        was_cached = document is not None
 
-            config_data = response.json()
+        try:
+            if document is None:
+                response = httpx2.get(str(config_url), **get_kwargs)
+                response.raise_for_status()
+
+                document = response.json()
+
+            config_data = dict(document)
             if strict is not None:
                 config_data["strict"] = strict
 
-            return cls.model_validate(config_data)
+            config = cls.model_validate(config_data)
         except Exception:
             logger.exception(
                 f"Unable to get OIDC configuration for config url: {config_url}"
             )
             raise
+
+        if not was_cached:
+            _cache_discovery_document(str(config_url), document)
+
+        return config
 
 
 class OIDCProxy(OAuthProxy):

--- a/tests/server/auth/conftest.py
+++ b/tests/server/auth/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from fastmcp.server.auth.oidc_proxy import clear_oidc_discovery_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_discovery_cache():
+    """Isolate tests from the process-local OIDC discovery cache.
+
+    Discovery results are cached per config URL for the life of the process, and
+    auth tests reuse a handful of config URLs across modules, so without this a
+    mocked discovery response from one test would satisfy the next one.
+    """
+    clear_oidc_discovery_cache()
+
+    yield
+
+    clear_oidc_discovery_cache()

--- a/tests/server/auth/test_oidc_proxy.py
+++ b/tests/server/auth/test_oidc_proxy.py
@@ -3,10 +3,12 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx2
 import pytest
 from httpx2 import Response
 from pydantic import AnyHttpUrl
 
+from fastmcp.server.auth import oidc_proxy
 from fastmcp.server.auth.oidc_proxy import OIDCConfiguration, OIDCProxy
 from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
 from fastmcp.server.auth.providers.jwt import JWTVerifier
@@ -424,6 +426,153 @@ class TestGetOIDCConfiguration:
 
             call_args = mock_get.call_args
             assert str(call_args[0][0]) == str(TEST_CONFIG_URL)
+
+
+class TestOIDCDiscoveryCache:
+    """Tests for caching of OIDC discovery documents."""
+
+    def test_identical_configuration_is_fetched_once(
+        self, valid_oidc_configuration_dict
+    ):
+        """Test that repeated discovery for the same config URL reuses one request."""
+        with patch("httpx2.get") as mock_get:
+            mock_response = MagicMock(spec=Response)
+            mock_response.json.return_value = valid_oidc_configuration_dict
+            mock_get.return_value = mock_response
+
+            first = OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+            second = OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+
+            mock_get.assert_called_once()
+            assert first == second
+            assert first is not second
+
+    def test_different_config_urls_are_fetched_separately(
+        self, valid_oidc_configuration_dict
+    ):
+        """Test that each config URL gets its own cache entry."""
+        with patch("httpx2.get") as mock_get:
+            mock_response = MagicMock(spec=Response)
+            mock_response.json.return_value = valid_oidc_configuration_dict
+            mock_get.return_value = mock_response
+
+            OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+            OIDCConfiguration.get_oidc_configuration(
+                config_url=AnyHttpUrl(
+                    "https://other.example.com/.well-known/openid-configuration"
+                ),
+                strict=True,
+                timeout_seconds=10,
+            )
+
+            assert mock_get.call_count == 2
+
+    def test_expired_entry_is_fetched_again(
+        self, valid_oidc_configuration_dict, monkeypatch
+    ):
+        """Test that discovery is repeated once a cached document has expired."""
+        monkeypatch.setattr(oidc_proxy, "OIDC_DISCOVERY_CACHE_TTL_SECONDS", 0)
+
+        with patch("httpx2.get") as mock_get:
+            mock_response = MagicMock(spec=Response)
+            mock_response.json.return_value = valid_oidc_configuration_dict
+            mock_get.return_value = mock_response
+
+            OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+            OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+
+            assert mock_get.call_count == 2
+
+    def test_failed_discovery_is_not_cached(self, valid_oidc_configuration_dict):
+        """Test that a failed request is retried rather than cached."""
+        with patch("httpx2.get") as mock_get:
+            mock_get.side_effect = httpx2.ConnectError("boom")
+
+            with pytest.raises(httpx2.ConnectError):
+                OIDCConfiguration.get_oidc_configuration(
+                    config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+                )
+
+            mock_response = MagicMock(spec=Response)
+            mock_response.json.return_value = valid_oidc_configuration_dict
+            mock_get.side_effect = None
+            mock_get.return_value = mock_response
+
+            config = OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+
+            assert mock_get.call_count == 2
+            validate_config(config, valid_oidc_configuration_dict)
+
+    def test_strict_is_applied_per_call(self, invalid_oidc_configuration_dict):
+        """Test that the cached document carries no strict flag of its own."""
+        with patch("httpx2.get") as mock_get:
+            mock_response = MagicMock(spec=Response)
+            mock_response.json.return_value = invalid_oidc_configuration_dict
+            mock_get.return_value = mock_response
+
+            OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=False, timeout_seconds=10
+            )
+
+            with pytest.raises(
+                ValueError, match="Missing required configuration metadata"
+            ):
+                OIDCConfiguration.get_oidc_configuration(
+                    config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+                )
+
+            mock_get.assert_called_once()
+
+    def test_cached_configuration_is_not_shared_between_callers(
+        self, valid_oidc_configuration_dict
+    ):
+        """Test that mutating a returned configuration does not affect later callers."""
+        with patch("httpx2.get") as mock_get:
+            mock_response = MagicMock(spec=Response)
+            mock_response.json.return_value = valid_oidc_configuration_dict
+            mock_get.return_value = mock_response
+
+            first = OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+            first.token_endpoint = "https://mutated.example.com/oauth/token"
+
+            second = OIDCConfiguration.get_oidc_configuration(
+                config_url=TEST_CONFIG_URL, strict=True, timeout_seconds=10
+            )
+
+            assert str(second.token_endpoint) == TEST_TOKEN_ENDPOINT
+
+    def test_proxies_share_a_single_discovery_request(
+        self, valid_oidc_configuration_dict
+    ):
+        """Test that two proxies for the same issuer only trigger one discovery."""
+        with patch("httpx2.get") as mock_get:
+            mock_response = MagicMock(spec=Response)
+            mock_response.json.return_value = valid_oidc_configuration_dict
+            mock_get.return_value = mock_response
+
+            for _ in range(2):
+                OIDCProxy(
+                    config_url=TEST_CONFIG_URL,
+                    client_id=TEST_CLIENT_ID,
+                    client_secret=TEST_CLIENT_SECRET,
+                    base_url=TEST_BASE_URL,
+                )
+
+            mock_get.assert_called_once()
 
 
 def validate_proxy(mock_get, proxy, oidc_config):


### PR DESCRIPTION
Fixes #4837.

OIDC discovery is now cached per config URL (5-minute TTL) so identical configuration is fetched once. Failures are not cached.

tests/server/auth: 1336 passed. Full suite 7208 passed.