### PR TITLE
fix: support Unicode tokens in BM25 search

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -3,6 +3,7 @@
 import hashlib
 import math
 import re
+import unicodedata
 from collections.abc import Sequence
 from typing import Annotated, Any
 
@@ -16,17 +17,9 @@ from fastmcp.tools.base import Tool
 
 
 def _tokenize(text: str) -> list[str]:
-    """Lowercase, split on non-alphanumeric, and retain mixed-script parts."""
-    tokens: list[str] = []
-    for token in re.split(r"[_\W]+", text.lower()):
-        if len(token) > 1:
-            tokens.append(token)
-        tokens.extend(
-            part
-            for part in re.findall(r"[a-z0-9]+|[^a-z0-9]+", token)
-            if len(part) > 1 and part != token
-        )
-    return tokens
+    """Normalize and extract Unicode alphanumeric tokens."""
+    normalized = unicodedata.normalize("NFKC", text).casefold()
+    return re.findall(r"[^\W_]{2,}", normalized)
 
 
 class _BM25Index:

--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -16,8 +16,17 @@ from fastmcp.tools.base import Tool
 
 
 def _tokenize(text: str) -> list[str]:
-    """Lowercase, split on non-alphanumeric, filter short tokens."""
-    return [t for t in re.split(r"[_\W]+", text.lower()) if len(t) > 1]
+    """Lowercase, split on non-alphanumeric, and retain mixed-script parts."""
+    tokens: list[str] = []
+    for token in re.split(r"[_\W]+", text.lower()):
+        if len(token) > 1:
+            tokens.append(token)
+        tokens.extend(
+            part
+            for part in re.findall(r"[a-z0-9]+|[^a-z0-9]+", token)
+            if len(part) > 1 and part != token
+        )
+    return tokens
 
 
 class _BM25Index:

--- a/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
+++ b/fastmcp_slim/fastmcp/server/transforms/search/bm25.py
@@ -17,7 +17,7 @@ from fastmcp.tools.base import Tool
 
 def _tokenize(text: str) -> list[str]:
     """Lowercase, split on non-alphanumeric, filter short tokens."""
-    return [t for t in re.split(r"[^a-z0-9]+", text.lower()) if len(t) > 1]
+    return [t for t in re.split(r"[_\W]+", text.lower()) if len(t) > 1]
 
 
 class _BM25Index:

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -441,6 +441,12 @@ class TestBM25Index:
         index.build(["show portfolio", "показать портфель"])
         assert index.query("портфель", 5) == [1]
 
+    def test_mixed_script_tokens(self):
+        index = _BM25Index()
+        index.build(["get天气"])
+        assert index.query("get", 5) == [0]
+        assert index.query("天气", 5) == [0]
+
 
 # ---------------------------------------------------------------------------
 # call_tool self-reference guard

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -441,11 +441,12 @@ class TestBM25Index:
         index.build(["show portfolio", "показать портфель"])
         assert index.query("портфель", 5) == [1]
 
-    def test_mixed_script_tokens(self):
+    def test_unicode_normalization(self):
         index = _BM25Index()
-        index.build(["get天气"])
-        assert index.query("get", 5) == [0]
-        assert index.query("天气", 5) == [0]
+        index.build(["Straße ＰＯＲＴＦＯＬＩＯ cafe\u0301"])
+        assert index.query("STRASSE", 5) == [0]
+        assert index.query("portfolio", 5) == [0]
+        assert index.query("café", 5) == [0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/transforms/test_search.py
+++ b/tests/server/transforms/test_search.py
@@ -436,6 +436,11 @@ class TestBM25Index:
         index.build(["alpha beta gamma"])
         assert index.query("zzz", 5) == []
 
+    def test_unicode_tokens(self):
+        index = _BM25Index()
+        index.build(["show portfolio", "показать портфель"])
+        assert index.query("портфель", 5) == [1]
+
 
 # ---------------------------------------------------------------------------
 # call_tool self-reference guard


### PR DESCRIPTION
BM25 tokenization currently discards every character outside ASCII letters and digits, so same-language Unicode queries cannot overlap with indexed tool metadata. Normalize text with NFKC and Unicode case folding, then extract Unicode alphanumeric tokens while continuing to split underscores; this preserves existing ASCII and snake_case behavior while making equivalent Unicode forms searchable.

The regression is captured at the index boundary:

```python
index.build(["show portfolio", "показать портфель"])
assert index.query("портфель", 5) == [1]
```

This deliberately does not introduce script-specific segmentation or translation; those require a separate search design.

Fixes #4886
