### PR TITLE
fix(auth): replay duplicate refresh rotations

### DIFF
--- a/docs/servers/auth/oauth-proxy.mdx
+++ b/docs/servers/auth/oauth-proxy.mdx
@@ -555,6 +555,26 @@ Extending the lifetime only works when the upstream provider issues a refresh to
 
 The proxy issues its own refresh tokens that map to upstream refresh tokens. When a client uses a FastMCP refresh token, the proxy refreshes the upstream token and issues a new FastMCP access token.
 
+By default, rotation enforces one-time use: retrying a consumed refresh token returns `invalid_grant`. Distributed clients sometimes submit the same refresh concurrently or retry after losing a successful response. You can opt into a short idempotency window with `refresh_token_grace_period_seconds`:
+
+```python
+from fastmcp.server.auth import OAuthProxy
+
+auth = OAuthProxy(
+    upstream_authorization_endpoint="https://provider.com/oauth/authorize",
+    upstream_token_endpoint="https://provider.com/oauth/token",
+    upstream_client_id="your-client-id",
+    upstream_client_secret="your-client-secret",
+    token_verifier=token_verifier,
+    base_url="https://your-server.com",
+    refresh_token_grace_period_seconds=30,
+)
+```
+
+During this window, an identical retry receives the exact response produced by the original rotation; it does not refresh upstream again or create another refresh-token descendant. A predecessor can only be replayed while its immediate successor remains active. Once that successor is consumed, revoked, or expired, older responses cannot be recovered.
+
+The setting defaults to `0` and accepts at most 60 seconds. A nonzero value deliberately trades some replay detection for resilience to lost responses: anyone holding the consumed bearer token during the window can obtain its successor. Use the shortest interval your clients require. The parameter is available on every provider built on the OAuth proxy.
+
 ### PKCE Forwarding
 
 The OAuth proxy automatically handles PKCE (Proof Key for Code Exchange) when working with providers that support or require it. The proxy generates its own PKCE parameters to send upstream while separately validating the client's PKCE, ensuring end-to-end security at both layers.

--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py
@@ -9,7 +9,11 @@ import hashlib
 from typing import Any, Final
 from urllib.parse import urlparse
 
-from mcp.shared.auth import InvalidRedirectUriError, OAuthClientInformationFull
+from mcp.shared.auth import (
+    InvalidRedirectUriError,
+    OAuthClientInformationFull,
+    OAuthToken,
+)
 from pydantic import AnyUrl, BaseModel, Field, ValidationError
 
 from fastmcp.server.auth.cimd import CIMDDocument
@@ -146,6 +150,18 @@ class RefreshTokenMetadata(BaseModel):
     client_id: str
     scopes: list[str]
     expires_at: int | None = None
+    created_at: float
+
+
+class RefreshTokenRotationResponse(BaseModel):
+    """A short-lived response for an idempotent refresh-token retry."""
+
+    client_id: str
+    refresh_token_scopes: list[str]
+    refresh_token_expires_at: int | None
+    request_scopes: list[str]
+    token_response: OAuthToken
+    successor_token_hash: str
     created_at: float
 
 

--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -105,6 +105,7 @@ from fastmcp.server.auth.oauth_proxy.models import (
     OAuthTransaction,
     ProxyDCRClient,
     RefreshTokenMetadata,
+    RefreshTokenRotationResponse,
     UpstreamTokenSet,
     _hash_token,
 )
@@ -341,6 +342,8 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         fastmcp_access_token_expiry_seconds: int | None = None,
         # Token refresh threshold
         token_expiry_threshold_seconds: int = 0,
+        # Client refresh-token retry grace period
+        refresh_token_grace_period_seconds: int = 0,
         # CIMD (Client ID Metadata Document) support
         enable_cimd: bool = True,
         # Identity assertion (SEP-990 ID-JAG) support
@@ -440,6 +443,11 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 a token as expired (default 0). This prevents race conditions where a token
                 passes the expiry check but expires before the next operation completes.
                 For example, set to 30 to refresh tokens that will expire within 30 seconds.
+            refresh_token_grace_period_seconds: Number of seconds after client-facing
+                refresh-token rotation in which an identical retry returns the original
+                successful response. Defaults to 0 (disabled) because accepting a consumed
+                bearer token weakens replay detection. Values from 1 to 60 can absorb lost
+                responses and concurrent refreshes without creating another token descendant.
             enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
                 client IDs. When True, clients can authenticate using HTTPS URLs as client
                 IDs, with metadata fetched from the URL. Supports private_key_jwt auth.
