### PR TITLE
fix: make BM25 tokenizer Unicode-aware (CJK/Cyrillic search)

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -17,7 +17,7 @@ from fastmcp.tools.base import Tool
 
 def _tokenize(text: str) -> list[str]:
     """Lowercase, split on non-alphanumeric (Unicode-aware), filter short tokens."""
-    return [t for t in re.split(r"\W+", text.lower()) if len(t) > 1]
+    return [t for t in re.split(r"\W+", text.lower().replace("_", " ")) if len(t) > 1]
 
 
 class _BM25Index:

--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -16,8 +16,8 @@ from fastmcp.tools.base import Tool
 
 
 def _tokenize(text: str) -> list[str]:
-    """Lowercase, split on non-alphanumeric, filter short tokens."""
-    return [t for t in re.split(r"[^a-z0-9]+", text.lower()) if len(t) > 1]
+    """Lowercase, split on non-alphanumeric (Unicode-aware), filter short tokens."""
+    return [t for t in re.split(r"\W+", text.lower()) if len(t) > 1]
 
 
 class _BM25Index:

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -413,6 +413,21 @@ class TestBM25Search:
 # ---------------------------------------------------------------------------
 
 
+    async def test_search_unicode_description(self) -> None:
+        """BM25 search should work with non-ASCII text (e.g. Cyrillic, CJK)."""
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        def get_portfolio() -> str:
+            """Показывает текущий портфель пользователя"""
+            return "portfolio"
+
+        mcp.add_transform(BM25SearchTransform())
+        await mcp.list_tools()
+        result = await mcp.call_tool("search_tools", {"query": "портфель"})
+        tools = _parse_tool_result(result)
+        assert any(t["name"] == "get_portfolio" for t in tools)
+
 class TestBM25Index:
     def test_basic_ranking(self):
         index = _BM25Index()


### PR DESCRIPTION
Fixes #4886

## Problem

`BM25SearchTransform` returns no results for non-ASCII queries. The `_tokenize`
function used `re.split(r"[^a-z0-9]+", text.lower())`, which only keeps ASCII
letters/digits. Any non-ASCII text (Cyrillic, CJK, accented Latin, etc.) is split
away entirely — a Russian query like `покажи мой портфель` produces zero tokens,
so the index can never match a Russian tool description.

## Fix

Use `re.split(r"\W+", text.lower().replace("_", " "))` — Python 3's `\W`
character class is Unicode-aware, so non-ASCII letters are preserved as tokens.
The explicit `replace("_", " ")` keeps the previous behavior of splitting
snake_case identifiers into word tokens (e.g. `get_portfolio` → `get`,
`portfolio`), so ASCII indexing/ranking is unchanged.

## Test

Added `test_search_unicode_description`: a tool documented with a Russian
description is now found by a Russian-language BM25 query.
