### PR TITLE
docs: prepare FastMCP 4 beta 4

### DIFF
--- a/dev-docs/v4-notes/index.md
+++ b/dev-docs/v4-notes/index.md
@@ -22,7 +22,7 @@ FastMCP v4.0 is an engine swap. Three forces drive the major version:
 
 The migration lives on `main`, which now depends on the stable MCP Python SDK 2.0 line. FastMCP continues cutting prereleases while the v4 APIs soak, then ships 4.0.0 from the same branch.
 
-- **`main` owns FastMCP 4.** It carries stable `mcp>=2.0.0` and `mcp-types>=2.0.0` dependencies. Beta 3 is the current prerelease target; the [Known Gaps](known-gaps.md) page tracks the remaining decisions before 4.0.0.
+- **`main` owns FastMCP 4.** It carries stable `mcp>=2.0.0` and `mcp-types>=2.0.0` dependencies. Beta 4 is the current prerelease target; the [Known Gaps](known-gaps.md) page tracks the remaining decisions before 4.0.0.
 - **`release/3.x` is the maintenance line.** A `release/3.x` branch is cut from pre-merge `main`. It stays on the SDK v1 line, receives upstream security patches, and serves users who cannot move to the SDK v2 beta yet.
 
 ### Release codenames
@@ -35,7 +35,8 @@ Following the pun-title convention (`v<version>: <pun>`), the v4 line runs a sin
 | `4.0.0a2` (alpha) | **Back and Fourth** | _back and forth_ — the second pass, where background tasks and stateless state land |
 | `4.0.0b1` (beta) | **Fourgone Conclusion** | _foregone conclusion_ — once the MCP SDK went v2, v4 was inevitable |
 | `4.0.0b2` (beta) | **Four the Better** | _for the better_ — a hardening release focused on correctness, compatibility, and security |
