### PR TITLE
Fix JSONDecodeError for optional string params in generate-cli

### DIFF
--- a/fastmcp_slim/fastmcp/cli/generate.py
+++ b/fastmcp_slim/fastmcp/cli/generate.py
@@ -76,6 +76,15 @@ def _schema_to_python_type(schema: dict[str, Any]) -> tuple[str, bool]:
     if is_simple_arr:
         return f"list[{item_type}]", False
 
+    # anyOf of simple types - how pydantic represents unions like ``str | None``
+    if "anyOf" in schema:
+        subschemas = schema["anyOf"]
+        if subschemas and all(_is_simple_type(s) for s in subschemas):
+            parts = list(
+                dict.fromkeys(_schema_to_python_type(s)[0] for s in subschemas)
+            )
+            return " | ".join(parts), False
+
     # Check for simple type
     if _is_simple_type(schema):
         schema_type = schema.get("type", "string")

--- a/tests/cli/test_generate_cli.py
+++ b/tests/cli/test_generate_cli.py
@@ -82,6 +82,31 @@ class TestSchemaToPythonType:
         assert py_type == "str | None"
         assert needs_json is False
 
+    def test_anyof_optional_string(self):
+        # pydantic emits ``anyOf`` for ``str | None`` parameters
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        )
+        assert py_type == "str | None"
+        assert needs_json is False
+
+    def test_anyof_optional_integer_with_default(self):
+        py_type, needs_json = _schema_to_python_type(
+            {
+                "anyOf": [{"type": "integer"}, {"type": "null"}],
+                "default": None,
+            }
+        )
+        assert py_type == "int | None"
+        assert needs_json is False
+
+    def test_anyof_union_of_simple_types(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        )
+        assert py_type == "str | int"
+        assert needs_json is False
+
 
 # ---------------------------------------------------------------------------
 # _to_python_identifier
@@ -176,6 +201,27 @@ class TestToolFunctionSource:
         assert "query: Annotated[str" in source
         assert "limit: Annotated[int | None" in source
         assert "= None" in source
+
+    def test_optional_param_with_anyof_schema(self):
+        # pydantic represents ``str | None = None`` as anyOf, not type-list
+        tool = mcp_types.Tool(
+            name="greet",
+            input_schema={
+                "properties": {
+                    "name": {"type": "string", "description": "Who to greet"},
+                    "greeting": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "description": "Optional greeting word",
+                    },
+                },
+                "required": ["name"],
+            },
+        )
+        source = _tool_function_source(tool)
+        assert "greeting: Annotated[str | None" in source
+        assert "json.loads(greeting)" not in source
+        assert "'greeting': greeting" in source
 
     def test_param_with_default(self):
         tool = mcp_types.Tool(


### PR DESCRIPTION
Generated CLIs wrap every parameter that isn't a plain `{"type": ...}` schema in `json.loads()`. Pydantic represents unions like `str | None` as `anyOf`, which the type mapper treated as complex — so any tool with an optional string parameter produced a CLI that crashed on ordinary input and buried the raw JSON Schema in `--help`:

```console
$ python mre_cli.py call-tool greet --name World --greeting Howdy
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The mapper now recognizes `anyOf` schemas whose subschemas are all simple types and treats them exactly like the equivalent type-list union — scalars pass through untouched and help text stays clean:

```console
$ python mre_cli.py call-tool greet --name World --greeting Howdy
{
  "result": "Howdy, World"
}
```

`anyOf` containing objects or nested arrays still takes the JSON-parsing path.

Fixes #4866

🤖 Generated with AI assistance
