### PR TITLE
fix: hydrate fixed-length prefixItems arrays as typed tuples

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/json_schema_type.py
+++ b/fastmcp_slim/fastmcp/utilities/json_schema_type.py
@@ -353,7 +353,22 @@ def _create_array_type(
     schemas: Mapping[str, Any],
     resolving_refs: frozenset[str],
 ) -> type | Annotated[Any, ...]:
-    """Create list/set type with optional constraints."""
+    """Create list/set/tuple type with optional constraints."""
+    prefix_items = schema.get("prefixItems")
+    if (
+        prefix_items
+        and not schema.get("items")
+        and schema.get("minItems") == len(prefix_items)
+        and schema.get("maxItems") == len(prefix_items)
+    ):
+        # Fixed-length positional schema (draft 2020-12), as generated for
+        # e.g. ``tuple[date, int]``: hydrate as a typed tuple. Length is
+        # implied by the tuple type itself.
+        item_types = tuple(
+            _schema_to_type(s, schemas, resolving_refs) for s in prefix_items
+        )
+        return tuple[item_types]  # ty:ignore[invalid-type-form]
+
     items = schema.get("items", {})
     if isinstance(items, list):
         # Handle positional item schemas

--- a/tests/utilities/json_schema_type/test_json_schema_type.py
+++ b/tests/utilities/json_schema_type/test_json_schema_type.py
@@ -21,6 +21,28 @@ def get_dataclass_field(type: type, field_name: str) -> Field:
 class TestSimpleTypes:
     """Test suite for basic type validation."""
 
+    def test_prefix_items_hydrate_to_typed_tuple(self):
+        schema = {
+            "type": "array",
+            "prefixItems": [{"type": "integer"}, {"type": "string"}],
+            "minItems": 2,
+            "maxItems": 2,
+        }
+        validator = TypeAdapter(json_schema_to_type(schema))
+        result = validator.validate_python([1, "a"])
+        assert result == (1, "a")
+        assert isinstance(result, tuple)
+        with pytest.raises(ValidationError):
+            validator.validate_python(["a", 1])
+
+    def test_prefix_items_with_open_tail_stays_list(self):
+        # Without a matching maxItems, additional items are allowed by the
+        # schema, so the result must remain a list.
+        schema = {"type": "array", "prefixItems": [{"type": "integer"}]}
+        validator = TypeAdapter(json_schema_to_type(schema))
+        result = validator.validate_python([1, 2, 3])
+        assert isinstance(result, list)
+
     @pytest.fixture
     def simple_string(self):
         return json_schema_to_type({"type": "string"})


### PR DESCRIPTION
## Description

`json_schema_to_type` ignores `prefixItems`, so tool results annotated as fixed-length tuples hydrate via `.data` as plain lists with untyped elements (structured-content validation against the original schema still rejects mismatched elements; only the hydrated type degrades). This converts fixed-length positional array schemas (`prefixItems` with matching `minItems`/`maxItems`) to typed tuples; open-ended `prefixItems` schemas keep the existing list behavior, since the schema allows additional items there.

Note: hydrating a `date` element inside a tuple additionally depends on the `FORMAT_TYPES` fix in #4921.

Closes #4922

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)