### PR TITLE
Reuse proxy backend sessions within requests

### DIFF
--- a/docs/servers/providers/proxy.mdx
+++ b/docs/servers/providers/proxy.mdx
@@ -360,29 +360,32 @@ provider = ProxyProvider(lambda: ProxyClient("http://backend/mcp"), cache_ttl=60
 provider = ProxyProvider(lambda: ProxyClient("http://backend/mcp"), cache_ttl=0)
 ```
 
-### Session Reuse for Stateless Backends
+### Request-Scoped Sessions
 
-By default, each tool call opens a fresh MCP session to the backend. This is the safe default because it prevents state from leaking between requests. However, for stateless HTTP backends where there's no session state to protect, this overhead is unnecessary.
+By default, `ProxyProvider` opens one backend session lazily for each frontend request. Component resolution and execution share that session, so a `tools/call` that must first fetch `tools/list` performs only one backend handshake. The session disconnects when the request ends.
 
-You can reuse a single backend session by providing a client factory that returns the same client instance:
+Request scope also provides the isolation a proxy needs for authentication and interaction forwarding: concurrent frontend requests never share a live backend session, even when the client factory returns the same disconnected client object. Requests handled entirely by local components do not connect to the proxy backend.
 
 ```python
-from fastmcp.server.providers.proxy import FastMCPProxy, ProxyClient
+from fastmcp.server.providers.proxy import ProxyProvider, ProxyClient
 
 base_client = ProxyClient("http://backend:8000/mcp")
-shared_client = base_client.new()
-
-proxy = FastMCPProxy(
-    client_factory=lambda: shared_client,
-    name="ReusedSessionProxy",
-)
+provider = ProxyProvider(lambda: base_client)
 ```
 
-This eliminates the MCP initialization handshake on every call, which can dramatically reduce latency under load. The `Client` uses reference counting for its session lifecycle, so concurrent callers sharing the same instance is safe.
+The factory still only creates or returns clients; connection happens on the first backend operation. Component-list caches remain shared across requests, but connected clients and proxy request context do not.
 
-<Warning>
-Only reuse sessions when you know the backend is stateless (e.g. stateless HTTP). For stateful backends (stdio processes, servers that track session state), use the default fresh-session behavior to avoid context mixing.
-</Warning>
+For compatibility with custom lifecycle strategies, set `session_scope="operation"`. This restores the legacy behavior where each list, read, render, or execution operation owns only its own client context. `StatefulProxyClient.new_stateful` requires this policy because it deliberately retains a backend session for an entire frontend connection.
+
+```python
+from fastmcp.server.providers.proxy import FastMCPProxy, StatefulProxyClient
+
+backend_client = StatefulProxyClient("backend_server.py")
+proxy = FastMCPProxy(
+    client_factory=backend_client.new_stateful,
+    session_scope="operation",
+)
+```
 
 ## Advanced Usage
 

--- a/fastmcp_slim/fastmcp/client/transports/config.py
+++ b/fastmcp_slim/fastmcp/client/transports/config.py
@@ -207,8 +207,8 @@ class MCPConfigTransport(ClientTransport):
         """Create underlying transport, proxy client, and proxy server for a single backend.
 
         The ProxyClient is connected via the AsyncExitStack *before* being
-        passed to create_proxy so the factory sees it as connected and reuses
-        the same session for all tool calls (instead of creating fresh copies).
+        passed to create_proxy and the proxy uses operation scope so every tool
+        call reuses that connection.
 
         `backend_mode` is the connect mode the calling client wants this backend
         leg to negotiate; `None` leaves the client at its own default era.
@@ -243,9 +243,9 @@ class MCPConfigTransport(ClientTransport):
         client = StatefulProxyClient(
             transport=transport, timeout=timeout, **client_kwargs
         )
-        # Connect the client *before* create_proxy so _create_client_factory
-        # detects it as connected and reuses it for all tool calls, preserving
-        # the session ID across requests. StatefulProxyClient is used instead
+        # Connect the client before create_proxy so its operation-scoped proxy
+        # reuses the connection across tool calls, preserving the session ID.
+        # StatefulProxyClient is used instead
         # of ProxyClient because its context-restoring handler wrappers prevent
         # stale ContextVars in the reused session's receive loop.
         #
@@ -263,6 +263,7 @@ class MCPConfigTransport(ClientTransport):
         proxy = create_proxy(
             client,
             name=f"Proxy-{name}",
+            session_scope="operation",
         )
         # Add tool transforms FIRST - they may add/modify tags
         if tool_transforms:

--- a/fastmcp_slim/fastmcp/server/low_level.py
+++ b/fastmcp_slim/fastmcp/server/low_level.py
@@ -182,6 +182,7 @@ class FastMCPServerMiddleware:
         self, ctx: ServerRequestContext, call_next: CallNext
     ) -> HandlerResult:
         from fastmcp.server.dependencies import bind_request_context
+        from fastmcp.server.request_resources import request_resource_scope
 
         fastmcp = self._ref()
         with (
@@ -189,15 +190,16 @@ class FastMCPServerMiddleware:
             bind_request_context(ctx),
             self._seam_span(fastmcp, ctx),
         ):
-            if fastmcp is None:
-                return await call_next(ctx)
-            if ctx.method == "initialize" and ctx.request_id is not None:
-                return await self._run_initialize_mw(fastmcp, ctx, call_next)
-            if ctx.method == "server/discover" and ctx.request_id is not None:
-                return await self._run_discover_mw(fastmcp, ctx, call_next)
-            if ctx.request_id is not None and ctx.method in _INTERIOR_METHODS:
-                return await self._dispatch_component(fastmcp, ctx, call_next)
-            return await self._run_outer_mw(fastmcp, ctx, call_next, _raise=None)
+            async with request_resource_scope():
+                if fastmcp is None:
+                    return await call_next(ctx)
+                if ctx.method == "initialize" and ctx.request_id is not None:
+                    return await self._run_initialize_mw(fastmcp, ctx, call_next)
+                if ctx.method == "server/discover" and ctx.request_id is not None:
+                    return await self._run_discover_mw(fastmcp, ctx, call_next)
+                if ctx.request_id is not None and ctx.method in _INTERIOR_METHODS:
+                    return await self._dispatch_component(fastmcp, ctx, call_next)
+                return await self._run_outer_mw(fastmcp, ctx, call_next, _raise=None)
 
     async def _dispatch_component(
         self,

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -11,7 +11,8 @@ import base64
 import inspect
 import time
 import warnings
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
@@ -59,6 +60,17 @@ from fastmcp.server.dependencies import fastmcp_request_ctx, get_context
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.server.providers.aggregate import ProviderErrorStrategy
 from fastmcp.server.providers.base import Provider
+from fastmcp.server.providers.proxy_sessions import (
+    ClientFactoryT,
+    ProxySessionScope,
+    RequestProxySession,
+)
+from fastmcp.server.request_resources import (
+    RequestResourceKey,
+    get_request_resource,
+    request_resources_active,
+    set_request_resource,
+)
 from fastmcp.server.server import FastMCP
 from fastmcp.telemetry import inject_trace_context
 from fastmcp.tools.base import InputRequiredToolResult, Tool, ToolResult
@@ -74,8 +86,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Type alias for client factory functions
-ClientFactoryT = Callable[[], Client] | Callable[[], Awaitable[Client]]
 ProxyIdentity = Literal["proxy", "upstream"]
 
 
@@ -235,13 +245,11 @@ async def _relay_read_resource(
 def _stash_proxy_request_context(client: Client, ctx: Context) -> None:
     """Stash the proxy's ``RequestContext`` on a ``ProxyClient`` before a backend call.
 
-    Every proxy component (tool, resource, template, prompt) must call this
-    before relaying to its backend so the forwarding handlers can restore the
-    proxy's request context before relaying a server-initiated request
-    (roots/sampling/elicitation) back to the proxy's client. Required for every
-    proxy client: under SDK v2 an in-memory backend shares this event loop, so a
-    handler's ``get_context()`` would otherwise resolve to the backend context
-    and the server-initiated request would hang until timeout.
+    The shared proxy client context manager calls this for every backend operation
+    so forwarding handlers can restore the frontend request before relaying a
+    server-initiated request (roots/sampling/elicitation). Under SDK v2 an
+    in-memory backend shares this event loop, so a handler's ``get_context()``
+    would otherwise resolve to the backend context and hang until timeout.
 
     We stash a ``(RequestContext, weakref[FastMCP])`` tuple — never a ``Context``
     instance — because ``Context`` properties are themselves ContextVar-dependent
@@ -252,6 +260,36 @@ def _stash_proxy_request_context(client: Client, ctx: Context) -> None:
             ctx.request_context,
             ctx._fastmcp,  # weakref to FastMCP, not the Context
         )
+
+
+_REQUEST_PROXY_SESSIONS = RequestResourceKey[dict[Client, RequestProxySession]]()
+
+
+@asynccontextmanager
+async def _proxy_client_context(client: Client) -> AsyncIterator[None]:
+    """Balance one operation while retaining its request-owned connection."""
+    try:
+        frontend_context = get_context()
+    except RuntimeError:
+        frontend_context = None
+    if frontend_context is not None:
+        _stash_proxy_request_context(client, frontend_context)
+
+    sessions = get_request_resource(_REQUEST_PROXY_SESSIONS)
+    request_session = sessions.get(client) if sessions is not None else None
+    try:
+        if request_session is not None:
+            await request_session.retain()
+        async with client:
+            yield
+    except MCPError as error:
+        if (
+            error.error.code == mcp_types.CONNECTION_CLOSED
+            and error.error.message == "Connection closed"
+            and not client.is_connected()
+        ):
+            raise _proxy_upstream_error(RuntimeError(error.error.message)) from error
+        raise
 
 
 class ProxyInitializeMiddleware(Middleware):
@@ -278,14 +316,7 @@ class ProxyInitializeMiddleware(Middleware):
         client = await self.proxy._get_client()
         upstream_instructions: str | None = None
         try:
-            if isinstance(client, ProxyClient):
-                ctx = context.fastmcp_context
-                if ctx is not None:
-                    client._proxy_rc_ref[0] = (
-                        ctx.request_context,
-                        ctx._fastmcp,
-                    )
-            async with client:
+            async with _proxy_client_context(client):
                 # Entering the context already ran connect-time negotiation.
                 # `initialize()` returns the handshake result on a legacy backend,
                 # but raises on a modern (server/discover) backend, which has no
@@ -387,9 +418,8 @@ class ProxyTool(Tool):
         ) as span:
             span.set_attribute("fastmcp.provider.type", "ProxyProvider")
             client = await self._get_client()
-            async with client:
+            async with _proxy_client_context(client):
                 ctx = context or get_context()
-                _stash_proxy_request_context(client, ctx)
                 # Forward the inbound request's hop-safe `_meta` (trace
                 # context, progress token, etc.) to the backend. Task
                 # submission is a first-class params field rather than context
@@ -535,8 +565,7 @@ class ProxyResource(Resource):
             span.set_attribute("fastmcp.provider.type", "ProxyProvider")
             client = await self._get_client()
             ctx = get_context()
-            async with client:
-                _stash_proxy_request_context(client, ctx)
+            async with _proxy_client_context(client):
                 result = await _relay_read_resource(client, backend_uri, ctx)
             if isinstance(result, mcp_types.InputRequiredResult):
                 return InputRequiredResourceResult(result)
@@ -636,8 +665,7 @@ class ProxyTemplate(ResourceTemplate):
         parameterized_uri = expand_uri_template(backend_template, params)
         client = await self._get_client()
         ctx = context or get_context()
-        async with client:
-            _stash_proxy_request_context(client, ctx)
+        async with _proxy_client_context(client):
             result = await _relay_read_resource(client, parameterized_uri, ctx)
 
         if isinstance(result, mcp_types.InputRequiredResult):
@@ -774,8 +802,7 @@ class ProxyPrompt(Prompt):
             span.set_attribute("fastmcp.provider.type", "ProxyProvider")
             client = await self._get_client()
             ctx = get_context()
-            async with client:
-                _stash_proxy_request_context(client, ctx)
+            async with _proxy_client_context(client):
                 meta = _forwardable_request_meta(ctx)
                 if client.protocol_version in MODERN_PROTOCOL_VERSIONS:
                     # See `_relay_read_resource`: surface a backend guard's ask
@@ -877,19 +904,28 @@ class ProxyProvider(Provider):
         self,
         client_factory: ClientFactoryT,
         cache_ttl: float | None = None,
+        session_scope: ProxySessionScope = "request",
     ):
         """Initialize a ProxyProvider.
 
         Args:
-            client_factory: A callable that returns a Client instance when called.
-                           This gives you full control over session creation and reuse.
-                           Can be either a synchronous or asynchronous function.
+            client_factory: A synchronous or asynchronous callable that creates
+                or returns a Client. The factory does not connect it; connection
+                lifetime is controlled by ``session_scope``.
             cache_ttl: How long (in seconds) to cache component lists for
                       individual lookups.  Defaults to 300.  Set to 0 to
                       disable caching.
+            session_scope: ``"request"`` reuses one isolated backend session
+                within each frontend request. ``"operation"`` preserves the
+                legacy behavior where every proxy operation manages only its
+                own client context.
         """
         super().__init__()
+        if session_scope not in ("request", "operation"):
+            raise ValueError("session_scope must be 'request' or 'operation'")
         self.client_factory = client_factory
+        self.session_scope = session_scope
+        self._request_session_key = RequestResourceKey[RequestProxySession]()
         self._cache_ttl = cache_ttl if cache_ttl is not None else _DEFAULT_CACHE_TTL
         self._tools_cache: _CacheEntry[Tool] | None = None
         self._resources_cache: _CacheEntry[Resource] | None = None
@@ -897,7 +933,24 @@ class ProxyProvider(Provider):
         self._prompts_cache: _CacheEntry[Prompt] | None = None
 
     async def _get_client(self) -> Client:
-        """Gets a client instance by calling the sync or async factory."""
+        """Get a client without connecting it."""
+        if self.session_scope == "request" and request_resources_active():
+            request_session = get_request_resource(self._request_session_key)
+            if request_session is None:
+                request_session = RequestProxySession(self.client_factory)
+                set_request_resource(
+                    self._request_session_key,
+                    request_session,
+                    request_session.close,
+                )
+            client = await request_session.get_client()
+            sessions = get_request_resource(_REQUEST_PROXY_SESSIONS)
+            if sessions is None:
+                sessions = {}
+                set_request_resource(_REQUEST_PROXY_SESSIONS, sessions)
+            sessions[client] = request_session
+            return client
+
         client = self.client_factory()
         if inspect.isawaitable(client):
             client = cast(Client, await client)
@@ -911,10 +964,10 @@ class ProxyProvider(Provider):
         """List all tools from the remote server."""
         try:
             client = await self._get_client()
-            async with client:
+            async with _proxy_client_context(client):
                 mcp_tools = await client.list_tools()
                 tools = [
-                    ProxyTool.from_mcp_tool(self.client_factory, t) for t in mcp_tools
+                    ProxyTool.from_mcp_tool(self._get_client, t) for t in mcp_tools
                 ]
         except MCPError as e:
             if e.error.code == METHOD_NOT_FOUND:
@@ -997,10 +1050,10 @@ class ProxyProvider(Provider):
         """List all resources from the remote server."""
         try:
             client = await self._get_client()
-            async with client:
+            async with _proxy_client_context(client):
                 mcp_resources = await client.list_resources()
                 resources = [
-                    ProxyResource.from_mcp_resource(self.client_factory, r)
+                    ProxyResource.from_mcp_resource(self._get_client, r)
                     for r in mcp_resources
                 ]
         except MCPError as e:
@@ -1036,10 +1089,10 @@ class ProxyProvider(Provider):
         """List all resource templates from the remote server."""
         try:
             client = await self._get_client()
-            async with client:
+            async with _proxy_client_context(client):
                 mcp_templates = await client.list_resource_templates()
                 templates = [
-                    ProxyTemplate.from_mcp_template(self.client_factory, t)
+                    ProxyTemplate.from_mcp_template(self._get_client, t)
                     for t in mcp_templates
                 ]
         except MCPError as e:
@@ -1075,10 +1128,10 @@ class ProxyProvider(Provider):
         """List all prompts from the remote server."""
         try:
             client = await self._get_client()
-            async with client:
+            async with _proxy_client_context(client):
                 mcp_prompts = await client.list_prompts()
                 prompts = [
-                    ProxyPrompt.from_mcp_prompt(self.client_factory, p)
+                    ProxyPrompt.from_mcp_prompt(self._get_client, p)
                     for p in mcp_prompts
                 ]
         except MCPError as e:
@@ -1205,16 +1258,9 @@ class ProxyMetadataMiddleware(Middleware):
             return _UpstreamServerMetadata.from_discover(result)
         return _UpstreamServerMetadata.from_client(client)
 
-    async def _read_upstream(
-        self, client: Client, context: Context | None
-    ) -> _UpstreamServerMetadata | None:
-        if context is not None:
-            _stash_proxy_request_context(client, context)
-
+    async def _read_upstream(self, client: Client) -> _UpstreamServerMetadata | None:
         try:
-            if client.is_connected():
-                return await self._read_connected(client)
-            async with client:
+            async with _proxy_client_context(client):
                 return await self._read_connected(client)
         except (MCPError, *_PROXY_TRANSPORT_ERRORS) as error:
             if isinstance(error, RuntimeError) and not _has_transport_cause(error):
@@ -1255,7 +1301,7 @@ class ProxyMetadataMiddleware(Middleware):
         result = await call_next(context)
         if result is None:
             return None
-        upstream = await self._read_upstream(client, context.fastmcp_context)
+        upstream = await self._read_upstream(client)
         if upstream is None:
             return result
         return result.model_copy(update=self._updates(result, upstream))
@@ -1272,7 +1318,7 @@ class ProxyMetadataMiddleware(Middleware):
         if not isinstance(result, mcp_types.DiscoverResult):
             return result
         client = await self.provider._get_client()
-        upstream = await self._read_upstream(client, context.fastmcp_context)
+        upstream = await self._read_upstream(client)
         if upstream is None:
             return result
         return result.model_copy(update=self._updates(result, upstream))
@@ -1460,38 +1506,42 @@ class FastMCPProxy(FastMCP):
         client_factory: ClientFactoryT,
         provider_error_strategy: ProviderErrorStrategy = "warn",
         identity: ProxyIdentity = "proxy",
+        session_scope: ProxySessionScope = "request",
         **kwargs,
     ):
         """Initialize the proxy server.
 
-        FastMCPProxy requires explicit session management via client_factory.
-        Use create_proxy() for convenience with automatic session strategy.
+        FastMCPProxy requires an explicit client factory. Use create_proxy() for
+        convenience when FastMCP should build the factory from a target.
 
         Args:
-            client_factory: A callable that returns a Client instance when called.
-                           This gives you full control over session creation and reuse.
-                           Can be either a synchronous or asynchronous function.
+            client_factory: A synchronous or asynchronous callable that creates
+                or returns a Client. It must not connect the client.
             provider_error_strategy: How provider errors should affect aggregate
                 operations. Defaults to ``"warn"`` for compatibility; use
                 ``"raise"`` when the proxy should surface upstream failures.
             identity: Whether clients see the proxy's server identity or the
                 upstream server's when available. Defaults to ``"proxy"``
                 for compatibility.
+            session_scope: Backend session lifetime. ``"request"`` reuses an
+                isolated session within one frontend request; ``"operation"``
+                preserves the legacy per-operation lifecycle.
             **kwargs: Additional settings for the FastMCP server.
         """
         super().__init__(**kwargs)
         self.provider_error_strategy = provider_error_strategy
         self.client_factory = client_factory
-        provider = ProxyProvider(client_factory)
-        self.add_provider(provider)
-        self.middleware.append(ProxyMetadataMiddleware(provider, identity=identity))
+        self._proxy_provider = ProxyProvider(
+            client_factory, session_scope=session_scope
+        )
+        self.add_provider(self._proxy_provider)
+        self.middleware.append(
+            ProxyMetadataMiddleware(self._proxy_provider, identity=identity)
+        )
         self._setup_proxy_ping_handler()
 
     async def _get_client(self) -> Client:
-        client = self.client_factory()
-        if inspect.isawaitable(client):
-            client = cast(Client, await client)
-        return client
+        return await self._proxy_provider._get_client()
 
     def _setup_proxy_ping_handler(self) -> None:
         async def ping_remote(
@@ -1499,7 +1549,7 @@ class FastMCPProxy(FastMCP):
             _params: mcp_types.RequestParams | None,
         ) -> mcp_types.EmptyResult:
             client = await self._get_client()
-            async with client:
+            async with _proxy_client_context(client):
                 await client.ping()
             return mcp_types.EmptyResult()
 

--- a/fastmcp_slim/fastmcp/server/providers/proxy_sessions.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy_sessions.py
@@ -1,0 +1,91 @@
+"""Request-scoped backend session ownership for proxy providers."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack
+from threading import Lock
+from typing import Literal, cast
+from weakref import ReferenceType, WeakKeyDictionary, ref
+
+import anyio
+
+from fastmcp.client.client import Client
+from fastmcp.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+ClientFactoryT = Callable[[], Client] | Callable[[], Awaitable[Client]]
+ProxySessionScope = Literal["request", "operation"]
+
+
+class RequestProxySession:
+    """A lazily connected client retained for one frontend request."""
+
+    def __init__(self, client_factory: ClientFactoryT) -> None:
+        self._client_factory = client_factory
+        self._client: Client | None = None
+        self._retained: AsyncExitStack | None = None
+        self._lock = anyio.Lock()
+
+    async def get_client(self) -> Client:
+        async with self._lock:
+            if self._client is not None:
+                return self._client
+
+            client = self._client_factory()
+            if inspect.isawaitable(client):
+                client = cast(Client, await client)
+
+            with _proxy_client_owners_lock:
+                owner_ref = _proxy_client_owners.get(client)
+                owner = owner_ref() if owner_ref is not None else None
+                if client.is_connected() or (owner is not None and owner is not self):
+                    client = client.new()
+                _proxy_client_owners[client] = ref(self)
+            self._client = client
+            return client
+
+    async def retain(self) -> None:
+        async with self._lock:
+            client = self._client
+            if client is None:
+                raise RuntimeError("Proxy request session has no client")
+            if self._retained is not None and client.is_connected():
+                return
+            if self._retained is not None:
+                await self._discard_retained()
+
+            retained = AsyncExitStack()
+            await retained.enter_async_context(client)
+            self._retained = retained
+
+    async def _discard_retained(self) -> None:
+        retained, self._retained = self._retained, None
+        if retained is None:
+            return
+        try:
+            await retained.aclose()
+        except Exception as error:
+            logger.debug("Could not release dead proxy backend session: %r", error)
+
+    async def close(self) -> None:
+        async with self._lock:
+            retained, self._retained = self._retained, None
+            client = self._client
+            try:
+                if retained is not None:
+                    await retained.aclose()
+            finally:
+                if client is not None:
+                    with _proxy_client_owners_lock:
+                        owner_ref = _proxy_client_owners.get(client)
+                        if owner_ref is not None and owner_ref() is self:
+                            del _proxy_client_owners[client]
+
+
+_proxy_client_owners: WeakKeyDictionary[Client, ReferenceType[RequestProxySession]] = (
+    WeakKeyDictionary()
+)
+_proxy_client_owners_lock = Lock()

--- a/fastmcp_slim/fastmcp/server/request_resources.py
+++ b/fastmcp_slim/fastmcp/server/request_resources.py
@@ -1,0 +1,90 @@
+"""Lifecycle for internal resources owned by one inbound MCP request."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from typing import Any, Generic, TypeVar, cast
+
+import anyio
+
+from fastmcp.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+ResourceT = TypeVar("ResourceT")
+
+
+class RequestResourceKey(Generic[ResourceT]):
+    """An identity key carrying the type of one internal request resource."""
+
+
+class _RequestResources:
+    """Resources retained until root dispatch finishes a request."""
+
+    def __init__(self) -> None:
+        self.resources: dict[RequestResourceKey[Any], Any] = {}
+        self.cleanup_callbacks: list[Callable[[], Awaitable[None]]] = []
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+        callbacks, self.cleanup_callbacks = self.cleanup_callbacks, []
+        self.resources.clear()
+        for callback in reversed(callbacks):
+            try:
+                with anyio.CancelScope(shield=True):
+                    await callback()
+            except Exception:
+                # Dispatch already owns the operation result or error. Cleanup
+                # must not replace it while the response unwinds to the wire.
+                logger.warning("Request resource cleanup failed", exc_info=True)
+
+
+_request_resources: ContextVar[_RequestResources | None] = ContextVar(
+    "fastmcp_request_resources", default=None
+)
+
+
+@asynccontextmanager
+async def request_resource_scope() -> AsyncIterator[None]:
+    """Bind and clean the resource owner for one root-dispatched request."""
+    resources = _RequestResources()
+    token = _request_resources.set(resources)
+    try:
+        yield
+    finally:
+        try:
+            await resources.close()
+        finally:
+            _request_resources.reset(token)
+
+
+def request_resources_active() -> bool:
+    resources = _request_resources.get()
+    return resources is not None and not resources.closed
+
+
+def get_request_resource(
+    key: RequestResourceKey[ResourceT],
+) -> ResourceT | None:
+    resources = _request_resources.get()
+    if resources is None or resources.closed:
+        return None
+    return cast("ResourceT | None", resources.resources.get(key))
+
+
+def set_request_resource(
+    key: RequestResourceKey[ResourceT],
+    value: ResourceT,
+    cleanup: Callable[[], Awaitable[None]] | None = None,
+) -> None:
+    resources = _request_resources.get()
+    if resources is None or resources.closed:
+        raise RuntimeError("No active FastMCP request resource scope")
+    if key in resources.resources:
+        raise RuntimeError("Request resource is already set")
+    resources.resources[key] = value
+    if cleanup is not None:
+        resources.cleanup_callbacks.append(cleanup)

--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -108,7 +108,7 @@ if TYPE_CHECKING:
     from fastmcp.server.providers.openapi import ComponentFn as OpenAPIComponentFn
     from fastmcp.server.providers.openapi import RouteMap
     from fastmcp.server.providers.openapi import RouteMapFn as OpenAPIRouteMapFn
-    from fastmcp.server.providers.proxy import FastMCPProxy
+    from fastmcp.server.providers.proxy import FastMCPProxy, ProxySessionScope
 
 logger = get_logger(__name__)
 
@@ -897,8 +897,9 @@ class FastMCP(
         Returns:
             The tool if found and authorized, None if not found or unauthorized.
         """
-        # Get tool from AggregateProvider (handles aggregation and namespacing)
-        tool = await super()._get_tool(name, version)
+        tool = await self._local_provider.get_tool(name, version)
+        if tool is None:
+            tool = await super()._get_tool(name, version)
         if tool is None:
             return None
 
@@ -1036,8 +1037,9 @@ class FastMCP(
         Returns:
             The resource if found and authorized, None if not found or unauthorized.
         """
-        # Get resource from AggregateProvider (handles aggregation and namespacing)
-        resource = await super()._get_resource(uri, version)
+        resource = await self._local_provider.get_resource(uri, version)
+        if resource is None:
+            resource = await super()._get_resource(uri, version)
         if resource is None:
             return None
 
@@ -1168,8 +1170,9 @@ class FastMCP(
         Returns:
             The template if found and authorized, None if not found or unauthorized.
         """
-        # Get template from AggregateProvider (handles aggregation and namespacing)
-        template = await super()._get_resource_template(uri, version)
+        template = await self._local_provider.get_resource_template(uri, version)
+        if template is None:
+            template = await super()._get_resource_template(uri, version)
         if template is None:
             return None
 
@@ -1294,8 +1297,9 @@ class FastMCP(
         Returns:
             The prompt if found and authorized, None if not found or unauthorized.
         """
-        # Get prompt from AggregateProvider (handles aggregation and namespacing)
-        prompt = await super()._get_prompt(name, version)
+        prompt = await self._local_provider.get_prompt(name, version)
+        if prompt is None:
+            prompt = await super()._get_prompt(name, version)
         if prompt is None:
             return None
 
@@ -2512,6 +2516,7 @@ def create_proxy(
     ),
     *,
     mode: str | None = None,
+    session_scope: ProxySessionScope = "request",
     **settings: Any,
 ) -> FastMCPProxy:
     """Create a FastMCP proxy server for the given target.
@@ -2538,6 +2543,9 @@ def create_proxy(
             backend era regardless of the front; this overrides mirroring and is
             appropriate when the backend only speaks one era. Ignored when
             `target` is already a `Client` (which carries its own mode).
+        session_scope: Backend session lifetime. ``"request"`` reuses one
+            isolated backend session within each frontend request. Use
+            ``"operation"`` to preserve the legacy per-operation lifecycle.
         **settings: Additional settings passed to FastMCPProxy (name, etc.)
 
     Returns:
@@ -2562,5 +2570,6 @@ def create_proxy(
     client_factory = _create_client_factory(target, mode=mode)
     return FastMCPProxy(
         client_factory=client_factory,
+        session_scope=session_scope,
         **settings,
     )

--- a/tests/server/providers/proxy/test_request_sessions.py
+++ b/tests/server/providers/proxy/test_request_sessions.py
@@ -1,0 +1,265 @@
+import asyncio
+from typing import Any
+
+import mcp_types
+import pytest
+from mcp.shared.exceptions import MCPError
+
+from fastmcp import Client, Context, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
+
+
+class InitializeCounter(Middleware):
+    def __init__(self) -> None:
+        self.count = 0
+
+    async def on_initialize(
+        self,
+        context: MiddlewareContext[mcp_types.InitializeRequest],
+        call_next: CallNext[
+            mcp_types.InitializeRequest, mcp_types.InitializeResult | None
+        ],
+    ) -> mcp_types.InitializeResult | None:
+        self.count += 1
+        return await call_next(context)
+
+
+async def raw_call_tool(
+    client: Client, name: str, arguments: dict[str, Any] | None = None
+) -> mcp_types.CallToolResult:
+    request = mcp_types.CallToolRequest(
+        params=mcp_types.CallToolRequestParams(
+            name=name,
+            arguments=arguments or {},
+        )
+    )
+    return await client.session.send_request(request, mcp_types.CallToolResult)
+
+
+def echo_backend(counter: InitializeCounter) -> FastMCP:
+    backend = FastMCP("backend", middleware=[counter])
+
+    @backend.tool
+    def echo(value: str) -> str:
+        return value
+
+    return backend
+
+
+async def test_raw_tool_call_uses_one_backend_handshake():
+    counter = InitializeCounter()
+    backend = echo_backend(counter)
+    base_client = ProxyClient(backend)
+    factory_calls = 0
+
+    def client_factory() -> ProxyClient:
+        nonlocal factory_calls
+        factory_calls += 1
+        return base_client
+
+    provider = ProxyProvider(client_factory, cache_ttl=0)
+    proxy = FastMCP("proxy", providers=[provider])
+
+    async with Client(proxy, mode="legacy") as client:
+        result = await raw_call_tool(client, "echo", {"value": "hello"})
+
+    assert result.structured_content == {"result": "hello"}
+    assert counter.count == 1
+    assert factory_calls == 1
+
+
+async def test_operation_scope_preserves_per_operation_lifecycle():
+    counter = InitializeCounter()
+    backend = echo_backend(counter)
+    provider = ProxyProvider(
+        lambda: ProxyClient(backend),
+        cache_ttl=0,
+        session_scope="operation",
+    )
+    proxy = FastMCP("proxy", providers=[provider])
+
+    async with Client(proxy, mode="legacy") as client:
+        result = await raw_call_tool(client, "echo", {"value": "legacy"})
+
+    assert result.structured_content == {"result": "legacy"}
+    assert counter.count == 2
+
+
+def test_invalid_session_scope_is_rejected():
+    with pytest.raises(ValueError, match="session_scope"):
+        ProxyProvider(
+            lambda: ProxyClient(FastMCP()),
+            session_scope="invalid",  # ty: ignore[invalid-argument-type]
+        )
+
+
+async def test_second_request_uses_fresh_backend_session():
+    counter = InitializeCounter()
+    backend = echo_backend(counter)
+    base_client = ProxyClient(backend)
+    provider = ProxyProvider(lambda: base_client, cache_ttl=0)
+    proxy = FastMCP("proxy", providers=[provider])
+
+    async with Client(proxy, mode="legacy") as client:
+        first = await raw_call_tool(client, "echo", {"value": "first"})
+        assert counter.count == 1
+        assert not base_client.is_connected()
+
+        second = await raw_call_tool(client, "echo", {"value": "second"})
+        assert counter.count == 2
+
+    assert first.structured_content == {"result": "first"}
+    assert second.structured_content == {"result": "second"}
+    assert not base_client.is_connected()
+
+
+async def test_concurrent_requests_use_distinct_backend_sessions():
+    counter = InitializeCounter()
+    backend = FastMCP("backend", middleware=[counter])
+    both_started = asyncio.Event()
+    session_ids: set[str] = set()
+
+    @backend.tool
+    async def hold(ctx: Context) -> str:
+        session_ids.add(ctx.session_id)
+        if len(session_ids) == 2:
+            both_started.set()
+        await asyncio.wait_for(both_started.wait(), timeout=2)
+        return ctx.session_id
+
+    base_client = ProxyClient(backend)
+    provider = ProxyProvider(lambda: base_client, cache_ttl=0)
+    proxy = FastMCP("proxy", providers=[provider])
+
+    async with Client(proxy, mode="legacy") as client:
+        first, second = await asyncio.gather(
+            raw_call_tool(client, "hold"),
+            raw_call_tool(client, "hold"),
+        )
+
+    assert not first.is_error
+    assert not second.is_error
+    assert len(session_ids) == 2
+    assert counter.count == 2
+
+
+async def test_local_tool_does_not_create_proxy_client():
+    backend = FastMCP("backend")
+    factory_calls = 0
+
+    def client_factory() -> ProxyClient:
+        nonlocal factory_calls
+        factory_calls += 1
+        return ProxyClient(backend)
+
+    proxy = FastMCP(
+        "mixed",
+        providers=[ProxyProvider(client_factory, cache_ttl=0)],
+    )
+
+    @proxy.tool
+    def local_echo(value: str) -> str:
+        return value
+
+    async with Client(proxy, mode="legacy") as client:
+        result = await raw_call_tool(client, "local_echo", {"value": "local"})
+
+    assert result.structured_content == {"result": "local"}
+    assert factory_calls == 0
+
+
+async def test_backend_tool_error_shape_is_preserved():
+    backend = FastMCP("backend")
+
+    @backend.tool
+    def explode() -> None:
+        raise ToolError("backend exploded")
+
+    proxy = FastMCP(
+        "proxy",
+        providers=[ProxyProvider(lambda: ProxyClient(backend), cache_ttl=0)],
+    )
+
+    async with Client(proxy, mode="legacy") as client:
+        result = await raw_call_tool(client, "explode")
+
+    assert result.is_error
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], mcp_types.TextContent)
+    assert result.content[0].text == "backend exploded"
+
+
+class CleanupFailureClient(ProxyClient):
+    cleanup_failures: int
+
+    def __init__(self, backend: FastMCP) -> None:
+        super().__init__(backend)
+        self.cleanup_failures = 0
+
+    async def _disconnect(self, force: bool = False) -> None:
+        was_connected = self.is_connected()
+        await super()._disconnect(force=force)
+        if was_connected and not self.is_connected():
+            self.cleanup_failures += 1
+            raise RuntimeError("backend cleanup failed")
+
+
+async def test_cleanup_failure_does_not_replace_tool_response():
+    counter = InitializeCounter()
+    backend = echo_backend(counter)
+    backend_client = CleanupFailureClient(backend)
+    proxy = FastMCP(
+        "proxy",
+        providers=[ProxyProvider(lambda: backend_client, cache_ttl=0)],
+    )
+
+    async with Client(proxy, mode="legacy") as client:
+        result = await raw_call_tool(client, "echo", {"value": "complete"})
+
+    assert result.structured_content == {"result": "complete"}
+    assert backend_client.cleanup_failures == 1
+
+
+class DiesOnceClient(ProxyClient):
+    should_die: bool
+
+    def __init__(self, backend: FastMCP) -> None:
+        super().__init__(backend)
+        self.should_die = True
+
+    async def list_tools(self, max_pages: int = 250) -> list[mcp_types.Tool]:
+        if self.should_die:
+            self.should_die = False
+            session_task = self._session_state.session_task
+            assert session_task is not None
+            session_task.cancel()
+            try:
+                await session_task
+            except asyncio.CancelledError:
+                pass
+            raise RuntimeError("backend session died")
+        return await super().list_tools(max_pages=max_pages)
+
+
+async def test_later_backend_use_reconnects_after_retained_session_dies():
+    counter = InitializeCounter()
+    backend = echo_backend(counter)
+    backend_client = DiesOnceClient(backend)
+    provider = ProxyProvider(lambda: backend_client, cache_ttl=0)
+    proxy = FastMCP("proxy")
+
+    @proxy.tool
+    async def recover() -> int:
+        try:
+            await provider._list_tools()
+        except MCPError:
+            pass
+        return len(await provider._list_tools())
+
+    async with Client(proxy, mode="legacy") as client:
+        result = await raw_call_tool(client, "recover")
+
+    assert result.structured_content == {"result": 1}
+    assert counter.count == 2

--- a/tests/server/providers/proxy/test_server_metadata.py
+++ b/tests/server/providers/proxy/test_server_metadata.py
@@ -484,6 +484,7 @@ async def test_stateful_pinned_metadata_uses_registered_client_lifecycle():
         name="stateful-proxy",
         client_factory=stateful_client.new_stateful,
         identity="upstream",
+        session_scope="operation",
     )
 
     async with Client(proxy, mode="auto") as client:

--- a/tests/server/providers/proxy/test_stateful_proxy_client.py
+++ b/tests/server/providers/proxy/test_stateful_proxy_client.py
@@ -67,7 +67,7 @@ async def stateful_proxy_server(fastmcp_server: FastMCP):
     # front `Client` to `mode="legacy"` too: those server-initiated
     # interactions do not exist on modern connections.
     client = StatefulProxyClient(transport=FastMCPTransport(fastmcp_server))
-    return FastMCPProxy(client_factory=client.new_stateful)
+    return FastMCPProxy(client_factory=client.new_stateful, session_scope="operation")
 
 
 @pytest.fixture
@@ -185,10 +185,12 @@ class TestStatefulProxyClient:
             return "b"
 
         proxy_mcp_a = FastMCPProxy(
-            client_factory=StatefulProxyClient(mcp_a).new_stateful
+            client_factory=StatefulProxyClient(mcp_a).new_stateful,
+            session_scope="operation",
         )
         proxy_mcp_b = FastMCPProxy(
-            client_factory=StatefulProxyClient(mcp_b).new_stateful
+            client_factory=StatefulProxyClient(mcp_b).new_stateful,
+            session_scope="operation",
         )
         multi_proxy_mcp = FastMCP()
         multi_proxy_mcp.mount(proxy_mcp_a, namespace="a")
@@ -234,6 +236,7 @@ class TestStatefulProxyClient:
         stateful_client = StatefulProxyClient(backend)
         proxy = FastMCPProxy(
             client_factory=stateful_client.new_stateful,
+            session_scope="operation",
             name="proxy",
         )
 


### PR DESCRIPTION
Proxy component resolution and execution previously opened separate backend client lifetimes, so one frontend call could negotiate with the backend more than once. `ProxyProvider` now lazily retains one isolated backend session for the root request and disconnects it during request cleanup; concurrent requests remain isolated and local component calls do not wake the backend.

The default is request scope, while stateful integrations can preserve their deliberate connection lifecycle explicitly:

```python
provider = ProxyProvider(lambda: ProxyClient(backend))
stateful_provider = ProxyProvider(
    stateful_client.new_stateful,
    session_scope="operation",
)
```

🤖 Generated with OpenAI GPT-5.6
