### PR TITLE
feat(client): add tool_name_prefix to Client

### DIFF
--- a/docs/clients/tools.mdx
+++ b/docs/clients/tools.mdx
@@ -29,6 +29,29 @@ async with client:
 
 Arguments are passed as a dictionary. For multi-server clients, tool names are automatically prefixed with the server name (e.g., `weather_get_forecast` for a tool named `get_forecast` on the `weather` server).
 
+## Tool Name Prefixes
+
+<VersionBadge version="4.0.0" />
+
+When an application composes tools from several independent clients — for example, providing tools from multiple servers to the same agent — tool names can collide. The `tool_name_prefix` parameter namespaces a single client's tools without involving a proxy or a multi-server configuration:
+
+```python
+from fastmcp import Client
+
+weather = Client("https://weather-api.example.com/mcp", tool_name_prefix="weather_")
+assistant = Client("https://assistant-api.example.com/mcp", tool_name_prefix="assistant_")
+
+async with weather:
+    tools = await weather.list_tools()
+    # tool names: weather_get_forecast, weather_get_temperature, ...
+
+    result = await weather.call_tool("weather_get_forecast", {"city": "Chicago"})
+```
+
+The prefix is a literal string used verbatim — include a trailing separator if you want one. `list_tools()` presents prefixed names and `call_tool()` accepts them (an unprefixed name raises `ValueError`), so the names an agent discovers are always the names it can call.
+
+The prefix is presentation-only and applies to tools only. The wire-level methods `list_tools_mcp()` and `call_tool_mcp()`, direct `client.session` access, and server-initiated messages such as notifications and sampling all use the server's unprefixed names — the server never sees the prefix.
+
 ## Execution Options
 
 The `call_tool()` method supports timeout control and progress monitoring:

--- a/fastmcp_slim/fastmcp/client/client.py
+++ b/fastmcp_slim/fastmcp/client/client.py
@@ -335,6 +335,15 @@ class Client(
             rather than replacing it. A claimed `call_tool` result is resolved
             transparently through the owning extension's resolver. For an advertise-only
             entry, use `mcp.client.advertise(identifier, settings)`.
+        tool_name_prefix: Optional literal string prepended to every tool name this
+            client presents. Applied to names in `list_tools()` results and stripped
+            from the name passed to `call_tool()`, so an application composing several
+            clients can namespace their tools (e.g. `tool_name_prefix="weather_"`).
+            The prefix is presentation-only and applies to tools only: the wire-level
+            `list_tools_mcp()` / `call_tool_mcp()` methods, direct `client.session`
+            access, and server-initiated messages (notifications, sampling) all use
+            the server's unprefixed names. The string is used verbatim — include a
+            separator if you want one.
         result_claims: Additional `ResultClaim`s (SEP-2133) keyed by the identifier of
             an extension already advertised through `extensions`, merged with that
             extension's own claims. Rarely needed directly; prefer declaring claims on
@@ -442,8 +451,11 @@ class Client(
         cache: CacheConfig | bool | None = None,
         extensions: Sequence[ClientExtension] | None = None,
         result_claims: Mapping[str, Sequence[ResultClaim[Any]]] | None = None,
+        tool_name_prefix: str | None = None,
     ) -> None:
         self.name = name or self.generate_name()
+
+        self.tool_name_prefix = tool_name_prefix
 
         self.input_required_max_rounds = input_required_max_rounds
 

--- a/fastmcp_slim/fastmcp/client/mixins/tools.py
+++ b/fastmcp_slim/fastmcp/client/mixins/tools.py
@@ -97,6 +97,10 @@ class ClientToolsMixin:
         returning the complete list. For manual pagination control (e.g., to handle
         large result sets incrementally), use list_tools_mcp() with the cursor parameter.
 
+        When the client was built with a `tool_name_prefix`, tool names in the
+        returned list carry that prefix; `list_tools_mcp()` always returns the
+        server's unprefixed names.
+
         Args:
             max_pages: Maximum number of pages to fetch before raising. Defaults to 250.
 
@@ -132,7 +136,35 @@ class ClientToolsMixin:
                 " or increase max_pages."
             )
 
+        prefix = self.tool_name_prefix
+        if prefix:
+            all_tools = [
+                tool.model_copy(update={"name": f"{prefix}{tool.name}"})
+                for tool in all_tools
+            ]
+
         return all_tools
+
+    def _strip_tool_name_prefix(self: Client, name: str) -> str:
+        """Map a presented (prefixed) tool name back to the server's name.
+
+        With no `tool_name_prefix` configured, names pass through untouched.
+        With one configured, `list_tools()` presents prefixed names, so
+        `call_tool()` only accepts prefixed names — an unprefixed name raises
+        rather than silently reaching the server under a name the caller never
+        saw in a listing.
+        """
+        prefix = self.tool_name_prefix
+        if not prefix:
+            return name
+        if not name.startswith(prefix):
+            raise ValueError(
+                f"[{self.name}] Tool name {name!r} does not start with this"
+                f" client's tool_name_prefix {prefix!r}. call_tool() expects the"
+                " prefixed names presented by list_tools(); use call_tool_mcp()"
+                " for unprefixed wire-level names."
+            )
+        return name[len(prefix) :]
 
     # --- Call Tool ---
 
@@ -287,7 +319,9 @@ class ClientToolsMixin:
         Unlike call_tool_mcp, this method raises a ToolError if the tool call results in an error.
 
         Args:
