### PR TITLE
fix: map binary and path JSON Schema formats to bytes and Path

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema_type.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema_type.py
@@ -61,6 +61,7 @@ from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import MISSING, field, make_dataclass
 from datetime import date, datetime
+from pathlib import Path
 from typing import (
     Annotated,
     Any,
@@ -123,6 +124,8 @@ FORMAT_TYPES: dict[str, Any] = {
     "email": EmailStr,
     "uri": AnyUrl,
     "json": Json,
+    "binary": bytes,
+    "path": Path,
 }
 
 _classes: dict[tuple[str, Any], type | None] = {}


### PR DESCRIPTION
## Summary

Fixes #4907: `json_schema_to_type` maps `"format": "binary"` and `"format": "path"` back to `str` instead of `bytes` and `pathlib.Path`, so tool results annotated with `bytes`/`Path` hydrate as plain strings on the client.

## Root cause

`FORMAT_TYPES` in `fastmcp_slim/fastmcp/utilities/json_schema_type.py` only maps `date-time`, `email`, `uri`, and `json`. Unknown formats fall through to `str` in `_create_string_type` via `FORMAT_TYPES.get(fmt, str)`.

## Change

- Map `"binary"` → `bytes` and `"path"` → `pathlib.Path`.
- Import `Path` from `pathlib`.

## Verification

- `json_schema_to_type({"type": "string", "format": "binary"})` is now `bytes`; `TypeAdapter(bytes).validate_python(b"\x00\x01")` round-trips.
- `json_schema_to_type({"type": "string", "format": "path"})` is now `Path`; `TypeAdapter(Path).validate_python("/tmp/foo.txt")` returns a `PosixPath`.
- Existing formats (`date-time`, `uri`, `email`) unaffected.
- Object schemas with nested `binary`/`path` properties hydrate correctly.