### PR TITLE
feat: add RS256/ES256 asymmetric JWT issuance and JWKS support

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/jwt_issuer.py
+++ b/fastmcp_slim/fastmcp/server/auth/jwt_issuer.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import base64
 import time
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -24,6 +24,14 @@ logger = get_logger(__name__)
 
 KDF_ITERATIONS = 1_000_000
 KDF_ITERATIONS_TEST = 10
+
+JWTSigningAlgorithm = Literal["HS256", "RS256", "ES256"]
+
+__all__ = [
+    "JWTIssuer",
+    "JWTSigningAlgorithm",
+    "derive_jwt_key",
+]
 
 
 @overload
@@ -77,30 +85,94 @@ def derive_jwt_key(
 
 
 class JWTIssuer:
-    """Issues and validates FastMCP-signed JWT tokens using HS256.
+    """Issues and validates FastMCP-signed JWT tokens.
 
     This issuer creates JWT tokens for MCP clients with proper audience claims,
-    maintaining OAuth 2.0 token boundaries. Tokens are signed with HS256 using
-    a key derived from the upstream client secret.
+    maintaining OAuth 2.0 token boundaries. Supports HS256 (symmetric) for
+    single-process deployments and RS256 / ES256 (asymmetric) for split-process
+    deployments where resource servers verify tokens via JWKS without holding
+    the minting key.
     """
 
     def __init__(
         self,
         issuer: str,
         audience: str,
-        signing_key: bytes,
-    ):
+        signing_key: bytes | str,
+        algorithm: JWTSigningAlgorithm = "HS256",
+        kid: str | None = None,
+    ) -> None:
         """Initialize JWT issuer.
 
         Args:
             issuer: Token issuer (FastMCP server base URL)
             audience: Token audience (typically {base_url}/mcp)
-            signing_key: HS256 signing key (32 bytes)
+            signing_key: For HS256, a symmetric key (32 bytes). For RS256 or
+                ES256, a PEM-encoded private key (bytes or string).
+            algorithm: Signing algorithm ("HS256", "RS256", or "ES256").
+            kid: Optional explicit key ID. When omitted, asymmetric keys use
+                their JWK thumbprint (RFC 7638) as the key ID. HS256 does not
+                require a key ID because tokens are verified in-process with
+                the same shared secret.
         """
         self.issuer = issuer
         self.audience = audience
-        self._signing_key = signing_key
-        self._jwt_key = jwk.import_key(signing_key, "oct")
+        self._signing_key = (
+            signing_key.encode() if isinstance(signing_key, str) else signing_key
+        )
+        self._algorithm: JWTSigningAlgorithm = algorithm
+
+        if algorithm == "HS256":
+            self._jwt_key = jwk.import_key(self._signing_key, "oct")
+        elif algorithm == "RS256":
+            self._jwt_key = jwk.import_key(self._signing_key, "RSA")
+        elif algorithm == "ES256":
+            self._jwt_key = jwk.import_key(self._signing_key, "EC")
+        else:
+            raise ValueError(f"Unsupported signing algorithm: {algorithm}")
+
+        if kid is not None:
+            self._kid: str | None = kid
+        elif algorithm != "HS256":
+            self._jwt_key.ensure_kid()
+            self._kid = self._jwt_key.kid
+        else:
+            self._kid = None
+
+    @property
+    def algorithm(self) -> JWTSigningAlgorithm:
+        """The signing algorithm used by this issuer."""
+        return self._algorithm
+
+    @property
+    def kid(self) -> str | None:
+        """The key ID included in JWT headers (None for HS256)."""
+        return self._kid
+
+    @property
+    def is_asymmetric(self) -> bool:
+        """Whether this issuer uses asymmetric signing."""
+        return self._algorithm in ("RS256", "ES256")
+
+    def public_jwks(self) -> dict[str, Any]:
+        """Return the public JSON Web Key Set for this issuer.
+
+        Only meaningful for asymmetric algorithms (RS256 / ES256). The returned
+        set contains public key material only — never the private signing key.
+
+        Returns:
+            A dict with a ``keys`` list of JWK objects suitable for serializing
+            as the body of a ``GET /.well-known/jwks.json`` response.
+
+        Raises:
+            ValueError: If called on an HS256 issuer (no JWKS exists).
+        """
+        if not self.is_asymmetric:
+            raise ValueError(
+                "public_jwks() is only available for asymmetric algorithms "
+                "(RS256 or ES256). HS256 uses a shared secret and has no JWKS."
+            )
+        return {"keys": [self._jwt_key.as_dict(private=False)]}
 
     def issue_access_token(
         self,
@@ -136,7 +208,7 @@ class JWTIssuer:
         """
         now = int(time.time())
 
-        header = {"alg": "HS256", "typ": "JWT"}
+        header = self._build_header()
         payload: dict[str, Any] = {
             "iss": self.issuer,
             "aud": self.audience,
@@ -160,7 +232,7 @@ class JWTIssuer:
             header,
             payload,
             self._jwt_key,
-            algorithms=["HS256"],
+            algorithms=[self._algorithm],
         )
 
         logger.debug(
@@ -198,7 +270,7 @@ class JWTIssuer:
         """
         now = int(time.time())
 
-        header = {"alg": "HS256", "typ": "JWT"}
+        header = self._build_header()
         payload: dict[str, Any] = {
             "iss": self.issuer,
             "aud": self.audience,
@@ -217,7 +289,7 @@ class JWTIssuer:
             header,
             payload,
             self._jwt_key,
-            algorithms=["HS256"],
+            algorithms=[self._algorithm],
         )
 
         logger.debug(
@@ -254,7 +326,7 @@ class JWTIssuer:
             payload = jwt.decode(
                 token,
                 self._jwt_key,
-                algorithms=["HS256"],
+                algorithms=[self._algorithm],
             ).claims
 
             # Validate token type
@@ -294,3 +366,10 @@ class JWTIssuer:
         except JoseError as e:
             logger.debug("Token validation failed: %s", e)
             raise
+
+    def _build_header(self) -> dict[str, Any]:
+        """Build the JWT header for this issuer's algorithm."""
+        header: dict[str, Any] = {"alg": self._algorithm, "typ": "JWT"}
+        if self._kid is not None:
+            header["kid"] = self._kid
+        return header

--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -19,6 +19,7 @@ production use with enterprise identity providers.
 from __future__ import annotations
 
 import hashlib
+import json
 import secrets
 import time
 from base64 import urlsafe_b64encode
@@ -63,6 +64,7 @@ from mcp.server.auth.settings import (
 from mcp.shared.auth import (
     OAuthClientInformationFull,
     OAuthClientMetadata,
+    OAuthMetadata,
     OAuthToken,
 )
 from pydantic import AnyHttpUrl, AnyUrl, SecretStr, ValidationError
@@ -90,6 +92,7 @@ from fastmcp.server.auth.identity_assertion import (
 )
 from fastmcp.server.auth.jwt_issuer import (
     JWTIssuer,
+    JWTSigningAlgorithm,
     derive_jwt_key,
 )
 from fastmcp.server.auth.oauth_proxy.consent import ConsentMixin
@@ -133,6 +136,18 @@ _REFRESH_LOCK_CACHE_SIZE = 10_000
 _pending_application_type: ContextVar[Literal["web", "native"] | None] = ContextVar(
     "_pending_application_type", default=None
 )
+
+
+class _ProxyOAuthMetadata(OAuthMetadata):
+    """OAuthMetadata with ``jwks_uri`` for asymmetric token signing.
+
+    RFC 8414 §2 defines ``jwks_uri`` as a standard authorization server
+    metadata parameter, but the SDK's model does not yet include it. This
+    subclass fills the gap so split-process deployments can discover the
+    proxy's public key set via standard metadata discovery.
+    """
+
+    jwks_uri: AnyHttpUrl | None = None
 
 
 class _ApplicationTypeRegistrationHandler:
@@ -331,6 +346,8 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         client_storage: AsyncKeyValue | None = None,
         # JWT signing key
         jwt_signing_key: str | bytes | None = None,
+        # JWT signing algorithm
+        jwt_signing_algorithm: JWTSigningAlgorithm = "HS256",
         # Consent screen configuration
         require_authorization_consent: bool | Literal["remember", "external"] = True,
         consent_csp_policy: str | None = None,
@@ -389,6 +406,12 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 If bytes are provided, they will be used as-is.
                 If a string is provided, it will be derived into a 32-byte key using PBKDF2 (1,000,000 iterations).
                 If not provided, it will be derived from the upstream client secret using HKDF.
+            jwt_signing_algorithm: Algorithm for signing FastMCP-issued JWTs.
+                "HS256" (default) uses the symmetric key for in-process verification.
+                "RS256" or "ES256" requires ``jwt_signing_key`` to be a PEM-encoded
+                private key and publishes public JWKS at ``/.well-known/jwks.json``
+                so separate resource servers can verify tokens without holding
+                the minting key. HS256 does not publish JWKS (no public half).
             require_authorization_consent: Consent screen behavior (default True).
                 - True: always show the consent screen before redirecting to the
                   upstream IdP. Strongest protection against AS-in-the-middle
@@ -554,7 +577,20 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         )
         self._token_expiry_threshold_seconds: int = token_expiry_threshold_seconds
 
-        if jwt_signing_key is None:
+        if jwt_signing_algorithm in ("RS256", "ES256"):
+            # Asymmetric signing requires a PEM-encoded private key; do not
+            # derive it from a passphrase or client secret.
+            if jwt_signing_key is None:
+                raise ValueError(
+                    f"jwt_signing_key must be a PEM-encoded private key when "
+                    f"jwt_signing_algorithm is {jwt_signing_algorithm}."
+                )
+            jwt_signing_key = (
+                jwt_signing_key.encode()
+                if isinstance(jwt_signing_key, str)
+                else jwt_signing_key
+            )
+        elif jwt_signing_key is None:
             if upstream_client_secret is None:
                 raise ValueError(
                     "jwt_signing_key is required when upstream_client_secret is not provided. "
@@ -578,6 +614,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
 
         # Store JWT signing key for deferred JWTIssuer creation in set_mcp_path()
         self._jwt_signing_key: bytes = jwt_signing_key
+        self._jwt_signing_algorithm: JWTSigningAlgorithm = jwt_signing_algorithm
         # JWTIssuer will be created in set_mcp_path() with correct audience
         self._jwt_issuer: JWTIssuer | None = None
 
@@ -784,6 +821,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             issuer=str(self.issuer_url),
             audience=str(self._resource_url),
             signing_key=self._jwt_signing_key,
+            algorithm=self._jwt_signing_algorithm,
         )
 
         logger.debug("Configured OAuth proxy for resource URL: %s", self._resource_url)
@@ -2520,6 +2558,11 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                     revocation_options,
                     supports_identity_assertion=self._identity_assertion is not None,
                 )
+                # Upgrade the SDK metadata model so ``jwks_uri`` is available
+                # for asymmetric signing (RFC 8414 §2).
+                metadata = _ProxyOAuthMetadata.model_validate(
+                    metadata.model_dump(mode="json", exclude_none=True)
+                )
                 # `build_metadata` derives both the `issuer` field and every
                 # endpoint URL from a single argument. Endpoints must stay on
                 # `base_url` (that is where the routes are actually mounted),
@@ -2533,6 +2576,14 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 # always be overridden to advertise support — not just when
                 # CIMD or identity assertion is also enabled.
                 metadata.authorization_response_iss_parameter_supported = True
+                if (
+                    self._jwt_signing_algorithm in ("RS256", "ES256")
+                    and self._jwt_issuer is not None
+                    and self._jwt_issuer.is_asymmetric
+                ):
+                    metadata.jwks_uri = AnyHttpUrl(
+                        f"{str(self.base_url).rstrip('/')}/.well-known/jwks.json"
+                    )
                 # Every client the proxy authenticates at the token endpoint is
                 # public: DCR-registered and synthesized clients are stored with
                 # `token_endpoint_auth_method="none"`, and CIMD clients use
@@ -2578,7 +2629,27 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             )
         )
 
