### PR TITLE
fix: preserve GitHub sessions across transient verification failures

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/providers/github.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/github.py
@@ -111,13 +111,14 @@ class GitHubTokenVerifier(TokenVerifier):
                     },
                 )
 
-                if response.status_code != 200:
+                if response.status_code == 401:
                     logger.debug(
                         "GitHub token verification failed: %d - %s",
                         response.status_code,
                         response.text[:200],
                     )
                     return None
+                response.raise_for_status()
 
                 user_data = response.json()
 
@@ -179,10 +180,7 @@ class GitHubTokenVerifier(TokenVerifier):
 
         except httpx2.RequestError as e:
             logger.debug("Failed to verify GitHub token: %s", e)
-            return None
-        except Exception as e:
-            logger.debug("GitHub token verification error: %s", e)
-            return None
+            raise
 
 
 class GitHubProvider(OAuthProxy):

--- a/tests/server/auth/providers/test_github_upstream_errors.py
+++ b/tests/server/auth/providers/test_github_upstream_errors.py
@@ -1,0 +1,46 @@
+"""Regression tests for GitHub token verifier upstream failures."""
+
+import httpx2
+import pytest
+
+from fastmcp.server.auth.providers.github import GitHubTokenVerifier
+from tests.utilities.httpx2_mock import HTTPXMock
+
+GITHUB_USER_URL = "https://api.github.com/user"
+
+
+async def test_github_401_is_invalid_token(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=GITHUB_USER_URL,
+        status_code=401,
+        text="Bad credentials",
+    )
+
+    verifier = GitHubTokenVerifier()
+
+    assert await verifier.verify_token("invalid-token") is None
+
+
+async def test_github_503_propagates_http_status_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=GITHUB_USER_URL,
+        status_code=503,
+        text="Service unavailable",
+    )
+
+    verifier = GitHubTokenVerifier()
+
+    with pytest.raises(httpx2.HTTPStatusError):
+        await verifier.verify_token("valid-token")
+
+
+async def test_github_transport_failure_propagates(httpx_mock: HTTPXMock):
+    httpx_mock.add_exception(
+        httpx2.ConnectError("simulated transport failure"),
+        url=GITHUB_USER_URL,
+    )
+
+    verifier = GitHubTokenVerifier()
+
+    with pytest.raises(httpx2.ConnectError):
+        await verifier.verify_token("valid-token")


### PR DESCRIPTION
Fixes #4854

This PR is intentionally closed until #4854 is assigned, per the repository contribution bot. Please reuse/reopen this PR rather than opening a replacement.

The prepared head branch contains the complete candidate from the issue discussion:

- Treat only GitHub `/user` `401` as invalid credentials.
- Propagate `/user` 429/5xx and transport failures instead of collapsing them into `None` / `invalid_token`.
- Treat `/user/repos` as supplementary scope discovery after `/user` verifies identity; 5xx/transport failure falls back to the verified basic `user` scope.
- Cache an accepted fallback verification so scope-endpoint degradation does not defeat `cache_ttl_seconds`.
- Do not grant unverified stronger scopes such as `repo` when scope discovery is unavailable.
- Preserve transient GitHub verification failures through the existing `OAuthProxy.load_access_token()` boundary for normal `GitHubProvider` users.

Regression coverage includes the credential-vs-upstream-failure distinction, rate limits, transport failures, degraded scope lookup, cache reuse, required-scope safety, and the OAuthProxy provider boundary.

## Validation

The exact candidate SHA `5eb6634072f1344f597ae25cb74a720f5925d5fb` was validated in the fork with static analysis and the full test matrix: Python 3.10 Ubuntu/Windows, Python 3.13 Ubuntu, lowest-direct dependencies, package install smoke, MCP conformance, and integration tests.

It was also independently exercised against the real production deployment from #4854 by the issue reporter. All nine regression cases passed, including `/user` 401/429/503 and transport failures, degraded `/user/repos`, cache reuse, required-scope safety, and the OAuthProxy provider boundary. The live server returned with its existing OAuth sessions intact.

The prepared branch is still exactly `5eb6634072f1344f597ae25cb74a720f5925d5fb` and remains one commit ahead of current upstream `main` with no behind commits. No replacement PR has been opened while #4854 remains unassigned.