### PR TITLE
Add FastMCP security report review skill

### DIFF
--- a/.claude/skills/review-security-report/SKILL.md
+++ b/.claude/skills/review-security-report/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: review-security-report
+description: Review private vulnerability reports and security advisories about FastMCP before accepting, rejecting, patching, scoring, or publishing them. Use for GitHub Security Advisories, bug-bounty reports, claimed OAuth or MCP vulnerabilities, and proposed security fixes where demonstrated behavior may instead be an explicit configuration tradeoff or protocol requirement.
+---
+
+# Review a FastMCP security report
+
+Determine whether a report shows a FastMCP security-boundary violation, a dangerous but
+documented configuration, expected protocol behavior, or a documentation gap. A working exploit
+is evidence of behavior, not by itself evidence of a vulnerability.
+
+## Preserve the report before changing anything
+
+Export the original report, comments, reporter configuration, affected versions, and proof of
+concept before editing an advisory. Record the FastMCP commit SHA used for reproduction.
+Derive the first affected and fixed release tags from git history; do not infer a version range
+from an approximate feature date or the reporter's estimate.
+
+Keep investigation read-only until the classification checkpoint below. Do not accept the
+report, rewrite advisory fields, create a private fork, request a CVE, assign severity, or write a
+patch merely because the proof of concept works.
+
+## Reproduce the actual claim
+
+Reproduce the smallest end-to-end attack against a supported FastMCP version. Record:
+
+- the exact non-default constructor arguments, environment settings, and deployment assumptions;
+- what the attacker controls and what the victim must do;
+- the credential or authority the attacker actually obtains;
+- which check the reporter claims was bypassed;
+- whether the same attack works with current defaults.
+
+Distinguish a validation bypass from a value that passed the intended validation. For OAuth DCR,
+a client may register a callback it owns. Sending that client's response to its registered
+callback is not an open redirect if FastMCP validates the authorization request against the
+client's registration.
+
+## Establish the intended security contract
+
+Read the implementation, public documentation, parameter docstrings, warnings, tests, and the
+commits or PRs that introduced the behavior. The key question is:
+
+> Which protection does FastMCP promise in this exact configuration, and was it bypassed?
+
+Answer all of these before assigning a verdict:
+
+1. Does the attack work with default settings?
+2. Does it require an explicit security opt-out or an assertion that replacement controls exist?
+3. Is the observed behavior required or permitted by OAuth, MCP, OIDC, or another implemented
+   protocol?
+4. Does FastMCP still enforce the checks it promises, such as client registration matching,
+   PKCE binding, audience validation, or user consent?
+5. Is the reporter crossing a documented trust boundary, or demonstrating the consequence of
+   removing it?
+6. Did older documentation promise more protection than current documentation or code provides?
+
+A warning or name such as `unsafe`, `insecure`, `external`, `disable`, or `development only` is
+not automatically dispositive. Confirm the full contract. Conversely, do not call the documented
+consequence of disabling a control a bypass of that control.
+
+## Apply FastMCP OAuth-specific checks
+
+For OAuth proxy reports, trace these boundaries separately:
+
+- **Client registration:** Open DCR intentionally lets previously unknown clients register.
+  Registration does not establish that FastMCP trusts the client.
+- **Redirect validation:** Verify that the authorization request matches the redirect URI stored
+  for that client. Do not conflate attacker-owned registration with a redirect-matching bypass.
+- **Downstream authorization:** FastMCP's consent screen identifies and authorizes the downstream
+  MCP client. Ordinary upstream consent usually authorizes FastMCP's shared upstream application,
+  not the downstream client.
+- **Explicit opt-outs:** `require_authorization_consent=False` removes FastMCP consent for local or
+  testing use. `"external"` asserts that equivalent consent and transaction binding exist outside
+  FastMCP; FastMCP does not verify those controls.
+- **PKCE:** PKCE blocks interception by a party that lacks the verifier. It does not stop a
+  malicious public client from redeeming a code issued for its own challenge.
+- **Redirect policy:** `allowed_client_redirect_uris` is an optional deployment policy. Requiring a
+  static allowlist can break hosted clients and open DCR, and it is not the only possible external
+  authorization control.
+
+Consult current primary specifications and relevant FastMCP history. Treat analogous project
+behavior as supporting context, not as proof of FastMCP's contract.
+
+## Classification checkpoint
+
+Write a short verdict before any mutation:
+
+- **Vulnerability:** A supported configuration violates a promised security boundary, a default
+  protection is bypassed, or an operator cannot safely supply the required replacement control.
+- **Dangerous explicit configuration:** The behavior follows from a documented, non-default
+  removal of the relevant protection. Recommend warnings or documentation only if the consequence
+  is unclear.
+- **Expected protocol behavior:** The report misclassifies required or intentional behavior such
+  as attacker-owned DCR registration. Explain the separate control that supplies authorization.
+- **Documentation gap:** The code follows the intended contract, but public guidance could
+  reasonably cause an operator to believe a missing protection exists.
+- **Unclear contract:** Stop and ask the subsystem maintainer whether the disputed pattern is
+  supported. Do this before accepting an advisory or preparing a fix.
+
+For any verdict other than **Vulnerability**, do not create a security patch or publish an
+advisory unless a maintainer explicitly chooses defense-in-depth work as a product change.
+
+## Evaluate a proposed fix as product policy
+
+A patch can prevent the proof of concept and still be wrong. Determine whether it:
+
+- fixes the violated boundary rather than compensating elsewhere;
+- changes an intentional default or makes an opt-in combination impossible;
+- breaks open DCR, hosted MCP clients, external consent systems, or other supported workflows;
+- assumes one replacement control is the only acceptable design;
+- actually enforces the claimed property instead of checking only that a setting is present;
+- adds a special-case babysitter to one unsafe setting while similar opt-outs remain intentional.
+
+If the patch changes the supported product contract, classify it as an enhancement and obtain
+maintainer agreement independently of the security report.
+
+## Recommend the next action
+
+Return one of these outcomes with evidence:
+
+- accept as a draft advisory and prepare a private patch;
+- request specific missing reproduction evidence;
+- close as expected behavior or an explicit security opt-out;
+- make a documentation or warning change without publishing an advisory;
+- ask the relevant maintainer to decide the contract.
+
+For a rejection, acknowledge any mechanically valid reproduction. Explain the decisive
+precondition, the intended contract, and the control that was explicitly removed or delegated.
+Do not insult the reporter or speculate about how the report was produced.

