### PR TITLE
docs: fix idempotent tool hint wording

### DIFF
--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -101,7 +101,7 @@ def search_products_implementation(query: str, category: str | None = None) -> l
       If true, the tool may perform destructive updates to its environment.
     </ParamField>
     <ParamField body="idempotentHint" type="bool | None">
-      If true, calling the tool repeatedly with the same arguments will have no additional effect on the its environment.
+      If true, calling the tool repeatedly with the same arguments will have no additional effect on its environment.
     </ParamField>
     <ParamField body="openWorldHint" type="bool | None">
       If true, this tool may interact with an "open world" of external entities. If false, the tool's domain of interaction is closed.


### PR DESCRIPTION
Fixes #4877

The `idempotentHint` description contains an extra "the", which makes the
tool annotation guidance read incorrectly. This corrects the sentence without
changing the documented behavior.

🤖 Prepared with Codex and reviewed by @Theater-ahyeon.