### PR TITLE
docs: fix beta 4 changelog MDX

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,7 +13,7 @@ FastMCP 4 beta 4 improves modern multi-server clients and adds Prefect Horizon a
 
 ### Enhancements ✨
 * Add Prefect Horizon account commands by [@parkedwards](https://github.com/parkedwards) in [#4786](https://github.com/PrefectHQ/fastmcp/pull/4786)
-* Cap anthropic dependency to <1 by [@craigie-ant](https://github.com/craigie-ant) in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
+* Cap anthropic dependency to &lt;1 by [@craigie-ant](https://github.com/craigie-ant) in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
 
 ### Security 🔒
 * Scope Marvin App token to each job's declared permissions by [@zzstoatzz](https://github.com/zzstoatzz) in [#4834](https://github.com/PrefectHQ/fastmcp/pull/4834)
@@ -31,9 +31,9 @@ FastMCP 4 beta 4 improves modern multi-server clients and adds Prefect Horizon a
 * docs: prepare FastMCP 4 beta 4 by [@zzstoatzz](https://github.com/zzstoatzz) in [#4914](https://github.com/PrefectHQ/fastmcp/pull/4914)
 
 ### Other Changes 🦾
-* chore(deps): Update j178/prek-action action to v3 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4808](https://github.com/PrefectHQ/fastmcp/pull/4808)
-* chore(deps): Update dependency node to v24 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4807](https://github.com/PrefectHQ/fastmcp/pull/4807)
-* chore(deps): Update astral-sh/setup-uv action to v9 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4806](https://github.com/PrefectHQ/fastmcp/pull/4806)
+* chore(deps): Update j178/prek-action action to v3 by [@prefect-renovate](https://github.com/apps/prefect-renovate)[bot] in [#4808](https://github.com/PrefectHQ/fastmcp/pull/4808)
+* chore(deps): Update dependency node to v24 by [@prefect-renovate](https://github.com/apps/prefect-renovate)[bot] in [#4807](https://github.com/PrefectHQ/fastmcp/pull/4807)
+* chore(deps): Update astral-sh/setup-uv action to v9 by [@prefect-renovate](https://github.com/apps/prefect-renovate)[bot] in [#4806](https://github.com/PrefectHQ/fastmcp/pull/4806)
 * Fix proxy forwarding of MCP transport headers by [@jakekaplan](https://github.com/jakekaplan) in [#4853](https://github.com/PrefectHQ/fastmcp/pull/4853)
 * Add FastMCP security report review skill by [@zzstoatzz](https://github.com/zzstoatzz) in [#4859](https://github.com/PrefectHQ/fastmcp/pull/4859)
 


### PR DESCRIPTION
The beta 4 changelog entry rendered `<1` as the start of an MDX element, so Mintlify rejected the production deployment after the release. This escapes the comparison and uses the established bot-link format, allowing the changelog to compile and the release docs to publish.

🤖 Generated with OpenAI Codex
