### PR TITLE
fix(auth): preserve GitHub sessions across transient verification failures

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/__init__.py
+++ b/fastmcp_slim/fastmcp/server/auth/__init__.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from .auth import (
     OAuthProvider,
     TokenVerifier,
+    TokenVerificationError,
     RemoteAuthProvider,
     MultiAuth,
     AccessToken,
@@ -75,6 +76,7 @@ __all__ = [
     "OIDCProxy",
     "RemoteAuthProvider",
     "StaticTokenVerifier",
+    "TokenVerificationError",
     "TokenVerifier",
     "require_roles",
     "require_scopes",

--- a/fastmcp_slim/fastmcp/server/auth/auth.py
+++ b/fastmcp_slim/fastmcp/server/auth/auth.py
@@ -476,6 +476,15 @@ class AuthProvider(TokenVerifierProtocol):
         return resource_base_url
 
 
+class TokenVerificationError(RuntimeError):
+    """Token validity could not be determined because verification was unavailable.
+
+    Verifiers should raise this for operational failures such as an upstream
+    service outage or transport error. Returning ``None`` remains reserved for
+    credentials that were actually determined to be invalid or unacceptable.
+    """
+
+
 class TokenVerifier(AuthProvider):
     """Base class for token verifiers (Resource Servers).
 

--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -76,6 +76,7 @@ from fastmcp.server.auth.auth import (
     OAuthProvider,
     PrivateKeyJWTClientAuthenticator,
     TokenHandler,
+    TokenVerificationError,
     TokenVerifier,
 )
 from fastmcp.server.auth.cimd import CIMDClientManager
@@ -2249,6 +2250,8 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                                 validated = await self._token_validator.verify_token(
                                     verification_token
                                 )
+                except TokenVerificationError:
+                    raise
                 except Exception as e:
                     logger.debug("Transparent upstream refresh failed: %s", e)
                     # In a distributed deployment, another worker may have
@@ -2266,6 +2269,8 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                                 )
                                 if validated:
                                     upstream_token_set = reloaded
+                    except TokenVerificationError:
+                        raise
                     except Exception:
                         pass
 
@@ -2307,6 +2312,8 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             )
             return validated
 
+        except TokenVerificationError:
+            raise
         except Exception as e:
             logger.debug("Token swap validation failed: %s", e)
             return None

--- a/fastmcp_slim/fastmcp/server/auth/providers/github.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/github.py
@@ -28,7 +28,7 @@ import httpx2
 from key_value.aio.protocols import AsyncKeyValue
 from pydantic import AnyHttpUrl
 
-from fastmcp.server.auth import TokenVerifier
+from fastmcp.server.auth import TokenVerificationError, TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.utilities.auth import parse_scopes
@@ -111,13 +111,23 @@ class GitHubTokenVerifier(TokenVerifier):
                     },
                 )
 
-                if response.status_code != 200:
+                if response.status_code == 401:
                     logger.debug(
                         "GitHub token verification failed: %d - %s",
                         response.status_code,
                         response.text[:200],
                     )
                     return None
+
+                if response.status_code != 200:
+                    logger.warning(
+                        "GitHub token verification unavailable: %d - %s",
+                        response.status_code,
+                        response.text[:200],
+                    )
+                    raise TokenVerificationError(
+                        f"GitHub token verification unavailable: HTTP {response.status_code}"
+                    )
 
                 user_data = response.json()
 
@@ -177,9 +187,13 @@ class GitHubTokenVerifier(TokenVerifier):
                     self._cache.set(token, result)
                 return result
 
+        except TokenVerificationError:
+            raise
         except httpx2.RequestError as e:
-            logger.debug("Failed to verify GitHub token: %s", e)
-            return None
+            logger.warning("GitHub token verification unavailable: %s", e)
+            raise TokenVerificationError(
+                "GitHub token verification unavailable due to a transport error"
+            ) from e
         except Exception as e:
             logger.debug("GitHub token verification error: %s", e)
             return None

--- a/fastmcp_slim/fastmcp/server/auth/providers/github.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/github.py
@@ -22,6 +22,7 @@ Example:
 from __future__ import annotations
 
 import contextlib
+from contextvars import ContextVar
 from typing import Literal
 
 import httpx2
@@ -31,11 +32,22 @@ from pydantic import AnyHttpUrl
 from fastmcp.server.auth import TokenVerificationError, TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.oauth_proxy.models import UpstreamTokenSet
 from fastmcp.utilities.auth import parse_scopes
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.token_cache import TokenCache
 
 logger = get_logger(__name__)
+
+# Scope discovery is a second GitHub request and can fail independently after
+# /user has established identity. Standalone verifiers must never invent scopes
+# in that case. GitHubProvider publishes the IdP-granted scopes from the current
+# OAuthProxy token swap as a one-shot, task-local value immediately before the
+# verifier runs. The verifier consumes it once, so it cannot leak into a later
+# standalone verification in the same task.
+_github_trusted_scope_context: ContextVar[tuple[str, tuple[str, ...]] | None] = (
+    ContextVar("github_trusted_scope_context", default=None)
+)
 
 
 class GitHubTokenVerifier(TokenVerifier):
@@ -90,6 +102,14 @@ class GitHubTokenVerifier(TokenVerifier):
 
     async def verify_token(self, token: str) -> AccessToken | None:
         """Verify GitHub OAuth token by calling GitHub API."""
+        trusted_context = _github_trusted_scope_context.get()
+        _github_trusted_scope_context.set(None)
+        trusted_scopes = (
+            trusted_context[1]
+            if trusted_context is not None and trusted_context[0] == token
+            else None
+        )
+
         is_cached, cached_result = self._cache.get(token)
         if is_cached:
             logger.debug("GitHub token cache hit")
@@ -131,13 +151,11 @@ class GitHubTokenVerifier(TokenVerifier):
 
                 user_data = response.json()
 
-                # /user/repos is supplementary scope discovery. Once /user has
-                # established identity, a transient failure here must not turn a
-                # token requiring only the basic user scope into invalid_token.
-                # Stronger scopes still need positive evidence, so an outage while
-                # they are required is operational rather than an auth rejection.
-                required_scopes_set = set(self.required_scopes)
-                basic_scope_only = required_scopes_set.issubset({"user"})
+                # /user/repos is supplementary scope discovery. A transient
+                # failure must not discard an otherwise valid provider session,
+                # but standalone verification cannot invent scopes. The provider
+                # path can safely fall back to the IdP grant already persisted by
+                # OAuthProxy for this exact upstream token.
                 try:
                     scopes_response = await client.get(
                         "https://api.github.com/user/repos",
@@ -148,10 +166,6 @@ class GitHubTokenVerifier(TokenVerifier):
                         },
                     )
                 except httpx2.RequestError as e:
-                    if not basic_scope_only:
-                        raise TokenVerificationError(
-                            "GitHub scope verification unavailable due to a transport error"
-                        ) from e
                     logger.warning("GitHub scope verification unavailable: %s", e)
                     oauth_scopes_header = ""
                 else:
@@ -163,11 +177,6 @@ class GitHubTokenVerifier(TokenVerifier):
                         )
                         return None
                     if scopes_response.status_code != 200:
-                        if not basic_scope_only:
-                            raise TokenVerificationError(
-                                "GitHub scope verification unavailable: "
-                                f"HTTP {scopes_response.status_code}"
-                            )
                         logger.warning(
                             "GitHub scope verification unavailable: %d - %s",
                             scopes_response.status_code,
@@ -185,15 +194,16 @@ class GitHubTokenVerifier(TokenVerifier):
                     if scope.strip()
                 ]
 
-                # If scope discovery is unavailable after /user verifies identity,
-                # the basic user scope is enough only when no stronger scope is
-                # required. Never synthesize stronger grants such as repo.
-                if not token_scopes:
-                    token_scopes = ["user"]
+                if not token_scopes and trusted_scopes is not None:
+                    token_scopes = list(trusted_scopes)
 
-                # Check required scopes
+                # Check required scopes. If scope discovery is unavailable in a
+                # standalone verifier, token_scopes stays empty and required
+                # scopes cannot be satisfied. Provider fallback never grants more
+                # than the IdP scopes already stored by OAuthProxy.
                 if self.required_scopes:
                     token_scopes_set = set(token_scopes)
+                    required_scopes_set = set(self.required_scopes)
                     if not required_scopes_set.issubset(token_scopes_set):
                         logger.debug(
                             "GitHub token missing required scopes. Has %d, needs %d",
@@ -218,8 +228,8 @@ class GitHubTokenVerifier(TokenVerifier):
                         "github_user_data": user_data,
                     },
                 )
-                # Cache every accepted verification result, including the safe
-                # basic-scope fallback used during supplementary scope outages.
+                # Cache every accepted result, including a provider result that
+                # used the trusted IdP grant during supplementary scope failure.
                 self._cache.set(token, result)
                 return result
 
@@ -379,3 +389,14 @@ class GitHubProvider(OAuthProxy):
             client_id,
             required_scopes_final,
         )
+
+    def _get_verification_token(
+        self, upstream_token_set: UpstreamTokenSet
+    ) -> str | None:
+        """Publish trusted IdP scopes for the immediately following verification."""
+        verification_token = super()._get_verification_token(upstream_token_set)
+        if verification_token is not None:
+            _github_trusted_scope_context.set(
+                (verification_token, tuple(upstream_token_set.scope.split()))
+            )
+        return verification_token

--- a/fastmcp_slim/fastmcp/server/auth/providers/github.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/github.py
@@ -131,34 +131,69 @@ class GitHubTokenVerifier(TokenVerifier):
 
                 user_data = response.json()
 
-                # Get token scopes from GitHub API
-                # GitHub includes scopes in the X-OAuth-Scopes header
-                scopes_response = await client.get(
-                    "https://api.github.com/user/repos",  # Any authenticated endpoint
-                    headers={
-                        "Authorization": f"Bearer {token}",
-                        "Accept": "application/vnd.github.v3+json",
-                        "User-Agent": "FastMCP-GitHub-OAuth",
-                    },
-                )
+                # /user/repos is supplementary scope discovery. Once /user has
+                # established identity, a transient failure here must not turn a
+                # token requiring only the basic user scope into invalid_token.
+                # Stronger scopes still need positive evidence, so an outage while
+                # they are required is operational rather than an auth rejection.
+                required_scopes_set = set(self.required_scopes)
+                basic_scope_only = required_scopes_set.issubset({"user"})
+                try:
+                    scopes_response = await client.get(
+                        "https://api.github.com/user/repos",
+                        headers={
+                            "Authorization": f"Bearer {token}",
+                            "Accept": "application/vnd.github.v3+json",
+                            "User-Agent": "FastMCP-GitHub-OAuth",
+                        },
+                    )
+                except httpx2.RequestError as e:
+                    if not basic_scope_only:
+                        raise TokenVerificationError(
+                            "GitHub scope verification unavailable due to a transport error"
+                        ) from e
+                    logger.warning("GitHub scope verification unavailable: %s", e)
+                    oauth_scopes_header = ""
+                else:
+                    if scopes_response.status_code == 401:
+                        logger.debug(
+                            "GitHub scope verification rejected credentials: %d - %s",
+                            scopes_response.status_code,
+                            scopes_response.text[:200],
+                        )
+                        return None
+                    if scopes_response.status_code != 200:
+                        if not basic_scope_only:
+                            raise TokenVerificationError(
+                                "GitHub scope verification unavailable: "
+                                f"HTTP {scopes_response.status_code}"
+                            )
+                        logger.warning(
+                            "GitHub scope verification unavailable: %d - %s",
+                            scopes_response.status_code,
+                            scopes_response.text[:200],
+                        )
+                        oauth_scopes_header = ""
+                    else:
+                        oauth_scopes_header = scopes_response.headers.get(
+                            "x-oauth-scopes", ""
+                        )
 
-                # Extract scopes from X-OAuth-Scopes header if available
-                scopes_verified = scopes_response.status_code == 200
-                oauth_scopes_header = scopes_response.headers.get("x-oauth-scopes", "")
                 token_scopes = [
                     scope.strip()
                     for scope in oauth_scopes_header.split(",")
                     if scope.strip()
                 ]
 
-                # If no scopes in header, assume basic scopes based on successful user API call
+                # If scope discovery is unavailable after /user verifies identity,
+                # the basic user scope is enough only when no stronger scope is
+                # required. Never synthesize stronger grants such as repo.
                 if not token_scopes:
-                    token_scopes = ["user"]  # Basic scope if we can access user info
+                    token_scopes = ["user"]
 
                 # Check required scopes
                 if self.required_scopes:
                     token_scopes_set = set(token_scopes)
-                    required_scopes_set = set(self.required_scopes)
                     if not required_scopes_set.issubset(token_scopes_set):
                         logger.debug(
                             "GitHub token missing required scopes. Has %d, needs %d",
@@ -183,8 +218,9 @@ class GitHubTokenVerifier(TokenVerifier):
                         "github_user_data": user_data,
                     },
                 )
-                if scopes_verified:
-                    self._cache.set(token, result)
+                # Cache every accepted verification result, including the safe
+                # basic-scope fallback used during supplementary scope outages.
+                self._cache.set(token, result)
                 return result
 
         except TokenVerificationError:

--- a/fastmcp_slim/fastmcp/server/auth/providers/github.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/github.py
@@ -22,7 +22,6 @@ Example:
 from __future__ import annotations
 
 import contextlib
-from contextvars import ContextVar
 from typing import Literal
 
 import httpx2
@@ -32,22 +31,11 @@ from pydantic import AnyHttpUrl
 from fastmcp.server.auth import TokenVerificationError, TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
-from fastmcp.server.auth.oauth_proxy.models import UpstreamTokenSet
 from fastmcp.utilities.auth import parse_scopes
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.token_cache import TokenCache
 
 logger = get_logger(__name__)
-
-# Scope discovery is a second GitHub request and can fail independently after
-# /user has established identity. Standalone verifiers must never invent scopes
-# in that case. GitHubProvider publishes the IdP-granted scopes from the current
-# OAuthProxy token swap as a one-shot, task-local value immediately before the
-# verifier runs. The verifier consumes it once, so it cannot leak into a later
-# standalone verification in the same task.
-_github_trusted_scope_context: ContextVar[tuple[str, tuple[str, ...]] | None] = (
-    ContextVar("github_trusted_scope_context", default=None)
-)
 
 
 class GitHubTokenVerifier(TokenVerifier):
@@ -102,14 +90,6 @@ class GitHubTokenVerifier(TokenVerifier):
 
     async def verify_token(self, token: str) -> AccessToken | None:
         """Verify GitHub OAuth token by calling GitHub API."""
-        trusted_context = _github_trusted_scope_context.get()
-        _github_trusted_scope_context.set(None)
-        trusted_scopes = (
-            trusted_context[1]
-            if trusted_context is not None and trusted_context[0] == token
-            else None
-        )
-
         is_cached, cached_result = self._cache.get(token)
         if is_cached:
             logger.debug("GitHub token cache hit")
@@ -121,7 +101,6 @@ class GitHubTokenVerifier(TokenVerifier):
                 if self._http_client is not None
                 else httpx2.AsyncClient(timeout=self.timeout_seconds)
             ) as client:
-                # Get token info from GitHub API
                 response = await client.get(
                     "https://api.github.com/user",
                     headers={
@@ -151,11 +130,10 @@ class GitHubTokenVerifier(TokenVerifier):
 
                 user_data = response.json()
 
-                # /user/repos is supplementary scope discovery. A transient
-                # failure must not discard an otherwise valid provider session,
-                # but standalone verification cannot invent scopes. The provider
-                # path can safely fall back to the IdP grant already persisted by
-                # OAuthProxy for this exact upstream token.
+                # Scope discovery is part of verification. A definitive 401 means
+                # the credential is invalid; transient HTTP/transport failures are
+                # operational failures and must propagate through OAuthProxy rather
+                # than being collapsed into invalid_token.
                 try:
                     scopes_response = await client.get(
                         "https://api.github.com/user/repos",
@@ -167,40 +145,39 @@ class GitHubTokenVerifier(TokenVerifier):
                     )
                 except httpx2.RequestError as e:
                     logger.warning("GitHub scope verification unavailable: %s", e)
-                    oauth_scopes_header = ""
-                else:
-                    if scopes_response.status_code == 401:
-                        logger.debug(
-                            "GitHub scope verification rejected credentials: %d - %s",
-                            scopes_response.status_code,
-                            scopes_response.text[:200],
-                        )
-                        return None
-                    if scopes_response.status_code != 200:
-                        logger.warning(
-                            "GitHub scope verification unavailable: %d - %s",
-                            scopes_response.status_code,
-                            scopes_response.text[:200],
-                        )
-                        oauth_scopes_header = ""
-                    else:
-                        oauth_scopes_header = scopes_response.headers.get(
-                            "x-oauth-scopes", ""
-                        )
+                    raise TokenVerificationError(
+                        "GitHub scope verification unavailable due to a transport error"
+                    ) from e
 
+                if scopes_response.status_code == 401:
+                    logger.debug(
+                        "GitHub scope verification rejected credentials: %d - %s",
+                        scopes_response.status_code,
+                        scopes_response.text[:200],
+                    )
+                    return None
+
+                if scopes_response.status_code != 200:
+                    logger.warning(
+                        "GitHub scope verification unavailable: %d - %s",
+                        scopes_response.status_code,
+                        scopes_response.text[:200],
+                    )
+                    raise TokenVerificationError(
+                        "GitHub scope verification unavailable: "
+                        f"HTTP {scopes_response.status_code}"
+                    )
+
+                oauth_scopes_header = scopes_response.headers.get("x-oauth-scopes", "")
                 token_scopes = [
                     scope.strip()
                     for scope in oauth_scopes_header.split(",")
                     if scope.strip()
                 ]
 
-                if not token_scopes and trusted_scopes is not None:
-                    token_scopes = list(trusted_scopes)
-
-                # Check required scopes. If scope discovery is unavailable in a
-                # standalone verifier, token_scopes stays empty and required
-                # scopes cannot be satisfied. Provider fallback never grants more
-                # than the IdP scopes already stored by OAuthProxy.
+                # Never synthesize a scope that GitHub did not report. A successful
+                # identity lookup proves the credential identifies a user, not that
+                # a particular OAuth grant (such as `user`) was issued.
                 if self.required_scopes:
                     token_scopes_set = set(token_scopes)
                     required_scopes_set = set(self.required_scopes)
@@ -212,12 +189,11 @@ class GitHubTokenVerifier(TokenVerifier):
                         )
                         return None
 
-                # Create AccessToken with GitHub user info
                 result = AccessToken(
                     token=token,
-                    client_id=str(user_data.get("id", "unknown")),  # Use GitHub user ID
+                    client_id=str(user_data.get("id", "unknown")),
                     scopes=token_scopes,
-                    expires_at=None,  # GitHub tokens don't typically expire
+                    expires_at=None,
                     subject=str(user_data["id"]),
                     claims={
                         "sub": str(user_data["id"]),
@@ -228,8 +204,6 @@ class GitHubTokenVerifier(TokenVerifier):
                         "github_user_data": user_data,
                     },
                 )
-                # Cache every accepted result, including a provider result that
-                # used the trusted IdP grant during supplementary scope failure.
                 self._cache.set(token, result)
                 return result
 
@@ -347,12 +321,10 @@ class GitHubProvider(OAuthProxy):
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
         """
-        # Parse scopes if provided as string
         required_scopes_final = (
             parse_scopes(required_scopes) if required_scopes is not None else ["user"]
         )
 
-        # Create GitHub token verifier
         token_verifier = GitHubTokenVerifier(
             required_scopes=required_scopes_final,
             timeout_seconds=timeout_seconds,
@@ -361,7 +333,6 @@ class GitHubProvider(OAuthProxy):
             http_client=http_client,
         )
 
-        # Initialize OAuth proxy with GitHub endpoints
         super().__init__(
             upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
             upstream_token_endpoint="https://github.com/login/oauth/access_token",
@@ -371,7 +342,7 @@ class GitHubProvider(OAuthProxy):
             base_url=base_url,
             resource_base_url=resource_base_url,
             redirect_path=redirect_path,
-            issuer_url=issuer_url or base_url,  # Default to base_url if not specified
+            issuer_url=issuer_url or base_url,
             allowed_client_redirect_uris=allowed_client_redirect_uris,
             client_storage=client_storage,
             jwt_signing_key=jwt_signing_key,
@@ -389,14 +360,3 @@ class GitHubProvider(OAuthProxy):
             client_id,
             required_scopes_final,
         )
-
-    def _get_verification_token(
-        self, upstream_token_set: UpstreamTokenSet
-    ) -> str | None:
-        """Publish trusted IdP scopes for the immediately following verification."""
-        verification_token = super()._get_verification_token(upstream_token_set)
-        if verification_token is not None:
-            _github_trusted_scope_context.set(
-                (verification_token, tuple(upstream_token_set.scope.split()))
-            )
-        return verification_token

--- a/tests/server/auth/providers/test_github.py
+++ b/tests/server/auth/providers/test_github.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from key_value.aio.stores.memory import MemoryStore
 
+from fastmcp.server.auth import TokenVerificationError
 from fastmcp.server.auth.providers.github import (
     GitHubProvider,
     GitHubTokenVerifier,
@@ -135,6 +136,7 @@ class TestGitHubTokenVerifier:
 
         # Mock successful scopes API response
         scopes_response = MagicMock()
+        scopes_response.status_code = 200
         scopes_response.headers = {"x-oauth-scopes": "user,repo"}
 
         # Set up the mock client to return our responses
@@ -278,8 +280,8 @@ class TestGitHubTokenVerifierCaching:
             assert result2 is not None
             assert result2.claims["login"] == "testuser"
 
-    async def test_scope_failure_skips_cache(self):
-        """Token verified with fallback scopes (scope API failed) should not be cached."""
+    async def test_scope_failure_raises_and_skips_cache(self):
+        """Operational scope failures should propagate and must not be cached."""
         verifier = GitHubTokenVerifier(cache_ttl_seconds=300)
 
         mock_client = AsyncMock()
@@ -296,6 +298,7 @@ class TestGitHubTokenVerifierCaching:
 
         scopes_response = MagicMock()
         scopes_response.status_code = 500
+        scopes_response.text = "simulated outage"
         scopes_response.headers = {}
 
         with patch(
@@ -304,9 +307,8 @@ class TestGitHubTokenVerifierCaching:
             mock_cls.return_value.__aenter__.return_value = mock_client
 
             mock_client.get.side_effect = [user_response, scopes_response]
-            result = await verifier.verify_token("tok-1")
-            assert result is not None
-            # Should NOT be cached because scope response was not 200
+            with pytest.raises(TokenVerificationError, match="500"):
+                await verifier.verify_token("tok-1")
             assert not verifier._cache.enabled or len(verifier._cache._entries) == 0
 
     def test_provider_passes_cache_params(self, memory_storage: MemoryStore):

--- a/tests/server/auth/providers/test_github_transient_failures.py
+++ b/tests/server/auth/providers/test_github_transient_failures.py
@@ -1,0 +1,107 @@
+"""Regression coverage for operational GitHub token verification failures."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx2
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+
+from fastmcp.server.auth import TokenVerificationError, TokenVerifier
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.oauth_proxy.models import JTIMapping, UpstreamTokenSet
+from fastmcp.server.auth.providers.github import GitHubTokenVerifier
+
+
+def _response(status_code: int, text: str = "simulated") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    return response
+
+
+async def test_github_401_is_still_an_invalid_token():
+    client = AsyncMock()
+    client.get.return_value = _response(401, "Bad credentials")
+    verifier = GitHubTokenVerifier(http_client=client)
+
+    assert await verifier.verify_token("bad-token") is None
+
+
+@pytest.mark.parametrize("status_code", [403, 429, 500, 503])
+async def test_github_operational_http_failure_raises_typed_error(status_code):
+    client = AsyncMock()
+    client.get.return_value = _response(status_code)
+    verifier = GitHubTokenVerifier(http_client=client)
+
+    with pytest.raises(TokenVerificationError, match=str(status_code)):
+        await verifier.verify_token("still-valid-token")
+
+
+async def test_github_transport_failure_raises_typed_error():
+    client = AsyncMock()
+    client.get.side_effect = httpx2.ConnectError(
+        "simulated transport failure",
+        request=httpx2.Request("GET", "https://api.github.com/user"),
+    )
+    verifier = GitHubTokenVerifier(http_client=client)
+
+    with pytest.raises(TokenVerificationError, match="transport"):
+        await verifier.verify_token("still-valid-token")
+
+
+class UnavailableVerifier(TokenVerifier):
+    async def verify_token(self, token: str):
+        raise TokenVerificationError("upstream verifier unavailable")
+
+
+async def test_oauth_proxy_propagates_operational_verification_error():
+    proxy = OAuthProxy(
+        upstream_authorization_endpoint="https://idp.example.com/authorize",
+        upstream_token_endpoint="https://idp.example.com/token",
+        upstream_client_id="upstream-client",
+        upstream_client_secret="upstream-secret",
+        token_verifier=UnavailableVerifier(),
+        base_url="https://proxy.example.com",
+        jwt_signing_key="test-signing-key",
+        client_storage=MemoryStore(),
+    )
+    proxy.set_mcp_path("/mcp")
+
+    now = time.time()
+    upstream_token_id = "upstream-token-id"
+    jti = "access-jti"
+    await proxy._upstream_token_store.put(
+        key=upstream_token_id,
+        value=UpstreamTokenSet(
+            upstream_token_id=upstream_token_id,
+            access_token="upstream-access-token",
+            refresh_token=None,
+            refresh_token_expires_at=None,
+            expires_at=now + 3600,
+            token_type="Bearer",
+            scope="user",
+            client_id="mcp-client",
+            created_at=now,
+            raw_token_data={"access_token": "upstream-access-token"},
+        ),
+        ttl=3600,
+    )
+    await proxy._jti_mapping_store.put(
+        key=jti,
+        value=JTIMapping(
+            jti=jti,
+            upstream_token_id=upstream_token_id,
+            created_at=now,
+        ),
+        ttl=3600,
+    )
+    fastmcp_token = proxy.jwt_issuer.issue_access_token(
+        client_id="mcp-client",
+        scopes=["user"],
+        jti=jti,
+        expires_in=3600,
+    )
+
+    with pytest.raises(TokenVerificationError, match="upstream verifier unavailable"):
+        await proxy.load_access_token(fastmcp_token)

--- a/tests/server/auth/providers/test_github_transient_failures.py
+++ b/tests/server/auth/providers/test_github_transient_failures.py
@@ -31,7 +31,6 @@ def _response(
 def _github_user_response() -> MagicMock:
     return _response(
         200,
-        headers={},
         json_data={
             "id": 12345,
             "login": "testuser",
@@ -114,15 +113,17 @@ async def test_github_transport_failure_raises_typed_error():
         await verifier.verify_token("still-valid-token")
 
 
-async def test_standalone_scope_outage_does_not_synthesize_user_scope():
+@pytest.mark.parametrize("status_code", [403, 429, 500, 503])
+async def test_scope_operational_http_failure_raises_typed_error(status_code):
     client = AsyncMock()
-    client.get.side_effect = [_github_user_response(), _response(503)]
+    client.get.side_effect = [_github_user_response(), _response(status_code)]
     verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
 
-    assert await verifier.verify_token("standalone-token") is None
+    with pytest.raises(TokenVerificationError, match=str(status_code)):
+        await verifier.verify_token("still-valid-token")
 
 
-async def test_standalone_scope_transport_failure_does_not_synthesize_user_scope():
+async def test_scope_transport_failure_raises_typed_error():
     client = AsyncMock()
     client.get.side_effect = [
         _github_user_response(),
@@ -133,7 +134,8 @@ async def test_standalone_scope_transport_failure_does_not_synthesize_user_scope
     ]
     verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
 
-    assert await verifier.verify_token("standalone-token") is None
+    with pytest.raises(TokenVerificationError, match="transport"):
+        await verifier.verify_token("still-valid-token")
 
 
 async def test_scope_401_is_still_an_invalid_token():
@@ -142,6 +144,35 @@ async def test_scope_401_is_still_an_invalid_token():
     verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
 
     assert await verifier.verify_token("revoked-token") is None
+
+
+async def test_missing_scope_header_does_not_synthesize_user_scope():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(200, headers={})]
+    verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
+
+    assert await verifier.verify_token("standalone-token") is None
+
+
+async def test_successful_scope_verification_is_cached():
+    client = AsyncMock()
+    client.get.side_effect = [
+        _github_user_response(),
+        _response(200, headers={"x-oauth-scopes": "user"}),
+    ]
+    verifier = GitHubTokenVerifier(
+        required_scopes=["user"],
+        cache_ttl_seconds=300,
+        http_client=client,
+    )
+
+    first = await verifier.verify_token("valid-token")
+    second = await verifier.verify_token("valid-token")
+
+    assert first is not None
+    assert first.scopes == ["user"]
+    assert second is first
+    assert client.get.call_count == 2
 
 
 class UnavailableVerifier(TokenVerifier):
@@ -166,7 +197,7 @@ async def test_oauth_proxy_propagates_operational_verification_error():
         await proxy.load_access_token(fastmcp_token)
 
 
-async def test_github_provider_scope_outage_uses_trusted_repo_grant():
+async def test_github_provider_scope_outage_propagates_operational_error():
     client = AsyncMock()
     client.get.side_effect = [_github_user_response(), _response(503)]
     provider = GitHubProvider(
@@ -180,30 +211,11 @@ async def test_github_provider_scope_outage_uses_trusted_repo_grant():
     )
     fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="repo")
 
-    result = await provider.load_access_token(fastmcp_token)
-
-    assert result is not None
-    assert result.scopes == ["repo"]
+    with pytest.raises(TokenVerificationError, match="503"):
+        await provider.load_access_token(fastmcp_token)
 
 
-async def test_github_provider_scope_outage_cannot_upgrade_trusted_scope():
-    client = AsyncMock()
-    client.get.side_effect = [_github_user_response(), _response(503)]
-    provider = GitHubProvider(
-        client_id="github-client",
-        client_secret="github-secret",
-        base_url="https://proxy.example.com",
-        required_scopes=["repo"],
-        http_client=client,
-        jwt_signing_key="test-signing-key",
-        client_storage=MemoryStore(),
-    )
-    fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="user")
-
-    assert await provider.load_access_token(fastmcp_token) is None
-
-
-async def test_github_provider_scope_401_overrides_trusted_grant():
+async def test_github_provider_scope_401_stays_invalid():
     client = AsyncMock()
     client.get.side_effect = [_github_user_response(), _response(401, "Bad credentials")]
     provider = GitHubProvider(
@@ -218,28 +230,3 @@ async def test_github_provider_scope_401_overrides_trusted_grant():
     fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="repo")
 
     assert await provider.load_access_token(fastmcp_token) is None
-
-
-async def test_github_provider_degraded_success_uses_cache():
-    client = AsyncMock()
-    client.get.side_effect = [_github_user_response(), _response(503)]
-    provider = GitHubProvider(
-        client_id="github-client",
-        client_secret="github-secret",
-        base_url="https://proxy.example.com",
-        required_scopes=["user"],
-        cache_ttl_seconds=300,
-        http_client=client,
-        jwt_signing_key="test-signing-key",
-        client_storage=MemoryStore(),
-    )
-    fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="user")
-
-    first = await provider.load_access_token(fastmcp_token)
-    second = await provider.load_access_token(fastmcp_token)
-
-    assert first is not None
-    assert first.scopes == ["user"]
-    assert second is not None
-    assert second.client_id == first.client_id
-    assert client.get.call_count == 2

--- a/tests/server/auth/providers/test_github_transient_failures.py
+++ b/tests/server/auth/providers/test_github_transient_failures.py
@@ -174,7 +174,10 @@ async def test_successful_scope_verification_is_cached():
 
     assert first is not None
     assert first.scopes == ["user"]
-    assert second is first
+    assert second is not None
+    assert second.scopes == ["user"]
+    assert second.client_id == first.client_id
+    assert second is not first
     assert client.get.call_count == 2
 
 

--- a/tests/server/auth/providers/test_github_transient_failures.py
+++ b/tests/server/auth/providers/test_github_transient_failures.py
@@ -114,26 +114,15 @@ async def test_github_transport_failure_raises_typed_error():
         await verifier.verify_token("still-valid-token")
 
 
-async def test_scope_outage_for_basic_user_scope_is_accepted_and_cached():
+async def test_standalone_scope_outage_does_not_synthesize_user_scope():
     client = AsyncMock()
     client.get.side_effect = [_github_user_response(), _response(503)]
-    verifier = GitHubTokenVerifier(
-        required_scopes=["user"],
-        cache_ttl_seconds=300,
-        http_client=client,
-    )
+    verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
 
-    first = await verifier.verify_token("still-valid-token")
-    second = await verifier.verify_token("still-valid-token")
-
-    assert first is not None
-    assert first.scopes == ["user"]
-    assert second is not None
-    assert second.client_id == first.client_id
-    assert client.get.call_count == 2
+    assert await verifier.verify_token("standalone-token") is None
 
 
-async def test_scope_transport_failure_for_basic_user_scope_is_cached():
+async def test_standalone_scope_transport_failure_does_not_synthesize_user_scope():
     client = AsyncMock()
     client.get.side_effect = [
         _github_user_response(),
@@ -142,18 +131,9 @@ async def test_scope_transport_failure_for_basic_user_scope_is_cached():
             request=httpx2.Request("GET", "https://api.github.com/user/repos"),
         ),
     ]
-    verifier = GitHubTokenVerifier(
-        required_scopes=["user"],
-        cache_ttl_seconds=300,
-        http_client=client,
-    )
+    verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
 
-    first = await verifier.verify_token("still-valid-token")
-    second = await verifier.verify_token("still-valid-token")
-
-    assert first is not None
-    assert second is not None
-    assert client.get.call_count == 2
+    assert await verifier.verify_token("standalone-token") is None
 
 
 async def test_scope_401_is_still_an_invalid_token():
@@ -162,15 +142,6 @@ async def test_scope_401_is_still_an_invalid_token():
     verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
 
     assert await verifier.verify_token("revoked-token") is None
-
-
-async def test_scope_outage_with_stronger_required_scope_is_operational():
-    client = AsyncMock()
-    client.get.side_effect = [_github_user_response(), _response(503)]
-    verifier = GitHubTokenVerifier(required_scopes=["repo"], http_client=client)
-
-    with pytest.raises(TokenVerificationError, match="503"):
-        await verifier.verify_token("still-valid-token")
 
 
 class UnavailableVerifier(TokenVerifier):
@@ -195,7 +166,7 @@ async def test_oauth_proxy_propagates_operational_verification_error():
         await proxy.load_access_token(fastmcp_token)
 
 
-async def test_github_provider_scope_outage_does_not_become_invalid_token():
+async def test_github_provider_scope_outage_uses_trusted_repo_grant():
     client = AsyncMock()
     client.get.side_effect = [_github_user_response(), _response(503)]
     provider = GitHubProvider(
@@ -209,8 +180,44 @@ async def test_github_provider_scope_outage_does_not_become_invalid_token():
     )
     fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="repo")
 
-    with pytest.raises(TokenVerificationError, match="503"):
-        await provider.load_access_token(fastmcp_token)
+    result = await provider.load_access_token(fastmcp_token)
+
+    assert result is not None
+    assert result.scopes == ["repo"]
+
+
+async def test_github_provider_scope_outage_cannot_upgrade_trusted_scope():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(503)]
+    provider = GitHubProvider(
+        client_id="github-client",
+        client_secret="github-secret",
+        base_url="https://proxy.example.com",
+        required_scopes=["repo"],
+        http_client=client,
+        jwt_signing_key="test-signing-key",
+        client_storage=MemoryStore(),
+    )
+    fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="user")
+
+    assert await provider.load_access_token(fastmcp_token) is None
+
+
+async def test_github_provider_scope_401_overrides_trusted_grant():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(401, "Bad credentials")]
+    provider = GitHubProvider(
+        client_id="github-client",
+        client_secret="github-secret",
+        base_url="https://proxy.example.com",
+        required_scopes=["repo"],
+        http_client=client,
+        jwt_signing_key="test-signing-key",
+        client_storage=MemoryStore(),
+    )
+    fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="repo")
+
+    assert await provider.load_access_token(fastmcp_token) is None
 
 
 async def test_github_provider_degraded_success_uses_cache():
@@ -232,5 +239,7 @@ async def test_github_provider_degraded_success_uses_cache():
     second = await provider.load_access_token(fastmcp_token)
 
     assert first is not None
+    assert first.scopes == ["user"]
     assert second is not None
+    assert second.client_id == first.client_id
     assert client.get.call_count == 2

--- a/tests/server/auth/providers/test_github_transient_failures.py
+++ b/tests/server/auth/providers/test_github_transient_failures.py
@@ -10,14 +10,78 @@ from key_value.aio.stores.memory import MemoryStore
 from fastmcp.server.auth import TokenVerificationError, TokenVerifier
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.oauth_proxy.models import JTIMapping, UpstreamTokenSet
-from fastmcp.server.auth.providers.github import GitHubTokenVerifier
+from fastmcp.server.auth.providers.github import GitHubProvider, GitHubTokenVerifier
 
 
-def _response(status_code: int, text: str = "simulated") -> MagicMock:
+def _response(
+    status_code: int,
+    text: str = "simulated",
+    *,
+    headers: dict[str, str] | None = None,
+    json_data: dict | None = None,
+) -> MagicMock:
     response = MagicMock()
     response.status_code = status_code
     response.text = text
+    response.headers = headers or {}
+    response.json.return_value = json_data or {}
     return response
+
+
+def _github_user_response() -> MagicMock:
+    return _response(
+        200,
+        headers={},
+        json_data={
+            "id": 12345,
+            "login": "testuser",
+            "name": "Test User",
+            "email": "test@example.com",
+            "avatar_url": "https://github.com/testuser.png",
+        },
+    )
+
+
+async def _store_proxy_access_token(
+    proxy: OAuthProxy,
+    *,
+    upstream_scope: str,
+) -> str:
+    proxy.set_mcp_path("/mcp")
+    now = time.time()
+    upstream_token_id = "upstream-token-id"
+    jti = "access-jti"
+    await proxy._upstream_token_store.put(
+        key=upstream_token_id,
+        value=UpstreamTokenSet(
+            upstream_token_id=upstream_token_id,
+            access_token="upstream-access-token",
+            refresh_token=None,
+            refresh_token_expires_at=None,
+            expires_at=now + 3600,
+            token_type="Bearer",
+            scope=upstream_scope,
+            client_id="mcp-client",
+            created_at=now,
+            raw_token_data={"access_token": "upstream-access-token"},
+        ),
+        ttl=3600,
+    )
+    await proxy._jti_mapping_store.put(
+        key=jti,
+        value=JTIMapping(
+            jti=jti,
+            upstream_token_id=upstream_token_id,
+            created_at=now,
+        ),
+        ttl=3600,
+    )
+    return proxy.jwt_issuer.issue_access_token(
+        client_id="mcp-client",
+        scopes=upstream_scope.split(),
+        jti=jti,
+        expires_in=3600,
+    )
 
 
 async def test_github_401_is_still_an_invalid_token():
@@ -50,6 +114,65 @@ async def test_github_transport_failure_raises_typed_error():
         await verifier.verify_token("still-valid-token")
 
 
+async def test_scope_outage_for_basic_user_scope_is_accepted_and_cached():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(503)]
+    verifier = GitHubTokenVerifier(
+        required_scopes=["user"],
+        cache_ttl_seconds=300,
+        http_client=client,
+    )
+
+    first = await verifier.verify_token("still-valid-token")
+    second = await verifier.verify_token("still-valid-token")
+
+    assert first is not None
+    assert first.scopes == ["user"]
+    assert second is not None
+    assert second.client_id == first.client_id
+    assert client.get.call_count == 2
+
+
+async def test_scope_transport_failure_for_basic_user_scope_is_cached():
+    client = AsyncMock()
+    client.get.side_effect = [
+        _github_user_response(),
+        httpx2.ConnectError(
+            "simulated scope transport failure",
+            request=httpx2.Request("GET", "https://api.github.com/user/repos"),
+        ),
+    ]
+    verifier = GitHubTokenVerifier(
+        required_scopes=["user"],
+        cache_ttl_seconds=300,
+        http_client=client,
+    )
+
+    first = await verifier.verify_token("still-valid-token")
+    second = await verifier.verify_token("still-valid-token")
+
+    assert first is not None
+    assert second is not None
+    assert client.get.call_count == 2
+
+
+async def test_scope_401_is_still_an_invalid_token():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(401, "Bad credentials")]
+    verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
+
+    assert await verifier.verify_token("revoked-token") is None
+
+
+async def test_scope_outage_with_stronger_required_scope_is_operational():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(503)]
+    verifier = GitHubTokenVerifier(required_scopes=["repo"], http_client=client)
+
+    with pytest.raises(TokenVerificationError, match="503"):
+        await verifier.verify_token("still-valid-token")
+
+
 class UnavailableVerifier(TokenVerifier):
     async def verify_token(self, token: str):
         raise TokenVerificationError("upstream verifier unavailable")
@@ -66,42 +189,48 @@ async def test_oauth_proxy_propagates_operational_verification_error():
         jwt_signing_key="test-signing-key",
         client_storage=MemoryStore(),
     )
-    proxy.set_mcp_path("/mcp")
-
-    now = time.time()
-    upstream_token_id = "upstream-token-id"
-    jti = "access-jti"
-    await proxy._upstream_token_store.put(
-        key=upstream_token_id,
-        value=UpstreamTokenSet(
-            upstream_token_id=upstream_token_id,
-            access_token="upstream-access-token",
-            refresh_token=None,
-            refresh_token_expires_at=None,
-            expires_at=now + 3600,
-            token_type="Bearer",
-            scope="user",
-            client_id="mcp-client",
-            created_at=now,
-            raw_token_data={"access_token": "upstream-access-token"},
-        ),
-        ttl=3600,
-    )
-    await proxy._jti_mapping_store.put(
-        key=jti,
-        value=JTIMapping(
-            jti=jti,
-            upstream_token_id=upstream_token_id,
-            created_at=now,
-        ),
-        ttl=3600,
-    )
-    fastmcp_token = proxy.jwt_issuer.issue_access_token(
-        client_id="mcp-client",
-        scopes=["user"],
-        jti=jti,
-        expires_in=3600,
-    )
+    fastmcp_token = await _store_proxy_access_token(proxy, upstream_scope="user")
 
     with pytest.raises(TokenVerificationError, match="upstream verifier unavailable"):
         await proxy.load_access_token(fastmcp_token)
+
+
+async def test_github_provider_scope_outage_does_not_become_invalid_token():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(503)]
+    provider = GitHubProvider(
+        client_id="github-client",
+        client_secret="github-secret",
+        base_url="https://proxy.example.com",
+        required_scopes=["repo"],
+        http_client=client,
+        jwt_signing_key="test-signing-key",
+        client_storage=MemoryStore(),
+    )
+    fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="repo")
+
+    with pytest.raises(TokenVerificationError, match="503"):
+        await provider.load_access_token(fastmcp_token)
+
+
+async def test_github_provider_degraded_success_uses_cache():
+    client = AsyncMock()
+    client.get.side_effect = [_github_user_response(), _response(503)]
+    provider = GitHubProvider(
+        client_id="github-client",
+        client_secret="github-secret",
+        base_url="https://proxy.example.com",
+        required_scopes=["user"],
+        cache_ttl_seconds=300,
+        http_client=client,
+        jwt_signing_key="test-signing-key",
+        client_storage=MemoryStore(),
+    )
+    fastmcp_token = await _store_proxy_access_token(provider, upstream_scope="user")
+
+    first = await provider.load_access_token(fastmcp_token)
+    second = await provider.load_access_token(fastmcp_token)
+
+    assert first is not None
+    assert second is not None
+    assert client.get.call_count == 2

--- a/tests/server/auth/providers/test_github_transient_failures.py
+++ b/tests/server/auth/providers/test_github_transient_failures.py
@@ -140,7 +140,10 @@ async def test_scope_transport_failure_raises_typed_error():
 
 async def test_scope_401_is_still_an_invalid_token():
     client = AsyncMock()
-    client.get.side_effect = [_github_user_response(), _response(401, "Bad credentials")]
+    client.get.side_effect = [
+        _github_user_response(),
+        _response(401, "Bad credentials"),
+    ]
     verifier = GitHubTokenVerifier(required_scopes=["user"], http_client=client)
 
     assert await verifier.verify_token("revoked-token") is None
@@ -217,7 +220,10 @@ async def test_github_provider_scope_outage_propagates_operational_error():
 
 async def test_github_provider_scope_401_stays_invalid():
     client = AsyncMock()
-    client.get.side_effect = [_github_user_response(), _response(401, "Bad credentials")]
+    client.get.side_effect = [
+        _github_user_response(),
+        _response(401, "Bad credentials"),
+    ]
     provider = GitHubProvider(
         client_id="github-client",
         client_secret="github-secret",


### PR DESCRIPTION
Fixes #4854

## Summary

Separate invalid GitHub credentials from temporary verifier outages at the shared `OAuthProxy.load_access_token()` boundary, per maintainer review.

- add `TokenVerificationError` as the typed operational-failure signal for token verifiers
- make shared `OAuthProxy.load_access_token()` propagate that signal instead of collapsing it to `None`
- reserve `None` for credentials that were actually determined to be invalid or unacceptable
- keep GitHub `/user` and `/user/repos` `401` responses as invalid-credential outcomes
- raise `TokenVerificationError` for other GitHub verification HTTP failures (including rate-limit/5xx responses) and transport failures
- preserve `MultiAuth` fallback ordering: later sources can still validate after an operational failure, but the typed failure is re-raised if no source succeeds
- treat malformed GitHub `200 /user` JSON and payloads missing the required `id` as operational verification failures
- never synthesize an OAuth scope that GitHub did not report
- cache successful, positively verified results normally

## Regression coverage

- `/user` 401 returns `None`
- `/user` 403 / 429 / 500 / 503 raise `TokenVerificationError`
- `/user` transport failures raise `TokenVerificationError`
- malformed `200 /user` JSON and missing user `id` raise `TokenVerificationError`
- `/user/repos` 401 returns `None`
- `/user/repos` 403 / 429 / 500 / 503 raise `TokenVerificationError`
- `/user/repos` transport failures raise `TokenVerificationError`
- `MultiAuth` re-raises an operational failure when no source validates
- `MultiAuth` still accepts a successful later fallback after an earlier operational failure
- a missing `X-OAuth-Scopes` header cannot synthesize `user` or satisfy required scopes
- successful scope verification is cached and preserves defensive-copy semantics
- `GitHubProvider` scope-verification outages propagate through the shared boundary

## Validation

Current head: `6a825cbcda068dca1c5f9e7edcea986937d0bef5`.

Exact-head GitHub Actions validation is green:

- **Run static analysis: SUCCESS**
- **Tests: SUCCESS**
- **Downstream smoke: SUCCESS**

Current upstream `main` is `1f9992994eabafa6c4dbfe1974e76cf3a193b1b2`. The upstream changes since this PR's base do not touch the review-fix paths, and GitHub reports the PR mergeable, so no rebase was done solely to chase `main`.

Fixes #4854