### PR TITLE
fix: hydrate binary and path formats in json_schema_to_type

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema_type.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema_type.py
@@ -61,6 +61,7 @@ from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import MISSING, field, make_dataclass
 from datetime import date, datetime, time, timedelta
+from pathlib import Path
 from typing import (
     Annotated,
     Any,
@@ -125,6 +126,8 @@ FORMAT_TYPES: dict[str, Any] = {
     "time": time,
     "duration": timedelta,
     "uuid": UUID,
+    "binary": bytes,
+    "path": Path,
     "email": EmailStr,
     "uri": AnyUrl,
     "json": Json,

--- a/fastmcp_slim/fastmcp/utilities/json_schema_type.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema_type.py
@@ -60,7 +60,7 @@ import warnings
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import MISSING, field, make_dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time, timedelta
 from typing import (
     Annotated,
     Any,
@@ -69,6 +69,7 @@ from typing import (
     Union,
     cast,
 )
+from uuid import UUID
 
 from pydantic import (
     AnyUrl,
@@ -120,6 +121,10 @@ _UnsatisfiableType = Annotated[Any, BeforeValidator(_reject_all)]
 
 FORMAT_TYPES: dict[str, Any] = {
     "date-time": datetime,
+    "date": date,
+    "time": time,
+    "duration": timedelta,
+    "uuid": UUID,
     "email": EmailStr,
     "uri": AnyUrl,
     "json": Json,

--- a/tests/utilities/json_schema_type/test_formats.py
+++ b/tests/utilities/json_schema_type/test_formats.py
@@ -1,7 +1,8 @@
 """Tests for format handling in JSON schema conversion."""
 
 from dataclasses import Field
-from datetime import datetime
+from datetime import date, datetime, time, timedelta
+from uuid import UUID
 
 import pytest
 from pydantic import AnyUrl, TypeAdapter, ValidationError
@@ -37,6 +38,37 @@ class TestFormatTypes:
     @pytest.fixture
     def json_format(self):
         return json_schema_to_type({"type": "string", "format": "json"})
+
+    @pytest.fixture
+    def date_format(self):
+        return json_schema_to_type({"type": "string", "format": "date"})
+
+    @pytest.fixture
+    def time_format(self):
+        return json_schema_to_type({"type": "string", "format": "time"})
+
+    @pytest.fixture
+    def duration_format(self):
+        return json_schema_to_type({"type": "string", "format": "duration"})
+
+    @pytest.fixture
+    def uuid_format(self):
+        return json_schema_to_type({"type": "string", "format": "uuid"})
+
+    @pytest.fixture
+    def datetime_family_object(self):
+        return json_schema_to_type(
+            {
+                "type": "object",
+                "properties": {
+                    "ts": {"type": "string", "format": "date-time"},
+                    "day": {"type": "string", "format": "date"},
+                    "at": {"type": "string", "format": "time"},
+                    "dur": {"type": "string", "format": "duration"},
+                    "ident": {"type": "string", "format": "uuid"},
+                },
+            }
+        )
 
     @pytest.fixture
     def mixed_formats_object(self):
@@ -104,6 +136,63 @@ class TestFormatTypes:
         validator = TypeAdapter(json_format)
         with pytest.raises(ValidationError):
             validator.validate_python("{invalid json}")
+
+    def test_date_valid(self, date_format):
+        validator = TypeAdapter(date_format)
+        result = validator.validate_python("2024-01-17")
+        assert isinstance(result, date)
+
+    def test_date_invalid(self, date_format):
+        validator = TypeAdapter(date_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-date")
+
+    def test_time_valid(self, time_format):
+        validator = TypeAdapter(time_format)
+        result = validator.validate_python("12:34:56")
+        assert isinstance(result, time)
+
+    def test_time_invalid(self, time_format):
+        validator = TypeAdapter(time_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-time")
+
+    def test_duration_valid(self, duration_format):
+        validator = TypeAdapter(duration_format)
+        result = validator.validate_python("P1D")
+        assert isinstance(result, timedelta)
+
+    def test_duration_invalid(self, duration_format):
+        validator = TypeAdapter(duration_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-duration")
+
+    def test_uuid_valid(self, uuid_format):
+        validator = TypeAdapter(uuid_format)
+        result = validator.validate_python("00000000-0000-0000-0000-000000000007")
+        assert isinstance(result, UUID)
+
+    def test_uuid_invalid(self, uuid_format):
+        validator = TypeAdapter(uuid_format)
+        with pytest.raises(ValidationError):
+            validator.validate_python("not-a-uuid")
+
+    def test_datetime_family_object_hydrates_all_types(self, datetime_family_object):
+        validator = TypeAdapter(datetime_family_object)
+        result = validator.validate_python(
+            {
+                "ts": "2024-01-01T12:00:00",
+                "day": "2024-01-01",
+                "at": "01:02:00",
+                "dur": "P1D",
+                "ident": "00000000-0000-0000-0000-000000000007",
+            }
+        )
+        assert isinstance(result.ts, datetime)
+        assert isinstance(result.day, date)
+        assert isinstance(result.at, time)
+        assert isinstance(result.dur, timedelta)
+        assert isinstance(result.ident, UUID)
 
     def test_mixed_formats_object(self, mixed_formats_object):
         validator = TypeAdapter(mixed_formats_object)

--- a/tests/utilities/json_schema_type/test_formats.py
+++ b/tests/utilities/json_schema_type/test_formats.py
@@ -2,6 +2,7 @@
 
 from dataclasses import Field
 from datetime import date, datetime, time, timedelta
+from pathlib import Path
 from uuid import UUID
 
 import pytest
@@ -54,6 +55,26 @@ class TestFormatTypes:
     @pytest.fixture
     def uuid_format(self):
         return json_schema_to_type({"type": "string", "format": "uuid"})
+
+    @pytest.fixture
+    def binary_format(self):
+        return json_schema_to_type({"type": "string", "format": "binary"})
+
+    @pytest.fixture
+    def path_format(self):
+        return json_schema_to_type({"type": "string", "format": "path"})
+
+    @pytest.fixture
+    def binary_path_object(self):
+        return json_schema_to_type(
+            {
+                "type": "object",
+                "properties": {
+                    "data": {"type": "string", "format": "binary"},
+                    "path": {"type": "string", "format": "path"},
+                },
+            }
+        )
 
     @pytest.fixture
     def datetime_family_object(self):
@@ -176,6 +197,26 @@ class TestFormatTypes:
         validator = TypeAdapter(uuid_format)
         with pytest.raises(ValidationError):
             validator.validate_python("not-a-uuid")
+
+    def test_binary_valid(self, binary_format):
+        validator = TypeAdapter(binary_format)
+        result = validator.validate_python("\x00\x01")
+        assert isinstance(result, bytes)
+        assert result == b"\x00\x01"
+
+    def test_path_valid(self, path_format):
+        validator = TypeAdapter(path_format)
+        result = validator.validate_python("/tmp/foo.txt")
+        assert isinstance(result, Path)
+
+    def test_binary_path_object_hydrates_types(self, binary_path_object):
+        validator = TypeAdapter(binary_path_object)
+        result = validator.validate_python(
+            {"data": "\x00\x01", "path": "/tmp/foo.txt"}
+        )
+        assert isinstance(result.data, bytes)
+        assert result.data == b"\x00\x01"
+        assert isinstance(result.path, Path)
 
     def test_datetime_family_object_hydrates_all_types(self, datetime_family_object):
         validator = TypeAdapter(datetime_family_object)


### PR DESCRIPTION
Fixes #4907

## Summary

`bytes` and `Path` tool outputs were returned to the client as raw strings instead of Python objects. The server's output schema already emits `"format": "binary"` for `bytes` and `"format": "path"` for `Path`, but `FORMAT_TYPES` in `json_schema_type.py` mapped neither, so `_create_string_type` fell back to `str`.

This PR adds the missing mappings so structured tool results hydrate to real Python types, matching the behavior of the other complex formats (`date-time`, `date`, `time`, `duration`, `uuid`).

## Changes

- `fastmcp_slim/fastmcp/utilities/json_schema_type.py`: map `"binary"` → `bytes` and `"path"` → `Path` in `FORMAT_TYPES`.
- `tests/utilities/json_schema_type/test_formats.py`: tests for binary/path scalar formats and an object mixing both.

Also included (same root cause, same file): mapping `"date"`, `"time"`, `"duration"`, and `"uuid"` formats so the full datetime family hydrates correctly.

## Verification

- `pytest tests/utilities/json_schema_type/` → 182 passed, 1 skipped.
- End-to-end: a tool returning `Reading(data=b"\x00\x01", path=Path("/tmp/foo.txt"))` now yields `data: bytes` and `path: Path` on the client.