-| `4.0.0b3` (beta) | **Fast Fourward** | _fast forward_ — the final beta carries the accumulated v4 work into its GA soak |
+| `4.0.0b3` (beta) | **Fast Fourward** | _fast forward_ — the accumulated v4 work enters its GA soak |
+| `4.0.0b4` (beta) | **Calm Befour the Storm** | _calm before the storm_ — one last hardening pass before the stable release |
 | `4.0.0` (stable) | **Fourmidable** | _formidable_ — the stable release of the new protocol foundation |
 
 ## How to read the register

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,46 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v4.0.0b4" description="2026-08-26">
+
+**[v4.0.0b4: Calm Befour the Storm](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b4)**
+
+FastMCP 4 beta 4 improves modern multi-server clients and adds Prefect Horizon account commands, while tightening proxy and CIMD security boundaries and fixing Unicode search and inspect output.
+
+### Enhancements ✨
+* Add Prefect Horizon account commands by [@parkedwards](https://github.com/parkedwards) in [#4786](https://github.com/PrefectHQ/fastmcp/pull/4786)
+* Cap anthropic dependency to <1 by [@craigie-ant](https://github.com/craigie-ant) in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
+
+### Security 🔒
+* Scope Marvin App token to each job's declared permissions by [@zzstoatzz](https://github.com/zzstoatzz) in [#4834](https://github.com/PrefectHQ/fastmcp/pull/4834)
+* Exclude Cookie from forwarded HTTP headers by [@zzstoatzz](https://github.com/zzstoatzz) in [#4843](https://github.com/PrefectHQ/fastmcp/pull/4843)
+* Bump cryptography to 50.0.0 in the testing_demo example by [@zzstoatzz](https://github.com/zzstoatzz) in [#4844](https://github.com/PrefectHQ/fastmcp/pull/4844)
+* Bound CIMD cache growth by [@jlowin](https://github.com/jlowin) in [#4852](https://github.com/PrefectHQ/fastmcp/pull/4852)
+
+### Fixes 🐞
+* Fix instructions in MCP inspect output by [@zzstoatzz](https://github.com/zzstoatzz) in [#4873](https://github.com/PrefectHQ/fastmcp/pull/4873)
+* fix: support Unicode tokens in BM25 search by [@zzstoatzz](https://github.com/zzstoatzz) in [#4889](https://github.com/PrefectHQ/fastmcp/pull/4889)
+* fix: support modern protocol in multi-server clients by [@zzstoatzz](https://github.com/zzstoatzz) in [#4893](https://github.com/PrefectHQ/fastmcp/pull/4893)
+
+### Docs 📚
+* docs: fix idempotent tool hint wording by [@Theater-ahyeon](https://github.com/Theater-ahyeon) in [#4875](https://github.com/PrefectHQ/fastmcp/pull/4875)
+
+### Other Changes 🦾
+* chore(deps): Update j178/prek-action action to v3 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4808](https://github.com/PrefectHQ/fastmcp/pull/4808)
+* chore(deps): Update dependency node to v24 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4807](https://github.com/PrefectHQ/fastmcp/pull/4807)
+* chore(deps): Update astral-sh/setup-uv action to v9 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4806](https://github.com/PrefectHQ/fastmcp/pull/4806)
+* Fix proxy forwarding of MCP transport headers by [@jakekaplan](https://github.com/jakekaplan) in [#4853](https://github.com/PrefectHQ/fastmcp/pull/4853)
+* Add FastMCP security report review skill by [@zzstoatzz](https://github.com/zzstoatzz) in [#4859](https://github.com/PrefectHQ/fastmcp/pull/4859)
+
+## New Contributors
+* @prefect-renovate[bot] made their first contribution in [#4808](https://github.com/PrefectHQ/fastmcp/pull/4808)
+* @craigie-ant made their first contribution in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
+* @Theater-ahyeon made their first contribution in [#4875](https://github.com/PrefectHQ/fastmcp/pull/4875)
+
+**Full Changelog**: [v4.0.0b3...v4.0.0b4](https://github.com/PrefectHQ/fastmcp/compare/v4.0.0b3...v4.0.0b4)
+
+</Update>
+
 <Update label="v4.0.0b3" description="2026-08-14">
 
 **[v4.0.0b3: Fast Fourward](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b3)**

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -28,6 +28,7 @@ FastMCP 4 beta 4 improves modern multi-server clients and adds Prefect Horizon a
 
 ### Docs 📚
 * docs: fix idempotent tool hint wording by [@Theater-ahyeon](https://github.com/Theater-ahyeon) in [#4875](https://github.com/PrefectHQ/fastmcp/pull/4875)
+* docs: prepare FastMCP 4 beta 4 by [@zzstoatzz](https://github.com/zzstoatzz) in [#4914](https://github.com/PrefectHQ/fastmcp/pull/4914)
 
 ### Other Changes 🦾
 * chore(deps): Update j178/prek-action action to v3 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4808](https://github.com/PrefectHQ/fastmcp/pull/4808)

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -18,7 +18,7 @@ pip install fastmcp
 ```
 
 <Note>
-**FastMCP 4 is in prerelease.** The commands above install the latest stable release, which is still 3.x. To get v4, pin the beta explicitly with `pip install "fastmcp==4.0.0b3"`, or see [Install the v4 Prerelease](/getting-started/upgrading/from-fastmcp-3#install-the-v4-prerelease) for the uv constraint you'll need.
+**FastMCP 4 is in prerelease.** The commands above install the latest stable release, which is still 3.x. To get v4, pin the beta explicitly with `pip install "fastmcp==4.0.0b4"`, or see [Install the v4 Prerelease](/getting-started/upgrading/from-fastmcp-3#install-the-v4-prerelease) for the uv constraint you'll need.
 </Note>
 
 ### Optional Dependencies
@@ -44,7 +44,7 @@ You should see output like the following:
 ```bash
 $ fastmcp version
 
-FastMCP version:                         4.0.0b3
+FastMCP version:                         4.0.0b4
 MCP version:                                2.0.0
 Python version:                            3.12.2
 Platform:            macOS-15.3.1-arm64-arm-64bit
@@ -115,7 +115,7 @@ FastMCP follows semantic versioning with pragmatic adaptations for the rapidly e
 
 For production use, always pin to exact versions:
 ```
-fastmcp==4.0.0b3  # Good - an exact version
+fastmcp==4.0.0b4  # Good - an exact version
 fastmcp>=4.0.0    # Bad - may install breaking changes
 ```
 

--- a/docs/getting-started/upgrading/from-fastmcp-3.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-3.mdx
@@ -16,17 +16,17 @@ The sections below cover what FastMCP handles for you, the changes you must make
 While FastMCP 4 is in prerelease, pin the beta explicitly. The `fastmcp` package is a thin wrapper that depends on `fastmcp-slim` at the same version, so asking for a prerelease of one means asking for a prerelease of the other. pip infers that on its own:
 
 ```bash
-pip install "fastmcp==4.0.0b3"
+pip install "fastmcp==4.0.0b4"
 ```
 
 uv is stricter: it allows prereleases only for packages you name, and `fastmcp-slim` arrives transitively. Constrain it alongside the requirement in `pyproject.toml`:
 
 ```toml
 [project]
-dependencies = ["fastmcp==4.0.0b3"]
+dependencies = ["fastmcp==4.0.0b4"]
 
 [tool.uv]
-constraint-dependencies = ["fastmcp-slim==4.0.0b3"]
+constraint-dependencies = ["fastmcp-slim==4.0.0b4"]
 ```
 
 Then run `uv lock` or `uv sync` normally. Naming the one package keeps the rest of your graph on stable releases, where `--prerelease allow` would opt every dependency into prereleases. The MCP SDK needs no constraint at all now that it ships stable releases — pinning `mcp==2.0.0b2` here would in fact break the resolution, since a prerelease does not satisfy FastMCP's own `mcp>=2.0.0` requirement.
@@ -307,12 +307,12 @@ The extension ships in a separate package, so the pin from [Install the v4 Prere
 
 ```toml
 [project]
-dependencies = ["fastmcp[tasks]==4.0.0b3"]
+dependencies = ["fastmcp[tasks]==4.0.0b4"]
 
 [tool.uv]
 constraint-dependencies = [
-    "fastmcp-slim==4.0.0b3",
-    "fastmcp-tasks==4.0.0b3",
+    "fastmcp-slim==4.0.0b4",
+    "fastmcp-tasks==4.0.0b4",
 ]
 ```
 

--- a/docs/getting-started/upgrading/from-low-level-sdk-v1.mdx
+++ b/docs/getting-started/upgrading/from-low-level-sdk-v1.mdx
@@ -84,7 +84,7 @@ For each item found, show the original code, say what it did, and give the FastM
 FastMCP 4 is in prerelease, so pin the exact version rather than installing unqualified — a bare `pip install fastmcp` resolves to the latest *stable* release, which today is FastMCP 3:
 
 ```bash
-pip install "fastmcp==4.0.0b3"
+pip install "fastmcp==4.0.0b4"
 ```
 
 An exact pip pin installs even though it's a prerelease; it does not need `--pre`. uv also needs an explicit constraint for the transitive `fastmcp-slim` prerelease, so follow [Install the v4 Prerelease](/getting-started/upgrading/from-fastmcp-3#install-the-v4-prerelease) for a reproducible uv setup.

--- a/docs/getting-started/upgrading/from-low-level-sdk-v2.mdx
+++ b/docs/getting-started/upgrading/from-low-level-sdk-v2.mdx
@@ -69,7 +69,7 @@ For each item found, show the original code, say what it did, and give the FastM
 FastMCP 4 is in prerelease, so pin the exact version rather than installing unqualified — a bare `pip install fastmcp` resolves to the latest *stable* release, which today is FastMCP 3:
 
 ```bash
-pip install "fastmcp==4.0.0b3"
+pip install "fastmcp==4.0.0b4"
 ```
 
 An exact pip pin installs even though it's a prerelease; it does not need `--pre`. uv also needs an explicit constraint for the transitive `fastmcp-slim` prerelease, so follow [Install the v4 Prerelease](/getting-started/upgrading/from-fastmcp-3#install-the-v4-prerelease) for a reproducible uv setup.

--- a/docs/getting-started/upgrading/from-mcp-sdk-v1.mdx
+++ b/docs/getting-started/upgrading/from-mcp-sdk-v1.mdx
@@ -54,7 +54,7 @@ If you have already moved to SDK v2 and write against `MCPServer` today, see [Up
 FastMCP 4 is in prerelease, so pin the exact version rather than installing unqualified — a bare `pip install fastmcp` resolves to the latest *stable* release, which today is FastMCP 3:
 
 ```bash
-pip install "fastmcp==4.0.0b3"
+pip install "fastmcp==4.0.0b4"
 ```
 
 An exact pip pin installs even though it's a prerelease; it does not need `--pre`. uv also needs an explicit constraint for the transitive `fastmcp-slim` prerelease, so follow [Install the v4 Prerelease](/getting-started/upgrading/from-fastmcp-3#install-the-v4-prerelease) for a reproducible uv setup.

--- a/docs/getting-started/upgrading/from-mcp-sdk-v2.mdx
+++ b/docs/getting-started/upgrading/from-mcp-sdk-v2.mdx
@@ -94,7 +94,7 @@ For each item found, show the original code, name what changed, and give the Fas
 FastMCP 4 is in prerelease, so pin the exact version rather than installing unqualified — a bare `pip install fastmcp` resolves to the latest *stable* release, which today is FastMCP 3:
 
 ```bash
-pip install "fastmcp==4.0.0b3"
+pip install "fastmcp==4.0.0b4"
 ```
 
 An exact pip pin installs even though it's a prerelease; it does not need `--pre`. uv also needs an explicit constraint for the transitive `fastmcp-slim` prerelease, so follow [Install the v4 Prerelease](/getting-started/upgrading/from-fastmcp-3#install-the-v4-prerelease) for a reproducible uv setup.

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,24 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 4.0.0b4" description="August 26, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v4.0.0b4: Calm Befour the Storm"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b4"
+cta="Read the release notes"
+>
+FastMCP 4 beta 4 is the final hardening pass before the stable release, improving modern multi-server clients, operational tooling, and security boundaries.
+
+🌐 **Modern multi-server clients** — proxy-backed client configurations now preserve modern protocol support instead of forcing the legacy handshake.
+
+☁️ **Horizon accounts** — new commands manage Prefect Horizon account authentication from the FastMCP CLI.
+
+🔐 **Safer boundaries** — HTTP proxies no longer forward cookies, MCP transport headers reach their backends correctly, and CIMD caches stay bounded.
+
+🔎 **Sharper tools** — BM25 search handles Unicode tokens and MCP inspect reports server instructions correctly.
+</Card>
+</Update>
+
 <Update label="FastMCP 4.0.0b3" description="August 14, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v4.0.0b3: Fast Fourward"


### PR DESCRIPTION
FastMCP 4 beta 4 is ready to ship as **Calm Befour the Storm**. This updates every active prerelease installation path, records the codename, and stages the complete changelog and update card before the tag is created.

The release centers on modern multi-server client compatibility, Prefect Horizon account commands, and another security-hardening pass across proxy headers and CIMD caching. The future release and comparison links will resolve as soon as `v4.0.0b4` is tagged after this merges.

🤖 Generated with OpenAI Codex