@@ -553,6 +561,11 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             fastmcp_access_token_expiry_seconds
         )
         self._token_expiry_threshold_seconds: int = token_expiry_threshold_seconds
+        if not 0 <= refresh_token_grace_period_seconds <= 60:
+            raise ValueError(
+                "refresh_token_grace_period_seconds must be between 0 and 60"
+            )
+        self._refresh_token_grace_period_seconds = refresh_token_grace_period_seconds
 
         if jwt_signing_key is None:
             if upstream_client_secret is None:
@@ -690,6 +703,14 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 default_collection="mcp-refresh-tokens",
                 raise_on_validation_error=True,
             )
+        )
+        self._refresh_token_rotation_store: PydanticAdapter[
+            RefreshTokenRotationResponse
+        ] = PydanticAdapter[RefreshTokenRotationResponse](
+            key_value=self._client_storage,
+            pydantic_model=RefreshTokenRotationResponse,
+            default_collection="mcp-refresh-token-rotations",
+            raise_on_validation_error=True,
         )
 
         # Use the provided token validator
@@ -1727,6 +1748,51 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         _ = idp_tokens
         return None
 
+    async def _load_refresh_token_rotation(
+        self,
+        token_hash: str,
+        client_id: str | None,
+        request_scopes: list[str] | None = None,
+    ) -> RefreshTokenRotationResponse | None:
+        if not self._refresh_token_grace_period_seconds or client_id is None:
+            return None
+
+        rotation = await self._refresh_token_rotation_store.get(key=token_hash)
+        if rotation is None or rotation.client_id != client_id:
+            return None
+        if request_scopes is not None and sorted(rotation.request_scopes) != sorted(
+            request_scopes
+        ):
+            return None
+
+        successor_token = rotation.token_response.refresh_token
+        successor = await self._refresh_token_store.get(
+            key=rotation.successor_token_hash
+        )
+        if (
+            successor_token is None
+            or successor is None
+            or successor.client_id != client_id
+        ):
+            await self._refresh_token_rotation_store.delete(key=token_hash)
+            return None
+        try:
+            successor_payload = self.jwt_issuer.verify_token(
+                successor_token, expected_token_use="refresh"
+            )
+            successor_jti = successor_payload["jti"]
+        except (JoseError, KeyError):
+            successor_jti = None
+        successor_mapping = (
+            await self._jti_mapping_store.get(key=successor_jti)
+            if successor_jti is not None
+            else None
+        )
+        if successor_mapping is None:
+            await self._refresh_token_rotation_store.delete(key=token_hash)
+            return None
+        return rotation
+
     async def load_refresh_token(
         self,
         client: OAuthClientInformationFull,
@@ -1740,6 +1806,16 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         token_hash = _hash_token(refresh_token)
         metadata = await self._refresh_token_store.get(key=token_hash)
         if not metadata:
+            rotation = await self._load_refresh_token_rotation(
+                token_hash, client.client_id
+            )
+            if rotation is not None:
+                return RefreshToken(
+                    token=refresh_token,
+                    client_id=rotation.client_id,
+                    scopes=rotation.refresh_token_scopes,
+                    expires_at=rotation.refresh_token_expires_at,
+                )
             logger.warning(
                 "Refresh token not found for client=%s (token_hash=%s); it was "
                 "already rotated, expired, or revoked. Rejecting with invalid_grant, "
@@ -1769,16 +1845,37 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         refresh_token: RefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        """Exchange FastMCP refresh token for new FastMCP access token.
+        """Exchange a FastMCP refresh token, replaying an eligible retry."""
+        if not self._refresh_token_grace_period_seconds:
+            return await self._exchange_refresh_token_once(
+                client, refresh_token, scopes
+            )
 
-        Implements two-tier refresh:
-        1. Verify FastMCP refresh token
-        2. Look up upstream token via JTI mapping
-        3. Refresh upstream token with upstream provider
-        4. Update stored upstream token
-        5. Issue new FastMCP access token
-        6. Keep same FastMCP refresh token (unless upstream rotates)
-        """
+        token_hash = _hash_token(refresh_token.token)
+        lock = self._get_refresh_lock(f"client-refresh:{token_hash}")
+        async with lock:
+            rotation = await self._load_refresh_token_rotation(
+                token_hash, client.client_id, scopes
+            )
+            if rotation is not None:
+                logger.info(
+                    "Replayed refresh-token rotation response for client=%s "
+                    "(token_hash=%s)",
+                    client.client_id,
+                    token_hash[:8],
+                )
+                return rotation.token_response
+            return await self._exchange_refresh_token_once(
+                client, refresh_token, scopes
+            )
+
+    async def _exchange_refresh_token_once(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        """Perform one upstream refresh and rotate the client-facing token."""
         # Verify FastMCP refresh token
         try:
             refresh_payload = self.jwt_issuer.verify_token(
@@ -1978,15 +2075,9 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             ttl=refresh_ttl,  # Align with upstream refresh token expiry
         )
 
-        # Invalidate old refresh token (refresh token rotation - enforces one-time use)
-        await self._jti_mapping_store.delete(key=refresh_jti)
-        logger.debug(
-            "Rotated refresh token (old JTI invalidated - one-time use enforced)"
-        )
-
-        # Store new refresh token metadata (keyed by hash)
+        new_refresh_token_hash = _hash_token(new_fastmcp_refresh)
         await self._refresh_token_store.put(
-            key=_hash_token(new_fastmcp_refresh),
+            key=new_refresh_token_hash,
             value=RefreshTokenMetadata(
                 client_id=client.client_id,
                 scopes=refreshed_scopes,
@@ -1996,8 +2087,40 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             ttl=refresh_ttl,
         )
 
-        # Delete old refresh token (by hash)
-        await self._refresh_token_store.delete(key=_hash_token(refresh_token.token))
+        client_token_response = OAuthToken(
+            access_token=new_fastmcp_access,
+            token_type="Bearer",
+            expires_in=fastmcp_access_expires_in,
+            refresh_token=new_fastmcp_refresh,
+            scope=" ".join(refreshed_scopes),
+        )
+        old_refresh_token_hash = _hash_token(refresh_token.token)
+        rotation_ttl = self._refresh_token_grace_period_seconds
+        if refresh_token.expires_at is not None:
+            rotation_ttl = min(
+                rotation_ttl,
+                max(refresh_token.expires_at - time.time(), 0),
+            )
+        if rotation_ttl:
+            await self._refresh_token_rotation_store.put(
+                key=old_refresh_token_hash,
+                value=RefreshTokenRotationResponse(
+                    client_id=client.client_id,
+                    refresh_token_scopes=refresh_token.scopes,
+                    refresh_token_expires_at=refresh_token.expires_at,
+                    request_scopes=scopes,
+                    token_response=client_token_response,
+                    successor_token_hash=new_refresh_token_hash,
+                    created_at=time.time(),
+                ),
+                ttl=rotation_ttl,
+            )
+
+        await self._jti_mapping_store.delete(key=refresh_jti)
+        await self._refresh_token_store.delete(key=old_refresh_token_hash)
+        logger.debug(
+            "Rotated refresh token (old JTI invalidated - one-time use enforced)"
+        )
 
         logger.info(
             "Issued new FastMCP tokens (rotated refresh) for client=%s (access_jti=%s, refresh_jti=%s)",
@@ -2005,15 +2128,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             new_access_jti[:8],
             new_refresh_jti[:8],
         )
-
-        # Return new FastMCP tokens (both access AND refresh are new)
-        return OAuthToken(
-            access_token=new_fastmcp_access,
-            token_type="Bearer",
-            expires_in=fastmcp_access_expires_in,
-            refresh_token=new_fastmcp_refresh,  # NEW refresh token (rotated)
-            scope=" ".join(refreshed_scopes),
-        )
+        return client_token_response
 
     # -------------------------------------------------------------------------
     # Token Validation
@@ -2332,7 +2447,9 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         """
         # For refresh tokens, delete from local storage by hash
         if isinstance(token, RefreshToken):
-            await self._refresh_token_store.delete(key=_hash_token(token.token))
+            token_hash = _hash_token(token.token)
+            await self._refresh_token_store.delete(key=token_hash)
+            await self._refresh_token_rotation_store.delete(key=token_hash)
 
         # ID-JAG access tokens are self-contained and never known upstream, so
         # upstream revocation cannot invalidate them. Track the jti locally so

--- a/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py
@@ -246,6 +246,8 @@ class OIDCProxy(OAuthProxy):
         fastmcp_access_token_expiry_seconds: int | None = None,
         # Token refresh threshold
         token_expiry_threshold_seconds: int = 0,
+        # Client refresh-token retry grace period
+        refresh_token_grace_period_seconds: int = 0,
         # CIMD configuration
         enable_cimd: bool = True,
         # Identity assertion (SEP-990 ID-JAG) support
@@ -339,6 +341,9 @@ class OIDCProxy(OAuthProxy):
             token_expiry_threshold_seconds: Number of seconds before actual expiry to consider
                 a token as expired (default 0). Prevents race conditions where a token
                 passes the expiry check but expires before the next operation completes.
+            refresh_token_grace_period_seconds: Number of seconds after client-facing
+                refresh-token rotation in which an identical retry returns the original
+                successful response. Defaults to 0; values must be between 0 and 60.
             enable_cimd: Whether to enable CIMD (Client ID Metadata Document) client support.
                 When True, clients can use their metadata document URL as client_id instead of
                 Dynamic Client Registration. Default is True.
@@ -436,6 +441,7 @@ class OIDCProxy(OAuthProxy):
             "fallback_refresh_token_expiry_seconds": fallback_refresh_token_expiry_seconds,
             "fastmcp_access_token_expiry_seconds": fastmcp_access_token_expiry_seconds,
             "token_expiry_threshold_seconds": token_expiry_threshold_seconds,
+            "refresh_token_grace_period_seconds": refresh_token_grace_period_seconds,
             "enable_cimd": enable_cimd,
             "identity_assertion": identity_assertion,
         }

--- a/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/auth0.py
@@ -104,6 +104,7 @@ class Auth0Provider(OIDCProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         enable_cimd: bool = True,
     ) -> None:
         """Initialize Auth0 OAuth provider.
@@ -150,6 +151,9 @@ class Auth0Provider(OIDCProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
             enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
                 client IDs (default True). Set to False to disable.
         """
@@ -178,6 +182,7 @@ class Auth0Provider(OIDCProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             enable_cimd=enable_cimd,
         )
 

--- a/fastmcp_slim/fastmcp/server/auth/providers/aws.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/aws.py
@@ -144,6 +144,7 @@ class AWSCognitoProvider(OIDCProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         enable_cimd: bool = True,
     ):
         """Initialize AWS Cognito OAuth provider.
@@ -190,6 +191,9 @@ class AWSCognitoProvider(OIDCProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
             enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
                 client IDs (default True). Set to False to disable.
         """
@@ -227,6 +231,7 @@ class AWSCognitoProvider(OIDCProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             enable_cimd=enable_cimd,
         )
 

--- a/fastmcp_slim/fastmcp/server/auth/providers/azure.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/azure.py
@@ -118,6 +118,7 @@ class AzureProvider(OAuthProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         base_authority: str = "login.microsoftonline.com",
         token_issuer: str | None = None,
         http_client: httpx2.AsyncClient | None = None,
@@ -193,6 +194,9 @@ class AzureProvider(OAuthProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
         """
         # Parse scopes if provided as string
         parsed_required_scopes = parse_scopes(required_scopes)
@@ -278,6 +282,7 @@ class AzureProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             valid_scopes=parsed_required_scopes,
             enable_cimd=enable_cimd,
         )

--- a/fastmcp_slim/fastmcp/server/auth/providers/clerk.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/clerk.py
@@ -293,6 +293,7 @@ class ClerkProvider(OAuthProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         extra_authorize_params: dict[str, str] | None = None,
         http_client: httpx2.AsyncClient | None = None,
         enable_cimd: bool = True,
@@ -350,6 +351,9 @@ class ClerkProvider(OAuthProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
         """
         domain = domain.rstrip("/")
 
@@ -395,6 +399,7 @@ class ClerkProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             extra_authorize_params=extra_authorize_params_final or None,
             valid_scopes=parsed_valid_scopes,
             enable_cimd=enable_cimd,

--- a/fastmcp_slim/fastmcp/server/auth/providers/discord.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/discord.py
@@ -211,6 +211,7 @@ class DiscordProvider(OAuthProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         http_client: httpx2.AsyncClient | None = None,
         enable_cimd: bool = True,
     ):
@@ -261,6 +262,9 @@ class DiscordProvider(OAuthProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
         """
         # Parse scopes if provided as string
         required_scopes_final = (
@@ -297,6 +301,7 @@ class DiscordProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             enable_cimd=enable_cimd,
         )
 

--- a/fastmcp_slim/fastmcp/server/auth/providers/github.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/github.py
@@ -235,6 +235,7 @@ class GitHubProvider(OAuthProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         http_client: httpx2.AsyncClient | None = None,
         enable_cimd: bool = True,
     ):
@@ -286,6 +287,9 @@ class GitHubProvider(OAuthProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
         """
         # Parse scopes if provided as string
         required_scopes_final = (
@@ -321,6 +325,7 @@ class GitHubProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             enable_cimd=enable_cimd,
         )
 

--- a/fastmcp_slim/fastmcp/server/auth/providers/google.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/google.py
@@ -271,6 +271,7 @@ class GoogleProvider(OAuthProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         extra_authorize_params: dict[str, str] | None = None,
         http_client: httpx2.AsyncClient | None = None,
         enable_cimd: bool = True,
@@ -334,6 +335,9 @@ class GoogleProvider(OAuthProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
         """
         # Parse scopes if provided as string
         # Google requires at least one scope - openid is the minimal OIDC scope
@@ -393,6 +397,7 @@ class GoogleProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             extra_authorize_params=extra_authorize_params_final,
             valid_scopes=valid_scopes_final,
             enable_cimd=enable_cimd,

--- a/fastmcp_slim/fastmcp/server/auth/providers/huggingface.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/huggingface.py
@@ -196,6 +196,7 @@ class HuggingFaceProvider(OAuthProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         extra_authorize_params: dict[str, str] | None = None,
         extra_token_params: dict[str, str] | None = None,
         http_client: httpx2.AsyncClient | None = None,
@@ -215,6 +216,9 @@ class HuggingFaceProvider(OAuthProxy):
             required_scopes: Required Hugging Face scopes. Defaults to
                 ``["openid", "profile"]``.
             valid_scopes: Scopes clients may request. Defaults to required scopes.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
             extra_authorize_params: Extra authorization parameters, such as
                 ``{"orgIds": "your-org-id"}`` for organization grants.
         """
@@ -256,6 +260,7 @@ class HuggingFaceProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             extra_authorize_params=extra_authorize_params,
             extra_token_params=extra_token_params,
             token_endpoint_auth_method="client_secret_basic"

--- a/fastmcp_slim/fastmcp/server/auth/providers/oci.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/oci.py
@@ -141,6 +141,7 @@ class OCIProvider(OIDCProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         enable_cimd: bool = True,
     ) -> None:
         """Initialize OCI OIDC provider.
@@ -175,6 +176,9 @@ class OCIProvider(OIDCProxy):
                 refresh gracefully (e.g. `mcp-remote`). See `OAuthProxy` for details.
             token_expiry_threshold_seconds: Number of seconds before actual expiry to
                 treat a token as expired, refreshing early to avoid races. Defaults to 0.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
             enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
                 client IDs (default True). Set to False to disable.
         """
@@ -203,6 +207,7 @@ class OCIProvider(OIDCProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             enable_cimd=enable_cimd,
         )
 

--- a/fastmcp_slim/fastmcp/server/auth/providers/workos.py
+++ b/fastmcp_slim/fastmcp/server/auth/providers/workos.py
@@ -180,6 +180,7 @@ class WorkOSProvider(OAuthProxy):
         fallback_refresh_token_expiry_seconds: int | None = None,
         fastmcp_access_token_expiry_seconds: int | None = None,
         token_expiry_threshold_seconds: int = 0,
+        refresh_token_grace_period_seconds: int = 0,
         extra_authorize_params: dict[str, str] | None = None,
         http_client: httpx2.AsyncClient | None = None,
         enable_cimd: bool = True,
@@ -232,6 +233,9 @@ class WorkOSProvider(OAuthProxy):
             token_expiry_threshold_seconds: Number of seconds before actual expiry to consider
                 a token as expired (default 0). Prevents race conditions where a token
                 passes the expiry check but expires before the next operation completes.
+            refresh_token_grace_period_seconds: Seconds in which an identical
+                retry of a rotated client refresh token returns the original response.
+                Defaults to 0 (disabled); values must be between 0 and 60.
             http_client: Optional httpx2.AsyncClient for connection pooling in token verification.
                 When provided, the client is reused across verify_token calls and the caller
                 is responsible for its lifecycle. When None (default), a fresh client is created per call.
@@ -278,6 +282,7 @@ class WorkOSProvider(OAuthProxy):
             fallback_refresh_token_expiry_seconds=fallback_refresh_token_expiry_seconds,
             fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
             token_expiry_threshold_seconds=token_expiry_threshold_seconds,
+            refresh_token_grace_period_seconds=refresh_token_grace_period_seconds,
             extra_authorize_params=extra_authorize_params,
             valid_scopes=valid_scopes_final,
             enable_cimd=enable_cimd,

--- a/tests/server/auth/oauth_proxy/test_refresh_token_rotation.py
+++ b/tests/server/auth/oauth_proxy/test_refresh_token_rotation.py
@@ -242,9 +242,7 @@ async def test_grace_does_not_replay_for_another_client():
         return_value=setup.upstream_client,
     ):
         first = await post_refresh(setup, setup.refresh_token)
-        replay = await setup.proxy.load_refresh_token(
-            other_client, setup.refresh_token
-        )
+        replay = await setup.proxy.load_refresh_token(other_client, setup.refresh_token)
 
     assert first.status_code == 200
     assert replay is None
@@ -262,9 +260,7 @@ async def test_revoking_predecessor_removes_rotation_response():
         return_value=setup.upstream_client,
     ):
         first = await post_refresh(setup, setup.refresh_token)
-        predecessor = await setup.proxy.load_refresh_token(
-            client, setup.refresh_token
-        )
+        predecessor = await setup.proxy.load_refresh_token(client, setup.refresh_token)
         assert predecessor is not None
         await setup.proxy.revoke_token(predecessor)
         replay = await setup.proxy.load_refresh_token(client, setup.refresh_token)

--- a/tests/server/auth/oauth_proxy/test_refresh_token_rotation.py
+++ b/tests/server/auth/oauth_proxy/test_refresh_token_rotation.py
@@ -1,0 +1,308 @@
+import asyncio
+import secrets
+import time
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import httpx2
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+from mcp.server.auth.provider import TokenError
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+from starlette.applications import Starlette
+
+from fastmcp import FastMCP
+from fastmcp.server.auth.auth import AccessToken, TokenVerifier
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.oauth_proxy.models import (
+    JTIMapping,
+    RefreshTokenMetadata,
+    UpstreamTokenSet,
+    _hash_token,
+)
+
+
+class AcceptingVerifier(TokenVerifier):
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return AccessToken(
+            token=token,
+            client_id="upstream-client",
+            scopes=["read"],
+            expires_at=int(time.time()) + 3600,
+        )
+
+
+@dataclass
+class RotationSetup:
+    proxy: OAuthProxy
+    app: Starlette
+    refresh_token: str
+    upstream_client: AsyncMock
+
+
+async def build_rotation_setup(
+    *, grace_period: int = 0, upstream_delay: float = 0
+) -> RotationSetup:
+    proxy = OAuthProxy(
+        upstream_authorization_endpoint="https://idp.example.com/authorize",
+        upstream_token_endpoint="https://idp.example.com/token",
+        upstream_client_id="upstream-client",
+        upstream_client_secret="upstream-secret",
+        token_verifier=AcceptingVerifier(),
+        base_url="https://proxy.example.com",
+        jwt_signing_key="test-only-signing-key",
+        client_storage=MemoryStore(),
+        refresh_token_grace_period_seconds=grace_period,
+    )
+    app = FastMCP("refresh rotation", auth=proxy).http_app()
+    await proxy.register_client(
+        OAuthClientInformationFull(
+            client_id="mcp-client",
+            client_secret="mcp-secret",
+            redirect_uris=[AnyUrl("http://localhost/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+        )
+    )
+
+    now = time.time()
+    ttl = 3600
+    upstream_token_id = secrets.token_urlsafe(16)
+    refresh_jti = secrets.token_urlsafe(16)
+    refresh_token = proxy.jwt_issuer.issue_refresh_token(
+        client_id="mcp-client",
+        scopes=["read"],
+        jti=refresh_jti,
+        expires_in=ttl,
+    )
+    await proxy._upstream_token_store.put(
+        key=upstream_token_id,
+        value=UpstreamTokenSet(
+            upstream_token_id=upstream_token_id,
+            access_token="upstream-access",
+            refresh_token="upstream-refresh",
+            refresh_token_expires_at=now + ttl,
+            expires_at=now + ttl,
+            token_type="Bearer",
+            scope="read",
+            client_id="mcp-client",
+            created_at=now,
+        ),
+        ttl=ttl,
+    )
+    await proxy._jti_mapping_store.put(
+        key=refresh_jti,
+        value=JTIMapping(
+            jti=refresh_jti,
+            upstream_token_id=upstream_token_id,
+            created_at=now,
+        ),
+        ttl=ttl,
+    )
+    await proxy._refresh_token_store.put(
+        key=_hash_token(refresh_token),
+        value=RefreshTokenMetadata(
+            client_id="mcp-client",
+            scopes=["read"],
+            expires_at=int(now) + ttl,
+            created_at=now,
+        ),
+        ttl=ttl,
+    )
+
+    async def refresh_upstream(*args, **kwargs):
+        if upstream_delay:
+            await asyncio.sleep(upstream_delay)
+        return {
+            "access_token": "refreshed-upstream-access",
+            "refresh_token": "upstream-refresh",
+            "expires_in": ttl,
+            "token_type": "Bearer",
+            "scope": "read",
+        }
+
+    upstream_client = AsyncMock()
+    upstream_client.refresh_token = AsyncMock(side_effect=refresh_upstream)
+    upstream_client.aclose = AsyncMock()
+    return RotationSetup(
+        proxy=proxy,
+        app=app,
+        refresh_token=refresh_token,
+        upstream_client=upstream_client,
+    )
+
+
+async def post_refresh(
+    setup: RotationSetup, refresh_token: str, *, scope: str = "read"
+) -> httpx2.Response:
+    transport = httpx2.ASGITransport(app=setup.app)
+    async with httpx2.AsyncClient(
+        transport=transport, base_url="https://proxy.example.com"
+    ) as client:
+        return await client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": "mcp-client",
+                "client_secret": "mcp-secret",
+                "scope": scope,
+            },
+        )
+
+
+async def test_refresh_retry_is_rejected_by_default():
+    setup = await build_rotation_setup()
+    with patch(
+        "fastmcp.server.auth.oauth_proxy.proxy.AsyncOAuth2Client",
+        return_value=setup.upstream_client,
+    ):
+        first = await post_refresh(setup, setup.refresh_token)
+        retry = await post_refresh(setup, setup.refresh_token)
+
+    assert first.status_code == 200
+    assert retry.status_code == 401
+    assert retry.json() == {
+        "error": "invalid_grant",
+        "error_description": "refresh token does not exist",
+    }
+    setup.upstream_client.refresh_token.assert_awaited_once()
+
+
+async def test_refresh_retry_replays_same_response_during_grace_period():
+    setup = await build_rotation_setup(grace_period=30)
+    with patch(
+        "fastmcp.server.auth.oauth_proxy.proxy.AsyncOAuth2Client",
+        return_value=setup.upstream_client,
+    ):
+        first = await post_refresh(setup, setup.refresh_token)
+        retry = await post_refresh(setup, setup.refresh_token)
+
+    assert first.status_code == retry.status_code == 200
+    assert first.json() == retry.json()
+    setup.upstream_client.refresh_token.assert_awaited_once()
+
+
+async def test_concurrent_refresh_replays_same_response():
+    setup = await build_rotation_setup(grace_period=30, upstream_delay=0.05)
+    with patch(
+        "fastmcp.server.auth.oauth_proxy.proxy.AsyncOAuth2Client",
+        return_value=setup.upstream_client,
+    ):
+        first, second = await asyncio.gather(
+            post_refresh(setup, setup.refresh_token),
+            post_refresh(setup, setup.refresh_token),
+        )
+
+    assert first.status_code == second.status_code == 200
+    assert first.json() == second.json()
+    setup.upstream_client.refresh_token.assert_awaited_once()
+
+
+async def test_grace_does_not_replay_for_different_scopes():
+    setup = await build_rotation_setup(grace_period=30)
+    with patch(
+        "fastmcp.server.auth.oauth_proxy.proxy.AsyncOAuth2Client",
+        return_value=setup.upstream_client,
+    ):
+        first = await post_refresh(setup, setup.refresh_token)
+        loaded = await setup.proxy.load_refresh_token(
+            OAuthClientInformationFull(
+                client_id="mcp-client",
+                client_secret="mcp-secret",
+                redirect_uris=[AnyUrl("http://localhost/callback")],
+            ),
+            setup.refresh_token,
+        )
+        assert loaded is not None
+        with pytest.raises(TokenError, match="Refresh token mapping not found"):
+            await setup.proxy.exchange_refresh_token(
+                OAuthClientInformationFull(
+                    client_id="mcp-client",
+                    client_secret="mcp-secret",
+                    redirect_uris=[AnyUrl("http://localhost/callback")],
+                ),
+                loaded,
+                ["read", "write"],
+            )
+
+    assert first.status_code == 200
+    setup.upstream_client.refresh_token.assert_awaited_once()
+
+
+async def test_grace_does_not_replay_for_another_client():
+    setup = await build_rotation_setup(grace_period=30)
+    other_client = OAuthClientInformationFull(
+        client_id="other-client",
+        client_secret="other-secret",
+        redirect_uris=[AnyUrl("http://localhost/callback")],
+    )
+    with patch(
+        "fastmcp.server.auth.oauth_proxy.proxy.AsyncOAuth2Client",
+        return_value=setup.upstream_client,
+    ):
+        first = await post_refresh(setup, setup.refresh_token)
+        replay = await setup.proxy.load_refresh_token(
+            other_client, setup.refresh_token
+        )
+
+    assert first.status_code == 200
+    assert replay is None
+
+
+async def test_revoking_predecessor_removes_rotation_response():
+    setup = await build_rotation_setup(grace_period=30)
+    client = OAuthClientInformationFull(
+        client_id="mcp-client",
+        client_secret="mcp-secret",
+        redirect_uris=[AnyUrl("http://localhost/callback")],
+    )
+    with patch(
+        "fastmcp.server.auth.oauth_proxy.proxy.AsyncOAuth2Client",
+        return_value=setup.upstream_client,
+    ):
+        first = await post_refresh(setup, setup.refresh_token)
+        predecessor = await setup.proxy.load_refresh_token(
+            client, setup.refresh_token
+        )
+        assert predecessor is not None
+        await setup.proxy.revoke_token(predecessor)
+        replay = await setup.proxy.load_refresh_token(client, setup.refresh_token)
+
+    assert first.status_code == 200
+    assert replay is None
+
+
+async def test_grace_does_not_replay_superseded_successor():
+    setup = await build_rotation_setup(grace_period=30)
+    with patch(
+        "fastmcp.server.auth.oauth_proxy.proxy.AsyncOAuth2Client",
+        return_value=setup.upstream_client,
+    ):
+        first = await post_refresh(setup, setup.refresh_token)
+        successor = first.json()["refresh_token"]
+        second = await post_refresh(setup, successor)
+        replay = await post_refresh(setup, setup.refresh_token)
+
+    assert first.status_code == second.status_code == 200
+    assert replay.status_code == 401
+    assert setup.upstream_client.refresh_token.await_count == 2
+
+
+@pytest.mark.parametrize("grace_period", [-1, 61])
+def test_refresh_grace_period_is_bounded(grace_period: int):
+    with pytest.raises(
+        ValueError,
+        match="refresh_token_grace_period_seconds must be between 0 and 60",
+    ):
+        OAuthProxy(
+            upstream_authorization_endpoint="https://idp.example.com/authorize",
+            upstream_token_endpoint="https://idp.example.com/token",
+            upstream_client_id="upstream-client",
+            upstream_client_secret="upstream-secret",
+            token_verifier=AcceptingVerifier(),
+            base_url="https://proxy.example.com",
+            jwt_signing_key="test-only-signing-key",
+            client_storage=MemoryStore(),
+            refresh_token_grace_period_seconds=grace_period,
+        )


### PR DESCRIPTION
A client-facing refresh token is currently deleted as soon as it rotates, so a lost-response retry or overlapping `/token` request can turn a successful refresh into `invalid_grant` and force a new authorization flow. This adds an opt-in, bounded idempotency window that returns the exact response from the original rotation rather than refreshing upstream or minting another descendant.

The secure default remains strict one-time use. Operators that observe duplicate refreshes can enable a window of at most 60 seconds on `OAuthProxy`, `OIDCProxy`, or any built-in proxy provider:

```python
from fastmcp.server.auth.providers.azure import AzureProvider

auth = AzureProvider(
    tenant_id="your-tenant-id",
    client_id="your-client-id",
    client_secret="your-client-secret",
    base_url="https://mcp.example.com",
    refresh_token_grace_period_seconds=30,
)
```

<details>
<summary>Security model</summary>

The window defaults to zero because accepting a consumed bearer token weakens replay detection. An eligible retry must use the same client and requested scopes, and its immediate successor must still have valid refresh-token metadata and a live JTI mapping. Consuming or revoking the successor invalidates the predecessor's cached response, preventing an older `A → B` response from being replayed after `B → C`. Explicitly revoking the predecessor also removes its cached response, and the cache lifetime never exceeds the predecessor's own expiry.

The exact response is retained in `client_storage` only for the configured window. FastMCP's default storage is encrypted; custom stores already hold upstream bearer credentials and must provide equivalent protection.

</details>

<details>
<summary>Concurrency boundary</summary>

A per-token lock serializes overlapping refreshes within one process. The short-lived response record is stored before the predecessor is invalidated, so retries and other workers arriving after that commit observe one successor. The generic key-value interface has no compare-and-swap primitive, so this does not claim global serialization when two different processes both pass the record check before either commits.

</details>

Fixes #4901

🤖 Generated with OpenAI Codex
