### PR TITLE
docs: prepare FastMCP 4 beta 5

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,30 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v4.0.0b5" description="2026-08-28">
+
+**[v4.0.0b5: Group Effourt](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b5)**
+
+FastMCP 4 beta 5 introduces `ClientGroup` — one managed client per server, each negotiating its own protocol era independently, with collision-checked tool namespacing and call routing and no proxy in the middle — and aligns middleware response limits with output schemas.
+
+### Enhancements ✨
+* Remove obsolete Docket memory-server reset fixtures by [@TyceHerrman](https://github.com/TyceHerrman) in [#4912](https://github.com/PrefectHQ/fastmcp/pull/4912)
+* add independent client groups by [@zzstoatzz](https://github.com/zzstoatzz) in [#4904](https://github.com/PrefectHQ/fastmcp/pull/4904)
+
+### Fixes 🐞
+* fix(ci): satisfy latest ty control-flow checks by [@zzstoatzz](https://github.com/zzstoatzz) in [#4928](https://github.com/PrefectHQ/fastmcp/pull/4928)
+* fix(middleware): align response limits with output schemas by [@zzstoatzz](https://github.com/zzstoatzz) in [#4931](https://github.com/PrefectHQ/fastmcp/pull/4931)
+
+### Docs 📚
+* docs: fix beta 4 changelog MDX by [@zzstoatzz](https://github.com/zzstoatzz) in [#4916](https://github.com/PrefectHQ/fastmcp/pull/4916)
+
+## New Contributors
+* @TyceHerrman made their first contribution in [#4912](https://github.com/PrefectHQ/fastmcp/pull/4912)
+
+**Full Changelog**: [v4.0.0b4...v4.0.0b5](https://github.com/PrefectHQ/fastmcp/compare/v4.0.0b4...v4.0.0b5)
+
+</Update>
+
 <Update label="v4.0.0b4" description="2026-08-26">
 
 **[v4.0.0b4: Calm Befour the Storm](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b4)**

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,20 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 4.0.0b5" description="August 28, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v4.0.0b5: Group Effourt"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b5"
+cta="Read the release notes"
+>
+FastMCP 4 beta 5 introduces client groups: coordinate several independent MCP server connections through one tool catalog, without a proxy in the middle.
+
+🤝 **Client groups** — `ClientGroup` manages one client per server, each negotiating its own protocol era, with collision-checked `{server}_{tool}` namespacing, call routing, and per-tool provenance for adapters.
+
+📏 **Consistent limits** — middleware response limits now align with declared output schemas.
+</Card>
+</Update>
+
 <Update label="FastMCP 4.0.0b4" description="August 26, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v4.0.0b4: Calm Befour the Storm"


### PR DESCRIPTION
Changelog and updates entries for v4.0.0b5 (Group Effourt), landed ahead of the tag so the release's publication carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrQJXPeMepQgJay5xF91yE
