### PR TITLE
Include instructions in MCP inspect output

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/inspect.py
+++ b/fastmcp_slim/fastmcp/utilities/inspect.py
@@ -489,6 +489,7 @@ async def format_mcp_info(mcp: FastMCP[Any] | SDKServer) -> bytes:
                 "mcp": importlib.metadata.version("mcp"),  # MCP protocol version
             },
             "serverInfo": server_info,
+            "instructions": client.initialize_result.instructions,
             "capabilities": {},  # MCP format doesn't include capabilities at top level
             "tools": tools_result.tools,
             "prompts": prompts_result.prompts,

--- a/tests/utilities/test_inspect_icons.py
+++ b/tests/utilities/test_inspect_icons.py
@@ -425,6 +425,7 @@ class TestFormatFunctions:
 
         # Check server version in MCP format
         assert data["serverInfo"]["version"] == "2.0.0"
+        assert data["instructions"] == "Test instructions"
 
         # MCP format SHOULD have environment fields
         assert "environment" in data


### PR DESCRIPTION
## Summary

`fastmcp inspect --format mcp` now includes the server instructions from the initialize result as a top-level `instructions` field, matching the MCP initialize shape.

This keeps the MCP-format output aligned with the FastMCP-format output for servers that define instructions.

Closes #4870.

## Tests

- `uv run pytest tests/utilities/test_inspect_icons.py -q`
- `uv run ruff check fastmcp_slim/fastmcp/utilities/inspect.py tests/utilities/test_inspect_icons.py`
- `uv run ruff format --check fastmcp_slim/fastmcp/utilities/inspect.py tests/utilities/test_inspect_icons.py`