### PR TITLE
fix(middleware): align response limits with output schemas

### DIFF
--- a/docs/servers/middleware.mdx
+++ b/docs/servers/middleware.mdx
@@ -618,7 +618,7 @@ def search(query: str) -> str:
 When a response exceeds the limit, the middleware extracts all text content, joins it together, truncates to fit within the limit, and returns a single `TextContent` block. For non-text responses, the serialized JSON is used as the text source.
 
 <Note>
-If a tool defines an `output_schema`, truncated responses will no longer conform to that schema — the client will receive a plain `TextContent` block instead of the expected structured output. Keep this in mind when setting size limits for tools with structured responses.
+Because truncation can replace structured output with plain text, the middleware omits `outputSchema` from `tools/list` for every tool it limits. Responses below the limit still include their original structured content, but clients cannot validate or hydrate it against an advertised output schema. Tools excluded with the `tools` parameter keep their output schemas.
 </Note>
 
 ```python

--- a/fastmcp_slim/fastmcp/server/middleware/response_limiting.py
+++ b/fastmcp_slim/fastmcp/server/middleware/response_limiting.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 import mcp_types as mt
 import pydantic_core
 from mcp_types import TextContent
 
-from fastmcp.tools.base import InputRequiredToolResult, ToolResult
+from fastmcp.tools.base import InputRequiredToolResult, Tool, ToolResult
 
 from .middleware import CallNext, Middleware, MiddlewareContext
 
@@ -68,6 +69,9 @@ class ResponseLimitingMiddleware(Middleware):
         self.truncation_suffix = truncation_suffix
         self.tools = set(tools) if tools is not None else None
 
+    def _limits_tool(self, name: str) -> bool:
+        return self.tools is None or name in self.tools
+
     def _truncate_to_result(
         self,
         text: str,
@@ -93,14 +97,24 @@ class ResponseLimitingMiddleware(Middleware):
                     + self.truncation_suffix
                 )
 
-        # Preserve original meta, falling back to {} when absent. Having
-        # meta set ensures to_mcp_result() returns a CallToolResult, which
-        # bypasses MCP SDK outputSchema validation — a truncated response
-        # is no longer valid structured output.
         return ToolResult(
             content=[TextContent(type="text", text=truncated)],
-            meta=meta if meta is not None else {},
+            meta=meta,
         )
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        """Hide schemas for tools whose response shape may be truncated to text."""
+        tools = await call_next(context)
+        return [
+            tool.model_copy(update={"output_schema": None})
+            if self._limits_tool(tool.name) and tool.output_schema is not None
+            else tool
+            for tool in tools
+        ]
 
     async def on_call_tool(
         self,
@@ -125,7 +139,7 @@ class ResponseLimitingMiddleware(Middleware):
             return result
 
         # Check if we should limit this tool
-        if self.tools is not None and context.message.name not in self.tools:
+        if not self._limits_tool(context.message.name):
             return result
 
         # Measure serialized size

--- a/tests/server/middleware/test_response_limiting.py
+++ b/tests/server/middleware/test_response_limiting.py
@@ -57,14 +57,18 @@ class TestResponseLimitingMiddleware:
         )
 
         @mcp_server.tool()
-        def limited_tool() -> ToolResult:
-            return ToolResult(content=[TextContent(type="text", text="x" * 10_000)])
+        def limited_tool() -> str:
+            return "x" * 10_000
 
         @mcp_server.tool()
-        def unlimited_tool() -> ToolResult:
-            return ToolResult(content=[TextContent(type="text", text="y" * 10_000)])
+        def unlimited_tool() -> str:
+            return "y" * 10_000
 
         async with Client(mcp_server) as client:
+            tools = {tool.name: tool for tool in await client.list_tools()}
+            assert tools["limited_tool"].output_schema is None
+            assert tools["unlimited_tool"].output_schema is not None
+
             # Limited tool should be truncated
             result = await client.call_tool("limited_tool", {})
             assert "[Response truncated" in result.content[0].text
@@ -78,10 +82,13 @@ class TestResponseLimitingMiddleware:
         mcp_server.add_middleware(ResponseLimitingMiddleware(max_size=100, tools=[]))
 
         @mcp_server.tool()
-        def any_tool() -> ToolResult:
-            return ToolResult(content=[TextContent(type="text", text="x" * 10_000)])
+        def any_tool() -> str:
+            return "x" * 10_000
 
         async with Client(mcp_server) as client:
+            tools = await client.list_tools()
+            assert tools[0].output_schema is not None
+
             result = await client.call_tool("any_tool", {})
             # Should NOT be truncated
             assert "[Response truncated" not in result.content[0].text
@@ -152,11 +159,10 @@ class TestResponseLimitingMiddleware:
     async def test_truncation_does_not_break_output_schema_tools(
         self, mcp_server: FastMCP
     ):
-        """Truncating a tool with outputSchema must not cause validation errors.
+        """Truncating a tool with outputSchema must not cause client validation errors.
 
-        Regression test for #3717: the MCP SDK rejects truncated results
-        from tools with outputSchema because structured_content is dropped.
-        We verify the server returns a successful (non-error) truncated result.
+        Regression test for #4926: an end-to-end client rejects truncated results
+        when tools/list still advertises the original outputSchema.
         """
         mcp_server.add_middleware(ResponseLimitingMiddleware(max_size=1_000))
 
@@ -164,7 +170,12 @@ class TestResponseLimitingMiddleware:
         def big_answer() -> Answer:
             return Answer(text="x" * 2_000)
 
-        result = await mcp_server.call_tool("big_answer", {})
+        async with Client(mcp_server) as client:
+            tools = await client.list_tools()
+            assert tools[0].output_schema is None
+            result = await client.call_tool("big_answer", {})
+
+        assert result.is_error is False
         first = result.content[0]
         assert isinstance(first, TextContent)
         assert "[Response truncated" in first.text


### PR DESCRIPTION
`ResponseLimitingMiddleware` can replace a successful structured result with plain text, but it still advertises the tool's original `outputSchema`. Every conforming client therefore rejects an oversized response before the truncated content reaches the caller; response metadata cannot bypass that client-side protocol validation.

This makes the advertised contract match the middleware's possible output by omitting `outputSchema` from `tools/list` for tools the middleware limits. The registered tool itself is unchanged, responses below the limit retain their structured content, and tools excluded with the `tools` filter retain their schemas. The regression test now drives the reported path through a real `Client` rather than calling the server directly.

```python
mcp.add_middleware(ResponseLimitingMiddleware(max_size=200))

@mcp.tool
def big() -> str:
    return "x" * 5_000

async with Client(mcp) as client:
    result = await client.call_tool("big", {})

assert "[Response truncated" in result.content[0].text
```

Fixes #4926

🤖 Generated with OpenAI Codex