--- a/.claude/skills/review-security-report/SKILL.md
+++ b/.claude/skills/review-security-report/SKILL.md
@@ -1,121 +1,95 @@
 ---
 name: review-security-report
-description: Review vulnerability reports about FastMCP before accepting, rejecting, patching, scoring, or publishing them. Use for GitHub Security Advisories, bug-bounty submissions, claimed OAuth or MCP vulnerabilities, and proposed security fixes where the result may instead be an ordinary bug, an upstream issue, expected protocol behavior, or an insecure deployment.
+description: Review FastMCP vulnerability reports before accepting, rejecting, patching, scoring, or publishing them. Use for security advisories, bug-bounty submissions, OAuth or MCP vulnerability claims, and proposed security fixes.
 ---
 
 # Review a FastMCP security report
 
-A working proof of concept establishes behavior, not ownership or classification. Determine which
-component violates which promised security boundary before changing code or advisory state.
+A working proof of concept establishes behavior, not ownership or classification. Identify the
+component that violates a promised security boundary before changing code or advisory state.
 
-## Preserve the original evidence
+## Preserve the evidence
 
-Export the original report, comments, proof of concept, reporter configuration, and claimed
-affected versions before editing an advisory. Record the FastMCP commit used for reproduction.
-Derive affected release tags from git history rather than the reporter's estimate.
+Before editing an advisory, export the report, comments, proof of concept, configuration, and
+claimed affected versions. Record the reproduced commit and derive affected releases from history.
 
-Keep the investigation read-only until the classification checkpoint. Do not accept the report,
-rewrite advisory fields, create a private fork, assign severity, request a CVE, or prepare a patch
+Keep the investigation read-only until classification. Do not mutate the advisory or prepare a fix
 merely because the proof of concept works.
 
