### PR TITLE
fix: handle optional scalar parameters in generated CLIs

### DIFF
--- a/fastmcp_slim/fastmcp/cli/generate.py
+++ b/fastmcp_slim/fastmcp/cli/generate.py
@@ -32,6 +32,9 @@ _SIMPLE_TYPES = {"string", "integer", "number", "boolean", "null"}
 def _is_simple_type(schema: dict[str, Any]) -> bool:
     """Check if a schema represents a simple (non-complex) type."""
     schema_type = schema.get("type")
+    union = schema.get("anyOf") or schema.get("oneOf")
+    if isinstance(union, list):
+        return all(_is_simple_type(option) for option in union)
     if isinstance(schema_type, list):
         # Union of types - simple only if all are simple
         return all(t in _SIMPLE_TYPES for t in schema_type)
@@ -78,6 +81,19 @@ def _schema_to_python_type(schema: dict[str, Any]) -> tuple[str, bool]:
 
     # Check for simple type
     if _is_simple_type(schema):
+        union = schema.get("anyOf") or schema.get("oneOf")
+        if isinstance(union, list):
+            type_map = {
+                "string": "str",
+                "integer": "int",
+                "number": "float",
+                "boolean": "bool",
+                "null": "None",
+            }
+            parts = [
+                type_map.get(option.get("type", "string"), "str") for option in union
+            ]
+            return " | ".join(parts), False
         schema_type = schema.get("type", "string")
         if isinstance(schema_type, list):
             # Union of simple types

--- a/tests/cli/test_generate_cli.py
+++ b/tests/cli/test_generate_cli.py
@@ -82,6 +82,13 @@ class TestSchemaToPythonType:
         assert py_type == "str | None"
         assert needs_json is False
 
+    def test_any_of_simple_types(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        )
+        assert py_type == "str | None"
+        assert needs_json is False
+
 
 # ---------------------------------------------------------------------------
 # _to_python_identifier
@@ -147,6 +154,20 @@ class TestSerializeTransport:
 
 
 class TestToolFunctionSource:
+    def test_optional_string_param_is_not_json_parsed(self):
+        tool = mcp_types.Tool(
+            name="greet",
+            input_schema={
+                "properties": {
+                    "greeting": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+                }
+            },
+        )
+        source = _tool_function_source(tool)
+        assert "greeting: Annotated[str | None" in source
+        assert "json.loads(greeting)" not in source
+        assert "'greeting': greeting" in source
+
     def test_required_param(self):
         tool = mcp_types.Tool(
             name="greet",


### PR DESCRIPTION
Fixes #4866\n\nGenerated CLIs now recognize JSON Schema anyOf/oneOf unions composed of scalar types, such as str | None, as native CLI parameters. This prevents optional string values from being passed through json.loads().\n\nTests: uv run --frozen pytest tests/cli/test_generate_cli.py -q (84 passed, 1 skipped)\n\nValidation: ruff format --check, ruff check, ty check, and git diff --check.