### PR TITLE
Cap anthropic dependency to <1

### DIFF
--- a/fastmcp_slim/pyproject.toml
+++ b/fastmcp_slim/pyproject.toml
@@ -65,7 +65,7 @@ bump = true
 fallback-version = "0.0.0"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
-anthropic = ["anthropic>=0.48.0"]
+anthropic = ["anthropic>=0.48.0,<1"]
 apps = ["prefab-ui>=0.18.0"]
 # PyJWT floor: transitive via msal; CVE-2026-32597 affects <= 2.11.0
 azure = ["azure-identity>=1.16.0", "PyJWT>=2.12.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-15T18:52:05.050937Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -1043,7 +1043,7 @@ server = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0,<1" },
     { name = "authlib", marker = "extra == 'client'", specifier = ">=1.6.11" },
     { name = "authlib", marker = "extra == 'server'", specifier = ">=1.6.11" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.16.0" },


### PR DESCRIPTION
Hey! We're releasing v1 of the `anthropic` SDK shortly. Your `anthropic` dependency has no upper bound, so your users will start getting 1.0, which would break `fastmcp-slim`.

This PR adds an `anthropic<1` constraint to prevent any potential breakage until you can fully migrate to v1.