-## Reproduce the exact claim
+## Reproduce the claim
 
-Use the smallest end-to-end reproduction against a supported FastMCP release. Record:
+Use the smallest end-to-end reproduction against a supported release. Record:
 
-- all non-default arguments, environment settings, and deployment assumptions;
-- what the attacker controls and what the victim must do;
-- the credential, data, or authority the attacker obtains;
-- the check or trust boundary allegedly bypassed;
-- whether the result occurs with current defaults.
+- defaults, non-default arguments, environment, and deployment assumptions;
+- what the attacker controls, what the victim does, and what authority the attacker gains;
+- the check or trust boundary allegedly bypassed; and
+- whether the attacker's prerequisites already provide equal or greater authority than the claimed
+  impact.
 
-Do not stop at reproduction. A supported non-default configuration can still contain a
-vulnerability, while a default can intentionally delegate a security decision elsewhere.
+A non-default configuration may still be vulnerable; a default may intentionally delegate a
+security decision elsewhere.
 
 ## Identify the responsible layer
 
-Classify where the disputed behavior lives:
+- **FastMCP vulnerability:** FastMCP violates a promised boundary in a supported configuration.
+- **FastMCP bug:** FastMCP behaves incorrectly without creating attacker capability.
+- **Upstream vulnerability:** The defect belongs to a standard, dependency, identity provider,
+  client, proxy, or platform.
+- **Insecure deployment:** The operator omits, disables, or delegates a required control without
+  supplying the replacement required by its contract.
+- **Expected behavior:** The result follows the documented API contract or protocol.
+- **Documentation gap:** The implementation follows its intended contract, but the guidance creates
+  a reasonable expectation of protection.
 
-- **FastMCP vulnerability:** FastMCP violates a security boundary promised for the supported
-  configuration.
-- **FastMCP bug:** FastMCP behaves incorrectly, but no security boundary or attacker capability is
-  involved.
-- **Upstream vulnerability:** The defect is in an implemented standard, dependency, identity
-  provider, client, reverse proxy, or deployment platform rather than FastMCP.
-- **Insecure deployment:** The operator omitted required controls, exposed a development mode, or
-  disabled or delegated the protection without supplying the replacement required by its
-  contract.
-- **Expected behavior:** The result follows the documented API contract or implemented protocol.
-- **Documentation gap:** The implementation follows its intended contract, but the guidance could
-  reasonably lead operators to expect a protection that does not exist.
-
-Name both the vulnerable component and the boundary it owns. Do not turn every dangerous setup
-into a FastMCP vulnerability, and do not dismiss a real FastMCP boundary violation merely because
-another layer could mitigate it.
+Attribute the violated boundary to its owner. Neither a dangerous configuration nor an available
+external mitigation decides ownership by itself. Distinguish failure of a primary control from
+failure of defense-in-depth.
 
 ## Establish FastMCP's contract
 
-Read the implementation, public documentation, docstrings, runtime warnings, tests, and the
-commits or PRs that introduced the behavior. Answer:
+Read the code, released documentation, tests, and history. Determine:
 
-1. What protection does FastMCP promise in this configuration?
-2. Was that protection bypassed, explicitly disabled, or delegated under a documented contract?
-3. Is the observed behavior required or permitted by OAuth, MCP, OIDC, or another implemented
-   protocol?
-4. Does the proof of concept use the public API as supported?
-5. Did earlier released documentation promise more than current code provides?
+1. What FastMCP promises for the exact configuration, supported API, and affected releases.
+2. Whether the proof of concept bypasses, disables, or delegates that protection.
+3. Whether the behavior follows the implemented protocol despite any stricter FastMCP promise.
 
-When the intended contract is unclear, stop and ask the subsystem maintainer before accepting the
-advisory or proposing a fix. Code shows current behavior; it does not by itself define supported
-product behavior.
+If the intended contract remains unclear, ask the subsystem maintainer before accepting the report
+or proposing a fix. Current code alone does not define supported product behavior.
 
-## Trace OAuth proxy boundaries separately
+## Separate OAuth proxy boundaries
 
