### PR TITLE
Preserve explicit null for nullable OpenAPI request-body properties

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -15,6 +15,44 @@ from .models import HTTPRoute, ParameterInfo
 logger = get_logger(__name__)
 
 
+def _is_nullable(schema: Any) -> bool:
+    """Whether a property schema explicitly permits null.
+
+    Covers the three spellings a spec may use: an OpenAPI 3.1 type array
+    (``{"type": ["string", "null"]}``), an OpenAPI 3.0 ``nullable: true``
+    flag, and a ``null`` branch inside ``anyOf``/``oneOf``.
+    """
+    if not isinstance(schema, dict):
+        return False
+    if schema.get("nullable") is True:
+        return True
+    schema_type = schema.get("type")
+    if schema_type == "null" or (
+        isinstance(schema_type, list) and "null" in schema_type
+    ):
+        return True
+    for keyword in ("anyOf", "oneOf"):
+        for subschema in schema.get(keyword) or ():
+            if _is_nullable(subschema):
+                return True
+    return False
+
+
+def _nullable_body_props(route: HTTPRoute) -> set[str]:
+    """Names of request-body properties whose schema explicitly permits null."""
+    request_body = getattr(route, "request_body", None)
+    content_schema = getattr(request_body, "content_schema", None)
+    if not content_schema:
+        return set()
+    body_schema = next(iter(content_schema.values()))
+    if not isinstance(body_schema, dict):
+        return set()
+    properties = body_schema.get("properties")
+    if not isinstance(properties, dict):
+        return set()
+    return {name for name, sub in properties.items() if _is_nullable(sub)}
+
+
 def _query_scalar_to_str(value: Any) -> str:
     """Convert a scalar to its query-string representation.
 
@@ -171,20 +209,32 @@ class RequestDirector:
         header_params = {}
         cookie_params = {}
         body_props = {}
+        nullable_body_props = _nullable_body_props(route)
 
         # Use parameter map to route arguments to correct locations
         if hasattr(route, "parameter_map") and route.parameter_map:
             for arg_name, value in flat_args.items():
-                if value is None:
-                    continue  # Skip None values for optional parameters
+                mapping = route.parameter_map.get(arg_name)
 
-                if arg_name not in route.parameter_map:
+                if value is None:
+                    # A null is only meaningful for a body property the spec
+                    # declares nullable: there it distinguishes "clear this
+                    # field" from "leave it unchanged". Everywhere else (path,
+                    # query, header, cookie, non-nullable body props) there is
+                    # nothing sensible to serialize, so the argument is skipped.
+                    if not (
+                        mapping is not None
+                        and mapping["location"] == "body"
+                        and mapping["openapi_name"] in nullable_body_props
+                    ):
+                        continue
+
+                if mapping is None:
                     logger.warning(
                         f"Argument '{arg_name}' not found in parameter map for {route.operation_id}"
                     )
                     continue
 
-                mapping = route.parameter_map[arg_name]
                 location = mapping["location"]
                 openapi_name = mapping["openapi_name"]
 
@@ -214,7 +264,16 @@ class RequestDirector:
             # Map arguments to locations
             for arg_name, value in flat_args.items():
                 if value is None:
-                    continue
+                    # Same rule as above: keep an explicit null only when it
+                    # lands on a body property the spec declares nullable.
+                    # In this branch a body property is one that is neither
+                    # location-suffixed nor a declared parameter.
+                    if not (
+                        "__" not in arg_name
+                        and arg_name not in param_locations
+                        and arg_name in nullable_body_props
+                    ):
+                        continue
 
                 # Check if it's a suffixed parameter (e.g., id__path)
                 if "__" in arg_name:

--- a/tests/utilities/openapi/test_director.py
+++ b/tests/utilities/openapi/test_director.py
@@ -1528,3 +1528,120 @@ class TestCookieParameters:
         assert "version=3" in cookie
         # Booleans use OpenAPI convention (true/false, not True/False)
         assert "debug=true" in cookie
+
+
+class TestNullableBodyProperties:
+    """Explicit JSON null must survive into a nullable request-body property."""
+
+    @pytest.fixture
+    def director(self, basic_openapi_30_spec):
+        return RequestDirector(SchemaPath.from_dict(basic_openapi_30_spec))
+
+    @staticmethod
+    def _route(folder_id_schema):
+        """PATCH route whose `folder_id` body property uses the given schema."""
+        return HTTPRoute(
+            path="/files/{file_id}",
+            method="PATCH",
+            operation_id="update_file",
+            parameters=[
+                ParameterInfo(
+                    name="file_id",
+                    location="path",
+                    required=True,
+                    schema={"type": "string"},
+                ),
+                ParameterInfo(
+                    name="version",
+                    location="query",
+                    required=False,
+                    schema={"type": "integer"},
+                ),
+            ],
+            request_body=RequestBodyInfo(
+                required=True,
+                content_schema={
+                    "application/json": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "folder_id": folder_id_schema,
+                        },
+                    }
+                },
+            ),
+            parameter_map={
+                "file_id": {"location": "path", "openapi_name": "file_id"},
+                "version": {"location": "query", "openapi_name": "version"},
+                "name": {"location": "body", "openapi_name": "name"},
+                "folder_id": {"location": "body", "openapi_name": "folder_id"},
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "folder_id_schema",
+        [
+            pytest.param({"type": ["string", "null"]}, id="openapi-31-type-array"),
+            pytest.param(
+                {"type": "string", "nullable": True}, id="openapi-30-nullable"
+            ),
+            pytest.param(
+                {"anyOf": [{"type": "string"}, {"type": "null"}]}, id="anyof-null"
+            ),
+        ],
+    )
+    def test_explicit_null_is_sent_for_nullable_body_property(
+        self, director, folder_id_schema
+    ):
+        """Sending null must clear the field, not read as "leave unchanged"."""
+        request = director.build(
+            self._route(folder_id_schema),
+            {"file_id": "f1", "name": "renamed", "folder_id": None},
+            "https://api.example.com",
+        )
+
+        assert json.loads(request.content) == {"name": "renamed", "folder_id": None}
+
+    def test_null_only_body_still_sends_json(self, director):
+        """A body of just one null must not collapse to an empty request."""
+        request = director.build(
+            self._route({"type": ["string", "null"]}),
+            {"file_id": "f1", "folder_id": None},
+            "https://api.example.com",
+        )
+
+        assert json.loads(request.content) == {"folder_id": None}
+        assert "application/json" in request.headers.get("content-type", "")
+
+    def test_null_non_nullable_body_property_is_still_dropped(self, director):
+        """A null on a property the spec never allows null for stays omitted."""
+        request = director.build(
+            self._route({"type": "string"}),
+            {"file_id": "f1", "name": "renamed", "folder_id": None},
+            "https://api.example.com",
+        )
+
+        assert json.loads(request.content) == {"name": "renamed"}
+
+    def test_null_query_parameter_is_still_dropped(self, director):
+        """Nullability only applies to the body; a null query param has no wire form."""
+        request = director.build(
+            self._route({"type": ["string", "null"]}),
+            {"file_id": "f1", "name": "renamed", "version": None},
+            "https://api.example.com",
+        )
+
+        assert "version" not in str(request.url)
+
+    def test_null_body_property_without_parameter_map(self, director):
+        """The fallback mapping path honours nullability too."""
+        route = self._route({"type": ["string", "null"]})
+        route.parameter_map = {}
+
+        request = director.build(
+            route,
+            {"file_id": "f1", "name": "renamed", "folder_id": None},
+            "https://api.example.com",
+        )
+
+        assert json.loads(request.content) == {"name": "renamed", "folder_id": None}


### PR DESCRIPTION
`RequestDirector._unflatten_arguments` starts its loop by dropping every argument whose value is `None`, and it does that *before* looking the argument up in `route.parameter_map`. Skipping a null is the right call for path, query, header and cookie parameters — there is no sensible way to put one on the wire. For a JSON request body it throws away information the caller deliberately supplied.

That matters because omitting a field and sending it as `null` mean different things in a partial update: "leave this alone" versus "clear it". Plenty of APIs document exactly that convention, and the schema half of FastMCP already supports it — #3768 fixed `nullable` conversion, so the generated tool schema correctly advertises `{"type": ["string", "null"]}` and a model is right to send a null. The request-building half was never reconciled with it, so the null is dropped and the request goes out looking identical to one that never mentioned the field. The server returns 200, nothing is cleared, and the model reports success.

The quieter variant is worse. When the null is the *only* body argument, `body_props` ends up empty, the truthiness check on body assembly leaves `body` as `None`, and httpx sends the request with no body and no `Content-Type` at all — which servers tend to reject with a schema-shaped error that points nowhere near the real cause.

## What this changes

Nulls are now preserved when the argument maps to a body property whose schema explicitly permits null. Everything else keeps the old behaviour: nulls on path, query, header and cookie parameters are still dropped, and so are nulls on body properties the spec does not mark nullable.

Nullability is resolved through a small `_is_nullable` helper that accepts all three spellings a spec might use — an OpenAPI 3.1 type array, an OpenAPI 3.0 `nullable: true`, and a `null` branch inside `anyOf`/`oneOf` — since which one you get depends on the source spec's version and how it was generated.

The same `if value is None: continue` exists a second time in the fallback branch that runs when a route has no `parameter_map`. I fixed that path too rather than leaving the two halves of the function disagreeing about what a null means.

The `mapping` lookup moved a few lines up (from `route.parameter_map[arg_name]` to a `.get()` before the null check) because the null decision needs to know the argument's location. The not-in-map warning is unchanged.

## Testing

New `TestNullableBodyProperties` class in `tests/utilities/openapi/test_director.py`: the reported case parametrised over all three nullable spellings, the null-only-body case asserting a real JSON body and `Content-Type` come out, the no-`parameter_map` fallback path, and two guards pinning the behaviour that must *not* change (non-nullable body property still dropped, null query parameter still absent from the URL).

```
uv run pytest tests/utilities/openapi tests/server/providers/openapi -q
```

- pristine `main`: `312 passed`
- with this change: `319 passed`

The delta is exactly the seven added tests, so nothing existing was skipped or broken. In particular `test_build_request_with_none_values`, which asserts a null on a non-nullable body property gets dropped, still passes untouched.

I also checked the new tests actually fail without the fix — reverting only `director.py` and keeping the tests gives 5 failures with real assertion diffs (`{'name': 'renamed'} != {'name': 'renamed', 'folder_id': None}`), while the two regression guards keep passing in both states.

`ruff check`, `ruff format --check` and `ty check` are clean on both touched files.

Fixes #4924
