### PR TITLE
fix: hydrate date, time, duration and uuid string formats in json_schema_to_type

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema_type.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema_type.py
@@ -60,7 +60,7 @@ import warnings
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import MISSING, field, make_dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time, timedelta
 from typing import (
     Annotated,
     Any,
@@ -69,6 +69,7 @@ from typing import (
     Union,
     cast,
 )
+from uuid import UUID
 
 from pydantic import (
     AnyUrl,
@@ -120,6 +121,10 @@ _UnsatisfiableType = Annotated[Any, BeforeValidator(_reject_all)]
 
 FORMAT_TYPES: dict[str, Any] = {
     "date-time": datetime,
+    "date": date,
+    "time": time,
+    "duration": timedelta,
+    "uuid": UUID,
     "email": EmailStr,
     "uri": AnyUrl,
     "json": Json,

--- a/tests/utilities/json_schema_type/test_formats.py
+++ b/tests/utilities/json_schema_type/test_formats.py
@@ -1,7 +1,8 @@
 """Tests for format handling in JSON schema conversion."""
 
 from dataclasses import Field
-from datetime import datetime
+from datetime import date, datetime, time, timedelta
+from uuid import UUID
 
 import pytest
 from pydantic import AnyUrl, TypeAdapter, ValidationError
@@ -37,6 +38,37 @@ class TestFormatTypes:
     @pytest.fixture
     def json_format(self):
         return json_schema_to_type({"type": "string", "format": "json"})
+
+    @pytest.fixture
+    def date_format(self):
+        return json_schema_to_type({"type": "string", "format": "date"})
+
+    @pytest.fixture
+    def time_format(self):
+        return json_schema_to_type({"type": "string", "format": "time"})
+
+    @pytest.fixture
+    def duration_format(self):
+        return json_schema_to_type({"type": "string", "format": "duration"})
+
+    @pytest.fixture
+    def uuid_format(self):
+        return json_schema_to_type({"type": "string", "format": "uuid"})
+
+    @pytest.fixture
+    def datetime_family_object(self):
+        return json_schema_to_type(
+            {
+                "type": "object",
+                "properties": {
+                    "ts": {"type": "string", "format": "date-time"},
+                    "day": {"type": "string", "format": "date"},
+                    "at": {"type": "string", "format": "time"},
+                    "dur": {"type": "string", "format": "duration"},
+                    "ident": {"type": "string", "format": "uuid"},
+                },
+            }
+        )
 
     @pytest.fixture
     def mixed_formats_object(self):
@@ -104,6 +136,63 @@ class TestFormatTypes:
         validator = TypeAdapter(json_format)
         with pytest.raises(ValidationError):
             validator.validate_python("{invalid json}")
+
+    def test_date_valid(self, date_format):
+        validator = TypeAdapter(date_format)
+        result = validator.validate_python("2024-01-17")
+        assert isinstance(result, date)
+
+    def test_date_invalid(self, date_format):
+        validator = TypeAdapter(date_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-date")
+
+    def test_time_valid(self, time_format):
+        validator = TypeAdapter(time_format)
+        result = validator.validate_python("12:34:56")
+        assert isinstance(result, time)
+
+    def test_time_invalid(self, time_format):
+        validator = TypeAdapter(time_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-time")
+
+    def test_duration_valid(self, duration_format):
+        validator = TypeAdapter(duration_format)
+        result = validator.validate_python("P1D")
+        assert isinstance(result, timedelta)
+
+    def test_duration_invalid(self, duration_format):
+        validator = TypeAdapter(duration_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-duration")
+
+    def test_uuid_valid(self, uuid_format):
+        validator = TypeAdapter(uuid_format)
+        result = validator.validate_python("00000000-0000-0000-0000-000000000007")
+        assert isinstance(result, UUID)
+
+    def test_uuid_invalid(self, uuid_format):
+        validator = TypeAdapter(uuid_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-uuid")
+
+    def test_datetime_family_object_hydrates_all_types(self, datetime_family_object):
+        validator = TypeAdapter(datetime_family_object)
+        result = validator.validate_python(
+            {
+                "ts": "2024-01-01T12:00:00",
+                "day": "2024-01-01",
+                "at": "01:02:00",
+                "dur": "P1D",
+                "ident": "00000000-0000-0000-0000-000000000007",
+            }
+        )
+        assert isinstance(result.ts, datetime)
+        assert isinstance(result.day, date)
+        assert isinstance(result.at, time)
+        assert isinstance(result.dur, timedelta)
+        assert isinstance(result.ident, UUID)
 
     def test_mixed_formats_object(self, mixed_formats_object):
         validator = TypeAdapter(mixed_formats_object)


### PR DESCRIPTION
## Description

`FORMAT_TYPES` in `json_schema_type.py` maps `date-time` to `datetime`, but leaves `date`, `time`, `duration` and `uuid` unmapped, so `_create_string_type` falls back to `str` for them. A client reconstructing a tool's output schema gets a real `datetime` for one field and an ISO string for the `date` sitting next to it, even though the server emitted `"format": "date"` for it.

All four are standard JSON Schema string formats, and pydantic both emits them for the corresponding Python types and validates them back from strings — so mapping them is the whole fix.

Closes #4899

## Contribution type

- Bug fix (simple, well-scoped fix for a clearly broken behavior)

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](https://github.com/PrefectHQ/fastmcp/blob/main/CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run the relevant test suite and all checks pass
- [x] I have self-reviewed my changes

## Tests

Added to `tests/utilities/json_schema_type/test_formats.py`, following the existing fixture-per-format pattern: valid/invalid cases for each of the four formats, plus one test over an object carrying the whole datetime family at once (the shape a model-returning tool actually produces).

Without the change, 9 of the 21 tests in that file fail; with it, all 21 pass. `tests/utilities/json_schema_type` is 179 passed / 1 skipped.

## Scope

Left alone deliberately, since they are not standard JSON Schema formats and are a separate decision: `format: path` (pydantic-specific, for `Path`) and `format: binary` (OpenAPI, for `bytes`) both still come back as `str`.
