### PR TITLE
fix: hydrate date, time, duration, uuid, and path string formats

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema_type.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema_type.py
@@ -60,7 +60,8 @@ import warnings
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import MISSING, field, make_dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
 from typing import (
     Annotated,
     Any,
@@ -69,6 +70,7 @@ from typing import (
     Union,
     cast,
 )
+from uuid import UUID
 
 from pydantic import (
     AnyUrl,
@@ -120,6 +122,11 @@ _UnsatisfiableType = Annotated[Any, BeforeValidator(_reject_all)]
 
 FORMAT_TYPES: dict[str, Any] = {
     "date-time": datetime,
+    "date": date,
+    "time": time,
+    "duration": timedelta,
+    "uuid": UUID,
+    "path": Path,
     "email": EmailStr,
     "uri": AnyUrl,
     "json": Json,

--- a/tests/utilities/json_schema_type/test_json_schema_type.py
+++ b/tests/utilities/json_schema_type/test_json_schema_type.py
@@ -3,8 +3,11 @@
 import dataclasses
 import warnings
 from dataclasses import Field
+from datetime import date, datetime, time, timedelta
 from enum import Enum
+from pathlib import Path
 from typing import Any, Literal, cast
+from uuid import UUID
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
@@ -20,6 +23,30 @@ def get_dataclass_field(type: type, field_name: str) -> Field:
 
 class TestSimpleTypes:
     """Test suite for basic type validation."""
+
+    @pytest.fixture
+    def format_cases(self):
+        return [
+            ("date-time", "2026-08-27T14:30:00", datetime(2026, 8, 27, 14, 30)),
+            ("date", "2026-08-27", date(2026, 8, 27)),
+            ("time", "14:30:00", time(14, 30)),
+            ("duration", "PT90S", timedelta(seconds=90)),
+            (
+                "uuid",
+                "550e8400-e29b-41d4-a716-446655440000",
+                UUID("550e8400-e29b-41d4-a716-446655440000"),
+            ),
+            ("path", "/tmp/example.txt", Path("/tmp/example.txt")),
+        ]
+
+    def test_string_formats_hydrate_to_python_types(self, format_cases):
+        for fmt, value, expected in format_cases:
+            validator = TypeAdapter(
+                json_schema_to_type({"type": "string", "format": fmt})
+            )
+            result = validator.validate_python(value)
+            assert result == expected
+            assert isinstance(result, type(expected))
 
     @pytest.fixture
     def simple_string(self):


### PR DESCRIPTION
## Description

`json_schema_to_type` only mapped the `date-time` string format, so `date`, `time`, `duration`, `uuid`, and `path` fell through to `str` and `.data` returned raw strings instead of Python objects. This adds the missing entries to `FORMAT_TYPES`, mirroring the existing `date-time` handling, with regression tests for all six formats.

`bytes` (format `binary`, #4907) is intentionally left out — Pydantic does not base64-decode strings by default, so round-tripping bytes needs a design decision.

Closes #4899

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