+        # Add JWKS endpoint for asymmetric signing algorithms
+        if self._jwt_signing_algorithm in ("RS256", "ES256"):
+            custom_routes.append(
+                Route(
+                    path="/.well-known/jwks.json",
+                    endpoint=self._handle_jwks,
+                    methods=["GET"],
+                )
+            )
+
         return custom_routes
+
+    async def _handle_jwks(self, request: Request) -> Response:
+        """Serve the public JSON Web Key Set for asymmetric token verification."""
+        issuer = self.jwt_issuer
+        jwks = issuer.public_jwks()
+        return Response(
+            content=json.dumps(jwks),
+            media_type="application/json",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
 
     # -------------------------------------------------------------------------
     # IdP Callback Forwarding

--- a/tests/server/auth/test_jwt_issuer.py
+++ b/tests/server/auth/test_jwt_issuer.py
@@ -1,12 +1,15 @@
 """Unit tests for JWT issuer and token encryption."""
 
 import base64
+import json
 
 import pytest
+from joserfc import jwk
 from joserfc.errors import JoseError
 
 from fastmcp.server.auth.jwt_issuer import (
     JWTIssuer,
+    JWTSigningAlgorithm,
     derive_jwt_key,
 )
 
@@ -309,3 +312,115 @@ class TestJWTIssuer:
 
         with pytest.raises(JoseError, match="Token type mismatch"):
             issuer.verify_token(token, expected_token_use="refresh")
+
+
+class TestAsymmetricJWTIssuer:
+    """Tests for RS256 and ES256 asymmetric token issuance."""
+
+    @pytest.fixture
+    def rsa_pem(self) -> bytes:
+        key = jwk.RSAKey.generate_key()
+        return key.as_pem(private=True)
+
+    @pytest.fixture
+    def ec_pem(self) -> bytes:
+        key = jwk.ECKey.generate_key("P-256")
+        return key.as_pem(private=True)
+
+    def test_rs256_issue_and_verify(self, rsa_pem):
+        issuer = JWTIssuer(
+            issuer="https://as.example.com",
+            audience="https://rs.example.com/mcp",
+            signing_key=rsa_pem,
+            algorithm="RS256",
+        )
+        assert issuer.algorithm == "RS256"
+        assert issuer.is_asymmetric
+
+        token = issuer.issue_access_token(
+            client_id="client-1", scopes=["read"], jti="jti-rs"
+        )
+        payload = issuer.verify_token(token)
+        assert payload["client_id"] == "client-1"
+
+    def test_es256_issue_and_verify(self, ec_pem):
+        issuer = JWTIssuer(
+            issuer="https://as.example.com",
+            audience="https://rs.example.com/mcp",
+            signing_key=ec_pem,
+            algorithm="ES256",
+        )
+        assert issuer.algorithm == "ES256"
+        assert issuer.is_asymmetric
+
+        token = issuer.issue_access_token(
+            client_id="client-2", scopes=["write"], jti="jti-es"
+        )
+        payload = issuer.verify_token(token)
+        assert payload["client_id"] == "client-2"
+
+    def test_asymmetric_tokens_carry_kid(self, rsa_pem):
+        issuer = JWTIssuer(
+            issuer="https://as.example.com",
+            audience="https://rs.example.com/mcp",
+            signing_key=rsa_pem,
+            algorithm="RS256",
+        )
+        assert issuer.kid is not None
+
+        token = issuer.issue_access_token(
+            client_id="client", scopes=["read"], jti="jti-kid"
+        )
+        header_b64 = token.split(".")[0]
+        header_b64 += "=" * (4 - len(header_b64) % 4)
+        header = json.loads(base64.urlsafe_b64decode(header_b64))
+        assert header["alg"] == "RS256"
+        assert header["kid"] == issuer.kid
+
+    def test_explicit_kid(self, rsa_pem):
+        issuer = JWTIssuer(
+            issuer="https://as.example.com",
+            audience="https://rs.example.com/mcp",
+            signing_key=rsa_pem,
+            algorithm="RS256",
+            kid="my-key-v1",
+        )
+        assert issuer.kid == "my-key-v1"
+
+    def test_public_jwks_contains_only_public_material(self, rsa_pem):
+        issuer = JWTIssuer(
+            issuer="https://as.example.com",
+            audience="https://rs.example.com/mcp",
+            signing_key=rsa_pem,
+            algorithm="RS256",
+        )
+        jwks = issuer.public_jwks()
+        assert len(jwks["keys"]) == 1
+        key_dict = jwks["keys"][0]
+        assert key_dict["kty"] == "RSA"
+        assert "n" in key_dict  # public modulus
+        assert "e" in key_dict  # public exponent
+        assert "d" not in key_dict  # private exponent must NOT be present
+        assert "p" not in key_dict  # RSA prime factor must NOT be present
+        assert "q" not in key_dict  # RSA prime factor must NOT be present
+
+    def test_hs256_rejects_public_jwks(self):
+        signing_key = derive_jwt_key(
+            low_entropy_material="test-secret", salt="test-salt"
+        )
+        issuer = JWTIssuer(
+            issuer="https://as.example.com",
+            audience="https://rs.example.com/mcp",
+            signing_key=signing_key,
+        )
+        with pytest.raises(ValueError, match="HS256"):
+            issuer.public_jwks()
+
+    def test_unsupported_algorithm(self, rsa_pem):
+        with pytest.raises(ValueError, match="Unsupported signing algorithm"):
+            JWTIssuer(
+                issuer="https://as.example.com",
+                audience="https://rs.example.com/mcp",
+                signing_key=rsa_pem,
+                algorithm="HS512",  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
## Description

Closes #4869

Extends `JWTIssuer` and `OAuthProxy` to support split issuer/resource-server deployments where resource servers verify tokens via public JWKS without holding the minting key.

**`JWTIssuer` changes:**
- Accepts RS256 / ES256 PEM-encoded private keys alongside existing HS256
- Includes `kid` header in issued JWTs (RFC 7638 JWK thumbprint by default; explicit override available)
- New `public_jwks()` method returns public-only JWK set (`as_dict(private=False)`)
- Full HS256 backward compatibility (default algorithm unchanged, no behavioral change for in-process proxy)

**`OAuthProxy` changes:**
- New `jwt_signing_algorithm` parameter (default `"HS256"`, unchanged behavior)
- When set to `"RS256"` or `"ES256"`, requires a PEM private key via `jwt_signing_key` (no PBKDF2 derivation — asymmetric keys are not derived from passphrases)
- Serves `GET /.well-known/jwks.json` with `Cache-Control: public, max-age=3600`
- Advertises `jwks_uri` in RFC 8414 authorization server metadata (via `_ProxyOAuthMetadata`, an SDK-compatible subclass adding the standard field)
- Rejects asymmetric algorithms without a PEM signing key at construction time

Resource servers remain unchanged: they continue using `JWTVerifier(jwks_uri=...)`.

## Contribution type

- [ ] Bug fix
- [ ] Documentation improvement
- [x] Enhancement

## Checklist

- [x] This PR addresses an existing issue (#4869)
- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes (8 new tests covering RS256/ES256 roundtrip, kid header presence, explicit kid, public-only JWKS material, HS256 JWKS rejection, unsupported algorithm rejection)
- [ ] I have run `uv run prek run --all-files` (environment dependency setup incomplete locally; all 1028 auth tests pass)
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

*This contribution was developed with LLM assistance following repo conventions.*