### PR TITLE
Add pluggable identity assertion replay storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ Because the docs land *before* the tag exists, derive the entry from the maintai
 
 - Python ≥ 3.10 with full type annotations
 - Follow existing patterns and maintain consistency
+- **Use `py-key-value` for stateful framework features.** New caches, replay tracking, token or session persistence, and other pluggable state should accept the existing `AsyncKeyValue` abstraction instead of introducing a feature-specific storage protocol. Add a specialized interface only when the required semantics cannot be represented by `AsyncKeyValue`, and document that constraint explicitly.
 - **Prioritize readable, understandable code** - clarity over cleverness
 - Avoid obfuscated or confusing patterns even if they're shorter
 - Each feature needs corresponding tests

--- a/docs/servers/auth/oauth-proxy.mdx
+++ b/docs/servers/auth/oauth-proxy.mdx
@@ -758,8 +758,56 @@ identity_assertion=IdentityAssertion(
 
 The subject asserted in the ID-JAG flows into the normal FastMCP auth context. Tools read it through `get_access_token()` exactly as they would for any other token, because the proxy issues the access token through its own token factory.
 
+By default, replay protection uses a bounded `InMemoryJTIReplayStore`, so each
+server process tracks its own consumed assertions. A horizontally-scaled
+deployment should pass a shared implementation of `JTIReplayStore` as
+`IdentityAssertion(jti_store=...)`. Its `check_and_store(jti, expires_at)` method
+must atomically reserve a previously unseen JTI until the supplied Unix
+timestamp and return `False` if an unexpired reservation already exists. Redis
+`SET ... NX` and database unique-insert operations are examples of suitable
+backend primitives. A generic key-value `get` followed by `put` is not atomic
+and does not provide replay protection under concurrent requests.
+
+For example, with `py-key-value-aio[redis]` installed, a Redis-backed store can
+use one atomic `SET` with the `NX` and `PX` options:
+
+```python
+import math
+import time
+
+from redis.asyncio import Redis
+
+from fastmcp.server.auth import IdentityAssertion, JTIReplayStore
+
+
+class RedisJTIReplayStore:
+    def __init__(self, redis: Redis) -> None:
+        self.redis = redis
+
+    async def check_and_store(self, jti: str, expires_at: float) -> bool:
+        ttl_ms = max(1, math.ceil((expires_at - time.time()) * 1000))
+        stored = await self.redis.set(
+            f"fastmcp:id-jag:{jti}",
+            "consumed",
+            nx=True,
+            px=ttl_ms,
+        )
+        return bool(stored)
+
+
+redis = Redis.from_url("redis://localhost:6379")
+jti_store: JTIReplayStore = RedisJTIReplayStore(redis)
+
+identity_assertion = IdentityAssertion(
+    trusted_issuers=["https://login.acme-corp.com"],
+    jti_store=jti_store,
+)
+```
+
 <Warning>
-Replay protection is per-process. Each server process tracks seen `jti` values in memory, so a horizontally-scaled deployment running multiple workers or replicas could accept the same assertion once per process. The same applies to revocation of ID-JAG access tokens: they are self-contained, so revocation is tracked in-process until the token's (short, 5-minute default) natural expiry. For deployments that require strict single-use enforcement across replicas, configure sticky routing so a given client's requests reach the same process, or place a shared store in front of the token endpoint. This mirrors the posture of CIMD `private_key_jwt` replay protection, which is also per-process.
+The same distributed-store option does not apply to revocation of already-issued
+ID-JAG access tokens. Those tokens are self-contained, so revocation remains
+process-local until the token's short (5-minute default) lifetime expires.
 </Warning>
 
 ## Security

--- a/docs/servers/auth/oauth-proxy.mdx
+++ b/docs/servers/auth/oauth-proxy.mdx
@@ -758,51 +758,32 @@ identity_assertion=IdentityAssertion(
 
 The subject asserted in the ID-JAG flows into the normal FastMCP auth context. Tools read it through `get_access_token()` exactly as they would for any other token, because the proxy issues the access token through its own token factory.
 
-By default, replay protection uses a bounded `InMemoryJTIReplayStore`, so each
-server process tracks its own consumed assertions. A horizontally-scaled
-deployment should pass a shared implementation of `JTIReplayStore` as
-`IdentityAssertion(jti_store=...)`. Its `check_and_store(jti, expires_at)` method
-must atomically reserve a previously unseen JTI until the supplied Unix
-timestamp and return `False` if an unexpired reservation already exists. Redis
-`SET ... NX` and database unique-insert operations are examples of suitable
-backend primitives. A generic key-value `get` followed by `put` is not atomic
-and does not provide replay protection under concurrent requests.
+By default, replay protection uses a bounded `MemoryStore`, so each server
+process tracks its own consumed assertions. A horizontally-scaled deployment
+should pass a shared `AsyncKeyValue` implementation as
+`IdentityAssertion(jti_store=...)`.
 
-For example, with `py-key-value-aio[redis]` installed, a Redis-backed store can
-use one atomic `SET` with the `NX` and `PX` options:
+For example, with `py-key-value-aio[redis]` installed, use its Redis store:
 
 ```python
-import math
-import time
+from key_value.aio.stores.redis import RedisStore
 
-from redis.asyncio import Redis
-
-from fastmcp.server.auth import IdentityAssertion, JTIReplayStore
-
-
-class RedisJTIReplayStore:
-    def __init__(self, redis: Redis) -> None:
-        self.redis = redis
-
-    async def check_and_store(self, jti: str, expires_at: float) -> bool:
-        ttl_ms = max(1, math.ceil((expires_at - time.time()) * 1000))
-        stored = await self.redis.set(
-            f"fastmcp:id-jag:{jti}",
-            "consumed",
-            nx=True,
-            px=ttl_ms,
-        )
-        return bool(stored)
-
-
-redis = Redis.from_url("redis://localhost:6379")
-jti_store: JTIReplayStore = RedisJTIReplayStore(redis)
+from fastmcp.server.auth import IdentityAssertion
 
 identity_assertion = IdentityAssertion(
     trusted_issuers=["https://login.acme-corp.com"],
-    jti_store=jti_store,
+    jti_store=RedisStore(url="redis://localhost:6379"),
 )
 ```
+
+<Warning>
+`AsyncKeyValue` currently exposes `get` and `put`, but no conditional insert.
+FastMCP serializes exchanges within one server process, while replicas sharing a
+store perform a non-atomic `get` followed by `put`. Simultaneous exchanges of
+the same assertion on different replicas can therefore race and both succeed.
+Keep assertions short-lived; the shared store still rejects ordinary sequential
+replay and closes the much larger process-local replay window.
+</Warning>
 
 <Warning>
 The same distributed-store option does not apply to revocation of already-issued

--- a/fastmcp_slim/fastmcp/server/auth/__init__.py
+++ b/fastmcp_slim/fastmcp/server/auth/__init__.py
@@ -18,11 +18,7 @@ from fastmcp.utilities.authorization import (
 )
 
 if TYPE_CHECKING:
-    from .identity_assertion import (
-        IdentityAssertion as IdentityAssertion,
-        InMemoryJTIReplayStore as InMemoryJTIReplayStore,
-        JTIReplayStore as JTIReplayStore,
-    )
+    from .identity_assertion import IdentityAssertion as IdentityAssertion
     from .oauth_proxy import OAuthProxy as OAuthProxy
     from .oidc_proxy import OIDCProxy as OIDCProxy
     from .providers.debug import DebugTokenVerifier as DebugTokenVerifier
@@ -54,14 +50,6 @@ def __getattr__(name: str) -> object:
         from .identity_assertion import IdentityAssertion
 
         return IdentityAssertion
-    if name == "InMemoryJTIReplayStore":
-        from .identity_assertion import InMemoryJTIReplayStore
-
-        return InMemoryJTIReplayStore
-    if name == "JTIReplayStore":
-        from .identity_assertion import JTIReplayStore
-
-        return JTIReplayStore
     if name == "OAuthProxy":
         from .oauth_proxy import OAuthProxy
 
@@ -80,8 +68,6 @@ __all__ = [
     "AuthProvider",
     "DebugTokenVerifier",
     "IdentityAssertion",
-    "InMemoryJTIReplayStore",
-    "JTIReplayStore",
     "JWTVerifier",
     "MultiAuth",
     "OAuthProvider",

--- a/fastmcp_slim/fastmcp/server/auth/__init__.py
+++ b/fastmcp_slim/fastmcp/server/auth/__init__.py
@@ -18,7 +18,11 @@ from fastmcp.utilities.authorization import (
 )
 
 if TYPE_CHECKING:
-    from .identity_assertion import IdentityAssertion as IdentityAssertion
+    from .identity_assertion import (
+        IdentityAssertion as IdentityAssertion,
+        InMemoryJTIReplayStore as InMemoryJTIReplayStore,
+        JTIReplayStore as JTIReplayStore,
+    )
     from .oauth_proxy import OAuthProxy as OAuthProxy
     from .oidc_proxy import OIDCProxy as OIDCProxy
     from .providers.debug import DebugTokenVerifier as DebugTokenVerifier
@@ -50,6 +54,14 @@ def __getattr__(name: str) -> object:
         from .identity_assertion import IdentityAssertion
 
         return IdentityAssertion
+    if name == "InMemoryJTIReplayStore":
+        from .identity_assertion import InMemoryJTIReplayStore
+
+        return InMemoryJTIReplayStore
+    if name == "JTIReplayStore":
+        from .identity_assertion import JTIReplayStore
+
+        return JTIReplayStore
     if name == "OAuthProxy":
         from .oauth_proxy import OAuthProxy
 
@@ -68,6 +80,8 @@ __all__ = [
     "AuthProvider",
     "DebugTokenVerifier",
     "IdentityAssertion",
+    "InMemoryJTIReplayStore",
+    "JTIReplayStore",
     "JWTVerifier",
     "MultiAuth",
     "OAuthProvider",

--- a/fastmcp_slim/fastmcp/server/auth/identity_assertion.py
+++ b/fastmcp_slim/fastmcp/server/auth/identity_assertion.py
@@ -28,11 +28,12 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING
+from threading import Lock
+from typing import TYPE_CHECKING, Annotated, Any, Protocol, runtime_checkable
 from urllib.parse import urlparse, urlunparse
 
 import httpx2
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, PlainValidator, field_validator
 
 from fastmcp.utilities.auth import decode_jwt_header
 from fastmcp.utilities.logging import get_logger
@@ -55,6 +56,82 @@ ID_JAG_TYP = "oauth-id-jag+jwt"
 SUPPORTED_ASSERTION_ALGORITHMS = frozenset(
     {"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
 )
+
+
+@runtime_checkable
+class JTIReplayStore(Protocol):
+    """Atomic storage contract for consumed identity-assertion JTIs.
+
+    Implementations shared by multiple workers or replicas must perform the
+    existence check and insertion as one atomic backend operation. A separate
+    ``get`` followed by ``put`` is not sufficient: two validators could both
+    observe a missing JTI and accept the same assertion.
+    """
+
+    async def check_and_store(self, jti: str, expires_at: float) -> bool:
+        """Atomically reserve ``jti`` until ``expires_at``.
+
+        Args:
+            jti: The assertion's JWT ID.
+            expires_at: Unix timestamp after which the reservation may be removed.
+
+        Returns:
+            ``True`` when this call reserved the JTI, or ``False`` when an
+            unexpired reservation already exists.
+        """
+        ...
+
+
+class InMemoryJTIReplayStore:
+    """Bounded, process-local identity-assertion replay store.
+
+    This is the default store. Pass a distributed :class:`JTIReplayStore` to
+    :class:`IdentityAssertion` when replay protection must span replicas.
+    """
+
+    def __init__(self, *, max_size: int = 10000) -> None:
+        if max_size <= 0:
+            raise ValueError("max_size must be greater than zero")
+        self._entries: dict[str, float] = {}
+        self._max_size = max_size
+        self._lock = Lock()
+
+    async def check_and_store(self, jti: str, expires_at: float) -> bool:
+        with self._lock:
+            now = time.time()
+            existing_expiry = self._entries.get(jti)
+            if existing_expiry is not None and existing_expiry > now:
+                return False
+
+            if existing_expiry is not None:
+                del self._entries[jti]
+
+            if len(self._entries) >= self._max_size:
+                self._entries = {
+                    stored_jti: stored_expiry
+                    for stored_jti, stored_expiry in self._entries.items()
+                    if stored_expiry > now
+                }
+                if len(self._entries) >= self._max_size:
+                    logger.warning(
+                        "ID-JAG jti replay store at capacity, possible attack"
+                    )
+                    raise RuntimeError("JTI replay store is at capacity")
+
+            self._entries[jti] = expires_at
+            return True
+
+
+def _validate_jti_store(value: object) -> JTIReplayStore | None:
+    if value is not None and not isinstance(value, JTIReplayStore):
+        raise ValueError("jti_store must implement check_and_store(jti, expires_at)")
+    return value
+
+
+_JTIReplayStoreField = Annotated[
+    JTIReplayStore | None,
+    PlainValidator(_validate_jti_store, json_schema_input_type=Any),
+]
 
 
 class IdentityAssertion(BaseModel):
@@ -138,6 +215,15 @@ class IdentityAssertion(BaseModel):
             "this is intentionally short and no refresh token is issued."
         ),
     )
+    jti_store: _JTIReplayStoreField = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Optional atomic replay store shared by all server replicas. The "
+            "default is a bounded per-process InMemoryJTIReplayStore."
+        ),
+    )
 
     @field_validator("trusted_issuers")
     @classmethod
@@ -196,11 +282,10 @@ class IdentityAssertionValidator:
     that the generic verifier does not cover: the ``typ`` JOSE header, a mandatory
     ``sub``, and ``jti`` replay rejection.
 
-    JTI replay protection mirrors :class:`CIMDAssertionValidator`: seen ``jti``
-    values are cached until the assertion would expire anyway, with periodic
-    cleanup and an emergency size cap. Like CIMD, the cache is per-process, so
-    replay protection is not shared across horizontally-scaled workers or
-    replicas; see the identity-assertion docs for the deployment caveat.
+    Seen ``jti`` values are retained until the assertion would expire. The
+    default :class:`InMemoryJTIReplayStore` is bounded and process-local; a
+    distributed store can be supplied for atomic replay protection across
+    horizontally-scaled workers or replicas.
     """
 
     #: RFC 7523 recommends short-lived assertions; reject anything longer.
@@ -227,10 +312,11 @@ class IdentityAssertionValidator:
             base = audience.rstrip("/")
             self.audience = [base, base + "/"]
 
-        self._jti_cache: dict[str, float] = {}
-        self._jti_cache_max_size = 10000
-        self._last_cleanup = time.monotonic()
-        self._cleanup_interval = 60
+        self._jti_store = (
+            config.jti_store
+            if config.jti_store is not None
+            else InMemoryJTIReplayStore()
+        )
         # One JWTVerifier per issuer, created lazily once the JWKS URI is known.
         self._verifiers: dict[str, JWTVerifier] = {}
         # OIDC discovery hardening: discovery runs before signature verification,
@@ -240,20 +326,6 @@ class IdentityAssertionValidator:
         self._discovery_locks: dict[str, asyncio.Lock] = {}
         self._discovery_failures: dict[str, float] = {}
         self._discovery_failure_cooldown = 30.0
-
-    def _cleanup_expired_jtis(self) -> None:
-        now = time.time()
-        expired = [jti for jti, exp in self._jti_cache.items() if exp < now]
-        for jti in expired:
-            del self._jti_cache[jti]
-        if expired:
-            logger.debug("Cleaned up %d expired ID-JAG jtis from cache", len(expired))
-
-    def _maybe_cleanup(self) -> None:
-        now = time.monotonic()
-        if now - self._last_cleanup > self._cleanup_interval:
-            self._cleanup_expired_jtis()
-            self._last_cleanup = now
 
     async def _discover_jwks_uri(self, issuer: str) -> str:
         """Discover an issuer's JWKS URI via OIDC discovery.
@@ -345,8 +417,6 @@ class IdentityAssertionValidator:
         Raises:
             IdentityAssertionError: If the assertion is invalid for any reason.
         """
-        self._maybe_cleanup()
-
         # 1. typ header MUST be oauth-id-jag+jwt (SEP-990 §5.1).
         try:
             header = decode_jwt_header(assertion)
@@ -450,22 +520,15 @@ class IdentityAssertionValidator:
         jti = claims.get("jti")
         if not jti or not isinstance(jti, str):
             raise IdentityAssertionError("Assertion must include a string jti claim")
-        cached_exp = self._jti_cache.get(jti)
-        if cached_exp is not None and cached_exp > now:
+        try:
+            stored = await self._jti_store.check_and_store(jti, exp)
+        except Exception as e:
+            # A replay-store outage must fail closed. Store implementations may
+            # surface backend-specific errors, so normalize them at this boundary.
+            logger.warning("ID-JAG jti replay store failed: %s", e)
+            raise IdentityAssertionError("JTI replay store unavailable") from e
+        if not stored:
             raise IdentityAssertionError(f"Assertion replay detected: jti {jti} reused")
-
-        # Enforce the cap BEFORE inserting so a rejected assertion never grows the
-        # cache. A fresh jti that would exceed capacity is rejected outright (after
-        # a cleanup pass to reclaim any expired entries first).
-        if (
-            jti not in self._jti_cache
-            and len(self._jti_cache) >= self._jti_cache_max_size
-        ):
-            self._cleanup_expired_jtis()
-            if len(self._jti_cache) >= self._jti_cache_max_size:
-                logger.warning("ID-JAG jti cache at capacity, possible attack")
-                raise IdentityAssertionError("Server overloaded, please retry")
-        self._jti_cache[jti] = exp
 
         logger.debug("ID-JAG validated for subject=%s issuer=%s", sub, iss)
         return claims

--- a/fastmcp_slim/fastmcp/server/auth/identity_assertion.py
+++ b/fastmcp_slim/fastmcp/server/auth/identity_assertion.py
@@ -27,12 +27,18 @@ This module provides:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import time
-from threading import Lock
-from typing import TYPE_CHECKING, Annotated, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Annotated, Any
 from urllib.parse import urlparse, urlunparse
 
 import httpx2
+from key_value.aio.protocols import AsyncKeyValue
+from key_value.aio.protocols.key_value import (
+    AsyncEnumerateKeysProtocol,
+    AsyncKeyValueProtocol,
+)
+from key_value.aio.stores.memory import MemoryStore
 from pydantic import BaseModel, Field, PlainValidator, field_validator
 
 from fastmcp.utilities.auth import decode_jwt_header
@@ -57,79 +63,21 @@ SUPPORTED_ASSERTION_ALGORITHMS = frozenset(
     {"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
 )
 
+#: Collection namespace for consumed identity-assertion JTIs.
+JTI_STORE_COLLECTION = "fastmcp_identity_assertion_jti"
 
-@runtime_checkable
-class JTIReplayStore(Protocol):
-    """Atomic storage contract for consumed identity-assertion JTIs.
-
-    Implementations shared by multiple workers or replicas must perform the
-    existence check and insertion as one atomic backend operation. A separate
-    ``get`` followed by ``put`` is not sufficient: two validators could both
-    observe a missing JTI and accept the same assertion.
-    """
-
-    async def check_and_store(self, jti: str, expires_at: float) -> bool:
-        """Atomically reserve ``jti`` until ``expires_at``.
-
-        Args:
-            jti: The assertion's JWT ID.
-            expires_at: Unix timestamp after which the reservation may be removed.
-
-        Returns:
-            ``True`` when this call reserved the JTI, or ``False`` when an
-            unexpired reservation already exists.
-        """
-        ...
+#: Maximum live entries retained by the default in-process store.
+DEFAULT_JTI_STORE_MAX_SIZE = 10000
 
 
-class InMemoryJTIReplayStore:
-    """Bounded, process-local identity-assertion replay store.
-
-    This is the default store. Pass a distributed :class:`JTIReplayStore` to
-    :class:`IdentityAssertion` when replay protection must span replicas.
-    """
-
-    def __init__(self, *, max_size: int = 10000) -> None:
-        if max_size <= 0:
-            raise ValueError("max_size must be greater than zero")
-        self._entries: dict[str, float] = {}
-        self._max_size = max_size
-        self._lock = Lock()
-
-    async def check_and_store(self, jti: str, expires_at: float) -> bool:
-        with self._lock:
-            now = time.time()
-            existing_expiry = self._entries.get(jti)
-            if existing_expiry is not None and existing_expiry > now:
-                return False
-
-            if existing_expiry is not None:
-                del self._entries[jti]
-
-            if len(self._entries) >= self._max_size:
-                self._entries = {
-                    stored_jti: stored_expiry
-                    for stored_jti, stored_expiry in self._entries.items()
-                    if stored_expiry > now
-                }
-                if len(self._entries) >= self._max_size:
-                    logger.warning(
-                        "ID-JAG jti replay store at capacity, possible attack"
-                    )
-                    raise RuntimeError("JTI replay store is at capacity")
-
-            self._entries[jti] = expires_at
-            return True
-
-
-def _validate_jti_store(value: object) -> JTIReplayStore | None:
-    if value is not None and not isinstance(value, JTIReplayStore):
-        raise ValueError("jti_store must implement check_and_store(jti, expires_at)")
+def _validate_jti_store(value: object) -> AsyncKeyValue | None:
+    if value is not None and not isinstance(value, AsyncKeyValueProtocol):
+        raise ValueError("jti_store must implement AsyncKeyValue")
     return value
 
 
-_JTIReplayStoreField = Annotated[
-    JTIReplayStore | None,
+_JTIStoreField = Annotated[
+    AsyncKeyValue | None,
     PlainValidator(_validate_jti_store, json_schema_input_type=Any),
 ]
 
@@ -215,13 +163,13 @@ class IdentityAssertion(BaseModel):
             "this is intentionally short and no refresh token is issued."
         ),
     )
-    jti_store: _JTIReplayStoreField = Field(
+    jti_store: _JTIStoreField = Field(
         default=None,
         exclude=True,
         repr=False,
         description=(
-            "Optional atomic replay store shared by all server replicas. The "
-            "default is a bounded per-process InMemoryJTIReplayStore."
+            "Optional AsyncKeyValue store for replay state shared by all server "
+            "replicas. The default is a bounded per-process MemoryStore."
         ),
     )
 
@@ -283,9 +231,13 @@ class IdentityAssertionValidator:
     ``sub``, and ``jti`` replay rejection.
 
     Seen ``jti`` values are retained until the assertion would expire. The
-    default :class:`InMemoryJTIReplayStore` is bounded and process-local; a
-    distributed store can be supplied for atomic replay protection across
-    horizontally-scaled workers or replicas.
+    default :class:`~key_value.aio.stores.memory.MemoryStore` is bounded and
+    process-local; any :class:`~key_value.aio.protocols.AsyncKeyValue` store can
+    be supplied to share replay state across workers or replicas.
+
+    ``AsyncKeyValue`` does not provide a conditional write, so the shared-store
+    check and write are not atomic across processes. Calls through one validator
+    are serialized, but simultaneous exchanges on different replicas can race.
     """
 
     #: RFC 7523 recommends short-lived assertions; reject anything longer.
@@ -312,11 +264,18 @@ class IdentityAssertionValidator:
             base = audience.rstrip("/")
             self.audience = [base, base + "/"]
 
-        self._jti_store = (
-            config.jti_store
-            if config.jti_store is not None
-            else InMemoryJTIReplayStore()
-        )
+        self._default_jti_store_size = 0
+        if config.jti_store is None:
+            self._jti_store: AsyncKeyValue = MemoryStore(
+                max_entries_per_collection=DEFAULT_JTI_STORE_MAX_SIZE
+            )
+            self._using_default_jti_store = True
+        else:
+            self._jti_store = config.jti_store
+            self._using_default_jti_store = False
+        # This closes the get/put race within a single validator. A shared store
+        # still needs conditional-write support to close it across processes.
+        self._jti_lock = asyncio.Lock()
         # One JWTVerifier per issuer, created lazily once the JWKS URI is known.
         self._verifiers: dict[str, JWTVerifier] = {}
         # OIDC discovery hardening: discovery runs before signature verification,
@@ -326,6 +285,54 @@ class IdentityAssertionValidator:
         self._discovery_locks: dict[str, asyncio.Lock] = {}
         self._discovery_failures: dict[str, float] = {}
         self._discovery_failure_cooldown = 30.0
+
+    @staticmethod
+    def _jti_store_key(*, issuer: str, jti: str) -> str:
+        """Build a backend-safe key scoped to the assertion issuer."""
+        value = f"{len(issuer)}:{issuer}{len(jti)}:{jti}"
+        return hashlib.sha256(value.encode()).hexdigest()
+
+    async def _ensure_default_jti_store_capacity(self) -> None:
+        """Fail closed instead of evicting an unexpired replay marker."""
+        if not self._using_default_jti_store:
+            return
+        if self._default_jti_store_size < DEFAULT_JTI_STORE_MAX_SIZE:
+            return
+
+        store = self._jti_store
+        if not isinstance(store, AsyncEnumerateKeysProtocol):
+            raise RuntimeError("Default JTI store cannot enumerate replay markers")
+        keys = await store.keys(
+            collection=JTI_STORE_COLLECTION,
+            limit=DEFAULT_JTI_STORE_MAX_SIZE,
+        )
+        self._default_jti_store_size = len(keys)
+        if self._default_jti_store_size >= DEFAULT_JTI_STORE_MAX_SIZE:
+            raise RuntimeError("JTI replay store is full")
+
+    async def _check_and_store_jti(
+        self, *, issuer: str, jti: str, expires_at: float
+    ) -> bool:
+        """Return false for a consumed JTI, otherwise retain it until expiry."""
+        key = self._jti_store_key(issuer=issuer, jti=jti)
+        async with self._jti_lock:
+            existing = await self._jti_store.get(
+                key,
+                collection=JTI_STORE_COLLECTION,
+            )
+            if existing is not None:
+                return False
+
+            await self._ensure_default_jti_store_capacity()
+            await self._jti_store.put(
+                key,
+                {"consumed": True},
+                collection=JTI_STORE_COLLECTION,
+                ttl=max(expires_at - time.time(), 1),
+            )
+            if self._using_default_jti_store:
+                self._default_jti_store_size += 1
+            return True
 
     async def _discover_jwks_uri(self, issuer: str) -> str:
         """Discover an issuer's JWKS URI via OIDC discovery.
@@ -439,7 +446,7 @@ class IdentityAssertionValidator:
         if not isinstance(unverified_claims, dict):
             raise IdentityAssertionError("Assertion payload is not a JSON object")
         iss = unverified_claims.get("iss")
-        if not iss or iss not in self.config.trusted_issuers:
+        if not isinstance(iss, str) or iss not in self.config.trusted_issuers:
             raise IdentityAssertionError(f"Untrusted assertion issuer: {iss!r}")
 
         # 3. Verify signature, iss, aud, and exp via JWTVerifier.
@@ -521,7 +528,11 @@ class IdentityAssertionValidator:
         if not jti or not isinstance(jti, str):
             raise IdentityAssertionError("Assertion must include a string jti claim")
         try:
-            stored = await self._jti_store.check_and_store(jti, exp)
+            stored = await self._check_and_store_jti(
+                issuer=iss,
+                jti=jti,
+                expires_at=exp,
+            )
         except Exception as e:
             # A replay-store outage must fail closed. Store implementations may
             # surface backend-specific errors, so normalize them at this boundary.

--- a/tests/server/auth/oauth_proxy/test_identity_assertion.py
+++ b/tests/server/auth/oauth_proxy/test_identity_assertion.py
@@ -9,6 +9,7 @@ import asyncio
 import subprocess
 import sys
 import time
+from typing import Any
 
 import httpx2
 import pytest
@@ -17,8 +18,9 @@ from key_value.aio.stores.memory import MemoryStore
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
 
+import fastmcp.server.auth.identity_assertion as identity_assertion_module
 from fastmcp import FastMCP
-from fastmcp.server.auth import IdentityAssertion, InMemoryJTIReplayStore
+from fastmcp.server.auth import IdentityAssertion
 from fastmcp.server.auth.identity_assertion import (
     ID_JAG_GRANT_PROFILE,
     ID_JAG_TYP,
@@ -36,24 +38,10 @@ JWKS_URI = "https://login.acme-corp.com/jwks"
 RESOURCE = f"{BASE_URL}/mcp"
 
 
-class SharedJTIStore:
-    """Minimal atomic replay store shared by independent proxy instances."""
-
-    def __init__(self) -> None:
-        self._expires_at: dict[str, float] = {}
-        self._lock = asyncio.Lock()
-
-    async def check_and_store(self, jti: str, expires_at: float) -> bool:
-        async with self._lock:
-            now = time.time()
-            if self._expires_at.get(jti, 0) > now:
-                return False
-            self._expires_at[jti] = expires_at
-            return True
-
-
-class FailingJTIStore:
-    async def check_and_store(self, jti: str, expires_at: float) -> bool:
+class FailingJTIStore(MemoryStore):
+    async def get(
+        self, key: str, *, collection: str | None = None
+    ) -> dict[str, Any] | None:
         raise ConnectionError("store unavailable")
 
 
@@ -203,8 +191,17 @@ class TestIdentityAssertionConfig:
         with pytest.raises(ValueError):
             IdentityAssertion(trusted_issuers=["  "])
 
+    def test_accepts_async_key_value_jti_store(self):
+        store = MemoryStore()
+        config = IdentityAssertion(
+            trusted_issuers=[ISSUER],
+            jti_store=store,
+        )
+
+        assert config.jti_store is store
+
     def test_rejects_invalid_jti_store(self):
-        with pytest.raises(ValueError, match="must implement check_and_store"):
+        with pytest.raises(ValueError, match="must implement AsyncKeyValue"):
             IdentityAssertion(
                 trusted_issuers=[ISSUER],
                 jti_store=object(),
@@ -253,25 +250,6 @@ class TestIdentityAssertionConfig:
         )
         assert result.returncode == 0, result.stderr
         assert "OK" in result.stdout
-
-
-class TestInMemoryJTIReplayStore:
-    async def test_check_and_store_is_atomic(self):
-        store = InMemoryJTIReplayStore()
-        expires_at = time.time() + 120
-
-        results = await asyncio.gather(
-            *(store.check_and_store("same-jti", expires_at) for _ in range(20))
-        )
-
-        assert results.count(True) == 1
-        assert results.count(False) == 19
-
-    async def test_expired_jti_can_be_stored_again(self):
-        store = InMemoryJTIReplayStore()
-
-        assert await store.check_and_store("expired-jti", time.time() - 1)
-        assert await store.check_and_store("expired-jti", time.time() + 120)
 
 
 class TestMetadataAdvertisement:
@@ -552,10 +530,24 @@ class TestValidationMatrix:
         assert second.status_code == 401
         assert second.json()["error"] == "invalid_grant"
 
+    async def test_concurrent_replay_rejected_within_one_proxy(
+        self, idp_key: RSAKeyPair, config: IdentityAssertion
+    ):
+        proxy = _make_proxy(config)
+        assertion = _mint_id_jag(idp_key, jti="concurrent-replay")
+        await _register_client(proxy)
+
+        responses = await asyncio.gather(
+            *(_post_token(proxy, assertion, register=False) for _ in range(10))
+        )
+
+        assert [response.status_code for response in responses].count(200) == 1
+        assert [response.status_code for response in responses].count(401) == 9
+
     async def test_replayed_jti_rejected_across_proxy_instances(
         self, idp_key: RSAKeyPair, httpx_mock: HTTPXMock
     ):
-        shared_store = SharedJTIStore()
+        shared_store = MemoryStore()
         config = IdentityAssertion(
             trusted_issuers=[ISSUER],
             jwks_uris={ISSUER: JWKS_URI},
@@ -840,20 +832,27 @@ class TestValidationMatrix:
 
         assert resp.status_code == 200
 
-    async def test_jti_cache_does_not_grow_past_capacity(self, idp_key: RSAKeyPair):
+    async def test_jti_cache_does_not_grow_past_capacity(
+        self, idp_key: RSAKeyPair, monkeypatch: pytest.MonkeyPatch
+    ):
         # Once the default store is full of still-valid entries, further fresh
         # assertions fail closed without growing the store.
-        store = InMemoryJTIReplayStore(max_size=2)
+        monkeypatch.setattr(
+            identity_assertion_module,
+            "DEFAULT_JTI_STORE_MAX_SIZE",
+            2,
+        )
         proxy = _make_proxy(
             IdentityAssertion(
                 trusted_issuers=[ISSUER],
                 jwks_uris={ISSUER: JWKS_URI},
-                jti_store=store,
             )
         )
-        future = time.time() + 120
-        assert await store.check_and_store("filler-a", future)
-        assert await store.check_and_store("filler-b", future)
+
+        for i in range(2):
+            assertion = _mint_id_jag(idp_key, jti=f"accepted-{i}")
+            resp = await _post_token(proxy, assertion)
+            assert resp.status_code == 200
 
         for i in range(3):
             assertion = _mint_id_jag(idp_key, jti=f"fresh-{i}")

--- a/tests/server/auth/oauth_proxy/test_identity_assertion.py
+++ b/tests/server/auth/oauth_proxy/test_identity_assertion.py
@@ -5,6 +5,7 @@ fake IdP JWT (a keypair is generated per test). The proxy's JWKS lookup is
 served via httpx_mock, so no real network calls are made.
 """
 
+import asyncio
 import subprocess
 import sys
 import time
@@ -17,7 +18,7 @@ from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
 
 from fastmcp import FastMCP
-from fastmcp.server.auth import IdentityAssertion
+from fastmcp.server.auth import IdentityAssertion, InMemoryJTIReplayStore
 from fastmcp.server.auth.identity_assertion import (
     ID_JAG_GRANT_PROFILE,
     ID_JAG_TYP,
@@ -33,6 +34,27 @@ BASE_URL = "https://myserver.com"
 ISSUER = "https://login.acme-corp.com"
 JWKS_URI = "https://login.acme-corp.com/jwks"
 RESOURCE = f"{BASE_URL}/mcp"
+
+
+class SharedJTIStore:
+    """Minimal atomic replay store shared by independent proxy instances."""
+
+    def __init__(self) -> None:
+        self._expires_at: dict[str, float] = {}
+        self._lock = asyncio.Lock()
+
+    async def check_and_store(self, jti: str, expires_at: float) -> bool:
+        async with self._lock:
+            now = time.time()
+            if self._expires_at.get(jti, 0) > now:
+                return False
+            self._expires_at[jti] = expires_at
+            return True
+
+
+class FailingJTIStore:
+    async def check_and_store(self, jti: str, expires_at: float) -> bool:
+        raise ConnectionError("store unavailable")
 
 
 def _b64url_json(value: object) -> str:
@@ -181,6 +203,13 @@ class TestIdentityAssertionConfig:
         with pytest.raises(ValueError):
             IdentityAssertion(trusted_issuers=["  "])
 
+    def test_rejects_invalid_jti_store(self):
+        with pytest.raises(ValueError, match="must implement check_and_store"):
+            IdentityAssertion(
+                trusted_issuers=[ISSUER],
+                jti_store=object(),
+            )
+
     @pytest.mark.parametrize("algorithm", ["ES256", "PS256", "RS384"])
     def test_accepts_asymmetric_algorithm(self, algorithm: str):
         IdentityAssertion(trusted_issuers=[ISSUER], algorithm=algorithm)
@@ -224,6 +253,25 @@ class TestIdentityAssertionConfig:
         )
         assert result.returncode == 0, result.stderr
         assert "OK" in result.stdout
+
+
+class TestInMemoryJTIReplayStore:
+    async def test_check_and_store_is_atomic(self):
+        store = InMemoryJTIReplayStore()
+        expires_at = time.time() + 120
+
+        results = await asyncio.gather(
+            *(store.check_and_store("same-jti", expires_at) for _ in range(20))
+        )
+
+        assert results.count(True) == 1
+        assert results.count(False) == 19
+
+    async def test_expired_jti_can_be_stored_again(self):
+        store = InMemoryJTIReplayStore()
+
+        assert await store.check_and_store("expired-jti", time.time() - 1)
+        assert await store.check_and_store("expired-jti", time.time() + 120)
 
 
 class TestMetadataAdvertisement:
@@ -504,6 +552,39 @@ class TestValidationMatrix:
         assert second.status_code == 401
         assert second.json()["error"] == "invalid_grant"
 
+    async def test_replayed_jti_rejected_across_proxy_instances(
+        self, idp_key: RSAKeyPair, httpx_mock: HTTPXMock
+    ):
+        shared_store = SharedJTIStore()
+        config = IdentityAssertion(
+            trusted_issuers=[ISSUER],
+            jwks_uris={ISSUER: JWKS_URI},
+            jti_store=shared_store,
+        )
+        first_proxy = _make_proxy(config)
+        second_proxy = _make_proxy(config)
+        assertion = _mint_id_jag(idp_key, jti="cross-instance-replay")
+        httpx_mock.add_response(url=JWKS_URI, json=_idp_jwks(idp_key), is_optional=True)
+
+        first = await _post_token(first_proxy, assertion)
+        second = await _post_token(second_proxy, assertion)
+
+        assert first.status_code == 200
+        assert second.status_code == 401
+        assert second.json()["error"] == "invalid_grant"
+
+    async def test_replay_store_error_fails_closed(self, idp_key: RSAKeyPair):
+        config = IdentityAssertion(
+            trusted_issuers=[ISSUER],
+            jwks_uris={ISSUER: JWKS_URI},
+            jti_store=FailingJTIStore(),
+        )
+
+        response = await _post_token(_make_proxy(config), _mint_id_jag(idp_key))
+
+        assert response.status_code == 401
+        assert response.json()["error"] == "invalid_grant"
+
     async def test_wrong_signature_rejected(
         self, config: IdentityAssertion, rsa_key_pair_2: RSAKeyPair
     ):
@@ -759,26 +840,26 @@ class TestValidationMatrix:
 
         assert resp.status_code == 200
 
-    async def test_jti_cache_does_not_grow_past_capacity(
-        self, idp_key: RSAKeyPair, config: IdentityAssertion
-    ):
-        # Once the JTI cache is full of still-valid entries, further fresh
-        # assertions are rejected as overloaded WITHOUT being inserted, so the
-        # cache never grows beyond its cap.
-        proxy = _make_proxy(config)
-        validator = proxy._identity_assertion_validator
-        assert validator is not None
-        validator._jti_cache_max_size = 2
+    async def test_jti_cache_does_not_grow_past_capacity(self, idp_key: RSAKeyPair):
+        # Once the default store is full of still-valid entries, further fresh
+        # assertions fail closed without growing the store.
+        store = InMemoryJTIReplayStore(max_size=2)
+        proxy = _make_proxy(
+            IdentityAssertion(
+                trusted_issuers=[ISSUER],
+                jwks_uris={ISSUER: JWKS_URI},
+                jti_store=store,
+            )
+        )
         future = time.time() + 120
-        validator._jti_cache = {"filler-a": future, "filler-b": future}
+        assert await store.check_and_store("filler-a", future)
+        assert await store.check_and_store("filler-b", future)
 
         for i in range(3):
             assertion = _mint_id_jag(idp_key, jti=f"fresh-{i}")
             resp = await _post_token(proxy, assertion)
             assert resp.status_code == 401
             assert resp.json()["error"] == "invalid_grant"
-
-        assert len(validator._jti_cache) == 2
 
 
 class TestAlgorithmConfig:


### PR DESCRIPTION
Identity assertion replay state currently lives in each process, so the same ID-JAG can be accepted once per replica. This routes consumed JTI state through py-key-value's `AsyncKeyValue` contract, with a bounded `MemoryStore` default and any shared backend accepted through `IdentityAssertion(jti_store=...)`.

py-key-value 0.4.x does not yet expose a conditional insert. FastMCP serializes exchanges within one validator, but replicas sharing a store perform a non-atomic `get` followed by `put`; simultaneous exchanges on different replicas can race and both succeed. Sequential replay is rejected, store failures fail closed, and an atomic follow-up is proposed in [py-key-value#369](https://github.com/strawgate/py-key-value/pull/369).

```python
from key_value.aio.stores.redis import RedisStore

from fastmcp.server.auth import IdentityAssertion

identity_assertion = IdentityAssertion(
    trusted_issuers=["https://login.example.com"],
    jti_store=RedisStore(url="redis://localhost:6379"),
)
```

Closes #4846
