### PR TITLE
fix: stringify OpenAPI header and path parameters

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -26,6 +26,17 @@ def _query_scalar_to_str(value: Any) -> str:
     return str(value)
 
 
+def _simple_style_to_str(value: Any) -> str:
+    """Serialize a value in OpenAPI `simple` style (default for path and header).
+
+    Arrays become comma-separated (`a,b`). Booleans use JSON/OpenAPI
+    `true`/`false` rather than Python's `True`/`False`.
+    """
+    if isinstance(value, list):
+        return ",".join(_query_scalar_to_str(v) for v in value)
+    return _query_scalar_to_str(value)
+
+
 class RequestDirector:
     """Builds httpx2.Request objects from HTTPRoute and arguments using openapi-core."""
 
@@ -72,7 +83,13 @@ class RequestDirector:
         # Step 4: Prepare request data
         method: str = route.method.upper()
         params = query_params if query_params else None
-        headers = header_params if header_params else None
+        # httpx requires header values to be str or bytes; use OpenAPI
+        # simple style (true/false, comma-separated arrays) like cookies.
+        headers = (
+            {k: _simple_style_to_str(v) for k, v in header_params.items()}
+            if header_params
+            else None
+        )
         json_body: dict[str, Any] | list[Any] | None = None
         content: str | bytes | None = None
 
@@ -134,7 +151,8 @@ class RequestDirector:
                     # sets application/json.
                     content = _json.dumps(body, allow_nan=False).encode("utf-8")
                     headers = dict(headers) if headers else {}
-                    headers["Content-Type"] = raw_content_type
+                    if raw_content_type is not None:
+                        headers["Content-Type"] = raw_content_type
                 else:
                     json_body = body
             else:
@@ -364,7 +382,9 @@ class RequestDirector:
         for param_name, param_value in path_params.items():
             placeholder = f"{{{param_name}}}"
             if placeholder in url_path:
-                safe_value = quote(str(param_value), safe="").replace(".", "%2E")
+                safe_value = quote(_simple_style_to_str(param_value), safe="").replace(
+                    ".", "%2E"
+                )
                 url_path = url_path.replace(placeholder, safe_value)
 
         # Combine with base URL

--- a/tests/utilities/openapi/test_director.py
+++ b/tests/utilities/openapi/test_director.py
@@ -1528,3 +1528,146 @@ class TestCookieParameters:
         assert "version=3" in cookie
         # Booleans use OpenAPI convention (true/false, not True/False)
         assert "debug=true" in cookie
+
+
+class TestHeaderParameterSerialization:
+    """Non-string header values must be stringified for httpx (OpenAPI simple style)."""
+
+    @pytest.fixture
+    def director(self):
+        spec = SchemaPath.from_dict(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "t", "version": "1"},
+                "paths": {},
+            }
+        )
+        return RequestDirector(spec)
+
+    def _header_route(self, name: str, schema: dict):
+        return HTTPRoute(
+            path="/items",
+            method="GET",
+            operation_id="get_items",
+            parameters=[
+                ParameterInfo(
+                    name=name,
+                    location="header",
+                    required=True,
+                    schema=schema,
+                ),
+            ],
+            parameter_map={
+                name: {"location": "header", "openapi_name": name},
+            },
+        )
+
+    def test_boolean_header_does_not_raise_and_sends_true(self, director):
+        """Boolean headers must be sent as true/false, not raise TypeError."""
+        route = self._header_route("X-Dry-Run", {"type": "boolean"})
+        request = director.build(route, {"X-Dry-Run": True})
+        assert request.headers["x-dry-run"] == "true"
+
+    def test_boolean_header_false_sends_false(self, director):
+        route = self._header_route("X-Dry-Run", {"type": "boolean"})
+        request = director.build(route, {"X-Dry-Run": False})
+        assert request.headers["x-dry-run"] == "false"
+
+    def test_integer_header_does_not_raise_and_sends_string(self, director):
+        """Integer headers must be stringified, not raise TypeError."""
+        route = self._header_route("X-Count", {"type": "integer"})
+        request = director.build(route, {"X-Count": 42})
+        assert request.headers["x-count"] == "42"
+
+    def test_array_header_serialized_simple_style(self, director):
+        """Array headers use OpenAPI simple style (a,b), not a Python list."""
+        route = self._header_route(
+            "X-Tags",
+            {"type": "array", "items": {"type": "string"}},
+        )
+        request = director.build(route, {"X-Tags": ["a", "b"]})
+        assert request.headers["x-tags"] == "a,b"
+
+
+class TestPathParameterSerialization:
+    """Path parameters use OpenAPI simple style, not Python repr."""
+
+    @pytest.fixture
+    def director(self):
+        spec = SchemaPath.from_dict(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "t", "version": "1"},
+                "paths": {},
+            }
+        )
+        return RequestDirector(spec)
+
+    def test_array_path_param_simple_style_not_python_repr(self, director):
+        """Array path params are comma-separated, not str([1, 2, 3])."""
+        route = HTTPRoute(
+            path="/items/{ids}",
+            method="GET",
+            operation_id="get_items",
+            parameters=[
+                ParameterInfo(
+                    name="ids",
+                    location="path",
+                    required=True,
+                    schema={"type": "array", "items": {"type": "integer"}},
+                ),
+            ],
+            parameter_map={
+                "ids": {"location": "path", "openapi_name": "ids"},
+            },
+        )
+        request = director.build(route, {"ids": [1, 2, 3]}, "https://api.example.com")
+        decoded = unquote(str(request.url))
+        assert decoded == "https://api.example.com/items/1,2,3"
+        assert "[" not in decoded
+        assert "%5B" not in str(request.url)
+
+    def test_boolean_path_param_is_lowercase_true(self, director):
+        """Boolean path params are true/false, not Python True/False."""
+        route = HTTPRoute(
+            path="/flags/{enabled}",
+            method="GET",
+            operation_id="get_flag",
+            parameters=[
+                ParameterInfo(
+                    name="enabled",
+                    location="path",
+                    required=True,
+                    schema={"type": "boolean"},
+                ),
+            ],
+            parameter_map={
+                "enabled": {"location": "path", "openapi_name": "enabled"},
+            },
+        )
+        request = director.build(route, {"enabled": True}, "https://api.example.com")
+        url = str(request.url)
+        assert url.endswith("/flags/true")
+        assert "True" not in url
+
+    def test_boolean_path_param_is_lowercase_false(self, director):
+        route = HTTPRoute(
+            path="/flags/{enabled}",
+            method="GET",
+            operation_id="get_flag",
+            parameters=[
+                ParameterInfo(
+                    name="enabled",
+                    location="path",
+                    required=True,
+                    schema={"type": "boolean"},
+                ),
+            ],
+            parameter_map={
+                "enabled": {"location": "path", "openapi_name": "enabled"},
+            },
+        )
+        request = director.build(route, {"enabled": False}, "https://api.example.com")
+        url = str(request.url)
+        assert url.endswith("/flags/false")
+        assert "False" not in url


### PR DESCRIPTION
## Description

`RequestDirector.build` already serializes query parameters and cookies (`true`/`false`, comma-separated arrays). Header values were passed through as native Python types, so a boolean, integer, or array header made httpx raise `TypeError: Header value must be str or bytes`. Path substitution used `str()`, so `/items/{ids}` with `[1, 2, 3]` became `/items/%5B1%2C%202%2C%203%5D` and a boolean path segment became `True`.

Both locations now use OpenAPI `simple` style, the same conversion already used for cookies.

Fixes #4897

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)