### PR TITLE
fix: make version list order deterministic in dedupe_with_versions

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/versions.py
+++ b/fastmcp_slim/fastmcp/utilities/versions.py
@@ -329,7 +329,7 @@ def dedupe_with_versions(
         if any(c.version is not None for c in versions):
             all_versions = sorted(
                 [c.version for c in versions if c.version is not None],
-                key=parse_version_key,
+                key=lambda v: (parse_version_key(v), v),
                 reverse=True,
             )
             meta = highest.meta or {}


### PR DESCRIPTION
Fixes #4867

In `dedupe_with_versions()`, when PEP 440-equivalent versions (e.g. "1" and "1.0") are present, `sorted()` with only `parse_version_key` as the sort key preserved registration order because the keys compare equal and Timsort is stable.

This fix adds the raw version string as a secondary sort key, so the result is always reproducible regardless of the order components are registered.

Reported by @simonyang08.