-For OAuth proxy reports, check each layer instead of treating the flow as one authorization step:
+For OAuth proxy reports, check each layer independently:
 
-- **DCR:** An unknown client may register redirect metadata. Registration alone does not establish
-  trust in that client.
-- **Redirect validation:** Verify that the authorization request matches the redirect URI stored
-  for that client. An attacker using its own correctly registered callback does not bypass
-  redirect matching.
-- **Downstream consent:** FastMCP's consent page identifies and authorizes the downstream MCP
-  client. Ordinary upstream consent generally authorizes FastMCP's shared upstream application,
-  not that downstream client.
-- **Consent opt-outs:** `require_authorization_consent=False` removes FastMCP consent for local or
-  testing use. `"external"` asserts that equivalent consent and transaction binding exist outside
-  FastMCP; FastMCP does not verify the replacement controls.
-- **PKCE:** PKCE prevents redemption by a party without the verifier. It does not prevent a
-  malicious client from redeeming a code issued for its own challenge.
-- **Redirect policy:** `allowed_client_redirect_uris` is an optional deployment policy. A static
-  allowlist can break hosted clients and open DCR, and it is not the only valid external control.
-
-Use current primary specifications and relevant FastMCP history. Other projects provide context,
-not proof of FastMCP's contract.
+- Open DCR lets unknown clients register redirects; a matching attacker callback is not a redirect
+  validation bypass.
+- FastMCP consent binds the downstream client; ordinary upstream consent binds FastMCP's shared app.
+- `require_authorization_consent=False` removes consent; `"external"` delegates equivalent consent
+  and transaction binding outside FastMCP.
+- PKCE protects the verifier, not a code issued for a malicious client's own challenge.
+- Redirect allowlists are optional policy and can break hosted clients or open DCR.
 
 ## Review the proposed fix independently
 
-A patch can block the proof of concept and still be wrong. Check whether it:
+A patch can block the proof of concept and still be wrong. Verify that it:
 
-- fixes the violated boundary at its source;
-- changes an intentional default or documented opt-in behavior;
-- breaks open DCR, hosted MCP clients, external consent systems, or another supported workflow;
-- assumes one replacement control is the only acceptable design;
-- enforces the claimed property rather than checking only that a setting is present.
+- fixes the violated boundary at its source and enforces the claimed property;
+- does not silently change an intentional default or opt-in contract; and
+- preserves supported workflows without assuming one replacement control is the only valid design.
 
-If the patch changes the supported product contract, treat it as an enhancement and obtain
-maintainer agreement independently of the security report.
+Treat a change to the supported product contract as an enhancement requiring maintainer agreement,
+independently of the security report.
 
 ## Classification checkpoint
 
-Before any GitHub mutation, return a short verdict with the decisive configuration, affected
-versions, violated or delegated boundary, responsible component, realistic impact, and proposed
-next action. Recommend exactly one:
+Before any GitHub mutation, state the decisive configuration and affected versions, boundary owner,
+realistic impact, and one disposition:
 
-- accept as a draft advisory and prepare a private patch;
+- accept a draft advisory and prepare a private patch;
 - request specific missing evidence;
 - route as a normal FastMCP bug or upstream issue;
 - close as expected behavior or an insecure deployment;
-- make a documentation or warning change without publishing an advisory;
 - ask the relevant maintainer to decide the contract.
 
-For a rejection, acknowledge any valid reproduction and explain the decisive precondition. Do not
-insult the reporter or speculate about how the report was produced.
+Separately recommend any documentation or warning clarification warranted by the investigation.
+
+When rejecting a report, acknowledge any valid reproduction and explain the decisive precondition.

--- a/.claude/skills/review-security-report/SKILL.md
+++ b/.claude/skills/review-security-report/SKILL.md
@@ -1,129 +1,120 @@
 ---
 name: review-security-report
