### PR TITLE
Remove obsolete Docket memory-server reset fixtures

### DIFF
--- a/tests/client/transports/test_memory_transport.py
+++ b/tests/client/transports/test_memory_transport.py
@@ -7,7 +7,6 @@ Client(server) with an in-process FastMCP server.
 import time
 
 import pytest
-from docket import Docket
 
 from fastmcp import Client, FastMCP
 from fastmcp.client.transports import FastMCPTransport
@@ -21,18 +20,8 @@ def test_transport_repr_includes_server_name():
     assert repr(transport) == "<FastMCPTransport(server='repr-test')>"
 
 
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-
-
 @pytest.mark.timeout(10)
-async def test_task_teardown_does_not_hang(reset_docket_memory_server):
+async def test_task_teardown_does_not_hang():
     """In-memory transport must tear down in under 2 seconds after a task call.
 
     This is a regression test for a teardown ordering bug where the Docket

--- a/tests/server/http/test_http_dependencies.py
+++ b/tests/server/http/test_http_dependencies.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from docket import Docket
 from fastmcp_tasks.context import _recall_snapshot, get_task_context
 from mcp_types import TextContent, TextResourceContents
 from starlette.requests import Request
@@ -12,16 +11,6 @@ from fastmcp.server.server import FastMCP
 from fastmcp.utilities.tests import ASGIServer, asgi_server
 from fastmcp_tasks import TasksExtension
 from tests.tasks.task_helpers import running_task_server, submit_task, wait_for_task
-
-
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 def _http_request_with_headers(headers: dict[str, str]) -> Request:
@@ -246,9 +235,7 @@ def _worker_snapshot_headers() -> dict[str, str]:
     return dict(snapshot.http_headers)
 
 
-async def test_background_task_can_read_snapshotted_request_headers(
-    reset_docket_memory_server,
-):
+async def test_background_task_can_read_snapshotted_request_headers():
     """A background task worker reads the HTTP headers snapshotted at submission.
 
     There is no client task-submission API yet (Phase 4), so the task is driven
@@ -278,9 +265,7 @@ async def test_background_task_can_read_snapshotted_request_headers(
     assert final.result["structuredContent"] == {"result": "tenant-123"}
 
 
-async def test_background_task_snapshot_preserves_all_request_headers(
-    reset_docket_memory_server,
-):
+async def test_background_task_snapshot_preserves_all_request_headers():
     """The task snapshot preserves every request header, including authorization."""
     server = FastMCP()
     server.add_extension(TasksExtension())

--- a/tests/server/mount/test_advanced.py
+++ b/tests/server/mount/test_advanced.py
@@ -1,7 +1,6 @@
 """Advanced mounting scenarios."""
 
 import pytest
-from docket import Docket
 from mcp_types import TextContent
 from starlette.routing import Route
 
@@ -11,16 +10,6 @@ from fastmcp.server.providers import FastMCPProvider
 from fastmcp.server.providers.wrapped_provider import _WrappedProvider
 from fastmcp_tasks import TasksExtension
 from tests.tasks.task_helpers import running_task_server
-
-
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 class TestDynamicChanges:
@@ -611,9 +600,7 @@ class TestMountedServerDocketBehavior:
     includes Docket creation.
     """
 
-    async def test_mounted_server_does_not_have_docket(
-        self, reset_docket_memory_server
-    ):
+    async def test_mounted_server_does_not_have_docket(self):
         """Test that a mounted server doesn't create its own Docket.
 
         MountedProvider.lifespan() should call only the server's _lifespan

--- a/tests/server/test_dependencies.py
+++ b/tests/server/test_dependencies.py
@@ -3,7 +3,6 @@
 from contextlib import asynccontextmanager, contextmanager
 
 import pytest
-from docket import Docket
 from mcp_types import TextContent, TextResourceContents
 
 from fastmcp import FastMCP
@@ -14,16 +13,6 @@ from fastmcp_tasks import TasksExtension
 from tests.conftest import make_server_request_context
 
 HUZZAH = "huzzah!"
-
-
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 class Connection:
@@ -1205,9 +1194,7 @@ class TestSharedDependencies:
             )
             assert call_count == 1
 
-    async def test_shared_resolves_on_task_capable_server(
-        self, reset_docket_memory_server
-    ):
+    async def test_shared_resolves_on_task_capable_server(self):
         """Shared() dependencies resolve on a normal request even when the server
         has task-enabled components.
 

--- a/tests/server/test_mrtr_guards.py
+++ b/tests/server/test_mrtr_guards.py
@@ -22,7 +22,6 @@ from typing import Annotated
 
 import mcp_types
 import pytest
-from docket import Docket
 from mcp.client._input_required import InputRequiredRoundsExceededError
 from mcp.server.request_state import RequestStateSecurity
 from mcp.shared.exceptions import MCPError
@@ -1177,18 +1176,7 @@ class TestTaskExecution:
     background task has no such request, so returning a guard result from a task
     is rejected with a clear error rather than silently yielding empty content."""
 
