### PR TITLE
fix(ci): satisfy latest ty control-flow checks

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/asgi_transport.py
+++ b/fastmcp_slim/fastmcp/utilities/asgi_transport.py
@@ -307,6 +307,7 @@ async def run_asgi_lifespan(app: ASGIApp) -> AsyncIterator[None]:
         raise
     finally:
         await receive_queue.put({"type": "lifespan.shutdown"})
+        results: tuple[object, ...] = ()
         with anyio.CancelScope(shield=True):
             results = await asyncio.gather(
                 shutdown_complete, task, return_exceptions=True

--- a/tests/cli/test_project_prepare.py
+++ b/tests/cli/test_project_prepare.py
@@ -253,15 +253,15 @@ class TestProjectPrepareCommand:
         mock_find.return_value = None
 
         # Run command without output_dir - should exit with error for missing output_dir
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("fastmcp.cli.cli.logger.error") as mock_error:
+        with patch("fastmcp.cli.cli.logger.error") as mock_error:
+            with pytest.raises(SystemExit) as exc_info:
                 await prepare(config_path=None, output_dir=None)
 
-        assert isinstance(exc_info.value, SystemExit)
-        assert exc_info.value.code == 1
-        mock_error.assert_called()
-        error_msg = mock_error.call_args[0][0]
-        assert "--output-dir parameter is required" in error_msg
+            assert isinstance(exc_info.value, SystemExit)
+            assert exc_info.value.code == 1
+            mock_error.assert_called()
+            error_msg = mock_error.call_args[0][0]
+            assert "--output-dir parameter is required" in error_msg
 
     @patch("pathlib.Path.exists")
     async def test_project_prepare_config_not_exists(self, mock_exists):
@@ -272,15 +272,15 @@ class TestProjectPrepareCommand:
         mock_exists.return_value = False
 
         # Run command without output_dir - should exit with error for missing output_dir
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("fastmcp.cli.cli.logger.error") as mock_error:
+        with patch("fastmcp.cli.cli.logger.error") as mock_error:
+            with pytest.raises(SystemExit) as exc_info:
                 await prepare(config_path="missing.json", output_dir=None)
 
-        assert isinstance(exc_info.value, SystemExit)
-        assert exc_info.value.code == 1
-        mock_error.assert_called()
-        error_msg = mock_error.call_args[0][0]
-        assert "--output-dir parameter is required" in error_msg
+            assert isinstance(exc_info.value, SystemExit)
+            assert exc_info.value.code == 1
+            mock_error.assert_called()
+            error_msg = mock_error.call_args[0][0]
+            assert "--output-dir parameter is required" in error_msg
 
     @patch("pathlib.Path.exists")
     @patch("fastmcp.utilities.mcp_server_config.MCPServerConfig.from_file")
@@ -295,12 +295,12 @@ class TestProjectPrepareCommand:
         mock_from_file.return_value = mock_config
 
         # Run command - should exit with error
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("fastmcp.cli.cli.console.print") as mock_print:
+        with patch("fastmcp.cli.cli.console.print") as mock_print:
+            with pytest.raises(SystemExit) as exc_info:
                 await prepare(config_path="config.json", output_dir="./test-env")
 
-        assert isinstance(exc_info.value, SystemExit)
-        assert exc_info.value.code == 1
-        # Should print error message
-        error_call = mock_print.call_args_list[-1][0][0]
-        assert "Failed to prepare project" in error_call
+            assert isinstance(exc_info.value, SystemExit)
+            assert exc_info.value.code == 1
+            # Should print error message
+            error_call = mock_print.call_args_list[-1][0][0]
+            assert "Failed to prepare project" in error_call

--- a/tests/client/auth/test_oauth_client.py
+++ b/tests/client/auth/test_oauth_client.py
@@ -225,9 +225,9 @@ async def test_oauth_callback_handler_propagates_iss_to_authorization_code_resul
         tg.start_soon(send_callback)
         result = await oauth.callback_handler()
 
-    assert result.code == "auth-code-123"
-    assert result.state == "state-xyz"
-    assert result.iss == "https://issuer.example.com"
+        assert result.code == "auth-code-123"
+        assert result.state == "state-xyz"
+        assert result.iss == "https://issuer.example.com"
 
 
 class TestOAuthClientUrlHandling:


### PR DESCRIPTION
The upgrade-check workflow is red because newer `ty` releases correctly treat context managers as potential exception suppressors, making values assigned only inside those contexts possibly undefined afterward.

This gives the ASGI lifespan teardown a safe empty result before entering its cancellation scope and keeps test assertions inside the patch/task-group contexts that define their values. Runtime behavior is unchanged, while both locked and upgraded dependency sets pass static analysis.

Fixes #4913

🤖 Generated with OpenAI Codex