-            name (str): The name of the tool to call.
+            name (str): The name of the tool to call. When the client was built with
+                a `tool_name_prefix`, this is the prefixed name as presented by
+                `list_tools()`; an unprefixed name raises ValueError.
             arguments (dict[str, Any] | None, optional): Arguments to pass to the tool. Defaults to None.
             version (str | None, optional): Specific tool version to call. If None, calls highest version.
             timeout (datetime.timedelta | float | int | None, optional): The timeout for the tool call. Defaults to None.
@@ -311,6 +345,8 @@ class ClientToolsMixin:
             MCPError: If the tool call request results in a TimeoutError | JSONRPCError
             RuntimeError: If called while the client is not connected.
         """
+        name = self._strip_tool_name_prefix(name)
+
         # Merge version into request-level meta (not arguments)
         request_meta = dict(meta) if meta else {}
         if version is not None:

--- a/tests/client/client/test_tool_name_prefix.py
+++ b/tests/client/client/test_tool_name_prefix.py
@@ -1,0 +1,85 @@
+"""Tests for Client(tool_name_prefix=...)."""
+
+import pytest
+
+from fastmcp import Client, FastMCP
+
+
+@pytest.fixture
+def server() -> FastMCP:
+    mcp = FastMCP("weather")
+
+    @mcp.tool
+    def get_forecast(city: str) -> dict[str, str]:
+        return {"city": city, "forecast": "sunny"}
+
+    @mcp.tool
+    def get_temperature(city: str) -> int:
+        return 72
+
+    return mcp
+
+
+class TestPrefixedListing:
+    async def test_list_tools_applies_prefix(self, server: FastMCP):
+        async with Client(server, tool_name_prefix="weather_") as client:
+            tools = await client.list_tools()
+            assert sorted(t.name for t in tools) == [
+                "weather_get_forecast",
+                "weather_get_temperature",
+            ]
+
+    async def test_prefix_is_literal_no_separator_added(self, server: FastMCP):
+        async with Client(server, tool_name_prefix="weather") as client:
+            tools = await client.list_tools()
+            assert "weatherget_forecast" in {t.name for t in tools}
+
+    async def test_list_tools_mcp_returns_unprefixed_names(self, server: FastMCP):
+        async with Client(server, tool_name_prefix="weather_") as client:
+            result = await client.list_tools_mcp()
+            assert sorted(t.name for t in result.tools) == [
+                "get_forecast",
+                "get_temperature",
+            ]
+
+    async def test_no_prefix_leaves_names_untouched(self, server: FastMCP):
+        async with Client(server) as client:
+            tools = await client.list_tools()
+            assert sorted(t.name for t in tools) == [
+                "get_forecast",
+                "get_temperature",
+            ]
+
+
+class TestPrefixedCalls:
+    async def test_call_tool_accepts_prefixed_name(self, server: FastMCP):
+        async with Client(server, tool_name_prefix="weather_") as client:
+            result = await client.call_tool("weather_get_forecast", {"city": "Chicago"})
+            assert result.data == {"city": "Chicago", "forecast": "sunny"}
+
+    async def test_call_tool_rejects_unprefixed_name(self, server: FastMCP):
+        async with Client(server, tool_name_prefix="weather_") as client:
+            with pytest.raises(ValueError, match="tool_name_prefix"):
+                await client.call_tool("get_forecast", {"city": "Chicago"})
+
+    async def test_call_tool_mcp_uses_unprefixed_names(self, server: FastMCP):
+        async with Client(server, tool_name_prefix="weather_") as client:
+            result = await client.call_tool_mcp("get_temperature", {"city": "NYC"})
+            assert not result.is_error
+
+    async def test_structured_output_parsing_uses_server_name(self, server: FastMCP):
+        # Output-schema lookup keys on the server's name; a prefixed call must
+        # still deserialize structured content.
+        async with Client(server, tool_name_prefix="weather_") as client:
+            result = await client.call_tool("weather_get_temperature", {"city": "LA"})
+            assert result.data == 72
+
+
+class TestPrefixConfiguration:
+    async def test_new_clone_preserves_prefix(self, server: FastMCP):
+        client = Client(server, tool_name_prefix="weather_")
+        clone = client.new()
+        assert clone.tool_name_prefix == "weather_"
+        async with clone:
+            tools = await clone.list_tools()
+            assert all(t.name.startswith("weather_") for t in tools)


### PR DESCRIPTION
Applications that hand tools from several servers to one agent need collision-free tool names, but the servers may need different per-connection configuration (protocol `mode`, auth, handlers) — which rules out `Client(config)`'s single aggregate endpoint. Today the only options are a proxy-backed multi-server client or hand-rolled renaming around each `Client`.

This adds `tool_name_prefix` to `Client`: a literal string prepended to tool names in `list_tools()` results and stripped from the name passed to `call_tool()`. The prefix is presentation-only and tools-only. The wire-level `list_tools_mcp()` / `call_tool_mcp()` methods, direct `client.session` access, and server-initiated messages (notifications, sampling) all carry the server's unprefixed names — the server never sees the prefix. Calling `call_tool()` with an unprefixed name raises `ValueError`, so the names an agent discovers are always the names it can call.

```python
from fastmcp import Client

weather = Client("https://weather-api.example.com/mcp", mode="auto", tool_name_prefix="weather_")
assistant = Client("https://assistant-api.example.com/mcp", mode="legacy", tool_name_prefix="assistant_")

async with weather:
    tools = await weather.list_tools()   # weather_get_forecast, ...
    result = await weather.call_tool("weather_get_forecast", {"city": "Chicago"})
```

The string is used verbatim (no separator is appended), so the entire API is one string — no separator, override, or callback knobs. Draft: this is one of two candidate homes for client-side tool naming; compare with the experimental `ClientGroup` in #4904, whose `{server}_{tool}` naming would delegate to this parameter if it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrQJXPeMepQgJay5xF91yE