-    @pytest.fixture
-    def reset_docket_memory_server(self):
-        """Force a fresh memory:// Docket server bound to this test's loop."""
-        if hasattr(Docket, "_memory_server"):
-            delattr(Docket, "_memory_server")
-        yield
-        if hasattr(Docket, "_memory_server"):
-            delattr(Docket, "_memory_server")
-
-    async def test_guard_result_from_task_parks_for_input(
-        self, reset_docket_memory_server
-    ):
+    async def test_guard_result_from_task_parks_for_input(self):
         mcp = FastMCP("guard-task")
         mcp.add_extension(TasksExtension())
 

--- a/tests/server/test_server_docket.py
+++ b/tests/server/test_server_docket.py
@@ -3,7 +3,6 @@
 import asyncio
 from contextlib import asynccontextmanager
 
-import pytest
 from docket import Docket
 from docket.worker import Worker
 from fastmcp_tasks.dependencies import CurrentDocket, CurrentWorker
@@ -14,16 +13,6 @@ from fastmcp.server.dependencies import get_context
 from fastmcp_tasks import TasksExtension
 
 HUZZAH = "huzzah!"
-
-
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to each test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 async def test_docket_not_initialized_without_task_components():

--- a/tests/tasks/server/conftest.py
+++ b/tests/tasks/server/conftest.py
@@ -9,26 +9,6 @@ from fastmcp.utilities.tests import temporary_settings
 
 
 @pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Reset the shared memory:// Docket server between tests.
-
-    Docket keeps a process-wide ``Docket._memory_server`` singleton for
-    ``memory://`` backends. It persists across tests and across event loops, so a
-    test that inherits a stale server from a previous loop can fail (e.g.
-    ``tasks/get`` raising ``TypeError`` from the dead client). Clearing it before
-    and after each test keeps the task suite isolation-safe rather than
-    order-dependent.
-    """
-    from docket import Docket
-
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-
-
-@pytest.fixture(autouse=True)
 def isolate_settings_home(_settings_home_root: Path):
     """Task-local override of the repo-wide ``isolate_settings_home`` fixture.
 

--- a/tests/tasks/server/test_task_mount.py
+++ b/tests/tasks/server/test_task_mount.py
@@ -44,16 +44,6 @@ from tests.tasks.task_helpers import (
 )
 
 
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Reset the shared memory:// Docket server between tests for isolation."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-
-
 @pytest.fixture
 def child_server() -> FastMCP:
     mcp = FastMCP("child-server")

--- a/tests/tasks/server/test_task_proxy.py
+++ b/tests/tasks/server/test_task_proxy.py
@@ -8,7 +8,6 @@ client opts the tasks extension in for the request.
 """
 
 import pytest
-from docket import Docket
 from fastmcp_tasks.models import CreateTaskResult
 
 from fastmcp import FastMCP
@@ -22,16 +21,6 @@ from tests.tasks.task_helpers import (
     auth_scope,
     running_task_server,
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to each test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 async def call_tool_with_optin(server: FastMCP, name: str, arguments: dict):

--- a/tests/tasks/server/test_task_return_types.py
+++ b/tests/tasks/server/test_task_return_types.py
@@ -16,7 +16,6 @@ from uuid import UUID
 
 import mcp_types
 import pytest
-from docket import Docket
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
@@ -29,16 +28,6 @@ from tests.tasks.task_helpers import (
     run_task,
     running_task_server,
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to each test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 def _sync_result_to_wire(result: ToolResult) -> dict[str, Any]:


### PR DESCRIPTION
## Description

pydocket 0.24.1 moved `memory://` servers into a URL-and-event-loop-keyed registry and removed `Docket._memory_server`. The reset fixtures therefore no longer reset anything, even though their names and docstrings claim to provide test isolation.

This removes all ten inert fixtures, their six injected test parameters, and imports used only by the obsolete cleanup. Tests that genuinely use `Docket` keep their imports, and the existing task behavior remains unchanged.

```python
# Removed no-op isolation
if hasattr(Docket, "_memory_server"):
    delattr(Docket, "_memory_server")
```

Fixes #4905

## Contribution type

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (not applicable: this PR removes inert test-only scaffolding and changes no behavior)
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions

🤖 Generated with Codex
