### PR TITLE
Defer uvicorn import to run_http_async

### DIFF
--- a/fastmcp_slim/fastmcp/server/mixins/transport.py
+++ b/fastmcp_slim/fastmcp/server/mixins/transport.py
@@ -8,7 +8,6 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
 import anyio
-import uvicorn
 from mcp.server.lowlevel.server import NotificationOptions
 from mcp.server.stdio import stdio_server
 from mcp.server.streamable_http import EventStore
@@ -296,6 +295,10 @@ class TransportMixin:
                 cross-origin responses.
             sockets: Pre-bound sockets to pass to Uvicorn
         """
+        # Deferred so importing FastMCP does not require uvicorn: http_app()
+        # can be served by any ASGI server, and only this method runs uvicorn.
+        import uvicorn
+
         # Allow stateless as alias for stateless_http
         if stateless is not None and stateless_http is None:
             stateless_http = stateless

--- a/tests/server/http/test_startup_imports.py
+++ b/tests/server/http/test_startup_imports.py
@@ -97,6 +97,44 @@ def test_default_http_app_does_not_load_opt_in_integrations() -> None:
 
 
 @pytest.mark.subprocess_heavy
+def test_http_app_does_not_require_uvicorn() -> None:
+    """Only run_http_async needs uvicorn; http_app() can be served by any ASGI server."""
+    script = textwrap.dedent(
+        """
+        import sys
+
+        class _UvicornBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "uvicorn" or fullname.startswith("uvicorn."):
+                    raise ImportError("uvicorn is blocked for this test")
+                return None
+
+        sys.meta_path.insert(0, _UvicornBlocker())
+
+        from fastmcp import FastMCP
+
+        server = FastMCP("uvicorn import guard")
+
+        @server.tool
+        def echo(value: str) -> str:
+            return value
+
+        app = server.http_app(transport="http", stateless_http=True)
+        assert app is not None
+        assert "uvicorn" not in sys.modules
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.subprocess_heavy
 def test_fastmcp_server_import_does_not_load_context() -> None:
     script = textwrap.dedent(
         """


### PR DESCRIPTION
Fixes #4883

Importing FastMCP no longer requires uvicorn: http_app() can be served by any ASGI server (granian, hypercorn, ...), and only run_http_async actually runs uvicorn. sse_starlette already guards its own uvicorn import, so the server import path now works without uvicorn installed.