-description: Review private vulnerability reports and security advisories about FastMCP before accepting, rejecting, patching, scoring, or publishing them. Use for GitHub Security Advisories, bug-bounty reports, claimed OAuth or MCP vulnerabilities, and proposed security fixes where demonstrated behavior may instead be an explicit configuration tradeoff or protocol requirement.
+description: Review vulnerability reports about FastMCP before accepting, rejecting, patching, scoring, or publishing them. Use for GitHub Security Advisories, bug-bounty submissions, claimed OAuth or MCP vulnerabilities, and proposed security fixes where the result may instead be an ordinary bug, an upstream issue, expected protocol behavior, or an insecure deployment.
 ---
 
 # Review a FastMCP security report
 
-Determine whether a report shows a FastMCP security-boundary violation, a dangerous but
-documented configuration, expected protocol behavior, or a documentation gap. A working exploit
-is evidence of behavior, not by itself evidence of a vulnerability.
+A working proof of concept establishes behavior, not ownership or classification. Determine which
+component violates which promised security boundary before changing code or advisory state.
 
-## Preserve the report before changing anything
+## Preserve the original evidence
 
-Export the original report, comments, reporter configuration, affected versions, and proof of
-concept before editing an advisory. Record the FastMCP commit SHA used for reproduction.
-Derive the first affected and fixed release tags from git history; do not infer a version range
-from an approximate feature date or the reporter's estimate.
+Export the original report, comments, proof of concept, reporter configuration, and claimed
+affected versions before editing an advisory. Record the FastMCP commit used for reproduction.
+Derive affected release tags from git history rather than the reporter's estimate.
 
-Keep investigation read-only until the classification checkpoint below. Do not accept the
-report, rewrite advisory fields, create a private fork, request a CVE, assign severity, or write a
-patch merely because the proof of concept works.
+Keep the investigation read-only until the classification checkpoint. Do not accept the report,
+rewrite advisory fields, create a private fork, assign severity, request a CVE, or prepare a patch
+merely because the proof of concept works.
 
-## Reproduce the actual claim
+## Reproduce the exact claim
 
-Reproduce the smallest end-to-end attack against a supported FastMCP version. Record:
+Use the smallest end-to-end reproduction against a supported FastMCP release. Record:
 
-- the exact non-default constructor arguments, environment settings, and deployment assumptions;
+- all non-default arguments, environment settings, and deployment assumptions;
 - what the attacker controls and what the victim must do;
-- the credential or authority the attacker actually obtains;
-- which check the reporter claims was bypassed;
-- whether the same attack works with current defaults.
+- the credential, data, or authority the attacker obtains;
+- the check or trust boundary allegedly bypassed;
+- whether the result occurs with current defaults.
 
-Distinguish a validation bypass from a value that passed the intended validation. For OAuth DCR,
-a client may register a callback it owns. Sending that client's response to its registered
-callback is not an open redirect if FastMCP validates the authorization request against the
-client's registration.
+Do not stop at reproduction. A supported non-default configuration can still contain a
+vulnerability, while a default can intentionally delegate a security decision elsewhere.
 
-## Establish the intended security contract
+## Identify the responsible layer
 
-Read the implementation, public documentation, parameter docstrings, warnings, tests, and the
-commits or PRs that introduced the behavior. The key question is:
+Classify where the disputed behavior lives:
 
-> Which protection does FastMCP promise in this exact configuration, and was it bypassed?
+- **FastMCP vulnerability:** FastMCP violates a security boundary promised for the supported
+  configuration.
+- **FastMCP bug:** FastMCP behaves incorrectly, but no security boundary or attacker capability is
+  involved.
+- **Upstream vulnerability:** The defect is in an implemented standard, dependency, identity
+  provider, client, reverse proxy, or deployment platform rather than FastMCP.
+- **Insecure deployment:** The operator omitted required controls, exposed a development mode, or
+  explicitly disabled or delegated the relevant protection.
+- **Expected behavior:** The result follows the documented API contract or implemented protocol.
+- **Documentation gap:** The implementation follows its intended contract, but the guidance could
+  reasonably lead operators to expect a protection that does not exist.
 
-Answer all of these before assigning a verdict:
+Name both the vulnerable component and the boundary it owns. Do not turn every dangerous setup
+into a FastMCP vulnerability, and do not dismiss a real FastMCP boundary violation merely because
+another layer could mitigate it.
 
