### PR TITLE
fix(cli): pass anyOf-typed parameters through in generated CLIs

### DIFF
--- a/fastmcp_slim/fastmcp/cli/generate.py
+++ b/fastmcp_slim/fastmcp/cli/generate.py
@@ -38,6 +38,23 @@ def _is_simple_type(schema: dict[str, Any]) -> bool:
     return schema_type in _SIMPLE_TYPES
 
 
+def _scalar_enum_type(schema: dict[str, Any]) -> str | None:
+    """Map an enum-valued schema to the scalar type of its values.
+
+    Returns ``None`` when the schema has no enum, or when the enum mixes
+    value kinds (or contains non-scalar values), in which case the caller
+    falls back to JSON parsing.
+    """
+    values = schema.get("enum")
+    if not isinstance(values, list) or not values:
+        return None
+    kinds = {type(value).__name__ for value in values}
+    kind_map = {"str": "str", "int": "int", "float": "float", "bool": "bool"}
+    if len(kinds) == 1 and (py_type := kind_map.get(kinds.pop())):
+        return py_type
+    return None
+
+
 def _is_simple_array(schema: dict[str, Any]) -> tuple[bool, str | None]:
     """Check if schema is an array of simple types.
 
@@ -76,6 +93,11 @@ def _schema_to_python_type(schema: dict[str, Any]) -> tuple[str, bool]:
     if is_simple_arr:
         return f"list[{item_type}]", False
 
+    # Enum of scalar values - pass through like its scalar type
+    enum_type = _scalar_enum_type(schema)
+    if enum_type is not None:
+        return enum_type, False
+
     # Check for simple type
     if _is_simple_type(schema):
         schema_type = schema.get("type", "string")
@@ -99,6 +121,23 @@ def _schema_to_python_type(schema: dict[str, Any]) -> tuple[str, bool]:
             "null": "None",
         }
         return type_map.get(schema_type, "str"), False
+
+    # Combinator schemas (anyOf/oneOf): pydantic emits these for unions and
+    # Optional[T] parameters. When every branch resolves without JSON
+    # parsing, the value can be passed through as-is.
+    parts: list[str] = []
+    for combinator in ("anyOf", "oneOf"):
+        branches = schema.get(combinator)
+        if not isinstance(branches, list) or not branches:
+            continue
+        for branch in branches:
+            branch_type, needs_json = _schema_to_python_type(branch)
+            if needs_json:
+                return "str", True
+            for token in branch_type.split(" | "):
+                if token not in parts:
+                    parts.append(token)
+        return " | ".join(parts), False
 
     # Complex type - needs JSON parsing
     return "str", True
@@ -220,12 +259,19 @@ def _tool_function_source(tool: mcp_types.Tool) -> str:
                     annotation = f'Annotated[{py_type}, cyclopts.Parameter(help="{help_escaped}")]'
                     param_lines.append(f"    {safe_name}: {annotation} = {default!r},")
             else:
-                # For list types, default to empty list; others default to None
-                if py_type.startswith("list["):
+                # For plain list types, default to an empty list; anything
+                # else defaults to None (without appending "| None" again
+                # when the resolved type already includes it).
+                if py_type.startswith("list[") and "|" not in py_type:
                     annotation = f'Annotated[{py_type}, cyclopts.Parameter(help="{help_escaped}")]'
                     param_lines.append(f"    {safe_name}: {annotation} = [],")
                 else:
-                    annotation = f'Annotated[{py_type} | None, cyclopts.Parameter(help="{help_escaped}")]'
+                    base_type = (
+                        py_type
+                        if "None" in py_type.split(" | ")
+                        else f"{py_type} | None"
+                    )
+                    annotation = f'Annotated[{base_type}, cyclopts.Parameter(help="{help_escaped}")]'
                     param_lines.append(f"    {safe_name}: {annotation} = None,")
 
         call_args.append(f"{prop_name!r}: {safe_name}")

--- a/tests/cli/test_generate_cli.py
+++ b/tests/cli/test_generate_cli.py
@@ -82,6 +82,77 @@ class TestSchemaToPythonType:
         assert py_type == "str | None"
         assert needs_json is False
 
+    def test_anyof_optional_string(self):
+        # pydantic emits anyOf for Optional[T] parameters
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        )
+        assert py_type == "str | None"
+        assert needs_json is False
+
+    def test_anyof_optional_integer(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+        )
+        assert py_type == "int | None"
+        assert needs_json is False
+
+    def test_anyof_optional_simple_array(self):
+        py_type, needs_json = _schema_to_python_type(
+            {
+                "anyOf": [
+                    {"type": "array", "items": {"type": "string"}},
+                    {"type": "null"},
+                ]
+            }
+        )
+        assert py_type == "list[str] | None"
+        assert needs_json is False
+
+    def test_anyof_union_of_simple_types(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        )
+        assert py_type == "str | int"
+        assert needs_json is False
+
+    def test_oneof_optional_boolean(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"oneOf": [{"type": "boolean"}, {"type": "null"}]}
+        )
+        assert py_type == "bool | None"
+        assert needs_json is False
+
+    def test_scalar_enum(self):
+        py_type, needs_json = _schema_to_python_type({"enum": ["fast", "slow"]})
+        assert py_type == "str"
+        assert needs_json is False
+
+    def test_anyof_enum_with_null(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"enum": ["fast", "slow"]}, {"type": "null"}]}
+        )
+        assert py_type == "str | None"
+        assert needs_json is False
+
+    def test_mixed_enum_kinds_falls_back(self):
+        _, needs_json = _schema_to_python_type({"enum": ["fast", 1]})
+        assert needs_json is True
+
+    def test_anyof_with_complex_branch_needs_json(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"type": "object"}, {"type": "null"}]}
+        )
+        assert py_type == "str"
+        assert needs_json is True
+
+    def test_anyof_with_ref_needs_json(self):
+        py_type, needs_json = _schema_to_python_type(
+            {"anyOf": [{"$ref": "#/$defs/Widget"}]}
+        )
+        assert py_type == "str"
+        assert needs_json is True
+
 
 # ---------------------------------------------------------------------------
 # _to_python_identifier
@@ -176,6 +247,101 @@ class TestToolFunctionSource:
         assert "query: Annotated[str" in source
         assert "limit: Annotated[int | None" in source
         assert "= None" in source
+
+    def test_optional_string_via_anyof_passes_through(self):
+        # pydantic emits anyOf for Optional[T]; the generated CLI must pass
+        # plain values through instead of JSON-parsing them (#4866).
+        tool = mcp_types.Tool(
+            name="greet",
+            input_schema={
+                "properties": {
+                    "name": {"type": "string", "description": "Who"},
+                    "greeting": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "description": "Optional greeting word.",
+                    },
+                },
+                "required": ["name"],
+            },
+        )
+        source = _tool_function_source(tool)
+        assert "greeting: Annotated[str | None" in source
+        assert "= None" in source
+        assert "greeting_parsed" not in source
+        assert "json.loads" not in source
+        assert "JSON Schema:" not in source
+        assert "'greeting': greeting" in source
+        compile(source, "<test>", "exec")
+
+    def test_optional_integer_via_anyof_no_double_none(self):
+        tool = mcp_types.Tool(
+            name="scale",
+            input_schema={
+                "properties": {
+                    "n": {
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                        "default": None,
+                    },
+                },
+            },
+        )
+        source = _tool_function_source(tool)
+        assert "n: Annotated[int | None" in source
+        assert "| None | None" not in source
+        compile(source, "<test>", "exec")
+
+    def test_optional_list_via_anyof_defaults_to_none(self):
+        tool = mcp_types.Tool(
+            name="pick",
+            input_schema={
+                "properties": {
+                    "items": {
+                        "anyOf": [
+                            {"type": "array", "items": {"type": "string"}},
+                            {"type": "null"},
+                        ],
+                        "default": None,
+                    },
+                },
+            },
+        )
+        source = _tool_function_source(tool)
+        assert "items: Annotated[list[str] | None" in source
+        assert "= None," in source
+
+    def test_required_union_via_anyof_passes_through(self):
+        tool = mcp_types.Tool(
+            name="echo",
+            input_schema={
+                "properties": {
+                    "value": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                },
+                "required": ["value"],
+            },
+        )
+        source = _tool_function_source(tool)
+        assert "value: Annotated[str | int" in source
+        assert "json.loads" not in source
+        compile(source, "<test>", "exec")
+
+    def test_optional_object_via_anyof_keeps_json_parsing(self):
+        tool = mcp_types.Tool(
+            name="configure",
+            input_schema={
+                "properties": {
+                    "config": {
+                        "anyOf": [{"type": "object"}, {"type": "null"}],
+                        "default": None,
+                    },
+                },
+            },
+        )
+        source = _tool_function_source(tool)
+        assert "config_parsed = json.loads(config) if isinstance(config, str)" in source
+        assert "'config': config_parsed" in source
+        assert "JSON Schema:" in source
+        compile(source, "<test>", "exec")
 
     def test_param_with_default(self):
         tool = mcp_types.Tool(
@@ -791,6 +957,25 @@ class TestGenerateSkillContent:
         assert "`--name`" in content
         assert "| string |" in content
         assert "| yes |" in content
+
+    def test_optional_string_via_anyof_not_marked_json(self):
+        tools = [
+            mcp_types.Tool(
+                name="greet",
+                input_schema={
+                    "properties": {
+                        "greeting": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "default": None,
+                        },
+                    },
+                },
+            ),
+        ]
+        content = generate_skill_content("test", "cli.py", tools)
+        assert "(JSON string)" not in content
+        assert "| string |" in content
+        assert "| no |" in content
 
     def test_frontmatter_with_tools_starts_at_column_zero(self):
         tools = [


### PR DESCRIPTION
## Problem

`fastmcp generate-cli` wraps every parameter whose JSON Schema uses `anyOf`/`oneOf` in `json.loads()` at call time. Since pydantic emits `anyOf` for **all** unions and optionals (`str | None = None` → `{"anyOf": [{"type": "string"}, {"type": "null"}]}`), every optional simple parameter crashed the generated CLI with `JSONDecodeError` when given a plain value (#4866):

```console
$ python mre_cli.py call-tool greet --name World --greeting Howdy
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
# only worked as: --greeting '"Howdy"'
```

Required parameters were unaffected because their schemas carry a plain "type". The same misclassification also dumped the raw JSON Schema into the parameter's `--help` text and added a spurious "(JSON string)" marker in SKILL.md for these parameters.

## Root cause

`_schema_to_python_type()` recognized only scalar `type` schemas and simple arrays; anything else fell into the complex-type fallback (`return "str", True`). It had no branch for combinator schemas, so pydantic's canonical `anyOf` shape was always classified as needing JSON parsing.

## Fix

- Resolve `anyOf`/`oneOf` recursively. When every branch is representable without JSON parsing (scalars, simple arrays, scalar enums like `Literal["fast", "slow"]`, nested unions), emit the joined annotation with `needs_json=False`. Any complex branch (`object`, `$ref`, mixed-kind enums) falls back to the existing JSON-parsing path unchanged.
- Deduplicate union tokens so an already-optional resolved type does not become `str | None | None`.
- Keep the ` = []` default only for exactly-list types; `list[T] | None` now defaults to `None`.
- Scalar-only enums (`{"enum": ["a", "b"]}`) classify as their value type instead of falling into JSON parsing.
- Resolve combinator schemas for SKILL.md labels and boolean flag detection, so optional booleans are documented as flags rather than value-taking strings.

Complex parameters behave exactly as before (JSON string input, schema shown in help).

## Testing

- 17 new cases in `tests/cli/test_generate_cli.py`: the MRE shape, unions, scalar enums, `anyOf`+enum, $ref/object fallbacks, list-optional defaults, no-double-`None`, skill-content consistency, and optional-boolean skill rendering — full file: **100 passed**.
- End-to-end against a real server via stdio transport: plain `--greeting Howdy` passes through, omitted optionals default correctly, optional ints work, complex params still require/parse JSON strings.

Closes #4866
