### PR TITLE
docs: publish beta 4 changelog fix

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,7 +13,7 @@ FastMCP 4 beta 4 improves modern multi-server clients and adds Prefect Horizon a
 
 ### Enhancements ✨
 * Add Prefect Horizon account commands by [@parkedwards](https://github.com/parkedwards) in [#4786](https://github.com/PrefectHQ/fastmcp/pull/4786)
-* Cap anthropic dependency to <1 by [@craigie-ant](https://github.com/craigie-ant) in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
+* Cap anthropic dependency to &lt;1 by [@craigie-ant](https://github.com/craigie-ant) in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
 
 ### Security 🔒
 * Scope Marvin App token to each job's declared permissions by [@zzstoatzz](https://github.com/zzstoatzz) in [#4834](https://github.com/PrefectHQ/fastmcp/pull/4834)
@@ -31,9 +31,9 @@ FastMCP 4 beta 4 improves modern multi-server clients and adds Prefect Horizon a
 * docs: prepare FastMCP 4 beta 4 by [@zzstoatzz](https://github.com/zzstoatzz) in [#4914](https://github.com/PrefectHQ/fastmcp/pull/4914)
 
 ### Other Changes 🦾
-* chore(deps): Update j178/prek-action action to v3 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4808](https://github.com/PrefectHQ/fastmcp/pull/4808)
-* chore(deps): Update dependency node to v24 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4807](https://github.com/PrefectHQ/fastmcp/pull/4807)
-* chore(deps): Update astral-sh/setup-uv action to v9 by [@prefect-renovate[bot]](https://github.com/prefect-renovate%5Bbot%5D) in [#4806](https://github.com/PrefectHQ/fastmcp/pull/4806)
+* chore(deps): Update j178/prek-action action to v3 by [@prefect-renovate](https://github.com/apps/prefect-renovate)[bot] in [#4808](https://github.com/PrefectHQ/fastmcp/pull/4808)
+* chore(deps): Update dependency node to v24 by [@prefect-renovate](https://github.com/apps/prefect-renovate)[bot] in [#4807](https://github.com/PrefectHQ/fastmcp/pull/4807)
+* chore(deps): Update astral-sh/setup-uv action to v9 by [@prefect-renovate](https://github.com/apps/prefect-renovate)[bot] in [#4806](https://github.com/PrefectHQ/fastmcp/pull/4806)
 * Fix proxy forwarding of MCP transport headers by [@jakekaplan](https://github.com/jakekaplan) in [#4853](https://github.com/PrefectHQ/fastmcp/pull/4853)
 * Add FastMCP security report review skill by [@zzstoatzz](https://github.com/zzstoatzz) in [#4859](https://github.com/PrefectHQ/fastmcp/pull/4859)
 


### PR DESCRIPTION
Updates `published-docs` to the corrected beta 4 changelog tree from `main`. The release entry now parses as valid MDX, allowing the production deployment to complete.

🤖 Generated with OpenAI Codex