-1. Does the attack work with default settings?
-2. Does it require an explicit security opt-out or an assertion that replacement controls exist?
+## Establish FastMCP's contract
+
+Read the implementation, public documentation, docstrings, runtime warnings, tests, and the
+commits or PRs that introduced the behavior. Answer:
+
+1. What protection does FastMCP promise in this configuration?
+2. Was that protection bypassed, explicitly disabled, or delegated under a documented contract?
 3. Is the observed behavior required or permitted by OAuth, MCP, OIDC, or another implemented
    protocol?
-4. Does FastMCP still enforce the checks it promises, such as client registration matching,
-   PKCE binding, audience validation, or user consent?
-5. Is the reporter crossing a documented trust boundary, or demonstrating the consequence of
-   removing it?
-6. Did older documentation promise more protection than current documentation or code provides?
+4. Does the proof of concept use the public API as supported?
+5. Did earlier released documentation promise more than current code provides?
 
-A warning or name such as `unsafe`, `insecure`, `external`, `disable`, or `development only` is
-not automatically dispositive. Confirm the full contract. Conversely, do not call the documented
-consequence of disabling a control a bypass of that control.
+When the intended contract is unclear, stop and ask the subsystem maintainer before accepting the
+advisory or proposing a fix. Code shows current behavior; it does not by itself define supported
+product behavior.
 
-## Apply FastMCP OAuth-specific checks
+## Trace OAuth proxy boundaries separately
 
-For OAuth proxy reports, trace these boundaries separately:
+For OAuth proxy reports, check each layer instead of treating the flow as one authorization step:
 
-- **Client registration:** Open DCR intentionally lets previously unknown clients register.
-  Registration does not establish that FastMCP trusts the client.
+- **DCR:** An unknown client may register redirect metadata. Registration alone does not establish
+  trust in that client.
 - **Redirect validation:** Verify that the authorization request matches the redirect URI stored
-  for that client. Do not conflate attacker-owned registration with a redirect-matching bypass.
-- **Downstream authorization:** FastMCP's consent screen identifies and authorizes the downstream
-  MCP client. Ordinary upstream consent usually authorizes FastMCP's shared upstream application,
-  not the downstream client.
-- **Explicit opt-outs:** `require_authorization_consent=False` removes FastMCP consent for local or
+  for that client. An attacker using its own correctly registered callback does not bypass
+  redirect matching.
+- **Downstream consent:** FastMCP's consent page identifies and authorizes the downstream MCP
+  client. Ordinary upstream consent generally authorizes FastMCP's shared upstream application,
+  not that downstream client.
+- **Consent opt-outs:** `require_authorization_consent=False` removes FastMCP consent for local or
   testing use. `"external"` asserts that equivalent consent and transaction binding exist outside
-  FastMCP; FastMCP does not verify those controls.
-- **PKCE:** PKCE blocks interception by a party that lacks the verifier. It does not stop a
-  malicious public client from redeeming a code issued for its own challenge.
-- **Redirect policy:** `allowed_client_redirect_uris` is an optional deployment policy. Requiring a
-  static allowlist can break hosted clients and open DCR, and it is not the only possible external
-  authorization control.
+  FastMCP; FastMCP does not verify the replacement controls.
+- **PKCE:** PKCE prevents redemption by a party without the verifier. It does not prevent a
+  malicious client from redeeming a code issued for its own challenge.
+- **Redirect policy:** `allowed_client_redirect_uris` is an optional deployment policy. A static
+  allowlist can break hosted clients and open DCR, and it is not the only valid external control.
 
-Consult current primary specifications and relevant FastMCP history. Treat analogous project
-behavior as supporting context, not as proof of FastMCP's contract.
+Use current primary specifications and relevant FastMCP history. Other projects provide context,
+not proof of FastMCP's contract.
+
+## Review the proposed fix independently
+
+A patch can block the proof of concept and still be wrong. Check whether it:
+
+- fixes the violated boundary at its source;
+- changes an intentional default or documented opt-in behavior;
+- breaks open DCR, hosted MCP clients, external consent systems, or another supported workflow;
+- assumes one replacement control is the only acceptable design;
+- enforces the claimed property rather than checking only that a setting is present.
+
+If the patch changes the supported product contract, treat it as an enhancement and obtain
+maintainer agreement independently of the security report.
 
 ## Classification checkpoint
 
