### PR TITLE
Add Horizon deployment source bundles

### DIFF
--- a/fastmcp_slim/fastmcp/cli/deploy/source.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source.py
@@ -100,7 +100,12 @@ def _resolve_entrypoint(source_path: Path, explicit_entrypoint: str | None) -> s
 def _server_binding_names(module: ast.Module) -> set[str]:
     candidates: set[str] = set()
     for statement in module.body:
-        if isinstance(statement, ast.Assign) and _is_server_constructor(
+        if isinstance(statement, ast.ImportFrom):
+            for alias in statement.names:
+                bound_name = alias.asname or alias.name
+                if bound_name in _COMMON_ENTRYPOINTS:
+                    candidates.add(bound_name)
+        elif isinstance(statement, ast.Assign) and _is_server_constructor(
             statement.value
         ):
             for target in statement.targets:

--- a/fastmcp_slim/fastmcp/cli/deploy/source.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source.py
@@ -7,6 +7,7 @@ import json
 import tokenize
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import quote
 
 from pydantic import ValidationError
 
@@ -217,13 +218,13 @@ def _resolve_dependencies(
             lines.append(f"-r {relative_path(source_root, requirements)}")
             required_paths.append(requirements)
         if project is not None:
-            lines.append(f"-e {relative_path(source_root, project)}")
+            lines.append(f"-e {_editable_requirement(source_root, project)}")
             required_paths.append(project)
             project_config = project / "pyproject.toml"
             if project_config.is_file():
                 required_paths.append(project_config)
         for path in sorted(editable, key=lambda item: relative_path(source_root, item)):
-            lines.append(f"-e {relative_path(source_root, path)}")
+            lines.append(f"-e {_editable_requirement(source_root, path)}")
             required_paths.append(path)
             editable_config = path / "pyproject.toml"
             if editable_config.is_file():
@@ -259,6 +260,11 @@ def _resolve_dependencies(
         )
 
     return _detect_dependency_input(source_root, source_path.parent)
+
+
+def _editable_requirement(source_root: Path, path: Path) -> str:
+    relative = relative_path(source_root, path)
+    return f"file:{quote(relative, safe='/')}"
 
 
 def _detect_dependency_input(source_root: Path, start: Path) -> _DependencyInput:

--- a/fastmcp_slim/fastmcp/cli/deploy/source.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source.py
@@ -1,0 +1,307 @@
+"""Resolve local source for a Horizon deployment."""
+
+from __future__ import annotations
+
+import ast
+import json
+import tokenize
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from fastmcp.cli.deploy.source_paths import (
+    SourceInvalidError,
+    relative_path,
+    require_included_path,
+    resolve_path,
+)
+from fastmcp.utilities.mcp_server_config import MCPServerConfig
+from fastmcp.utilities.mcp_server_config.v1.sources.filesystem import FileSystemSource
+
+GENERATED_REQUIREMENTS_PATH = ".fastmcp-deploy-requirements.txt"
+_COMMON_ENTRYPOINTS = ("mcp", "server", "app")
+
+
+@dataclass(frozen=True)
+class DeploySource:
+    """A resolved local source before archive creation."""
+
+    source_root: Path
+    entrypoint: str
+    dependency_path: str | None
+    generated_requirements: str | None = field(default=None, repr=False)
+    required_paths: tuple[Path, ...] = field(default=(), repr=False)
+
+
+@dataclass(frozen=True)
+class _DependencyInput:
+    path: str | None
+    generated_requirements: str | None
+    required_paths: tuple[Path, ...]
+
+
+class _ModuleBindingVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Store):
+            self.names.add(node.id)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        pass
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.names.add(alias.asname or alias.name.partition(".")[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name != "*":
+                self.names.add(alias.asname or alias.name)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        pass
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        pass
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        pass
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        pass
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        pass
+
+
+async def resolve_deploy_source(server_spec: str | None) -> DeploySource:
+    """Resolve a FastMCP server input without applying runtime settings."""
+    config, source_root = _load_config(server_spec)
+    source_path = resolve_path(
+        source_root,
+        config.source.path,
+        label="Server source",
+        file=True,
+    )
+    require_included_path(source_root, source_path, label="Server source")
+
+    if config.source.entrypoint and ":" in config.source.entrypoint:
+        raise SourceInvalidError(
+            "Deployment entrypoints must use a file and one object name"
+        )
+
+    object_name = _resolve_entrypoint(source_path, config.source.entrypoint)
+    relative_source = source_path.relative_to(source_root).as_posix()
+    dependency = _resolve_dependencies(config, source_root, source_path)
+    return DeploySource(
+        source_root=source_root,
+        entrypoint=f"{relative_source}:{object_name}",
+        dependency_path=dependency.path,
+        generated_requirements=dependency.generated_requirements,
+        required_paths=(source_path, *dependency.required_paths),
+    )
+
+
+def _resolve_entrypoint(source_path: Path, explicit_entrypoint: str | None) -> str:
+    if explicit_entrypoint:
+        return explicit_entrypoint
+
+    try:
+        with tokenize.open(source_path) as source_file:
+            source_text = source_file.read()
+        module = ast.parse(source_text, filename=str(source_path))
+    except (OSError, SyntaxError, UnicodeError) as exc:
+        raise SourceInvalidError(
+            f"The server source could not be parsed: {exc}"
+        ) from exc
+
+    bindings = _ModuleBindingVisitor()
+    bindings.visit(module)
+    for name in _COMMON_ENTRYPOINTS:
+        if name in bindings.names:
+            return name
+    raise SourceInvalidError(
+        "No server object named mcp, server, or app was found; provide an entrypoint"
+    )
+
+
+def _load_config(server_spec: str | None) -> tuple[MCPServerConfig, Path]:
+    if server_spec is None:
+        config_path = MCPServerConfig.find_config()
+        if config_path is None:
+            raise SourceInvalidError(
+                "Provide a server input or add fastmcp.json to the current directory"
+            )
+        return _read_config(config_path), config_path.parent.resolve()
+
+    if server_spec.endswith(".json"):
+        config_path = Path(server_spec).expanduser().absolute()
+        return _read_config(config_path), config_path.parent.resolve()
+
+    return (
+        MCPServerConfig(source=FileSystemSource(path=server_spec)),
+        Path.cwd().resolve(),
+    )
+
+
+def _read_config(config_path: Path) -> MCPServerConfig:
+    try:
+        return MCPServerConfig.from_file(config_path)
+    except (FileNotFoundError, json.JSONDecodeError, ValidationError) as exc:
+        raise SourceInvalidError(
+            f"The FastMCP configuration is invalid: {config_path}"
+        ) from exc
+
+
+def _resolve_dependencies(
+    config: MCPServerConfig,
+    source_root: Path,
+    source_path: Path,
+) -> _DependencyInput:
+    environment = config.environment
+    requirements = (
+        resolve_path(
+            source_root,
+            environment.requirements,
+            label="Requirements file",
+            file=True,
+        )
+        if environment.requirements is not None
+        else None
+    )
+    project = (
+        resolve_path(
+            source_root,
+            environment.project,
+            label="Environment project",
+            directory=True,
+        )
+        if environment.project is not None
+        else None
+    )
+    editable = tuple(
+        resolve_path(
+            source_root,
+            path,
+            label="Editable dependency",
+            directory=True,
+        )
+        for path in (environment.editable or [])
+    )
+
+    for label, path in (
+        ("Requirements file", requirements),
+        ("Environment project", project),
+        *(("Editable dependency", path) for path in editable),
+    ):
+        if path is not None:
+            require_included_path(source_root, path, label=label)
+
+    dependencies = sorted(set(environment.dependencies or []))
+    needs_generated = bool(
+        dependencies or editable or (project is not None and requirements is not None)
+    )
+    if needs_generated:
+        lines: list[str] = []
+        required_paths: list[Path] = []
+        if requirements is not None:
+            lines.append(f"-r {relative_path(source_root, requirements)}")
+            required_paths.append(requirements)
+        if project is not None:
+            lines.append(f"-e {relative_path(source_root, project)}")
+            required_paths.append(project)
+            project_config = project / "pyproject.toml"
+            if project_config.is_file():
+                required_paths.append(project_config)
+        for path in sorted(editable, key=lambda item: relative_path(source_root, item)):
+            lines.append(f"-e {relative_path(source_root, path)}")
+            required_paths.append(path)
+            editable_config = path / "pyproject.toml"
+            if editable_config.is_file():
+                required_paths.append(editable_config)
+        lines.extend(dependencies)
+        return _DependencyInput(
+            path=GENERATED_REQUIREMENTS_PATH,
+            generated_requirements="\n".join(lines) + "\n",
+            required_paths=tuple(required_paths),
+        )
+
+    if requirements is not None:
+        return _DependencyInput(
+            path=relative_path(source_root, requirements),
+            generated_requirements=None,
+            required_paths=(requirements,),
+        )
+
+    if project is not None:
+        dependency = _dependency_input_in(
+            source_root,
+            project,
+            include_requirements=False,
+        )
+        if dependency is not None:
+            return _DependencyInput(
+                path=dependency.path,
+                generated_requirements=None,
+                required_paths=(project, *dependency.required_paths),
+            )
+        raise SourceInvalidError(
+            "The environment project has no pyproject.toml dependency file"
+        )
+
+    return _detect_dependency_input(source_root, source_path.parent)
+
+
+def _detect_dependency_input(source_root: Path, start: Path) -> _DependencyInput:
+    current = start
+    while True:
+        dependency = _dependency_input_in(source_root, current)
+        if dependency is not None:
+            return dependency
+        if current == source_root:
+            return _DependencyInput(
+                path=None,
+                generated_requirements=None,
+                required_paths=(),
+            )
+        current = current.parent
+
+
+def _dependency_input_in(
+    source_root: Path,
+    directory: Path,
+    *,
+    include_requirements: bool = True,
+) -> _DependencyInput | None:
+    requirements = directory / "requirements.txt"
+    if include_requirements and requirements.is_file():
+        return _DependencyInput(
+            path=relative_path(source_root, requirements),
+            generated_requirements=None,
+            required_paths=(requirements,),
+        )
+
+    uv_lock = directory / "uv.lock"
+    pyproject = directory / "pyproject.toml"
+    if uv_lock.is_file() and pyproject.is_file():
+        return _DependencyInput(
+            path=relative_path(source_root, uv_lock),
+            generated_requirements=None,
+            required_paths=(uv_lock, pyproject),
+        )
+    if pyproject.is_file():
+        return _DependencyInput(
+            path=relative_path(source_root, pyproject),
+            generated_requirements=None,
+            required_paths=(pyproject,),
+        )
+    return None

--- a/fastmcp_slim/fastmcp/cli/deploy/source.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source.py
@@ -33,6 +33,7 @@ class DeploySource:
     dependency_path: str | None
     generated_requirements: str | None = field(default=None, repr=False)
     required_paths: tuple[Path, ...] = field(default=(), repr=False)
+    excluded_paths: tuple[Path, ...] = field(default=(), repr=False)
 
 
 @dataclass(frozen=True)
@@ -42,51 +43,9 @@ class _DependencyInput:
     required_paths: tuple[Path, ...]
 
 
-class _ModuleBindingVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
-        self.names: set[str] = set()
-
-    def visit_Name(self, node: ast.Name) -> None:
-        if isinstance(node.ctx, ast.Store):
-            self.names.add(node.id)
-
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self.names.add(node.name)
-
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        self.names.add(node.name)
-
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        pass
-
-    def visit_Import(self, node: ast.Import) -> None:
-        for alias in node.names:
-            self.names.add(alias.asname or alias.name.partition(".")[0])
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        for alias in node.names:
-            if alias.name != "*":
-                self.names.add(alias.asname or alias.name)
-
-    def visit_ListComp(self, node: ast.ListComp) -> None:
-        pass
-
-    def visit_SetComp(self, node: ast.SetComp) -> None:
-        pass
-
-    def visit_DictComp(self, node: ast.DictComp) -> None:
-        pass
-
-    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
-        pass
-
-    def visit_Lambda(self, node: ast.Lambda) -> None:
-        pass
-
-
 async def resolve_deploy_source(server_spec: str | None) -> DeploySource:
     """Resolve a FastMCP server input without applying runtime settings."""
-    config, source_root = _load_config(server_spec)
+    config, source_root, config_path = _load_config(server_spec)
     source_path = resolve_path(
         source_root,
         config.source.path,
@@ -109,6 +68,7 @@ async def resolve_deploy_source(server_spec: str | None) -> DeploySource:
         dependency_path=dependency.path,
         generated_requirements=dependency.generated_requirements,
         required_paths=(source_path, *dependency.required_paths),
+        excluded_paths=(config_path,) if config_path is not None else (),
     )
 
 
@@ -125,33 +85,92 @@ def _resolve_entrypoint(source_path: Path, explicit_entrypoint: str | None) -> s
             f"The server source could not be parsed: {exc}"
         ) from exc
 
-    bindings = _ModuleBindingVisitor()
-    bindings.visit(module)
-    for name in _COMMON_ENTRYPOINTS:
-        if name in bindings.names:
-            return name
+    candidates = _server_binding_names(module)
+    if len(candidates) == 1:
+        return candidates.pop()
+    if candidates:
+        raise SourceInvalidError(
+            "Multiple possible server objects were found; provide an entrypoint"
+        )
     raise SourceInvalidError(
         "No server object named mcp, server, or app was found; provide an entrypoint"
     )
 
 
-def _load_config(server_spec: str | None) -> tuple[MCPServerConfig, Path]:
+def _server_binding_names(module: ast.Module) -> set[str]:
+    candidates: set[str] = set()
+    for statement in module.body:
+        if isinstance(statement, ast.Assign) and _is_server_constructor(
+            statement.value
+        ):
+            for target in statement.targets:
+                candidates.update(_assigned_common_names(target))
+        elif isinstance(statement, ast.AnnAssign) and _is_server_constructor(
+            statement.value
+        ):
+            candidates.update(_assigned_common_names(statement.target))
+        elif isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef):
+            if statement.name in _COMMON_ENTRYPOINTS and any(
+                isinstance(child, ast.Return) and _is_server_constructor(child.value)
+                for child in statement.body
+            ):
+                candidates.add(statement.name)
+    return candidates
+
+
+def _assigned_common_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name) and target.id in _COMMON_ENTRYPOINTS:
+        return {target.id}
+    return set()
+
+
+def _is_server_constructor(value: ast.expr | None) -> bool:
+    if not isinstance(value, ast.Call):
+        return False
+    function = value.func
+    return _is_server_type_reference(function) or (
+        isinstance(function, ast.Attribute)
+        and _is_server_type_reference(function.value)
+    )
+
+
+def _is_server_type_reference(value: ast.expr) -> bool:
+    return (isinstance(value, ast.Name) and value.id in {"FastMCP", "MCPServer"}) or (
+        isinstance(value, ast.Attribute) and value.attr in {"FastMCP", "MCPServer"}
+    )
+
+
+def _load_config(
+    server_spec: str | None,
+) -> tuple[MCPServerConfig, Path, Path | None]:
     if server_spec is None:
         config_path = MCPServerConfig.find_config()
         if config_path is None:
             raise SourceInvalidError(
                 "Provide a server input or add fastmcp.json to the current directory"
             )
