### PR TITLE
Fix instructions in MCP inspect output

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/inspect.py
+++ b/fastmcp_slim/fastmcp/utilities/inspect.py
@@ -489,6 +489,7 @@ async def format_mcp_info(mcp: FastMCP[Any] | SDKServer) -> bytes:
                 "mcp": importlib.metadata.version("mcp"),  # MCP protocol version
             },
             "serverInfo": server_info,
+            "instructions": client.initialize_result.instructions,
             "capabilities": {},  # MCP format doesn't include capabilities at top level
             "tools": tools_result.tools,
             "prompts": prompts_result.prompts,

--- a/tests/utilities/test_inspect_icons.py
+++ b/tests/utilities/test_inspect_icons.py
@@ -425,6 +425,7 @@ class TestFormatFunctions:
 
         # Check server version in MCP format
         assert data["serverInfo"]["version"] == "2.0.0"
+        assert data["instructions"] == "Test instructions"
 
         # MCP format SHOULD have environment fields
         assert "environment" in data


### PR DESCRIPTION
`fastmcp inspect --format mcp` promises to show what MCP clients receive, but its manually assembled manifest drops the standard top-level `instructions` value from the initialization result. A server's behavioral guidance is therefore present in the actual handshake and FastMCP-format inspection while disappearing from MCP-format inspection.

Preserve `client.initialize_result.instructions` alongside `serverInfo` and cover the populated value in the formatter regression test. This follows the same focused approach as #4871, which was closed automatically by the issue-assignment workflow.

```python
mcp = FastMCP("demo", instructions="Use this server to do X.")
manifest = json.loads(await format_info(mcp, "mcp"))

assert manifest["instructions"] == "Use this server to do X."
```

Closes #4870.