-Write a short verdict before any mutation:
-
-- **Vulnerability:** A supported configuration violates a promised security boundary, a default
-  protection is bypassed, or an operator cannot safely supply the required replacement control.
-- **Dangerous explicit configuration:** The behavior follows from a documented, non-default
-  removal of the relevant protection. Recommend warnings or documentation only if the consequence
-  is unclear.
-- **Expected protocol behavior:** The report misclassifies required or intentional behavior such
-  as attacker-owned DCR registration. Explain the separate control that supplies authorization.
-- **Documentation gap:** The code follows the intended contract, but public guidance could
-  reasonably cause an operator to believe a missing protection exists.
-- **Unclear contract:** Stop and ask the subsystem maintainer whether the disputed pattern is
-  supported. Do this before accepting an advisory or preparing a fix.
-
-For any verdict other than **Vulnerability**, do not create a security patch or publish an
-advisory unless a maintainer explicitly chooses defense-in-depth work as a product change.
-
-## Evaluate a proposed fix as product policy
-
-A patch can prevent the proof of concept and still be wrong. Determine whether it:
-
-- fixes the violated boundary rather than compensating elsewhere;
-- changes an intentional default or makes an opt-in combination impossible;
-- breaks open DCR, hosted MCP clients, external consent systems, or other supported workflows;
-- assumes one replacement control is the only acceptable design;
-- actually enforces the claimed property instead of checking only that a setting is present;
-- adds a special-case babysitter to one unsafe setting while similar opt-outs remain intentional.
-
-If the patch changes the supported product contract, classify it as an enhancement and obtain
-maintainer agreement independently of the security report.
-
-## Recommend the next action
-
-Return one of these outcomes with evidence:
+Before any GitHub mutation, return a short verdict with the decisive configuration, affected
+versions, violated or delegated boundary, responsible component, realistic impact, and proposed
+next action. Recommend exactly one:
 
 - accept as a draft advisory and prepare a private patch;
-- request specific missing reproduction evidence;
-- close as expected behavior or an explicit security opt-out;
+- request specific missing evidence;
+- route as a normal FastMCP bug or upstream issue;
+- close as expected behavior or an insecure deployment;
 - make a documentation or warning change without publishing an advisory;
 - ask the relevant maintainer to decide the contract.
 
-For a rejection, acknowledge any mechanically valid reproduction. Explain the decisive
-precondition, the intended contract, and the control that was explicitly removed or delegated.
-Do not insult the reporter or speculate about how the report was produced.
+For a rejection, acknowledge any valid reproduction and explain the decisive precondition. Do not
+insult the reporter or speculate about how the report was produced.

--- a/.claude/skills/review-security-report/SKILL.md
+++ b/.claude/skills/review-security-report/SKILL.md
@@ -42,7 +42,8 @@ Classify where the disputed behavior lives:
 - **Upstream vulnerability:** The defect is in an implemented standard, dependency, identity
   provider, client, reverse proxy, or deployment platform rather than FastMCP.
 - **Insecure deployment:** The operator omitted required controls, exposed a development mode, or
-  explicitly disabled or delegated the relevant protection.
+  disabled or delegated the protection without supplying the replacement required by its
+  contract.
 - **Expected behavior:** The result follows the documented API contract or implemented protocol.
 - **Documentation gap:** The implementation follows its intended contract, but the guidance could
   reasonably lead operators to expect a protection that does not exist.


### PR DESCRIPTION
A working proof of concept can establish dangerous behavior without showing that FastMCP violated a promised security boundary. Treating reproduction as acceptance can misclassify expected protocol behavior or an insecure deployment and produce a patch that breaks supported workflows.

This adds a project-local review skill that keeps advisory work read-only until the exact configuration, attacker capability, boundary owner, and supported contract are established. It includes the FastMCP-specific OAuth distinctions needed to reason about open DCR, downstream consent, PKCE, and delegated protection, then reviews any proposed fix independently of the report.

```text
reproduce → identify the boundary owner → establish the contract → classify → mutate
```