-        return _read_config(config_path), config_path.parent.resolve()
+        return _load_config_file(config_path)
 
     if server_spec.endswith(".json"):
-        config_path = Path(server_spec).expanduser().absolute()
-        return _read_config(config_path), config_path.parent.resolve()
+        return _load_config_file(Path(server_spec))
 
     return (
         MCPServerConfig(source=FileSystemSource(path=server_spec)),
         Path.cwd().resolve(),
+        None,
     )
+
+
+def _load_config_file(config_path: Path) -> tuple[MCPServerConfig, Path, Path]:
+    candidate = config_path.expanduser().absolute()
+    source_root = candidate.parent.resolve()
+    candidate = resolve_path(
+        source_root,
+        candidate,
+        label="Server config",
+        file=True,
+    )
+    return _read_config(candidate), source_root, candidate
 
 
 def _read_config(config_path: Path) -> MCPServerConfig:
@@ -207,22 +226,43 @@ def _resolve_dependencies(
         if path is not None:
             require_included_path(source_root, path, label=label)
 
+    project_input = (
+        (
+            project,
+            resolve_path(
+                source_root,
+                project / "pyproject.toml",
+                label="Environment project pyproject.toml",
+                file=True,
+            ),
+        )
+        if project is not None
+        else None
+    )
+
     dependencies = sorted(set(environment.dependencies or []))
     needs_generated = bool(
-        dependencies or editable or (project is not None and requirements is not None)
+        dependencies
+        or editable
+        or (project_input is not None and requirements is not None)
     )
     if needs_generated:
         lines: list[str] = []
         required_paths: list[Path] = []
         if requirements is not None:
-            lines.append(f"-r {relative_path(source_root, requirements)}")
+            requirements_path = relative_path(source_root, requirements)
+            if any(
+                character in requirements_path for character in {"#", "\\", "\r", "\n"}
+            ):
+                raise SourceInvalidError(
+                    "The requirements file path contains unsupported characters"
+                )
+            lines.append(f"-r {requirements_path}")
             required_paths.append(requirements)
-        if project is not None:
+        if project_input is not None:
+            project, project_config = project_input
             lines.append(f"-e {_editable_requirement(source_root, project)}")
-            required_paths.append(project)
-            project_config = project / "pyproject.toml"
-            if project_config.is_file():
-                required_paths.append(project_config)
+            required_paths.extend((project, project_config))
         for path in sorted(editable, key=lambda item: relative_path(source_root, item)):
             lines.append(f"-e {_editable_requirement(source_root, path)}")
             required_paths.append(path)
@@ -243,20 +283,19 @@ def _resolve_dependencies(
             required_paths=(requirements,),
         )
 
-    if project is not None:
-        dependency = _dependency_input_in(
-            source_root,
-            project,
-            include_requirements=False,
-        )
-        if dependency is not None:
+    if project_input is not None:
+        project, project_config = project_input
+        uv_lock = project / "uv.lock"
+        if uv_lock.is_file():
             return _DependencyInput(
-                path=dependency.path,
+                path=relative_path(source_root, uv_lock),
                 generated_requirements=None,
-                required_paths=(project, *dependency.required_paths),
+                required_paths=(project, uv_lock, project_config),
             )
-        raise SourceInvalidError(
-            "The environment project has no pyproject.toml dependency file"
+        return _DependencyInput(
+            path=relative_path(source_root, project_config),
+            generated_requirements=None,
+            required_paths=(project, project_config),
         )
 
     return _detect_dependency_input(source_root, source_path.parent)

--- a/fastmcp_slim/fastmcp/cli/deploy/source_bundle.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source_bundle.py
@@ -78,6 +78,7 @@ def create_source_bundle(
         source_root,
         archive_path,
         required_paths=source.required_paths,
+        excluded_paths=source.excluded_paths,
     )
     if source.generated_requirements is not None:
         generated_path = source_root / GENERATED_REQUIREMENTS_PATH
@@ -131,18 +132,33 @@ def _archive_entries(
     archive_path: Path,
     *,
     required_paths: tuple[Path, ...],
+    excluded_paths: tuple[Path, ...],
 ) -> list[tuple[str, Path | bytes]]:
     required = _expand_required_paths(source_root, required_paths)
     required_directories = {path for path in required if path.is_dir()}
+    excluded = _expand_excluded_paths(excluded_paths)
+    if any(
+        path.absolute() in excluded or path.resolve(strict=False) in excluded
+        for path in required
+    ):
+        raise SourceInvalidError(
+            "The selected config file cannot be a required source path"
+        )
     entries: dict[str, Path] = {}
     rules_by_directory: dict[
         Path,
         tuple[tuple[Path, pathspec.GitIgnoreSpec], ...],
     ] = {source_root: ()}
 
+    def raise_walk_error(error: OSError) -> None:
+        raise SourceInvalidError(
+            f"The source directory could not be read: {error.filename or source_root}"
+        ) from error
+
     for current_root, directory_names, file_names in os.walk(
         source_root,
         topdown=True,
+        onerror=raise_walk_error,
         followlinks=False,
     ):
         current = Path(current_root)
@@ -175,7 +191,7 @@ def _archive_entries(
 
         for name in sorted(file_names):
             path = current / name
-            if path.absolute() == archive_path:
+            if path.absolute() == archive_path or path.absolute() in excluded:
                 continue
             relative = path.relative_to(source_root)
             if is_fixed_exclusion(relative):
@@ -197,6 +213,19 @@ def _archive_entries(
         entries[relative.as_posix()] = path
 
     return list(entries.items())
+
+
+def _expand_excluded_paths(excluded_paths: tuple[Path, ...]) -> set[Path]:
+    excluded: set[Path] = set()
+    for path in excluded_paths:
+        excluded.add(path.absolute())
+        try:
+            excluded.add(path.resolve(strict=True))
+        except (OSError, RuntimeError) as exc:
+            raise SourceInvalidError(
+                f"The excluded source path could not be resolved: {path}"
+            ) from exc
+    return excluded
 
 
 def _expand_required_paths(

--- a/fastmcp_slim/fastmcp/cli/deploy/source_bundle.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source_bundle.py
@@ -1,0 +1,671 @@
+"""Resolve and archive local source for a Horizon deployment."""
+
+from __future__ import annotations
+
+import ast
+import gzip
+import hashlib
+import io
+import json
+import os
+import stat
+import tarfile
+import tokenize
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pathspec
+from pydantic import ValidationError
+
+from fastmcp.utilities.mcp_server_config import MCPServerConfig
+from fastmcp.utilities.mcp_server_config.v1.sources.filesystem import FileSystemSource
+
+MAX_SOURCE_UPLOAD_BYTES = 250 * 1024 * 1024
+GENERATED_REQUIREMENTS_PATH = ".fastmcp-deploy-requirements.txt"
+
+_EXCLUDED_DIRECTORY_NAMES = {
+    ".fastmcp",
+    ".git",
+    ".mypy_cache",
+    ".nox",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "env",
+    "venv",
+    "virtualenv",
+}
+_EXCLUDED_FILE_NAMES = {".DS_Store"}
+_EXCLUDED_FILE_SUFFIXES = {".pyc", ".pyo"}
+_COMMON_ENTRYPOINTS = ("mcp", "server", "app")
+
+
+class SourceInvalidError(ValueError):
+    """The local deployment source is invalid or unsafe."""
+
+
+class ArchiveTooLargeError(ValueError):
+    """The compressed source archive exceeds Horizon's upload limit."""
+
+
+class _CompressedSizeWriter:
+    def __init__(self, file: io.BufferedWriter) -> None:
+        self._file = file
+
+    def write(self, data: bytes) -> int:
+        if self._file.tell() + len(data) > MAX_SOURCE_UPLOAD_BYTES:
+            raise ArchiveTooLargeError(
+                "The compressed source archive exceeds the 250 MB Horizon limit"
+            )
+        return self._file.write(data)
+
+    def flush(self) -> None:
+        self._file.flush()
+
+
+@dataclass(frozen=True)
+class DeploySource:
+    """A resolved local source before archive creation."""
+
+    source_root: Path
+    entrypoint: str
+    dependency_path: str | None
+    _generated_requirements: str | None = field(default=None, repr=False)
+    _required_paths: tuple[Path, ...] = field(default=(), repr=False)
+
+
+@dataclass(frozen=True)
+class SourceBundle:
+    """An immutable archive ready for source upload."""
+
+    archive_path: Path
+    size_bytes: int
+    checksum_sha256: str
+    entrypoint: str
+    dependency_path: str | None
+
+
+@dataclass(frozen=True)
+class _DependencyInput:
+    path: str | None
+    generated_requirements: str | None
+    required_paths: tuple[Path, ...]
+
+
+class _ModuleBindingVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Store):
+            self.names.add(node.id)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        pass
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.names.add(alias.asname or alias.name.partition(".")[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name != "*":
+                self.names.add(alias.asname or alias.name)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        pass
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        pass
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        pass
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        pass
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        pass
+
+
+async def resolve_deploy_source(server_spec: str | None) -> DeploySource:
+    """Resolve a FastMCP server input without applying runtime settings."""
+    config, source_root = _load_config(server_spec)
+    source_path = _resolve_path(
+        source_root,
+        config.source.path,
+        label="Server source",
+        file=True,
+    )
+    _require_included_path(source_root, source_path, label="Server source")
+
+    if config.source.entrypoint and ":" in config.source.entrypoint:
+        raise SourceInvalidError(
+            "Deployment entrypoints must use a file and one object name"
+        )
+
+    object_name = _resolve_entrypoint(source_path, config.source.entrypoint)
+    relative_source = source_path.relative_to(source_root).as_posix()
+    dependency = _resolve_dependencies(config, source_root, source_path)
+    return DeploySource(
+        source_root=source_root,
+        entrypoint=f"{relative_source}:{object_name}",
+        dependency_path=dependency.path,
+        _generated_requirements=dependency.generated_requirements,
+        _required_paths=(source_path, *dependency.required_paths),
+    )
+
+
+def _resolve_entrypoint(source_path: Path, explicit_entrypoint: str | None) -> str:
+    if explicit_entrypoint:
+        return explicit_entrypoint
+
+    try:
+        with tokenize.open(source_path) as source_file:
+            source_text = source_file.read()
+        module = ast.parse(source_text, filename=str(source_path))
+    except (OSError, SyntaxError, UnicodeError) as exc:
+        raise SourceInvalidError(
+            f"The server source could not be parsed: {exc}"
+        ) from exc
+
+    bindings = _ModuleBindingVisitor()
+    bindings.visit(module)
+    for name in _COMMON_ENTRYPOINTS:
+        if name in bindings.names:
+            return name
+    raise SourceInvalidError(
+        "No server object named mcp, server, or app was found; provide an entrypoint"
+    )
+
+
+def create_source_bundle(
+    source: DeploySource,
+    archive_path: Path,
+) -> SourceBundle:
+    """Create a deterministic source archive and return its upload metadata."""
+    source_root = source.source_root.resolve(strict=True)
+    try:
+        archive_path = Path(archive_path).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise SourceInvalidError(
+            "The source archive path could not be resolved"
+        ) from exc
+    try:
+        archive_path.relative_to(source_root)
+    except ValueError:
+        pass
+    else:
+        raise SourceInvalidError("The source archive must be outside the source root")
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+    entries = _archive_entries(
+        source_root,
+        archive_path,
+        required_paths=source._required_paths,
+    )
+    if source._generated_requirements is not None:
+        generated_path = source_root / GENERATED_REQUIREMENTS_PATH
+        if os.path.lexists(generated_path):
+            raise SourceInvalidError(
+                f"The generated dependency path is reserved: {GENERATED_REQUIREMENTS_PATH}"
+            )
+        entries.append(
+            (GENERATED_REQUIREMENTS_PATH, source._generated_requirements.encode())
+        )
+    entries.sort(key=lambda entry: entry[0])
+
+    try:
+        with (
+            archive_path.open("wb") as raw_file,
+            gzip.GzipFile(
+                filename="",
+                fileobj=_CompressedSizeWriter(raw_file),
+                mode="wb",
+                mtime=0,
+            ) as gzip_file,
+            tarfile.open(
+                fileobj=gzip_file,
+                mode="w",
+                format=tarfile.PAX_FORMAT,
+            ) as archive,
+        ):
+            for name, entry_source in entries:
+                _add_archive_entry(archive, name, entry_source, source_root)
+    except (ArchiveTooLargeError, SourceInvalidError):
+        archive_path.unlink(missing_ok=True)
+        raise
+    except OSError as exc:
+        archive_path.unlink(missing_ok=True)
+        raise SourceInvalidError(
+            f"The source archive could not be created: {exc}"
+        ) from exc
+
+    size_bytes = archive_path.stat().st_size
+    return SourceBundle(
+        archive_path=archive_path,
+        size_bytes=size_bytes,
+        checksum_sha256=_sha256(archive_path),
+        entrypoint=source.entrypoint,
+        dependency_path=source.dependency_path,
+    )
+
+
+def _load_config(server_spec: str | None) -> tuple[MCPServerConfig, Path]:
+    if server_spec is None:
+        config_path = MCPServerConfig.find_config()
+        if config_path is None:
+            raise SourceInvalidError(
+                "Provide a server input or add fastmcp.json to the current directory"
+            )
+        return _read_config(config_path), config_path.parent.resolve()
+
+    if server_spec.endswith(".json"):
+        config_path = Path(server_spec).expanduser().absolute()
+        return _read_config(config_path), config_path.parent.resolve()
+
+    return (
+        MCPServerConfig(source=FileSystemSource(path=server_spec)),
+        Path.cwd().resolve(),
+    )
+
+
+def _read_config(config_path: Path) -> MCPServerConfig:
+    try:
+        return MCPServerConfig.from_file(config_path)
+    except (FileNotFoundError, json.JSONDecodeError, ValidationError) as exc:
+        raise SourceInvalidError(
+            f"The FastMCP configuration is invalid: {config_path}"
+        ) from exc
+
+
+def _resolve_dependencies(
+    config: MCPServerConfig,
+    source_root: Path,
+    source_path: Path,
+) -> _DependencyInput:
+    environment = config.environment
+    requirements = (
+        _resolve_path(
+            source_root,
+            environment.requirements,
+            label="Requirements file",
+            file=True,
+        )
+        if environment.requirements is not None
+        else None
+    )
+    project = (
+        _resolve_path(
+            source_root,
+            environment.project,
+            label="Environment project",
+            directory=True,
+        )
+        if environment.project is not None
+        else None
+    )
+    editable = tuple(
+        _resolve_path(
+            source_root,
+            path,
+            label="Editable dependency",
+            directory=True,
+        )
+        for path in (environment.editable or [])
+    )
+
+    for label, path in (
+        ("Requirements file", requirements),
+        ("Environment project", project),
+        *(("Editable dependency", path) for path in editable),
+    ):
+        if path is not None:
+            _require_included_path(source_root, path, label=label)
+
+    dependencies = sorted(set(environment.dependencies or []))
+    needs_generated = bool(
+        dependencies or editable or (project is not None and requirements is not None)
+    )
+    if needs_generated:
+        lines: list[str] = []
+        required_paths: list[Path] = []
+        if requirements is not None:
+            lines.append(f"-r {_relative_path(source_root, requirements)}")
+            required_paths.append(requirements)
+        if project is not None:
+            lines.append(f"-e {_relative_path(source_root, project)}")
+            required_paths.append(project)
+            project_config = project / "pyproject.toml"
+            if project_config.is_file():
+                required_paths.append(project_config)
+        for path in sorted(
+            editable, key=lambda item: _relative_path(source_root, item)
+        ):
+            lines.append(f"-e {_relative_path(source_root, path)}")
+            required_paths.append(path)
+            editable_config = path / "pyproject.toml"
+            if editable_config.is_file():
+                required_paths.append(editable_config)
+        lines.extend(dependencies)
+        return _DependencyInput(
+            path=GENERATED_REQUIREMENTS_PATH,
+            generated_requirements="\n".join(lines) + "\n",
+            required_paths=tuple(required_paths),
+        )
+
+    if requirements is not None:
+        return _DependencyInput(
+            path=_relative_path(source_root, requirements),
+            generated_requirements=None,
+            required_paths=(requirements,),
+        )
+
+    if project is not None:
+        dependency = _dependency_input_in(
+            source_root,
+            project,
+            include_requirements=False,
+        )
+        if dependency is not None:
+            return _DependencyInput(
+                path=dependency.path,
+                generated_requirements=None,
+                required_paths=(project, *dependency.required_paths),
+            )
+        raise SourceInvalidError(
+            "The environment project has no pyproject.toml dependency file"
+        )
+
+    return _detect_dependency_input(source_root, source_path.parent)
+
+
+def _detect_dependency_input(source_root: Path, start: Path) -> _DependencyInput:
+    current = start
+    while True:
+        dependency = _dependency_input_in(source_root, current)
+        if dependency is not None:
+            return dependency
+        if current == source_root:
+            return _DependencyInput(
+                path=None,
+                generated_requirements=None,
+                required_paths=(),
+            )
+        current = current.parent
+
+
+def _dependency_input_in(
+    source_root: Path,
+    directory: Path,
+    *,
+    include_requirements: bool = True,
+) -> _DependencyInput | None:
+    requirements = directory / "requirements.txt"
+    if include_requirements and requirements.is_file():
+        return _DependencyInput(
+            path=_relative_path(source_root, requirements),
+            generated_requirements=None,
+            required_paths=(requirements,),
+        )
+
+    uv_lock = directory / "uv.lock"
+    pyproject = directory / "pyproject.toml"
+    if uv_lock.is_file() and pyproject.is_file():
+        return _DependencyInput(
+            path=_relative_path(source_root, uv_lock),
+            generated_requirements=None,
+            required_paths=(uv_lock, pyproject),
+        )
+    if pyproject.is_file():
+        return _DependencyInput(
+            path=_relative_path(source_root, pyproject),
+            generated_requirements=None,
+            required_paths=(pyproject,),
+        )
+    return None
+
+
+def _resolve_path(
+    source_root: Path,
+    value: str | Path,
+    *,
+    label: str,
+    file: bool = False,
+    directory: bool = False,
+) -> Path:
+    requested = Path(value).expanduser()
+    candidate = Path(
+        os.path.abspath(
+            requested if requested.is_absolute() else source_root / requested
+        )
+    )
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise SourceInvalidError(f"{label} does not exist: {value}") from exc
+    try:
+        resolved.relative_to(source_root)
+    except ValueError:
+        raise SourceInvalidError(f"{label} leaves the source root: {value}") from None
+    if file and not candidate.is_file():
+        raise SourceInvalidError(f"{label} is not a file: {value}")
+    if directory and not candidate.is_dir():
+        raise SourceInvalidError(f"{label} is not a directory: {value}")
+    return candidate
+
+
+def _require_included_path(source_root: Path, path: Path, *, label: str) -> None:
+    relative = path.relative_to(source_root)
+    if _is_fixed_exclusion(relative):
+        raise SourceInvalidError(f"{label} is excluded from deployment: {relative}")
+
+
+def _relative_path(source_root: Path, path: Path) -> str:
+    relative = path.relative_to(source_root).as_posix()
+    return relative or "."
+
+
+def _archive_entries(
+    source_root: Path,
+    archive_path: Path,
+    *,
+    required_paths: tuple[Path, ...],
+) -> list[tuple[str, Path | bytes]]:
+    required = _expand_required_paths(source_root, required_paths)
+    required_directories = {path for path in required if path.is_dir()}
+    entries: dict[str, Path] = {}
+    rules_by_directory: dict[
+        Path,
+        tuple[tuple[Path, pathspec.GitIgnoreSpec], ...],
+    ] = {source_root: ()}
+
+    for current_root, directory_names, file_names in os.walk(
+        source_root,
+        topdown=True,
+        followlinks=False,
+    ):
+        current = Path(current_root)
+        rules = rules_by_directory[current]
+        local_rules = _read_gitignore(source_root, current)
+        if local_rules is not None:
+            rules = (*rules, (current, local_rules))
+
+        traversable_directories: list[str] = []
+        for name in sorted(directory_names):
+            path = current / name
+            relative = path.relative_to(source_root)
+            if _is_fixed_exclusion(relative):
+                continue
+            if _is_gitignored(path, rules, directory=True):
+                if any(
+                    required.is_relative_to(path) for required in required_directories
+                ):
+                    raise SourceInvalidError(
+                        f"Required source directory is ignored: {relative}"
+                    )
+                continue
+            if path.is_symlink():
+                _validate_symlink(source_root, path)
+                entries[relative.as_posix()] = path
+            else:
+                traversable_directories.append(name)
+                rules_by_directory[path] = rules
+        directory_names[:] = traversable_directories
+
+        for name in sorted(file_names):
+            path = current / name
+            if path.absolute() == archive_path:
+                continue
+            relative = path.relative_to(source_root)
+            if _is_fixed_exclusion(relative):
+                continue
+            if path.absolute() not in required and _is_gitignored(path, rules):
+                continue
+            if path.is_symlink():
+                _validate_symlink(source_root, path)
+            elif not path.is_file():
+                continue
+            entries[relative.as_posix()] = path
+
+    for path in required:
+        relative = path.relative_to(source_root)
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise SourceInvalidError(f"Required source file is missing: {relative}")
+        entries[relative.as_posix()] = path
+
+    return list(entries.items())
+
+
+def _expand_required_paths(
+    source_root: Path,
+    required_paths: tuple[Path, ...],
+) -> set[Path]:
+    pending = list(required_paths)
+    required: set[Path] = set()
+    while pending:
+        path = pending.pop().absolute()
+        if path in required:
+            continue
+        _require_included_path(source_root, path, label="Required source path")
+        required.add(path)
+        if path.is_symlink():
+            pending.append(_validate_symlink(source_root, path))
+    return required
+
+
+def _read_gitignore(
+    source_root: Path,
+    directory: Path,
+) -> pathspec.GitIgnoreSpec | None:
+    gitignore = directory / ".gitignore"
+    if not gitignore.is_file():
+        return None
+    if gitignore.is_symlink():
+        _validate_symlink(source_root, gitignore)
+    try:
+        lines = gitignore.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as exc:
+        relative = gitignore.relative_to(source_root)
+        raise SourceInvalidError(
+            f"The .gitignore file could not be read: {relative}"
+        ) from exc
+    return pathspec.GitIgnoreSpec.from_lines(lines)
+
+
+def _is_gitignored(
+    path: Path,
+    rules: tuple[tuple[Path, pathspec.GitIgnoreSpec], ...],
+    *,
+    directory: bool = False,
+) -> bool:
+    ignored = False
+    for base, spec in rules:
+        relative = path.relative_to(base).as_posix()
+        result = spec.check_file(relative + "/" if directory else relative)
+        if result.include is not None:
+            ignored = result.include
+    return ignored
+
+
+def _is_fixed_exclusion(relative: Path) -> bool:
+    parts = relative.parts
+    if any(part in _EXCLUDED_DIRECTORY_NAMES for part in parts[:-1]):
+        return True
+    name = relative.name
+    return (
+        name in _EXCLUDED_DIRECTORY_NAMES
+        or name in _EXCLUDED_FILE_NAMES
+        or name == ".env"
+        or name.startswith(".env.")
+        or relative.suffix in _EXCLUDED_FILE_SUFFIXES
+    )
+
+
+def _validate_symlink(source_root: Path, path: Path) -> Path:
+    try:
+        target = path.resolve(strict=True)
+        target.relative_to(source_root)
+    except (OSError, RuntimeError, ValueError):
+        relative = path.relative_to(source_root)
+        raise SourceInvalidError(
+            f"Symbolic link leaves the source root: {relative}"
+        ) from None
+    return target
+
+
+def _add_archive_entry(
+    archive: tarfile.TarFile,
+    name: str,
+    entry_source: Path | bytes,
+    source_root: Path,
+) -> None:
+    info = tarfile.TarInfo(name)
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.mtime = 0
+    info.pax_headers = {}
+
+    if isinstance(entry_source, bytes):
+        info.mode = 0o644
+        info.size = len(entry_source)
+        archive.addfile(info, io.BytesIO(entry_source))
+        return
+
+    if entry_source.is_symlink():
+        target = _validate_symlink(source_root, entry_source)
+        info.type = tarfile.SYMTYPE
+        info.mode = 0o777
+        info.linkname = os.path.relpath(target, entry_source.parent).replace(
+            os.sep, "/"
+        )
+        archive.addfile(info)
+        return
+
+    file_stat = entry_source.stat()
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise SourceInvalidError(f"Source entry is not a regular file: {name}")
+    info.mode = 0o755 if file_stat.st_mode & 0o111 else 0o644
+    info.size = file_stat.st_size
+    with entry_source.open("rb") as source_file:
+        archive.addfile(info, source_file)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as archive_file:
+        for chunk in iter(lambda: archive_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/fastmcp_slim/fastmcp/cli/deploy/source_bundle.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source_bundle.py
@@ -1,49 +1,27 @@
-"""Resolve and archive local source for a Horizon deployment."""
+"""Create deterministic archives for Horizon deployment source."""
 
 from __future__ import annotations
 
-import ast
 import gzip
 import hashlib
 import io
-import json
 import os
 import stat
 import tarfile
-import tokenize
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import pathspec
-from pydantic import ValidationError
 
-from fastmcp.utilities.mcp_server_config import MCPServerConfig
-from fastmcp.utilities.mcp_server_config.v1.sources.filesystem import FileSystemSource
+from fastmcp.cli.deploy.source import GENERATED_REQUIREMENTS_PATH, DeploySource
+from fastmcp.cli.deploy.source_paths import (
+    SourceInvalidError,
+    is_fixed_exclusion,
+    require_included_path,
+    validate_symlink,
+)
 
 MAX_SOURCE_UPLOAD_BYTES = 250 * 1024 * 1024
-GENERATED_REQUIREMENTS_PATH = ".fastmcp-deploy-requirements.txt"
-
-_EXCLUDED_DIRECTORY_NAMES = {
-    ".fastmcp",
-    ".git",
-    ".mypy_cache",
-    ".nox",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".tox",
-    ".venv",
-    "__pycache__",
-    "env",
-    "venv",
-    "virtualenv",
-}
-_EXCLUDED_FILE_NAMES = {".DS_Store"}
-_EXCLUDED_FILE_SUFFIXES = {".pyc", ".pyo"}
-_COMMON_ENTRYPOINTS = ("mcp", "server", "app")
-
-
-class SourceInvalidError(ValueError):
-    """The local deployment source is invalid or unsafe."""
 
 
 class ArchiveTooLargeError(ValueError):
@@ -66,17 +44,6 @@ class _CompressedSizeWriter:
 
 
 @dataclass(frozen=True)
-class DeploySource:
-    """A resolved local source before archive creation."""
-
-    source_root: Path
-    entrypoint: str
-    dependency_path: str | None
-    _generated_requirements: str | None = field(default=None, repr=False)
-    _required_paths: tuple[Path, ...] = field(default=(), repr=False)
-
-
-@dataclass(frozen=True)
 class SourceBundle:
     """An immutable archive ready for source upload."""
 
@@ -85,106 +52,6 @@ class SourceBundle:
     checksum_sha256: str
     entrypoint: str
     dependency_path: str | None
-
-
-@dataclass(frozen=True)
-class _DependencyInput:
-    path: str | None
-    generated_requirements: str | None
-    required_paths: tuple[Path, ...]
-
-
-class _ModuleBindingVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
-        self.names: set[str] = set()
-
-    def visit_Name(self, node: ast.Name) -> None:
-        if isinstance(node.ctx, ast.Store):
-            self.names.add(node.id)
-
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self.names.add(node.name)
-
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        self.names.add(node.name)
-
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        pass
-
-    def visit_Import(self, node: ast.Import) -> None:
-        for alias in node.names:
-            self.names.add(alias.asname or alias.name.partition(".")[0])
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        for alias in node.names:
-            if alias.name != "*":
-                self.names.add(alias.asname or alias.name)
-
-    def visit_ListComp(self, node: ast.ListComp) -> None:
-        pass
-
-    def visit_SetComp(self, node: ast.SetComp) -> None:
-        pass
-
-    def visit_DictComp(self, node: ast.DictComp) -> None:
-        pass
-
-    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
-        pass
-
-    def visit_Lambda(self, node: ast.Lambda) -> None:
-        pass
-
-
-async def resolve_deploy_source(server_spec: str | None) -> DeploySource:
-    """Resolve a FastMCP server input without applying runtime settings."""
-    config, source_root = _load_config(server_spec)
-    source_path = _resolve_path(
-        source_root,
-        config.source.path,
-        label="Server source",
-        file=True,
-    )
-    _require_included_path(source_root, source_path, label="Server source")
-
-    if config.source.entrypoint and ":" in config.source.entrypoint:
-        raise SourceInvalidError(
-            "Deployment entrypoints must use a file and one object name"
-        )
-
-    object_name = _resolve_entrypoint(source_path, config.source.entrypoint)
-    relative_source = source_path.relative_to(source_root).as_posix()
-    dependency = _resolve_dependencies(config, source_root, source_path)
-    return DeploySource(
-        source_root=source_root,
-        entrypoint=f"{relative_source}:{object_name}",
-        dependency_path=dependency.path,
-        _generated_requirements=dependency.generated_requirements,
-        _required_paths=(source_path, *dependency.required_paths),
-    )
-
-
-def _resolve_entrypoint(source_path: Path, explicit_entrypoint: str | None) -> str:
-    if explicit_entrypoint:
-        return explicit_entrypoint
-
-    try:
-        with tokenize.open(source_path) as source_file:
-            source_text = source_file.read()
-        module = ast.parse(source_text, filename=str(source_path))
-    except (OSError, SyntaxError, UnicodeError) as exc:
-        raise SourceInvalidError(
-            f"The server source could not be parsed: {exc}"
-        ) from exc
-
-    bindings = _ModuleBindingVisitor()
-    bindings.visit(module)
-    for name in _COMMON_ENTRYPOINTS:
-        if name in bindings.names:
-            return name
-    raise SourceInvalidError(
-        "No server object named mcp, server, or app was found; provide an entrypoint"
-    )
 
 
 def create_source_bundle(
@@ -210,16 +77,16 @@ def create_source_bundle(
     entries = _archive_entries(
         source_root,
         archive_path,
-        required_paths=source._required_paths,
+        required_paths=source.required_paths,
     )
-    if source._generated_requirements is not None:
+    if source.generated_requirements is not None:
         generated_path = source_root / GENERATED_REQUIREMENTS_PATH
         if os.path.lexists(generated_path):
             raise SourceInvalidError(
                 f"The generated dependency path is reserved: {GENERATED_REQUIREMENTS_PATH}"
             )
         entries.append(
-            (GENERATED_REQUIREMENTS_PATH, source._generated_requirements.encode())
+            (GENERATED_REQUIREMENTS_PATH, source.generated_requirements.encode())
         )
     entries.sort(key=lambda entry: entry[0])
 
@@ -259,221 +126,6 @@ def create_source_bundle(
     )
 
 
-def _load_config(server_spec: str | None) -> tuple[MCPServerConfig, Path]:
-    if server_spec is None:
-        config_path = MCPServerConfig.find_config()
-        if config_path is None:
-            raise SourceInvalidError(
-                "Provide a server input or add fastmcp.json to the current directory"
-            )
-        return _read_config(config_path), config_path.parent.resolve()
-
-    if server_spec.endswith(".json"):
-        config_path = Path(server_spec).expanduser().absolute()
-        return _read_config(config_path), config_path.parent.resolve()
-
-    return (
-        MCPServerConfig(source=FileSystemSource(path=server_spec)),
-        Path.cwd().resolve(),
-    )
-
-
-def _read_config(config_path: Path) -> MCPServerConfig:
-    try:
-        return MCPServerConfig.from_file(config_path)
-    except (FileNotFoundError, json.JSONDecodeError, ValidationError) as exc:
-        raise SourceInvalidError(
-            f"The FastMCP configuration is invalid: {config_path}"
-        ) from exc
-
-
-def _resolve_dependencies(
-    config: MCPServerConfig,
-    source_root: Path,
-    source_path: Path,
-) -> _DependencyInput:
-    environment = config.environment
-    requirements = (
-        _resolve_path(
-            source_root,
-            environment.requirements,
-            label="Requirements file",
-            file=True,
-        )
-        if environment.requirements is not None
-        else None
-    )
-    project = (
-        _resolve_path(
-            source_root,
-            environment.project,
-            label="Environment project",
-            directory=True,
-        )
-        if environment.project is not None
-        else None
-    )
-    editable = tuple(
-        _resolve_path(
-            source_root,
-            path,
-            label="Editable dependency",
-            directory=True,
-        )
-        for path in (environment.editable or [])
-    )
-
-    for label, path in (
-        ("Requirements file", requirements),
-        ("Environment project", project),
-        *(("Editable dependency", path) for path in editable),
-    ):
-        if path is not None:
-            _require_included_path(source_root, path, label=label)
-
-    dependencies = sorted(set(environment.dependencies or []))
-    needs_generated = bool(
-        dependencies or editable or (project is not None and requirements is not None)
-    )
-    if needs_generated:
-        lines: list[str] = []
-        required_paths: list[Path] = []
-        if requirements is not None:
-            lines.append(f"-r {_relative_path(source_root, requirements)}")
-            required_paths.append(requirements)
-        if project is not None:
-            lines.append(f"-e {_relative_path(source_root, project)}")
-            required_paths.append(project)
-            project_config = project / "pyproject.toml"
-            if project_config.is_file():
-                required_paths.append(project_config)
-        for path in sorted(
-            editable, key=lambda item: _relative_path(source_root, item)
-        ):
-            lines.append(f"-e {_relative_path(source_root, path)}")
-            required_paths.append(path)
-            editable_config = path / "pyproject.toml"
-            if editable_config.is_file():
-                required_paths.append(editable_config)
-        lines.extend(dependencies)
-        return _DependencyInput(
-            path=GENERATED_REQUIREMENTS_PATH,
-            generated_requirements="\n".join(lines) + "\n",
-            required_paths=tuple(required_paths),
-        )
-
-    if requirements is not None:
-        return _DependencyInput(
-            path=_relative_path(source_root, requirements),
-            generated_requirements=None,
-            required_paths=(requirements,),
-        )
-
-    if project is not None:
-        dependency = _dependency_input_in(
-            source_root,
-            project,
-            include_requirements=False,
-        )
-        if dependency is not None:
-            return _DependencyInput(
-                path=dependency.path,
-                generated_requirements=None,
-                required_paths=(project, *dependency.required_paths),
-            )
-        raise SourceInvalidError(
-            "The environment project has no pyproject.toml dependency file"
-        )
-
-    return _detect_dependency_input(source_root, source_path.parent)
-
-
-def _detect_dependency_input(source_root: Path, start: Path) -> _DependencyInput:
-    current = start
-    while True:
-        dependency = _dependency_input_in(source_root, current)
-        if dependency is not None:
-            return dependency
-        if current == source_root:
-            return _DependencyInput(
-                path=None,
-                generated_requirements=None,
-                required_paths=(),
-            )
-        current = current.parent
-
-
-def _dependency_input_in(
-    source_root: Path,
-    directory: Path,
-    *,
-    include_requirements: bool = True,
-) -> _DependencyInput | None:
-    requirements = directory / "requirements.txt"
-    if include_requirements and requirements.is_file():
-        return _DependencyInput(
-            path=_relative_path(source_root, requirements),
-            generated_requirements=None,
-            required_paths=(requirements,),
-        )
-
-    uv_lock = directory / "uv.lock"
-    pyproject = directory / "pyproject.toml"
-    if uv_lock.is_file() and pyproject.is_file():
-        return _DependencyInput(
-            path=_relative_path(source_root, uv_lock),
-            generated_requirements=None,
-            required_paths=(uv_lock, pyproject),
-        )
-    if pyproject.is_file():
-        return _DependencyInput(
-            path=_relative_path(source_root, pyproject),
-            generated_requirements=None,
-            required_paths=(pyproject,),
-        )
-    return None
-
-
-def _resolve_path(
-    source_root: Path,
-    value: str | Path,
-    *,
-    label: str,
-    file: bool = False,
-    directory: bool = False,
-) -> Path:
-    requested = Path(value).expanduser()
-    candidate = Path(
-        os.path.abspath(
-            requested if requested.is_absolute() else source_root / requested
-        )
-    )
-    try:
-        resolved = candidate.resolve(strict=True)
-    except (OSError, RuntimeError) as exc:
-        raise SourceInvalidError(f"{label} does not exist: {value}") from exc
-    try:
-        resolved.relative_to(source_root)
-    except ValueError:
-        raise SourceInvalidError(f"{label} leaves the source root: {value}") from None
-    if file and not candidate.is_file():
-        raise SourceInvalidError(f"{label} is not a file: {value}")
-    if directory and not candidate.is_dir():
-        raise SourceInvalidError(f"{label} is not a directory: {value}")
-    return candidate
-
-
-def _require_included_path(source_root: Path, path: Path, *, label: str) -> None:
-    relative = path.relative_to(source_root)
-    if _is_fixed_exclusion(relative):
-        raise SourceInvalidError(f"{label} is excluded from deployment: {relative}")
-
-
-def _relative_path(source_root: Path, path: Path) -> str:
-    relative = path.relative_to(source_root).as_posix()
-    return relative or "."
-
-
 def _archive_entries(
     source_root: Path,
     archive_path: Path,
@@ -503,7 +155,7 @@ def _archive_entries(
         for name in sorted(directory_names):
             path = current / name
             relative = path.relative_to(source_root)
-            if _is_fixed_exclusion(relative):
+            if is_fixed_exclusion(relative):
                 continue
             if _is_gitignored(path, rules, directory=True):
                 if any(
@@ -514,7 +166,7 @@ def _archive_entries(
                     )
                 continue
             if path.is_symlink():
-                _validate_symlink(source_root, path)
+                validate_symlink(source_root, path)
                 entries[relative.as_posix()] = path
             else:
                 traversable_directories.append(name)
@@ -526,12 +178,12 @@ def _archive_entries(
             if path.absolute() == archive_path:
                 continue
             relative = path.relative_to(source_root)
-            if _is_fixed_exclusion(relative):
+            if is_fixed_exclusion(relative):
                 continue
             if path.absolute() not in required and _is_gitignored(path, rules):
                 continue
             if path.is_symlink():
-                _validate_symlink(source_root, path)
+                validate_symlink(source_root, path)
             elif not path.is_file():
                 continue
             entries[relative.as_posix()] = path
@@ -557,10 +209,10 @@ def _expand_required_paths(
         path = pending.pop().absolute()
         if path in required:
             continue
-        _require_included_path(source_root, path, label="Required source path")
+        require_included_path(source_root, path, label="Required source path")
         required.add(path)
         if path.is_symlink():
-            pending.append(_validate_symlink(source_root, path))
+            pending.append(validate_symlink(source_root, path))
     return required
 
 
@@ -572,7 +224,7 @@ def _read_gitignore(
     if not gitignore.is_file():
         return None
     if gitignore.is_symlink():
-        _validate_symlink(source_root, gitignore)
+        validate_symlink(source_root, gitignore)
     try:
         lines = gitignore.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeError) as exc:
@@ -598,32 +250,6 @@ def _is_gitignored(
     return ignored
 
 
-def _is_fixed_exclusion(relative: Path) -> bool:
-    parts = relative.parts
-    if any(part in _EXCLUDED_DIRECTORY_NAMES for part in parts[:-1]):
-        return True
-    name = relative.name
-    return (
-        name in _EXCLUDED_DIRECTORY_NAMES
-        or name in _EXCLUDED_FILE_NAMES
-        or name == ".env"
-        or name.startswith(".env.")
-        or relative.suffix in _EXCLUDED_FILE_SUFFIXES
-    )
-
-
-def _validate_symlink(source_root: Path, path: Path) -> Path:
-    try:
-        target = path.resolve(strict=True)
-        target.relative_to(source_root)
-    except (OSError, RuntimeError, ValueError):
-        relative = path.relative_to(source_root)
-        raise SourceInvalidError(
-            f"Symbolic link leaves the source root: {relative}"
-        ) from None
-    return target
-
-
 def _add_archive_entry(
     archive: tarfile.TarFile,
     name: str,
@@ -645,7 +271,7 @@ def _add_archive_entry(
         return
 
     if entry_source.is_symlink():
-        target = _validate_symlink(source_root, entry_source)
+        target = validate_symlink(source_root, entry_source)
         info.type = tarfile.SYMTYPE
         info.mode = 0o777
         info.linkname = os.path.relpath(target, entry_source.parent).replace(

--- a/fastmcp_slim/fastmcp/cli/deploy/source_paths.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source_paths.py
@@ -1,0 +1,93 @@
+"""Validate local paths for Horizon deployment source."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_EXCLUDED_DIRECTORY_NAMES = {
+    ".fastmcp",
+    ".git",
+    ".mypy_cache",
+    ".nox",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "env",
+    "venv",
+    "virtualenv",
+}
+_EXCLUDED_FILE_NAMES = {".DS_Store"}
+_EXCLUDED_FILE_SUFFIXES = {".pyc", ".pyo"}
+
+
+class SourceInvalidError(ValueError):
+    """The local deployment source is invalid or unsafe."""
+
+
+def resolve_path(
+    source_root: Path,
+    value: str | Path,
+    *,
+    label: str,
+    file: bool = False,
+    directory: bool = False,
+) -> Path:
+    requested = Path(value).expanduser()
+    candidate = Path(
+        os.path.abspath(
+            requested if requested.is_absolute() else source_root / requested
+        )
+    )
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise SourceInvalidError(f"{label} does not exist: {value}") from exc
+    try:
+        resolved.relative_to(source_root)
+    except ValueError:
+        raise SourceInvalidError(f"{label} leaves the source root: {value}") from None
+    if file and not candidate.is_file():
+        raise SourceInvalidError(f"{label} is not a file: {value}")
+    if directory and not candidate.is_dir():
+        raise SourceInvalidError(f"{label} is not a directory: {value}")
+    return candidate
+
+
+def require_included_path(source_root: Path, path: Path, *, label: str) -> None:
+    relative = path.relative_to(source_root)
+    if is_fixed_exclusion(relative):
+        raise SourceInvalidError(f"{label} is excluded from deployment: {relative}")
+
+
+def relative_path(source_root: Path, path: Path) -> str:
+    relative = path.relative_to(source_root).as_posix()
+    return relative or "."
+
+
+def is_fixed_exclusion(relative: Path) -> bool:
+    parts = relative.parts
+    if any(part in _EXCLUDED_DIRECTORY_NAMES for part in parts[:-1]):
+        return True
+    name = relative.name
+    return (
+        name in _EXCLUDED_DIRECTORY_NAMES
+        or name in _EXCLUDED_FILE_NAMES
+        or name == ".env"
+        or name.startswith(".env.")
+        or relative.suffix in _EXCLUDED_FILE_SUFFIXES
+    )
+
+
+def validate_symlink(source_root: Path, path: Path) -> Path:
+    try:
+        target = path.resolve(strict=True)
+        target.relative_to(source_root)
+    except (OSError, RuntimeError, ValueError):
+        relative = path.relative_to(source_root)
+        raise SourceInvalidError(
+            f"Symbolic link leaves the source root: {relative}"
+        ) from None
+    return target

--- a/fastmcp_slim/fastmcp/cli/deploy/source_paths.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source_paths.py
@@ -57,9 +57,17 @@ def resolve_path(
 
 
 def require_included_path(source_root: Path, path: Path, *, label: str) -> None:
-    relative = path.relative_to(source_root)
-    if is_fixed_exclusion(relative):
-        raise SourceInvalidError(f"{label} is excluded from deployment: {relative}")
+    try:
+        resolved = path.resolve(strict=False)
+        relative_paths = (
+            path.relative_to(source_root),
+            resolved.relative_to(source_root),
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise SourceInvalidError(f"{label} leaves the source root: {path}") from exc
+    for relative in relative_paths:
+        if is_fixed_exclusion(relative):
+            raise SourceInvalidError(f"{label} is excluded from deployment: {relative}")
 
 
 def relative_path(source_root: Path, path: Path) -> str:

--- a/fastmcp_slim/fastmcp/cli/deploy/source_paths.py
+++ b/fastmcp_slim/fastmcp/cli/deploy/source_paths.py
@@ -83,6 +83,7 @@ def is_fixed_exclusion(relative: Path) -> bool:
     return (
         name in _EXCLUDED_DIRECTORY_NAMES
         or name in _EXCLUDED_FILE_NAMES
+        or name.endswith("fastmcp.json")
         or name == ".env"
         or name.startswith(".env.")
         or relative.suffix in _EXCLUDED_FILE_SUFFIXES

--- a/fastmcp_slim/pyproject.toml
+++ b/fastmcp_slim/pyproject.toml
@@ -99,6 +99,7 @@ server = [
     "joserfc>=1.5.0",
     "openapi-pydantic>=0.5.1",
     "packaging>=24.0",
+    "pathspec>=0.12.1",
     "py-key-value-aio[filetree,keyring,memory]>=0.4.4,<0.5.0",
     "pyperclip>=1.9.0",
     "python-multipart>=0.0.26",

--- a/tests/cli/deploy/test_source_bundle.py
+++ b/tests/cli/deploy/test_source_bundle.py
@@ -8,11 +8,10 @@ from pathlib import Path
 import pytest
 
 import fastmcp.cli.deploy.source_bundle as source_bundle_module
+from fastmcp.cli.deploy.source import SourceInvalidError, resolve_deploy_source
 from fastmcp.cli.deploy.source_bundle import (
     ArchiveTooLargeError,
-    SourceInvalidError,
     create_source_bundle,
-    resolve_deploy_source,
 )
 
 

--- a/tests/cli/deploy/test_source_bundle.py
+++ b/tests/cli/deploy/test_source_bundle.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+import json
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+
+import fastmcp.cli.deploy.source_bundle as source_bundle_module
+from fastmcp.cli.deploy.source_bundle import (
+    ArchiveTooLargeError,
+    SourceInvalidError,
+    create_source_bundle,
+    resolve_deploy_source,
+)
+
+
+def write_server(path: Path, name: str = "mcp") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "from fastmcp import FastMCP\n"
+        f'{name} = FastMCP("Test")\n'
+        f"@{name}.tool\n"
+        "def ping() -> str:\n"
+        '    return "pong"\n'
+    )
+
+
+def archive_names(path: Path) -> set[str]:
+    with tarfile.open(path, "r:gz") as archive:
+        return {member.name for member in archive.getmembers()}
+
+
+@pytest.fixture
+def in_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+async def test_resolve_explicit_server_uses_current_directory(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "src" / "server.py")
+
+    source = await resolve_deploy_source("src/server.py")
+
+    assert source.source_root == in_project
+    assert source.entrypoint == "src/server.py:mcp"
+    assert source.dependency_path is None
+
+
+async def test_explicit_source_detects_nearest_dependency_file(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "services" / "api" / "server.py")
+    (in_project / "requirements.txt").write_text("fastmcp==4.*\n")
+
+    source = await resolve_deploy_source("services/api/server.py")
+
+    assert source.dependency_path == "requirements.txt"
+
+
+async def test_resolve_config_uses_config_directory_and_dependencies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    write_server(project / "src" / "server.py", name="app")
+    (project / "requirements.txt").write_text("fastmcp==4.*\n")
+    (project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "src/server.py", "entrypoint": "app"},
+                "environment": {"requirements": "requirements.txt"},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+
+    source = await resolve_deploy_source("project/fastmcp.json")
+
+    assert source.source_root == project
+    assert source.entrypoint == "src/server.py:app"
+    assert source.dependency_path == "requirements.txt"
+
+
+async def test_explicit_entrypoint_does_not_import_declared_dependencies(
+    in_project: Path,
+) -> None:
+    (in_project / "server.py").write_text(
+        "import fastmcp_deployment_only_dependency\n"
+        "from fastmcp import FastMCP\n"
+        'app = FastMCP("Test")\n'
+    )
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py", "entrypoint": "app"},
+                "environment": {"dependencies": ["fastmcp-deployment-only-dependency"]},
+            }
+        )
+    )
+
+    source = await resolve_deploy_source(None)
+
+    assert source.entrypoint == "server.py:app"
+    assert source.dependency_path == ".fastmcp-deploy-requirements.txt"
+
+
+async def test_inferred_entrypoint_does_not_import_declared_dependencies(
+    in_project: Path,
+) -> None:
+    (in_project / "server.py").write_text(
+        "import fastmcp_deployment_only_dependency\n"
+        "from fastmcp import FastMCP\n"
+        'server = FastMCP("Test")\n'
+    )
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {"dependencies": ["fastmcp-deployment-only-dependency"]},
+            }
+        )
+    )
+
+    source = await resolve_deploy_source(None)
+
+    assert source.entrypoint == "server.py:server"
+
+
+async def test_inferred_entrypoint_ignores_function_local_names(
+    in_project: Path,
+) -> None:
+    (in_project / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        "def setup():\n"
+        '    mcp = FastMCP("Nested")\n'
+        "    return mcp\n"
+    )
+
+    with pytest.raises(SourceInvalidError, match="provide an entrypoint"):
+        await resolve_deploy_source("server.py")
+
+
+async def test_resolve_without_input_discovers_fastmcp_config(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "fastmcp.json").write_text(
+        json.dumps({"source": {"path": "server.py"}})
+    )
+
+    source = await resolve_deploy_source(None)
+
+    assert source.entrypoint == "server.py:mcp"
+
+
+async def test_resolve_does_not_apply_deployment_environment_or_cwd(
+    in_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "work").mkdir()
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "deployment": {
+                    "cwd": "work",
+                    "env": {"FASTMCP_DEPLOY_TEST_SECRET": "not-applied"},
+                },
+            }
+        )
+    )
+    monkeypatch.delenv("FASTMCP_DEPLOY_TEST_SECRET", raising=False)
+
+    await resolve_deploy_source(None)
+
+    assert Path.cwd() == in_project
+    assert "FASTMCP_DEPLOY_TEST_SECRET" not in os.environ
+
+
+async def test_inline_and_file_dependencies_create_generated_requirements(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "requirements-base.txt").write_text("fastmcp==4.*\n")
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {
+                    "requirements": "requirements-base.txt",
+                    "dependencies": ["httpx>=0.27", "pydantic>=2", "httpx>=0.27"],
+                },
+            }
+        )
+    )
+    source = await resolve_deploy_source(None)
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    assert bundle.dependency_path == ".fastmcp-deploy-requirements.txt"
+    with tarfile.open(bundle.archive_path, "r:gz") as archive:
+        generated = archive.extractfile(".fastmcp-deploy-requirements.txt")
+        assert generated is not None
+        assert generated.read().decode() == (
+            "-r requirements-base.txt\nhttpx>=0.27\npydantic>=2\n"
+        )
+
+
+async def test_project_and_editable_dependencies_stay_inside_source_root(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    package = in_project / "package"
+    package.mkdir()
+    (package / "pyproject.toml").write_text(
+        '[project]\nname = "package"\nversion = "0.1.0"\n'
+        '[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
+    )
+    (package / "package.py").write_text("PACKAGE = True\n")
+    editable = in_project / "shared"
+    editable.mkdir()
+    (editable / "pyproject.toml").write_text(
+        '[project]\nname = "shared"\nversion = "0.1.0"\n'
+        '[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
+    )
+    (editable / "shared.py").write_text("SHARED = True\n")
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {
+                    "project": "package",
+                    "editable": ["shared"],
+                },
+            }
+        )
+    )
+    source = await resolve_deploy_source(None)
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    with tarfile.open(bundle.archive_path, "r:gz") as archive:
+        generated = archive.extractfile(".fastmcp-deploy-requirements.txt")
+        assert generated is not None
+        assert generated.read().decode() == "-e package\n-e shared\n"
+    names = archive_names(bundle.archive_path)
+    assert "package/package.py" in names
+    assert "shared/shared.py" in names
+
+
+async def test_ignored_explicit_editable_directory_is_rejected(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    editable = in_project / "shared"
+    editable.mkdir()
+    (editable / "pyproject.toml").write_text('[project]\nname = "shared"\n')
+    (editable / "shared.py").write_text("SHARED = True\n")
+    (in_project / ".gitignore").write_text("shared/\n")
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {"editable": ["shared"]},
+            }
+        )
+    )
+    source = await resolve_deploy_source(None)
+
+    with pytest.raises(SourceInvalidError, match="source directory is ignored"):
+        create_source_bundle(source, tmp_path / "source.tar.gz")
+
+
+async def test_single_project_dependency_uses_project_file(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "src" / "server.py")
+    (in_project / "pyproject.toml").write_text('[project]\nname = "test"\n')
+    (in_project / "uv.lock").write_text("version = 1\n")
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "src/server.py"},
+                "environment": {"project": "."},
+            }
+        )
+    )
+
+    source = await resolve_deploy_source(None)
+
+    assert source.dependency_path == "uv.lock"
+
+
+async def test_archive_is_deterministic(in_project: Path, tmp_path: Path) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "requirements.txt").write_text("fastmcp==4.*\n")
+    source = await resolve_deploy_source("server.py:mcp")
+
+    first = create_source_bundle(source, tmp_path / "first.tar.gz")
+    second = create_source_bundle(source, tmp_path / "second.tar.gz")
+
+    assert first.checksum_sha256 == second.checksum_sha256
+    assert first.size_bytes == second.size_bytes
+    assert first.archive_path.read_bytes() == second.archive_path.read_bytes()
+    with tarfile.open(first.archive_path, "r:gz") as archive:
+        server = archive.getmember("server.py")
+        assert (server.uid, server.gid, server.uname, server.gname) == (0, 0, "", "")
+        assert server.mtime == 0
+        assert server.mode == 0o644
+
+
+async def test_archive_path_inside_source_root_is_rejected(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    source = await resolve_deploy_source("server.py")
+
+    with pytest.raises(SourceInvalidError, match="outside the source root"):
+        create_source_bundle(source, in_project / "source.tar.gz")
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="Symlink creation needs extra access on Windows"
+)
+async def test_archive_link_to_source_file_is_rejected(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    server_path = in_project / "server.py"
+    write_server(server_path)
+    original_source = server_path.read_bytes()
+    source = await resolve_deploy_source("server.py")
+    archive_path = tmp_path / "source.tar.gz"
+    archive_path.symlink_to(server_path)
+
+    with pytest.raises(SourceInvalidError, match="outside the source root"):
+        create_source_bundle(source, archive_path)
+
+    assert server_path.read_bytes() == original_source
+
+
+async def test_archive_applies_fixed_and_gitignore_exclusions(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "keep.txt").write_text("keep")
+    (in_project / "ignored.txt").write_text("ignored")
+    (in_project / ".gitignore").write_text("ignored.txt\nignored-dir/\n")
+    (in_project / "ignored-dir").mkdir()
+    (in_project / "ignored-dir" / "data.txt").write_text("ignored")
+    (in_project / ".env").write_text("TOKEN=secret")
+    (in_project / ".env.production").write_text("TOKEN=secret")
+    (in_project / ".git").mkdir()
+    (in_project / ".git" / "config").write_text("secret")
+    (in_project / ".fastmcp").mkdir()
+    (in_project / ".fastmcp" / "project.json").write_text("secret")
+    (in_project / "__pycache__").mkdir()
+    (in_project / "__pycache__" / "server.pyc").write_bytes(b"cache")
+    (in_project / ".venv").mkdir()
+    (in_project / ".venv" / "secret.txt").write_text("secret")
+    source = await resolve_deploy_source("server.py")
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    names = archive_names(bundle.archive_path)
+    assert {"server.py", "keep.txt", ".gitignore"} <= names
+    assert "ignored.txt" not in names
+    assert not any(name.startswith("ignored-dir/") for name in names)
+    assert not any(name.startswith(".env") for name in names)
+    assert not any(name.startswith(".git/") for name in names)
+    assert not any(name.startswith(".fastmcp/") for name in names)
+    assert not any("__pycache__" in name for name in names)
+    assert not any(name.startswith(".venv/") for name in names)
+
+
+async def test_archive_applies_nested_gitignore_rules(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / ".gitignore").write_text("*.txt\n")
+    app = in_project / "app"
+    app.mkdir()
+    (app / ".gitignore").write_text("credentials.json\n!keep.txt\n")
+    (app / "credentials.json").write_text("secret")
+    (app / "keep.txt").write_text("keep")
+    source = await resolve_deploy_source("server.py")
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    names = archive_names(bundle.archive_path)
+    assert "app/credentials.json" not in names
+    assert "app/keep.txt" in names
+
+
+async def test_required_source_is_not_removed_by_gitignore(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / ".gitignore").write_text("server.py\n")
+    source = await resolve_deploy_source("server.py")
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    assert "server.py" in archive_names(bundle.archive_path)
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="Symlink creation needs extra access on Windows"
+)
+async def test_external_symlink_is_rejected(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+    (in_project / "outside-link").symlink_to(outside)
+    source = await resolve_deploy_source("server.py")
+
+    with pytest.raises(SourceInvalidError, match="leaves the source root"):
+        create_source_bundle(source, tmp_path / "source.tar.gz")
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="Symlink creation needs extra access on Windows"
+)
+async def test_internal_symlink_uses_a_relative_archive_target(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "data.txt").write_text("data")
+    (in_project / "data-link").symlink_to(in_project / "data.txt")
+    source = await resolve_deploy_source("server.py")
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    with tarfile.open(bundle.archive_path, "r:gz") as archive:
+        link = archive.getmember("data-link")
+        assert link.issym()
+        assert link.linkname == "data.txt"
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="Symlink creation needs extra access on Windows"
+)
+async def test_required_symlink_target_overrides_gitignore(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    target = in_project / "actual.py"
+    write_server(target)
+    (in_project / "server.py").symlink_to(target)
+    (in_project / ".gitignore").write_text("actual.py\n")
+    source = await resolve_deploy_source("server.py")
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    names = archive_names(bundle.archive_path)
+    assert "server.py" in names
+    assert "actual.py" in names
+
+
+async def test_dependency_outside_source_root_is_rejected(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    outside = tmp_path / "requirements.txt"
+    outside.write_text("fastmcp==4.*\n")
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {"requirements": "../requirements.txt"},
+            }
+        )
+    )
+
+    with pytest.raises(SourceInvalidError, match="leaves the source root"):
+        await resolve_deploy_source(None)
+
+
+async def test_archive_size_limit_uses_compressed_size(
+    in_project: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "a-data.bin").write_bytes(os.urandom(1024 * 1024))
+    (in_project / "z-after-limit.txt").write_text("not reached")
+    source = await resolve_deploy_source("server.py")
+    monkeypatch.setattr(source_bundle_module, "MAX_SOURCE_UPLOAD_BYTES", 100)
+    archive_path = tmp_path / "source.tar.gz"
+    visited: list[str] = []
+    original_add_archive_entry = source_bundle_module._add_archive_entry
+
+    def record_archive_entry(
+        archive: tarfile.TarFile,
+        name: str,
+        entry_source: Path | bytes,
+        source_root: Path,
+    ) -> None:
+        visited.append(name)
+        original_add_archive_entry(archive, name, entry_source, source_root)
+
+    monkeypatch.setattr(
+        source_bundle_module,
+        "_add_archive_entry",
+        record_archive_entry,
+    )
+
+    with pytest.raises(ArchiveTooLargeError, match="250 MB"):
+        create_source_bundle(source, archive_path)
+
+    assert "z-after-limit.txt" not in visited
+    assert not archive_path.exists()

--- a/tests/cli/deploy/test_source_bundle.py
+++ b/tests/cli/deploy/test_source_bundle.py
@@ -136,6 +136,18 @@ async def test_inferred_entrypoint_ignores_unrelated_imports(
     assert source.entrypoint == "server.py:server"
 
 
+async def test_inferred_entrypoint_accepts_imported_server(
+    in_project: Path,
+) -> None:
+    (in_project / "server.py").write_text(
+        "from deployment_only_package import app as mcp\n"
+    )
+
+    source = await resolve_deploy_source("server.py")
+
+    assert source.entrypoint == "server.py:mcp"
+
+
 async def test_inferred_entrypoint_rejects_multiple_server_definitions(
     in_project: Path,
 ) -> None:
@@ -202,6 +214,26 @@ async def test_resolve_does_not_archive_deployment_environment(
     assert Path.cwd() == in_project
     assert "FASTMCP_DEPLOY_TEST_SECRET" not in os.environ
     assert "fastmcp.json" not in archive_names(bundle.archive_path)
+
+
+async def test_explicit_source_excludes_fastmcp_configs(
+    in_project: Path,
+    tmp_path: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    config = {
+        "source": {"path": "server.py"},
+        "deployment": {"env": {"API_KEY": "secret"}},
+    }
+    (in_project / "fastmcp.json").write_text(json.dumps(config))
+    (in_project / "production.fastmcp.json").write_text(json.dumps(config))
+    source = await resolve_deploy_source("server.py")
+
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
+
+    names = archive_names(bundle.archive_path)
+    assert "fastmcp.json" not in names
+    assert "production.fastmcp.json" not in names
 
 
 async def test_inline_and_file_dependencies_create_generated_requirements(

--- a/tests/cli/deploy/test_source_bundle.py
+++ b/tests/cli/deploy/test_source_bundle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import tarfile
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -112,11 +113,12 @@ async def test_explicit_entrypoint_does_not_import_declared_dependencies(
     assert source.dependency_path == ".fastmcp-deploy-requirements.txt"
 
 
-async def test_inferred_entrypoint_does_not_import_declared_dependencies(
+async def test_inferred_entrypoint_ignores_unrelated_imports(
     in_project: Path,
 ) -> None:
     (in_project / "server.py").write_text(
         "import fastmcp_deployment_only_dependency\n"
+        "import mcp\n"
         "from fastmcp import FastMCP\n"
         'server = FastMCP("Test")\n'
     )
@@ -132,6 +134,19 @@ async def test_inferred_entrypoint_does_not_import_declared_dependencies(
     source = await resolve_deploy_source(None)
 
     assert source.entrypoint == "server.py:server"
+
+
+async def test_inferred_entrypoint_rejects_multiple_server_definitions(
+    in_project: Path,
+) -> None:
+    (in_project / "server.py").write_text(
+        "from fastmcp import FastMCP\n"
+        'mcp = FastMCP("First")\n'
+        'server = FastMCP("Second")\n'
+    )
+
+    with pytest.raises(SourceInvalidError, match="Multiple possible server objects"):
+        await resolve_deploy_source("server.py")
 
 
 async def test_inferred_entrypoint_ignores_function_local_names(
@@ -161,8 +176,9 @@ async def test_resolve_without_input_discovers_fastmcp_config(
     assert source.entrypoint == "server.py:mcp"
 
 
-async def test_resolve_does_not_apply_deployment_environment_or_cwd(
+async def test_resolve_does_not_archive_deployment_environment(
     in_project: Path,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     write_server(in_project / "server.py")
@@ -180,10 +196,12 @@ async def test_resolve_does_not_apply_deployment_environment_or_cwd(
     )
     monkeypatch.delenv("FASTMCP_DEPLOY_TEST_SECRET", raising=False)
 
-    await resolve_deploy_source(None)
+    source = await resolve_deploy_source(None)
+    bundle = create_source_bundle(source, tmp_path / "source.tar.gz")
 
     assert Path.cwd() == in_project
     assert "FASTMCP_DEPLOY_TEST_SECRET" not in os.environ
+    assert "fastmcp.json" not in archive_names(bundle.archive_path)
 
 
 async def test_inline_and_file_dependencies_create_generated_requirements(
@@ -283,6 +301,48 @@ async def test_ignored_explicit_editable_directory_is_rejected(
 
     with pytest.raises(SourceInvalidError, match="source directory is ignored"):
         create_source_bundle(source, tmp_path / "source.tar.gz")
+
+
+async def test_project_with_inline_dependency_requires_pyproject(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "package").mkdir()
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {
+                    "project": "package",
+                    "dependencies": ["httpx"],
+                },
+            }
+        )
+    )
+
+    with pytest.raises(SourceInvalidError, match="pyproject.toml does not exist"):
+        await resolve_deploy_source(None)
+
+
+async def test_generated_requirements_rejects_comment_in_include_path(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    (in_project / "requirements#prod.txt").write_text("fastmcp\n")
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {
+                    "requirements": "requirements#prod.txt",
+                    "dependencies": ["httpx"],
+                },
+            }
+        )
+    )
+
+    with pytest.raises(SourceInvalidError, match="unsupported characters"):
+        await resolve_deploy_source(None)
 
 
 async def test_single_project_dependency_uses_project_file(
@@ -386,6 +446,29 @@ async def test_archive_applies_fixed_and_gitignore_exclusions(
     assert not any(name.startswith(".fastmcp/") for name in names)
     assert not any("__pycache__" in name for name in names)
     assert not any(name.startswith(".venv/") for name in names)
+
+
+async def test_unreadable_source_directory_is_rejected(
+    in_project: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_server(in_project / "server.py")
+    blocked = in_project / "blocked"
+    blocked.mkdir()
+    (blocked / "data.txt").write_text("data")
+    source = await resolve_deploy_source("server.py")
+    real_scandir = os.scandir
+
+    def fail_for_blocked(path: Path) -> Iterator[os.DirEntry[str]]:
+        if Path(path) == blocked:
+            raise PermissionError(13, "Permission denied", str(blocked))
+        return real_scandir(path)
+
+    monkeypatch.setattr(source_bundle_module.os, "scandir", fail_for_blocked)
+
+    with pytest.raises(SourceInvalidError, match="source directory could not be read"):
+        create_source_bundle(source, tmp_path / "source.tar.gz")
 
 
 async def test_archive_applies_nested_gitignore_rules(

--- a/tests/cli/deploy/test_source_bundle.py
+++ b/tests/cli/deploy/test_source_bundle.py
@@ -221,14 +221,14 @@ async def test_project_and_editable_dependencies_stay_inside_source_root(
     tmp_path: Path,
 ) -> None:
     write_server(in_project / "server.py")
-    package = in_project / "package"
+    package = in_project / "package dir"
     package.mkdir()
     (package / "pyproject.toml").write_text(
         '[project]\nname = "package"\nversion = "0.1.0"\n'
         '[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
     )
     (package / "package.py").write_text("PACKAGE = True\n")
-    editable = in_project / "shared"
+    editable = in_project / "shared dir"
     editable.mkdir()
     (editable / "pyproject.toml").write_text(
         '[project]\nname = "shared"\nversion = "0.1.0"\n'
@@ -240,8 +240,8 @@ async def test_project_and_editable_dependencies_stay_inside_source_root(
             {
                 "source": {"path": "server.py"},
                 "environment": {
-                    "project": "package",
-                    "editable": ["shared"],
+                    "project": "package dir",
+                    "editable": ["shared dir"],
                 },
             }
         )
@@ -253,10 +253,12 @@ async def test_project_and_editable_dependencies_stay_inside_source_root(
     with tarfile.open(bundle.archive_path, "r:gz") as archive:
         generated = archive.extractfile(".fastmcp-deploy-requirements.txt")
         assert generated is not None
-        assert generated.read().decode() == "-e package\n-e shared\n"
+        assert generated.read().decode() == (
+            "-e file:package%20dir\n-e file:shared%20dir\n"
+        )
     names = archive_names(bundle.archive_path)
-    assert "package/package.py" in names
-    assert "shared/shared.py" in names
+    assert "package dir/package.py" in names
+    assert "shared dir/shared.py" in names
 
 
 async def test_ignored_explicit_editable_directory_is_rejected(
@@ -493,6 +495,30 @@ async def test_dependency_outside_source_root_is_rejected(
     )
 
     with pytest.raises(SourceInvalidError, match="leaves the source root"):
+        await resolve_deploy_source(None)
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="Symlink creation needs extra access on Windows"
+)
+async def test_dependency_through_excluded_directory_link_is_rejected(
+    in_project: Path,
+) -> None:
+    write_server(in_project / "server.py")
+    virtual_environment = in_project / ".venv"
+    virtual_environment.mkdir()
+    (virtual_environment / "requirements.txt").write_text("secret-package\n")
+    (in_project / "deps").symlink_to(virtual_environment, target_is_directory=True)
+    (in_project / "fastmcp.json").write_text(
+        json.dumps(
+            {
+                "source": {"path": "server.py"},
+                "environment": {"requirements": "deps/requirements.txt"},
+            }
+        )
+    )
+
+    with pytest.raises(SourceInvalidError, match="excluded from deployment: .venv"):
         await resolve_deploy_source(None)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version < '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -63,7 +63,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -1030,6 +1030,7 @@ server = [
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
+    { name = "pathspec" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pyperclip" },
     { name = "python-multipart" },
@@ -1070,6 +1071,7 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'mcp'", specifier = ">=1.28.0" },
     { name = "opentelemetry-api", marker = "extra == 'server'", specifier = ">=1.28.0" },
     { name = "packaging", marker = "extra == 'server'", specifier = ">=24.0" },
+    { name = "pathspec", marker = "extra == 'server'", specifier = ">=0.12.1" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "prefab-ui", marker = "extra == 'apps'", specifier = ">=0.18.0" },
     { name = "py-key-value-aio", extras = ["filetree", "keyring", "memory"], marker = "extra == 'client'", specifier = ">=0.4.4,<0.5.0" },
@@ -1311,7 +1313,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1358,17 +1360,17 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1388,18 +1390,18 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -1411,7 +1413,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1952,7 +1954,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3163,8 +3165,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3234,8 +3236,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
This adds deterministic, size-bounded source bundles for Horizon deployments in [HRZN-1361](https://linear.app/prefect/issue/HRZN-1361/resolve-and-archive-local-fastmcp-deployment-source), and resolves FastMCP entrypoints and dependency inputs from local source.

Entrypoint inference uses static AST analysis rather than importing the server because deployment-only dependencies are unavailable during local resolution. Explicit dependency directories fail when ignore rules exclude them, rather than overriding ignore rules and risking secret exposure.