### PR TITLE
fix(openapi): keep explicit null body properties in the request

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -175,9 +175,6 @@ class RequestDirector:
         # Use parameter map to route arguments to correct locations
         if hasattr(route, "parameter_map") and route.parameter_map:
             for arg_name, value in flat_args.items():
-                if value is None:
-                    continue  # Skip None values for optional parameters
-
                 if arg_name not in route.parameter_map:
                     logger.warning(
                         f"Argument '{arg_name}' not found in parameter map for {route.operation_id}"
@@ -187,6 +184,11 @@ class RequestDirector:
                 mapping = route.parameter_map[arg_name]
                 location = mapping["location"]
                 openapi_name = mapping["openapi_name"]
+
+                # A null body property means "clear this field" and has to survive.
+                # There is no serialization for a null path, query, header or cookie.
+                if value is None and location != "body":
+                    continue
 
                 if location == "path":
                     path_params[openapi_name] = value
@@ -213,13 +215,12 @@ class RequestDirector:
 
             # Map arguments to locations
             for arg_name, value in flat_args.items():
-                if value is None:
-                    continue
-
                 # Check if it's a suffixed parameter (e.g., id__path)
                 if "__" in arg_name:
                     base_name, location = arg_name.rsplit("__", 1)
                     if location in ["path", "query", "header", "cookie"]:
+                        if value is None:
+                            continue
                         if location == "path":
                             path_params[base_name] = value
                         elif location == "query":
@@ -232,6 +233,8 @@ class RequestDirector:
 
                 # Check if it's a known parameter
                 if arg_name in param_locations:
+                    if value is None:
+                        continue
                     location = param_locations[arg_name]
                     if location == "path":
                         path_params[arg_name] = value

--- a/tests/utilities/openapi/test_director.py
+++ b/tests/utilities/openapi/test_director.py
@@ -221,13 +221,13 @@ class TestRequestDirector:
         assert body_data["name"] == "John Doe"
 
     def test_build_request_with_none_values(self, director, complex_route):
-        """Test that None values are skipped for optional parameters."""
+        """None query and header values are dropped; a null body property is sent."""
         flat_args = {
             "id": "item123",
             "version": None,  # Optional, should be skipped
             "X-Client-Version": None,  # Optional, should be skipped
             "title": "Required Title",
-            "description": None,  # Optional body param, should be skipped
+            "description": None,  # Optional body param, clears the field
         }
 
         request = director.build(complex_route, flat_args, "https://api.example.com")
@@ -241,7 +241,20 @@ class TestRequestDirector:
 
         body_data = json.loads(request.content)
         assert body_data["title"] == "Required Title"
-        assert "description" not in body_data  # Should not include None description
+        assert body_data["description"] is None
+
+    def test_build_request_with_only_a_null_body_property(
+        self, director, complex_route
+    ):
+        """A body of nothing but nulls is still a body, not an omitted request body."""
+        request = director.build(
+            complex_route,
+            {"id": "item123", "description": None},
+            "https://api.example.com",
+        )
+
+        assert json.loads(request.content) == {"description": None}
+        assert request.headers["content-type"].startswith("application/json")
 
     def test_build_request_fallback_mapping(self, director):
         """Test fallback parameter mapping when parameter_map is not available."""


### PR DESCRIPTION
## Description

Closes #4924

`RequestDirector._unflatten_arguments` discards any argument whose value is `None` at the top of its loop, before `route.parameter_map` says where that argument belongs. Dropping a null is correct for path, query, header and cookie parameters, which have no serialization for one. For a JSON body it is not: omitting a field and sending it as `null` mean different things, and this collapses them.

The result is that the "send `null` to clear" half of the usual PATCH convention is unreachable, and it fails quietly. With other fields present the request returns `200` with the field untouched; with the null as the only body argument, `body_props` ends up empty, the truthiness gate on body assembly leaves `body` as `None`, and httpx sends the request with no body and no `Content-Type`.

The check now runs after the location lookup, so it only skips the parameter kinds that cannot carry a null. The fallback mapping branch below had the same ordering, so it is fixed the same way.

The schema half was already right: since #3768 these fields are advertised as `{"type": ["string", "null"]}`, so a model sending `null` is doing what the tool told it to.

### One existing assertion changed

`test_build_request_with_none_values` asserted `"description" not in body_data` for a null body property. That assertion encodes the behaviour this PR fixes, so it now asserts the null arrives instead. Its query and header assertions are unchanged. It came in wholesale with #2513 as a description of the parser's behaviour rather than as a decision about null semantics, which #3768 had already settled the other way.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

### Verification

- `test_build_request_with_only_a_null_body_property` covers the empty-body case; both it and the updated `test_build_request_with_none_values` fail without the change.
- `pytest tests/utilities/openapi tests/server/providers/openapi tests/client/test_openapi.py`: 326 passed.
- `prek`: `ruff check`, `ruff format`, `loq`, `codespell` pass. `ty` fails on this Windows host only, on `fcntl.flock` / `fcntl.LOCK_EX` in `tests/utilities/json_schema_type/test_real_world_schemas.py`, before and after the change.

An LLM helped trace the call path and draft the tests; the diagnosis, the scope decision and the final code are mine, and I ran everything above locally.