### PR TITLE
docs: publish main to published-docs (b5 changelog, client docs)

### DIFF
--- a/dev-docs/v4-notes/client-groups.md
+++ b/dev-docs/v4-notes/client-groups.md
@@ -1,0 +1,33 @@
+---
+title: Client Groups
+---
+
+**Status: In review (#4904).** `ClientGroup` coordinates independent FastMCP clients — one managed connection per server — with collision-checked tool namespacing and call routing. User-facing usage is documented at [Client Groups](https://gofastmcp.com/clients/client-groups).
+
+## TL;DR
+
+Applications that hand tools from several servers to one agent previously chose between two bad shapes. `Client(config)` composes servers behind an in-process proxy, so every backend shares one negotiated protocol era — one handshake-era backend reconnects every modern backend under the handshake era — and concurrent calls funnel through one frontend session. One `Client` per server keeps each negotiated era, but nothing owns the composition: callers hand-roll namespacing, collision detection, lifecycle, and routing.
+
+`ClientGroup` is the object between those two: a mapping of named clients where each connection negotiates independently, tools are published as `{server}_{tool}`, and calls route back through the client that advertised the tool. It lives at `fastmcp.client.group` — in the main namespace, since the surface is additive and small.
+
+## Motivation
+
+The immediate driver was per-server protocol pinning: agent integrations need `mode="legacy"` on one server and `mode="auto"` on another, which a single aggregate connection cannot express. Namespacing requests (a prefix for a single server's tools) kept arriving alongside it, because the same integrations feed multiple servers' tools to one model.
+
+## Decisions
+
+**Group over kwarg.** A `tool_name_prefix` kwarg on `Client` was fully implemented as a comparison (#4932, closed). It was rejected because a prefix is collision policy, and collision policy belongs with the composition object that detects collisions. It also would have made the stable single-server client present names the server never advertised. The group's dict keys are the namespace; a one-client group is the supported way to get namespacing alone.
+
+**No synthetic frontend.** There is no aggregate session and no protocol translation. `resolve_tool()` returns the server name, the owning `Client`, and the upstream tool name, because tool adapters need to bind per-tool behavior (session-driven input loops, handlers, interceptors) to the real connection. The group never stands between an adapter and the client.
+
+**Invariants over flexibility.** Membership is immutable after construction (routes hold the advertising client and would go stale under mutation). Group entry is race-guarded and connects clients concurrently, unwinding successes on partial failure. A known route only requires its own client to be connected, so one dead server does not fail calls routed to healthy servers; full-fleet connectivity is required only for catalog discovery, which queries everyone.
+
+**Tool-only for now.** Resources have URI-based identity with different collision rules, and prompts a different invocation surface. Expanding beyond tools should follow concrete usage rather than declaring those policies by analogy.
+
+## Performance
+
+Measured against two real local streamable-HTTP servers (ratios are the finding, not the absolute numbers): routed calls through the group are indistinguishable from direct client calls (p50 1.89ms both), while the `Client(config)` proxy adds ~65% per call. Under concurrency the difference compounds — 200 concurrent calls across both servers completed ~6x faster through the group (~145ms vs ~875ms), because the group fans out over independent sessions while the proxy serializes through one. Group entry connects clients concurrently, so entry latency stays roughly one handshake deep instead of growing linearly with server count.
+
+## Relationship to the upstream SDK group
+
+The MCP Python SDK's `ClientSessionGroup` is the prior art. Its `connect_to_server()` owns lifecycle but only speaks the classic handshake; `connect_with_session()` can register an externally negotiated modern session but does not own it. `ClientGroup` combines independent modern negotiation with group-owned lifecycle while keeping calls on the configured FastMCP client surface (auth, tracing, caching, result parsing, progress, multi-round tools).

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,30 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v4.0.0b5" description="2026-08-28">
+
+**[v4.0.0b5: Group Effourt](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b5)**
+
+FastMCP 4 beta 5 introduces `ClientGroup` — one managed client per server, each negotiating its own protocol era independently, with collision-checked tool namespacing and call routing and no proxy in the middle — and aligns middleware response limits with output schemas.
+
+### Enhancements ✨
+* Remove obsolete Docket memory-server reset fixtures by [@TyceHerrman](https://github.com/TyceHerrman) in [#4912](https://github.com/PrefectHQ/fastmcp/pull/4912)
+* add independent client groups by [@zzstoatzz](https://github.com/zzstoatzz) in [#4904](https://github.com/PrefectHQ/fastmcp/pull/4904)
+
+### Fixes 🐞
+* fix(ci): satisfy latest ty control-flow checks by [@zzstoatzz](https://github.com/zzstoatzz) in [#4928](https://github.com/PrefectHQ/fastmcp/pull/4928)
+* fix(middleware): align response limits with output schemas by [@zzstoatzz](https://github.com/zzstoatzz) in [#4931](https://github.com/PrefectHQ/fastmcp/pull/4931)
+
+### Docs 📚
+* docs: fix beta 4 changelog MDX by [@zzstoatzz](https://github.com/zzstoatzz) in [#4916](https://github.com/PrefectHQ/fastmcp/pull/4916)
+
+## New Contributors
+* @TyceHerrman made their first contribution in [#4912](https://github.com/PrefectHQ/fastmcp/pull/4912)
+
+**Full Changelog**: [v4.0.0b4...v4.0.0b5](https://github.com/PrefectHQ/fastmcp/compare/v4.0.0b4...v4.0.0b5)
+
+</Update>
+
 <Update label="v4.0.0b4" description="2026-08-26">
 
 **[v4.0.0b4: Calm Befour the Storm](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b4)**

--- a/docs/clients/client-groups.mdx
+++ b/docs/clients/client-groups.mdx
@@ -1,0 +1,115 @@
+---
+title: Client Groups
+sidebarTitle: Client Groups
+icon: layer-group
+---
+
+import { VersionBadge } from '/snippets/version-badge.mdx'
+
+<VersionBadge version="4.0.0" />
+
+A `ClientGroup` coordinates several independent FastMCP clients without combining them behind a proxy server. Each client keeps its own connection, negotiated protocol version, capabilities, and handlers. The group adds namespaced tool discovery and routes each call back to the client that advertised the tool.
+
+This differs from passing a multi-server configuration directly to `Client`. `Client(config)` presents one aggregate MCP endpoint and therefore selects one protocol era shared by its proxy chain. A `ClientGroup` retains one MCP connection per configured server, so legacy and modern servers can operate in their native eras at the same time.
+
+## Create a group from clients
+
+Construct the clients explicitly when each server needs its own handlers, authentication, or connection settings:
+
+```python
+import asyncio
+
+from fastmcp import Client
+from fastmcp.client.group import ClientGroup
+
+legacy_client = Client("legacy_server.py", mode="legacy")
+modern_client = Client("https://modern.example.com/mcp", mode="auto")
+
+group = ClientGroup(
+    {
+        "legacy": legacy_client,
+        "modern": modern_client,
+    }
+)
+
+
+async def main() -> None:
+    async with group:
+        tools = await group.list_tools()
+        print([tool.name for tool in tools])
+
+        result = await group.call_tool(
+            "modern_get_weather",
+            {"city": "Chicago"},
+        )
+        print(result)
+
+
+asyncio.run(main())
+```
+
+Tool names are prefixed with the configured client name by default. For example, a `get_weather` tool exposed by the `modern` client becomes `modern_get_weather`.
+
+A group with a single client is a supported way to get namespacing alone: the one server's tools are presented under its configured name, with no other behavior change.
+
+The first routed call loads the tool catalog lazily. After a successful load, unknown tool names fail locally rather than repeating discovery against every server. Call `list_tools()` explicitly to refresh the routes when servers add or remove tools dynamically — the explicit call refreshes past any client-side response cache, so the catalog reflects what every server advertises now.
+
+## Bind tools to their owning client
+
+Tool adapters — code that turns MCP tools into callables for an agent framework — often need more than routed calls: session-driven input loops, handler context, and interceptors must run on the connection that owns the tool. `resolve_tool()` returns that route, so an adapter can discover through the group and still bind each generated tool to its real client:
+
+```python
+async with group:
+    for tool in await group.list_tools():
+        route = await group.resolve_tool(tool.name)
+        # route.client is the connected FastMCP client for this tool;
+        # route.upstream_name is the name the server itself advertises
+        register_agent_tool(tool, client=route.client, name=route.upstream_name)
+```
+
+The group aggregates names and detects collisions; it never stands between the adapter and the client, so everything a single `Client` supports keeps working per tool.
+
+## Create a group from configuration
+
+`ClientGroup.from_config` creates one client per server rather than passing the entire configuration through a proxy. A FastMCP-specific `mode` field can select the protocol behavior for each server:
+
+```python
+from fastmcp.client.group import ClientGroup
+
+config = {
+    "mcpServers": {
+        "legacy": {
+            "command": "python",
+            "args": ["legacy_server.py"],
+            "mode": "legacy",
+        },
+        "modern": {
+            "url": "https://modern.example.com/mcp",
+            "mode": "auto",
+        },
+    }
+}
+
+group = ClientGroup.from_config(config)
+```
+
+Entries without a `mode` use `"auto"` by default.
+
+## Manage connections explicitly
+
+Using the group as a context manager is optional. Applications can own each client connection and use the group only for discovery and routing:
+
+```python
+async with legacy_client, modern_client:
+    tools = await group.list_tools()
+```
+
+It is also safe to enter the group inside a client context. FastMCP client contexts are reference counted, so leaving the group does not close a connection still owned by an outer context.
+
+The group adds no session handling of its own. Each client owns its transport and session exactly as it does standalone, so a legacy stateful session (for example over SSE or stdio) is held open by its client for as long as that client's context is active, whether the group or the caller entered it.
+
+## Relationship to SDK session groups
+
+The upstream official MCP Python SDK provides `ClientSessionGroup` for aggregating raw `ClientSession` connections, including tools, resources, and prompts. Its `connect_to_server()` path uses the classic `initialize` handshake, so it does not negotiate the modern protocol. Use it when classic sessions, raw SDK results, and dynamic group membership fit the application.
+
+`connect_with_session()` can register a modern session that was connected separately, but the caller must create and keep that client alive because the SDK group does not own sessions registered this way. `ClientGroup` instead manages fully configured FastMCP clients directly. Each client can negotiate its own modern or legacy protocol, and calls continue through that client, preserving its authentication, handlers, caching, tracing, result parsing, and multi-round tool behavior. The API is intentionally narrower and currently aggregates tools only.

--- a/docs/clients/client.mdx
+++ b/docs/clients/client.mdx
@@ -121,6 +121,10 @@ async with client:
     icons = await client.read_resource("weather://weather/icons/sunny")
 ```
 
+<Note>
+A multi-server configuration presents one aggregate MCP endpoint. Each entry still configures its own transport, headers, and auth, but every backend shares the outer client's negotiated protocol era, handlers, and client-level policy. To hold several fully independent connections — each with its own protocol `mode` and handlers — see [Client Groups](/clients/client-groups).
+</Note>
+
 ## Connection Lifecycle
 
 The client uses context managers for connection management. When you enter the context, the client establishes a connection and negotiates the protocol era with the server. Metadata returned by either legacy initialization or modern discovery is exposed through the same client properties.
@@ -212,7 +216,7 @@ async with Client("https://example.com/mcp", mode="auto") as client:
 <Note>
 `mode="auto"` is the default as of FastMCP 4.0. Earlier versions defaulted to `"legacy"`. If a server behaves unexpectedly under discovery, or you depend on the legacy `initialize` result, pin the old behavior with `Client(..., mode="legacy")`.
 
-The SSE transport is legacy-only — it cannot carry the sessionless modern era — so a client connecting over SSE always negotiates the legacy handshake, even under `mode="auto"`. A multi-server config (`MCPConfigTransport` with more than one server) negotiates the best era shared by every connected backend: it stays modern when every backend is modern-capable and reconnects every leg under the handshake era when any backend requires legacy. Pinning `mode="legacy"` or a modern version applies that mode to every backend. All-modern configurations follow normal modern semantics; applications that rely on handshake-era server-initiated sampling or elicitation should pin `mode="legacy"`.
+The SSE transport is legacy-only — it cannot carry the sessionless modern era — so a client connecting over SSE always negotiates the legacy handshake, even under `mode="auto"`. A multi-server config (`MCPConfigTransport` with more than one server) negotiates the best era shared by every connected backend: it stays modern when every backend is modern-capable and reconnects every leg under the handshake era when any backend requires legacy. Pinning `mode="legacy"` or a modern version applies that mode to every backend. All-modern configurations follow normal modern semantics; applications that rely on handshake-era server-initiated sampling or elicitation should pin `mode="legacy"`. To keep each server on its own natively negotiated era instead, use one client per server — [Client Groups](/clients/client-groups) coordinate several independent clients under one tool catalog.
 </Note>
 
 ## Response caching
@@ -243,11 +247,11 @@ config = CacheConfig(target_id="weather-api", default_ttl_ms=60_000)
 client = Client("https://example.com/mcp", mode="auto", cache=config)
 ```
 
-The high-level `list_tools`, `list_resources`, and `list_prompts` methods always use the cache when one is configured. To override the behavior for a single call, use the lower-level `list_tools_mcp`, `list_resources_mcp`, `list_resource_templates_mcp`, and `list_prompts_mcp` variants, which accept a `cache_mode` argument: `"use"` (the default) serves and stores, `"refresh"` stores a fresh result without serving a cached one, and `"bypass"` skips the cache entirely.
+The listing methods use the cache by default when one is configured. To override the behavior for a single call, pass `cache_mode`: `"use"` (the default) serves and stores, `"refresh"` stores a fresh result without serving a cached one, and `"bypass"` skips the cache entirely. `list_tools` accepts it directly; the lower-level `list_tools_mcp`, `list_resources_mcp`, `list_resource_templates_mcp`, and `list_prompts_mcp` variants accept it as well.
 
 ```python
 async with client:
-    fresh = await client.list_tools_mcp(cache_mode="refresh")
+    fresh = await client.list_tools(cache_mode="refresh")
 ```
 
 ### Sharing a cache across clients

--- a/docs/clients/tools.mdx
+++ b/docs/clients/tools.mdx
@@ -11,7 +11,32 @@ import { VersionBadge } from '/snippets/version-badge.mdx'
 
 Use this when you need to execute server-side functions and process their results.
 
-Tools are executable functions exposed by MCP servers. The client's `call_tool()` method executes a tool by name with arguments and returns structured results.
+Tools are executable functions exposed by MCP servers. The client's `list_tools()` method discovers what a server offers, and `call_tool()` executes a tool by name with arguments and returns structured results.
+
+## Discovering Tools
+
+`list_tools()` returns every tool the server advertises as a list of `mcp_types.Tool` objects, each carrying the tool's name, description, and JSON `input_schema`. It follows pagination automatically, so the result is the complete catalog.
+
+```python
+async with client:
+    tools = await client.list_tools()
+    for tool in tools:
+        print(tool.name, tool.description)
+        print(tool.input_schema)
+```
+
+Servers can change their catalog while the connection is open and notify the client with a `notifications/tools/list_changed` notification; a fresh `list_tools()` call reflects the new set. See [Notifications](/clients/notifications) for reacting to that notification.
+
+For page-by-page control over large catalogs, `list_tools_mcp()` returns one raw `ListToolsResult` at a time and accepts the `cursor` from the previous page's `next_cursor`.
+
+```python
+async with client:
+    page = await client.list_tools_mcp()
+    while page.next_cursor:
+        page = await client.list_tools_mcp(cursor=page.next_cursor)
+```
+
+Both methods accept a `cache_mode` argument when the client was built with a [response cache](/clients/client#response-caching).
 
 ## Basic Execution
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -243,6 +243,7 @@
                   "clients/client",
                   "clients/client-only-package",
                   "clients/transports",
+                  "clients/client-groups",
                   "clients/fastmcp-remote",
                   {
                     "collapsed": true,

--- a/docs/servers/middleware.mdx
+++ b/docs/servers/middleware.mdx
@@ -618,7 +618,7 @@ def search(query: str) -> str:
 When a response exceeds the limit, the middleware extracts all text content, joins it together, truncates to fit within the limit, and returns a single `TextContent` block. For non-text responses, the serialized JSON is used as the text source.
 
 <Note>
-If a tool defines an `output_schema`, truncated responses will no longer conform to that schema — the client will receive a plain `TextContent` block instead of the expected structured output. Keep this in mind when setting size limits for tools with structured responses.
+Because truncation can replace structured output with plain text, the middleware omits `outputSchema` from `tools/list` for every tool it limits. Responses below the limit still include their original structured content, but clients cannot validate or hydrate it against an advertised output schema. Tools excluded with the `tools` parameter keep their output schemas.
 </Note>
 
 ```python

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,20 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 4.0.0b5" description="August 28, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v4.0.0b5: Group Effourt"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0b5"
+cta="Read the release notes"
+>
+FastMCP 4 beta 5 introduces client groups: coordinate several independent MCP server connections through one tool catalog, without a proxy in the middle.
+
+🤝 **Client groups** — `ClientGroup` manages one client per server, each negotiating its own protocol era, with collision-checked `{server}_{tool}` namespacing, call routing, and per-tool provenance for adapters.
+
+📏 **Consistent limits** — middleware response limits now align with declared output schemas.
+</Card>
+</Update>
+
 <Update label="FastMCP 4.0.0b4" description="August 26, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v4.0.0b4: Calm Befour the Storm"

--- a/fastmcp_slim/fastmcp/client/group.py
+++ b/fastmcp_slim/fastmcp/client/group.py
@@ -1,0 +1,264 @@
+"""Coordination of independent MCP client connections."""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType, TracebackType
+from typing import Any
+
+import anyio
+import mcp_types
+from mcp.client.caching import CacheMode
+
+from fastmcp.client.client import CallToolResult, Client, ConnectMode
+from fastmcp.client.progress import ProgressHandler
+from fastmcp.mcp_config import MCPConfig
+from fastmcp.utilities.async_utils import gather
+
+
+@dataclass(frozen=True)
+class ToolRoute:
+    """The client and upstream name behind a public group tool name."""
+
+    server_name: str
+    client: Client[Any]
+    upstream_name: str
+
+
+class ClientGroup:
+    """Coordinate independent clients without introducing a proxy server.
+
+    Each client retains its own transport, session, capabilities, and protocol
+    version. The group only combines tool discovery and routes tool calls.
+
+    Callers may manage the clients' connections themselves or use the group as
+    a convenience context manager. Entering an already-connected FastMCP client
+    is safe because client contexts are reference counted.
+    """
+
+    def __init__(self, clients: Mapping[str, Client[Any]]) -> None:
+        if not clients:
+            raise ValueError("ClientGroup requires at least one client")
+
+        self._clients = dict(clients)
+        self._exit_stack: contextlib.AsyncExitStack | None = None
+        self._tool_routes: dict[str, ToolRoute] = {}
+        self._catalog_loaded = False
+        self._route_lock = anyio.Lock()
+
+    @property
+    def clients(self) -> Mapping[str, Client[Any]]:
+        """The group's clients, keyed by server name.
+
+        Read-only: membership is fixed at construction, since discovered routes
+        hold the client that advertised each tool and would silently go stale
+        if the mapping were swapped underneath them.
+        """
+        return MappingProxyType(self._clients)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: MCPConfig | dict[str, Any],
+        *,
+        default_mode: ConnectMode = "auto",
+    ) -> ClientGroup:
+        """Create one independent client for each configured server.
+
+        A server entry may include a FastMCP-specific ``mode`` field. It applies
+        only to that server; entries without one use ``default_mode``.
+        """
+        parsed = (
+            config if isinstance(config, MCPConfig) else MCPConfig.from_dict(config)
+        )
+        clients: dict[str, Client[Any]] = {}
+
+        for name, server in parsed.mcpServers.items():
+            configured_mode = (server.model_extra or {}).get("mode", default_mode)
+            if not isinstance(configured_mode, str):
+                raise TypeError(f"Protocol mode for server {name!r} must be a string")
+            clients[name] = Client(server.to_transport(), mode=configured_mode)
+
+        return cls(clients)
+
+    @property
+    def protocol_versions(self) -> dict[str, str | None]:
+        return {name: client.protocol_version for name, client in self._clients.items()}
+
+    async def __aenter__(self) -> ClientGroup:
+        if self._exit_stack is not None:
+            raise RuntimeError("ClientGroup is already connected")
+
+        # Claim the stack before the first await so a concurrent entry hits the
+        # guard above instead of racing past it and overwriting this one.
+        stack = contextlib.AsyncExitStack()
+        self._exit_stack = stack
+        await stack.__aenter__()
+
+        # Connect concurrently: entry latency stays one handshake deep instead
+        # of growing linearly with the number of servers. With
+        # return_exceptions=True every connection attempt runs to completion,
+        # so on partial failure the successes are known and can be unwound.
+        clients = list(self._clients.values())
+        results = await gather(
+            (client.__aenter__() for client in clients), return_exceptions=True
+        )
+        errors = [result for result in results if isinstance(result, BaseException)]
+        if errors:
+            for client, result in zip(clients, results, strict=True):
+                if not isinstance(result, BaseException):
+                    with contextlib.suppress(Exception):
+                        await client.__aexit__(None, None, None)
+            self._exit_stack = None
+            await stack.aclose()
+            raise errors[0]
+
+        for client in clients:
+            stack.push_async_exit(client)
+
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        stack = self._exit_stack
+        self._exit_stack = None
+        self._tool_routes.clear()
+        self._catalog_loaded = False
+        if stack is not None:
+            return await stack.__aexit__(exc_type, exc_value, traceback)
+        return None
+
+    def _require_connected(self) -> None:
+        disconnected = [
+            name for name, client in self._clients.items() if not client.is_connected()
+        ]
+        if disconnected:
+            names = ", ".join(repr(name) for name in disconnected)
+            raise RuntimeError(f"ClientGroup clients are not connected: {names}")
+
+    def _require_route_connected(self, route: ToolRoute) -> None:
+        if not route.client.is_connected():
+            raise RuntimeError(
+                f"ClientGroup client for server {route.server_name!r} is not connected"
+            )
+
+    async def list_tools(
+        self, *, cache_mode: CacheMode = "refresh"
+    ) -> list[mcp_types.Tool]:
+        """List tools from every client with namespaced names.
+
+        An explicit call is the group's catalog-refresh mechanism, so it
+        defaults to `cache_mode="refresh"`: a client-side response cache
+        (SEP-2549) is repopulated rather than served, and the routes reflect
+        what every server advertises now. Pass `cache_mode="use"` to allow
+        cache hits when staleness within the server's hint is acceptable.
+        """
+        self._require_connected()
+        tools: list[mcp_types.Tool] = []
+        routes: dict[str, ToolRoute] = {}
+        clients = list(self._clients.items())
+        tool_lists = await gather(
+            client.list_tools(cache_mode=cache_mode) for _, client in clients
+        )
+
+        for (server_name, client), server_tools in zip(
+            clients, tool_lists, strict=True
+        ):
+            for tool in server_tools:
+                public_name = f"{server_name}_{tool.name}"
+                if public_name in routes:
+                    raise ValueError(f"Tool name collision: {public_name!r}")
+                routes[public_name] = ToolRoute(
+                    server_name=server_name,
+                    client=client,
+                    upstream_name=tool.name,
+                )
+                tools.append(tool.model_copy(update={"name": public_name}))
+
+        self._tool_routes = routes
+        self._catalog_loaded = True
+        return tools
+
+    async def resolve_tool(self, name: str) -> ToolRoute:
+        """Resolve a public tool name to its client and upstream identity.
+
+        A known route only requires its own client to be connected; one dead
+        server does not couple failures onto calls routed to healthy servers.
+        Loading the catalog (the first resolution, or after a refresh) still
+        requires every client, since discovery queries them all.
+        """
+        route = self._tool_routes.get(name)
+        if route is not None:
+            self._require_route_connected(route)
+            return route
+        if self._catalog_loaded:
+            raise KeyError(
+                f"Unknown tool: {name!r}. If servers changed their tools,"
+                " call list_tools() to refresh the catalog."
+            )
+
+        async with self._route_lock:
+            route = self._tool_routes.get(name)
+            if route is not None:
+                return route
+            if not self._catalog_loaded:
+                # Lazy cold-start discovery may serve a cached listing; only an
+                # explicit list_tools() call promises a refreshed catalog.
+                await self.list_tools(cache_mode="use")
+                route = self._tool_routes.get(name)
+
+        if route is None:
+            raise KeyError(
+                f"Unknown tool: {name!r}. If servers changed their tools,"
+                " call list_tools() to refresh the catalog."
+            )
+        return route
+
+    async def call_tool_mcp(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        timeout: datetime.timedelta | float | int | None = None,
+        progress_handler: ProgressHandler | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> mcp_types.CallToolResult:
+        """Call a namespaced tool and return its raw MCP result."""
+        route = await self.resolve_tool(name)
+        return await route.client.call_tool_mcp(
+            route.upstream_name,
+            arguments or {},
+            timeout=timeout,
+            progress_handler=progress_handler,
+            meta=meta,
+        )
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        version: str | None = None,
+        timeout: datetime.timedelta | float | int | None = None,
+        progress_handler: ProgressHandler | None = None,
+        raise_on_error: bool = True,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
+        """Call a namespaced tool through the client that advertised it."""
+        route = await self.resolve_tool(name)
+        return await route.client.call_tool(
+            route.upstream_name,
+            arguments,
+            version=version,
+            timeout=timeout,
+            progress_handler=progress_handler,
+            raise_on_error=raise_on_error,
+            meta=meta,
+        )

--- a/fastmcp_slim/fastmcp/client/mixins/tools.py
+++ b/fastmcp_slim/fastmcp/client/mixins/tools.py
@@ -90,6 +90,8 @@ class ClientToolsMixin:
     async def list_tools(
         self: Client,
         max_pages: int = AUTO_PAGINATION_MAX_PAGES,
+        *,
+        cache_mode: CacheMode = "use",
     ) -> list[mcp_types.Tool]:
         """Retrieve all tools available on the server.
 
@@ -99,6 +101,11 @@ class ClientToolsMixin:
 
         Args:
             max_pages: Maximum number of pages to fetch before raising. Defaults to 250.
+            cache_mode: Response-cache behavior for the first page (only active when
+                the client was built with a cache and the connection is modern).
+                `"use"` (default) serves and stores; `"refresh"` stores without
+                serving; `"bypass"` skips the cache. Subsequent cursor pages always
+                skip the cache.
 
         Returns:
             list[mcp_types.Tool]: A list of all Tool objects.
@@ -112,7 +119,7 @@ class ClientToolsMixin:
         seen_cursors: set[str] = set()
 
         for _ in range(max_pages):
-            result = await self.list_tools_mcp(cursor=cursor)
+            result = await self.list_tools_mcp(cursor=cursor, cache_mode=cache_mode)
             all_tools.extend(result.tools)
             if not result.next_cursor:
                 break

--- a/fastmcp_slim/fastmcp/server/middleware/response_limiting.py
+++ b/fastmcp_slim/fastmcp/server/middleware/response_limiting.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 import mcp_types as mt
 import pydantic_core
 from mcp_types import TextContent
 
-from fastmcp.tools.base import InputRequiredToolResult, ToolResult
+from fastmcp.tools.base import InputRequiredToolResult, Tool, ToolResult
 
 from .middleware import CallNext, Middleware, MiddlewareContext
 
@@ -68,6 +69,9 @@ class ResponseLimitingMiddleware(Middleware):
         self.truncation_suffix = truncation_suffix
         self.tools = set(tools) if tools is not None else None
 
+    def _limits_tool(self, name: str) -> bool:
+        return self.tools is None or name in self.tools
+
     def _truncate_to_result(
         self,
         text: str,
@@ -93,14 +97,24 @@ class ResponseLimitingMiddleware(Middleware):
                     + self.truncation_suffix
                 )
 
-        # Preserve original meta, falling back to {} when absent. Having
-        # meta set ensures to_mcp_result() returns a CallToolResult, which
-        # bypasses MCP SDK outputSchema validation — a truncated response
-        # is no longer valid structured output.
         return ToolResult(
             content=[TextContent(type="text", text=truncated)],
-            meta=meta if meta is not None else {},
+            meta=meta,
         )
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        """Hide schemas for tools whose response shape may be truncated to text."""
+        tools = await call_next(context)
+        return [
+            tool.model_copy(update={"output_schema": None})
+            if self._limits_tool(tool.name) and tool.output_schema is not None
+            else tool
+            for tool in tools
+        ]
 
     async def on_call_tool(
         self,
@@ -125,7 +139,7 @@ class ResponseLimitingMiddleware(Middleware):
             return result
 
         # Check if we should limit this tool
-        if self.tools is not None and context.message.name not in self.tools:
+        if not self._limits_tool(context.message.name):
             return result
 
         # Measure serialized size

--- a/fastmcp_slim/fastmcp/utilities/asgi_transport.py
+++ b/fastmcp_slim/fastmcp/utilities/asgi_transport.py
@@ -307,6 +307,7 @@ async def run_asgi_lifespan(app: ASGIApp) -> AsyncIterator[None]:
         raise
     finally:
         await receive_queue.put({"type": "lifespan.shutdown"})
+        results: tuple[object, ...] = ()
         with anyio.CancelScope(shield=True):
             results = await asyncio.gather(
                 shutdown_complete, task, return_exceptions=True

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-api_ref_package := "fastmcp-slim[anthropic,apps,azure,code-mode,full,gemini,openai,tasks] @ file://" + justfile_directory() + "/fastmcp_slim"
+api_ref_package := "fastmcp-slim[anthropic,apps,azure,client,code-mode,gemini,openai,server] @ file://" + justfile_directory() + "/fastmcp_slim"
 
 # Build the project
 build:

--- a/tests/cli/test_project_prepare.py
+++ b/tests/cli/test_project_prepare.py
@@ -253,15 +253,15 @@ class TestProjectPrepareCommand:
         mock_find.return_value = None
 
         # Run command without output_dir - should exit with error for missing output_dir
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("fastmcp.cli.cli.logger.error") as mock_error:
+        with patch("fastmcp.cli.cli.logger.error") as mock_error:
+            with pytest.raises(SystemExit) as exc_info:
                 await prepare(config_path=None, output_dir=None)
 
-        assert isinstance(exc_info.value, SystemExit)
-        assert exc_info.value.code == 1
-        mock_error.assert_called()
-        error_msg = mock_error.call_args[0][0]
-        assert "--output-dir parameter is required" in error_msg
+            assert isinstance(exc_info.value, SystemExit)
+            assert exc_info.value.code == 1
+            mock_error.assert_called()
+            error_msg = mock_error.call_args[0][0]
+            assert "--output-dir parameter is required" in error_msg
 
     @patch("pathlib.Path.exists")
     async def test_project_prepare_config_not_exists(self, mock_exists):
@@ -272,15 +272,15 @@ class TestProjectPrepareCommand:
         mock_exists.return_value = False
 
         # Run command without output_dir - should exit with error for missing output_dir
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("fastmcp.cli.cli.logger.error") as mock_error:
+        with patch("fastmcp.cli.cli.logger.error") as mock_error:
+            with pytest.raises(SystemExit) as exc_info:
                 await prepare(config_path="missing.json", output_dir=None)
 
-        assert isinstance(exc_info.value, SystemExit)
-        assert exc_info.value.code == 1
-        mock_error.assert_called()
-        error_msg = mock_error.call_args[0][0]
-        assert "--output-dir parameter is required" in error_msg
+            assert isinstance(exc_info.value, SystemExit)
+            assert exc_info.value.code == 1
+            mock_error.assert_called()
+            error_msg = mock_error.call_args[0][0]
+            assert "--output-dir parameter is required" in error_msg
 
     @patch("pathlib.Path.exists")
     @patch("fastmcp.utilities.mcp_server_config.MCPServerConfig.from_file")
@@ -295,12 +295,12 @@ class TestProjectPrepareCommand:
         mock_from_file.return_value = mock_config
 
         # Run command - should exit with error
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("fastmcp.cli.cli.console.print") as mock_print:
+        with patch("fastmcp.cli.cli.console.print") as mock_print:
+            with pytest.raises(SystemExit) as exc_info:
                 await prepare(config_path="config.json", output_dir="./test-env")
 
-        assert isinstance(exc_info.value, SystemExit)
-        assert exc_info.value.code == 1
-        # Should print error message
-        error_call = mock_print.call_args_list[-1][0][0]
-        assert "Failed to prepare project" in error_call
+            assert isinstance(exc_info.value, SystemExit)
+            assert exc_info.value.code == 1
+            # Should print error message
+            error_call = mock_print.call_args_list[-1][0][0]
+            assert "Failed to prepare project" in error_call

--- a/tests/client/auth/test_oauth_client.py
+++ b/tests/client/auth/test_oauth_client.py
@@ -225,9 +225,9 @@ async def test_oauth_callback_handler_propagates_iss_to_authorization_code_resul
         tg.start_soon(send_callback)
         result = await oauth.callback_handler()
 
-    assert result.code == "auth-code-123"
-    assert result.state == "state-xyz"
-    assert result.iss == "https://issuer.example.com"
+        assert result.code == "auth-code-123"
+        assert result.state == "state-xyz"
+        assert result.iss == "https://issuer.example.com"
 
 
 class TestOAuthClientUrlHandling:

--- a/tests/client/group/test_client_group.py
+++ b/tests/client/group/test_client_group.py
@@ -1,0 +1,349 @@
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ConfigDict
+
+from fastmcp import Client, Context, FastMCP
+from fastmcp.client.group import ClientGroup
+from fastmcp.client.transports import FastMCPTransport
+from fastmcp.mcp_config import MCPConfig, StdioMCPServer
+
+
+class LegacyFastMCPTransport(FastMCPTransport):
+    legacy_only = True
+
+
+class InMemoryServer(StdioMCPServer):
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+    mcp: FastMCP
+    command: str = "in-memory"
+
+    def to_transport(self) -> FastMCPTransport:
+        return FastMCPTransport(self.mcp)
+
+
+class LegacyInMemoryServer(InMemoryServer):
+    def to_transport(self) -> FastMCPTransport:
+        return LegacyFastMCPTransport(self.mcp)
+
+
+def make_server(name: str) -> FastMCP:
+    server = FastMCP(name)
+
+    @server.tool
+    async def protocol_era(ctx: Context) -> str:
+        request_context = ctx.request_context
+        assert request_context is not None
+        return request_context.protocol_version
+
+    @server.tool
+    def echo(value: str) -> str:
+        return f"{name}: {value}"
+
+    return server
+
+
+async def test_clients_negotiate_independently():
+    legacy = Client(LegacyFastMCPTransport(make_server("legacy")))
+    modern = Client(FastMCPTransport(make_server("modern")))
+    group = ClientGroup({"old": legacy, "new": modern})
+
+    async with group:
+        assert group.protocol_versions == {
+            "old": "2025-11-25",
+            "new": "2026-07-28",
+        }
+
+        tools = await group.list_tools()
+        assert {tool.name for tool in tools} == {
+            "old_protocol_era",
+            "old_echo",
+            "new_protocol_era",
+            "new_echo",
+        }
+        route = await group.resolve_tool("new_echo")
+        assert route.server_name == "new"
+        assert route.client is modern
+        assert route.upstream_name == "echo"
+
+        old_era = await group.call_tool("old_protocol_era")
+        new_era = await group.call_tool("new_protocol_era")
+        echoed = await group.call_tool("new_echo", {"value": "hello"})
+
+        assert old_era.data == "2025-11-25"
+        assert new_era.data == "2026-07-28"
+        assert echoed.data == "modern: hello"
+
+    assert not legacy.is_connected()
+    assert not modern.is_connected()
+
+
+async def test_from_config_applies_mode_per_server():
+    config = MCPConfig(
+        mcpServers={
+            "old": InMemoryServer(mcp=make_server("old"), mode="legacy"),
+            "new": InMemoryServer(mcp=make_server("new"), mode="auto"),
+        }
+    )
+    group = ClientGroup.from_config(config)
+
+    async with group:
+        assert group.protocol_versions == {
+            "old": "2025-11-25",
+            "new": "2026-07-28",
+        }
+
+
+async def test_call_tool_populates_routes_lazily():
+    group = ClientGroup({"server": Client(make_server("server"))})
+
+    async with group:
+        result = await group.call_tool("server_echo", {"value": "hello"})
+
+    assert result.data == "server: hello"
+
+
+async def test_concurrent_cold_calls_share_tool_discovery():
+    first = Client(make_server("first"))
+    second = Client(make_server("second"))
+    group = ClientGroup({"first": first, "second": second})
+
+    with (
+        patch.object(first, "list_tools", wraps=first.list_tools) as first_list,
+        patch.object(second, "list_tools", wraps=second.list_tools) as second_list,
+    ):
+        async with group:
+            results = await asyncio.gather(
+                group.call_tool("first_echo", {"value": "one"}),
+                group.call_tool("second_echo", {"value": "two"}),
+                group.call_tool("first_protocol_era"),
+            )
+
+    assert [result.data for result in results] == [
+        "first: one",
+        "second: two",
+        "2026-07-28",
+    ]
+    assert first_list.call_count == 1
+    assert second_list.call_count == 1
+
+
+async def test_unknown_tools_do_not_repeat_discovery():
+    first = Client(make_server("first"))
+    second = Client(make_server("second"))
+    group = ClientGroup({"first": first, "second": second})
+
+    with (
+        patch.object(first, "list_tools", wraps=first.list_tools) as first_list,
+        patch.object(second, "list_tools", wraps=second.list_tools) as second_list,
+    ):
+        async with group:
+            for name in ("missing", "also_missing", "missing"):
+                with pytest.raises(KeyError, match=f"Unknown tool: {name!r}"):
+                    await group.call_tool(name)
+
+    assert first_list.call_count == 1
+    assert second_list.call_count == 1
+
+
+async def test_callers_can_manage_connections():
+    old = Client(LegacyFastMCPTransport(make_server("old")))
+    new = Client(FastMCPTransport(make_server("new")))
+    group = ClientGroup({"old": old, "new": new})
+
+    async with old, new:
+        tools = await group.list_tools()
+        result = await group.call_tool("new_echo", {"value": "hello"})
+
+        assert {tool.name for tool in tools} >= {"old_echo", "new_echo"}
+        assert result.data == "new: hello"
+        assert group.protocol_versions == {
+            "old": "2025-11-25",
+            "new": "2026-07-28",
+        }
+
+    assert not old.is_connected()
+    assert not new.is_connected()
+
+
+async def test_group_context_does_not_close_caller_owned_client():
+    client = Client(make_server("server"))
+    group = ClientGroup({"server": client})
+
+    async with client:
+        async with group:
+            result = await group.call_tool("server_echo", {"value": "hello"})
+            assert result.data == "server: hello"
+
+        assert client.is_connected()
+
+    assert not client.is_connected()
+
+
+async def test_group_requires_each_client_to_be_connected():
+    connected = Client(make_server("connected"))
+    disconnected = Client(make_server("disconnected"))
+    group = ClientGroup({"connected": connected, "disconnected": disconnected})
+
+    async with connected:
+        try:
+            await group.list_tools()
+        except RuntimeError as exc:
+            assert str(exc) == "ClientGroup clients are not connected: 'disconnected'"
+        else:
+            raise AssertionError("Expected a disconnected-client error")
+
+
+async def test_group_keeps_one_connection_per_server():
+    lifecycles = {"entered": 0, "exited": 0}
+
+    @asynccontextmanager
+    async def lifespan(_server: FastMCP) -> AsyncIterator[dict[str, Any]]:
+        lifecycles["entered"] += 1
+        try:
+            yield {}
+        finally:
+            lifecycles["exited"] += 1
+
+    server = FastMCP("stateful", lifespan=lifespan)
+
+    @server.tool
+    def echo(value: str) -> str:
+        return value
+
+    group = ClientGroup({"stateful": Client(server)})
+    async with group:
+        await group.list_tools()
+        await group.call_tool("stateful_echo", {"value": "one"})
+        await group.call_tool("stateful_echo", {"value": "two"})
+        assert lifecycles == {"entered": 1, "exited": 0}
+
+    assert lifecycles == {"entered": 1, "exited": 1}
+
+
+async def test_tool_name_collisions_are_rejected():
+    first = FastMCP("first")
+    second = FastMCP("second")
+
+    @first.tool(name="b_echo")
+    def first_echo() -> str:
+        return "first"
+
+    @second.tool(name="echo")
+    def second_echo() -> str:
+        return "second"
+
+    group = ClientGroup(
+        {
+            "a": Client(first),
+            "a_b": Client(second),
+        }
+    )
+
+    async with group:
+        try:
+            await group.list_tools()
+        except ValueError as exc:
+            assert str(exc) == "Tool name collision: 'a_b_echo'"
+        else:
+            raise AssertionError("Expected a tool name collision")
+
+
+async def test_single_client_group_provides_namespacing_alone():
+    group = ClientGroup({"solo": Client(FastMCPTransport(make_server("solo")))})
+
+    async with group:
+        tools = await group.list_tools()
+        assert sorted(tool.name for tool in tools) == ["solo_echo", "solo_protocol_era"]
+
+        result = await group.call_tool("solo_echo", {"value": "hi"})
+        assert result.data == "solo: hi"
+
+
+async def test_client_membership_is_immutable():
+    group = ClientGroup({"solo": Client(FastMCPTransport(make_server("solo")))})
+
+    with pytest.raises(TypeError):
+        group.clients["other"] = Client(  # ty: ignore[invalid-assignment]
+            FastMCPTransport(make_server("other"))
+        )
+
+
+async def test_concurrent_group_entry_does_not_double_connect():
+    client = Client(FastMCPTransport(make_server("solo")))
+    group = ClientGroup({"solo": client})
+
+    results = await asyncio.gather(
+        group.__aenter__(), group.__aenter__(), return_exceptions=True
+    )
+    errors = [r for r in results if isinstance(r, BaseException)]
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+
+    await group.__aexit__(None, None, None)
+    assert not client.is_connected()
+
+
+async def test_known_route_survives_an_unrelated_dead_client():
+    healthy = Client(FastMCPTransport(make_server("healthy")))
+    doomed = Client(FastMCPTransport(make_server("doomed")))
+    group = ClientGroup({"healthy": healthy, "doomed": doomed})
+
+    async with healthy:
+        async with doomed:
+            await group.list_tools()
+        assert not doomed.is_connected()
+
+        result = await group.call_tool("healthy_echo", {"value": "hi"})
+        assert result.data == "healthy: hi"
+
+        with pytest.raises(RuntimeError, match="doomed"):
+            await group.call_tool("doomed_echo", {"value": "hi"})
+
+
+async def test_partial_connect_failure_unwinds_connected_clients():
+    ok = Client(FastMCPTransport(make_server("ok")))
+    bad = Client(FastMCPTransport(make_server("bad")))
+    group = ClientGroup({"ok": ok, "bad": bad})
+
+    from unittest.mock import AsyncMock
+
+    with patch.object(bad, "__aenter__", AsyncMock(side_effect=RuntimeError("boom"))):
+        with pytest.raises(RuntimeError, match="boom"):
+            async with group:
+                pass
+
+    assert not ok.is_connected()
+    assert group._exit_stack is None
+
+
+async def test_explicit_list_tools_refreshes_past_client_response_cache():
+    """A cache-hinted server must not leave group.list_tools() serving a stale
+    catalog: the explicit call is the documented refresh mechanism."""
+    server = FastMCP("hinted", cache_ttl=60000)
+
+    @server.tool
+    def original() -> str:
+        return "original"
+
+    client = Client(FastMCPTransport(server), cache=True)
+    group = ClientGroup({"hinted": client})
+
+    async with group:
+        tools = await group.list_tools()
+        assert [tool.name for tool in tools] == ["hinted_original"]
+
+        @server.tool
+        def added() -> str:
+            return "added"
+
+        refreshed = await group.list_tools()
+        assert {tool.name for tool in refreshed} == {"hinted_original", "hinted_added"}
+
+        result = await group.call_tool("hinted_added")
+        assert result.data == "added"

--- a/tests/client/transports/test_memory_transport.py
+++ b/tests/client/transports/test_memory_transport.py
@@ -7,7 +7,6 @@ Client(server) with an in-process FastMCP server.
 import time
 
 import pytest
-from docket import Docket
 
 from fastmcp import Client, FastMCP
 from fastmcp.client.transports import FastMCPTransport
@@ -21,18 +20,8 @@ def test_transport_repr_includes_server_name():
     assert repr(transport) == "<FastMCPTransport(server='repr-test')>"
 
 
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-
-
 @pytest.mark.timeout(10)
-async def test_task_teardown_does_not_hang(reset_docket_memory_server):
+async def test_task_teardown_does_not_hang():
     """In-memory transport must tear down in under 2 seconds after a task call.
 
     This is a regression test for a teardown ordering bug where the Docket

--- a/tests/server/http/test_http_dependencies.py
+++ b/tests/server/http/test_http_dependencies.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from docket import Docket
 from fastmcp_tasks.context import _recall_snapshot, get_task_context
 from mcp_types import TextContent, TextResourceContents
 from starlette.requests import Request
@@ -12,16 +11,6 @@ from fastmcp.server.server import FastMCP
 from fastmcp.utilities.tests import ASGIServer, asgi_server
 from fastmcp_tasks import TasksExtension
 from tests.tasks.task_helpers import running_task_server, submit_task, wait_for_task
-
-
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 def _http_request_with_headers(headers: dict[str, str]) -> Request:
@@ -246,9 +235,7 @@ def _worker_snapshot_headers() -> dict[str, str]:
     return dict(snapshot.http_headers)
 
 
-async def test_background_task_can_read_snapshotted_request_headers(
-    reset_docket_memory_server,
-):
+async def test_background_task_can_read_snapshotted_request_headers():
     """A background task worker reads the HTTP headers snapshotted at submission.
 
     There is no client task-submission API yet (Phase 4), so the task is driven
@@ -278,9 +265,7 @@ async def test_background_task_can_read_snapshotted_request_headers(
     assert final.result["structuredContent"] == {"result": "tenant-123"}
 
 
-async def test_background_task_snapshot_preserves_all_request_headers(
-    reset_docket_memory_server,
-):
+async def test_background_task_snapshot_preserves_all_request_headers():
     """The task snapshot preserves every request header, including authorization."""
     server = FastMCP()
     server.add_extension(TasksExtension())

--- a/tests/server/middleware/test_response_limiting.py
+++ b/tests/server/middleware/test_response_limiting.py
@@ -57,14 +57,18 @@ class TestResponseLimitingMiddleware:
         )
 
         @mcp_server.tool()
-        def limited_tool() -> ToolResult:
-            return ToolResult(content=[TextContent(type="text", text="x" * 10_000)])
+        def limited_tool() -> str:
+            return "x" * 10_000
 
         @mcp_server.tool()
-        def unlimited_tool() -> ToolResult:
-            return ToolResult(content=[TextContent(type="text", text="y" * 10_000)])
+        def unlimited_tool() -> str:
+            return "y" * 10_000
 
         async with Client(mcp_server) as client:
+            tools = {tool.name: tool for tool in await client.list_tools()}
+            assert tools["limited_tool"].output_schema is None
+            assert tools["unlimited_tool"].output_schema is not None
+
             # Limited tool should be truncated
             result = await client.call_tool("limited_tool", {})
             assert "[Response truncated" in result.content[0].text
@@ -78,10 +82,13 @@ class TestResponseLimitingMiddleware:
         mcp_server.add_middleware(ResponseLimitingMiddleware(max_size=100, tools=[]))
 
         @mcp_server.tool()
-        def any_tool() -> ToolResult:
-            return ToolResult(content=[TextContent(type="text", text="x" * 10_000)])
+        def any_tool() -> str:
+            return "x" * 10_000
 
         async with Client(mcp_server) as client:
+            tools = await client.list_tools()
+            assert tools[0].output_schema is not None
+
             result = await client.call_tool("any_tool", {})
             # Should NOT be truncated
             assert "[Response truncated" not in result.content[0].text
@@ -152,11 +159,10 @@ class TestResponseLimitingMiddleware:
     async def test_truncation_does_not_break_output_schema_tools(
         self, mcp_server: FastMCP
     ):
-        """Truncating a tool with outputSchema must not cause validation errors.
+        """Truncating a tool with outputSchema must not cause client validation errors.
 
-        Regression test for #3717: the MCP SDK rejects truncated results
-        from tools with outputSchema because structured_content is dropped.
-        We verify the server returns a successful (non-error) truncated result.
+        Regression test for #4926: an end-to-end client rejects truncated results
+        when tools/list still advertises the original outputSchema.
         """
         mcp_server.add_middleware(ResponseLimitingMiddleware(max_size=1_000))
 
@@ -164,7 +170,12 @@ class TestResponseLimitingMiddleware:
         def big_answer() -> Answer:
             return Answer(text="x" * 2_000)
 
-        result = await mcp_server.call_tool("big_answer", {})
+        async with Client(mcp_server) as client:
+            tools = await client.list_tools()
+            assert tools[0].output_schema is None
+            result = await client.call_tool("big_answer", {})
+
+        assert result.is_error is False
         first = result.content[0]
         assert isinstance(first, TextContent)
         assert "[Response truncated" in first.text

--- a/tests/server/mount/test_advanced.py
+++ b/tests/server/mount/test_advanced.py
@@ -1,7 +1,6 @@
 """Advanced mounting scenarios."""
 
 import pytest
-from docket import Docket
 from mcp_types import TextContent
 from starlette.routing import Route
 
@@ -11,16 +10,6 @@ from fastmcp.server.providers import FastMCPProvider
 from fastmcp.server.providers.wrapped_provider import _WrappedProvider
 from fastmcp_tasks import TasksExtension
 from tests.tasks.task_helpers import running_task_server
-
-
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 class TestDynamicChanges:
@@ -611,9 +600,7 @@ class TestMountedServerDocketBehavior:
     includes Docket creation.
     """
 
-    async def test_mounted_server_does_not_have_docket(
-        self, reset_docket_memory_server
-    ):
+    async def test_mounted_server_does_not_have_docket(self):
         """Test that a mounted server doesn't create its own Docket.
 
         MountedProvider.lifespan() should call only the server's _lifespan

--- a/tests/server/test_dependencies.py
+++ b/tests/server/test_dependencies.py
@@ -3,7 +3,6 @@
 from contextlib import asynccontextmanager, contextmanager
 
 import pytest
-from docket import Docket
 from mcp_types import TextContent, TextResourceContents
 
 from fastmcp import FastMCP
@@ -14,16 +13,6 @@ from fastmcp_tasks import TasksExtension
 from tests.conftest import make_server_request_context
 
 HUZZAH = "huzzah!"
-
-
-@pytest.fixture
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to this test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 class Connection:
@@ -1205,9 +1194,7 @@ class TestSharedDependencies:
             )
             assert call_count == 1
 
-    async def test_shared_resolves_on_task_capable_server(
-        self, reset_docket_memory_server
-    ):
+    async def test_shared_resolves_on_task_capable_server(self):
         """Shared() dependencies resolve on a normal request even when the server
         has task-enabled components.
 

--- a/tests/server/test_mrtr_guards.py
+++ b/tests/server/test_mrtr_guards.py
@@ -22,7 +22,6 @@ from typing import Annotated
 
 import mcp_types
 import pytest
-from docket import Docket
 from mcp.client._input_required import InputRequiredRoundsExceededError
 from mcp.server.request_state import RequestStateSecurity
 from mcp.shared.exceptions import MCPError
@@ -1177,18 +1176,7 @@ class TestTaskExecution:
     background task has no such request, so returning a guard result from a task
     is rejected with a clear error rather than silently yielding empty content."""
 
-    @pytest.fixture
-    def reset_docket_memory_server(self):
-        """Force a fresh memory:// Docket server bound to this test's loop."""
-        if hasattr(Docket, "_memory_server"):
-            delattr(Docket, "_memory_server")
-        yield
-        if hasattr(Docket, "_memory_server"):
-            delattr(Docket, "_memory_server")
-
-    async def test_guard_result_from_task_parks_for_input(
-        self, reset_docket_memory_server
-    ):
+    async def test_guard_result_from_task_parks_for_input(self):
         mcp = FastMCP("guard-task")
         mcp.add_extension(TasksExtension())
 

--- a/tests/server/test_pagination.py
+++ b/tests/server/test_pagination.py
@@ -263,6 +263,7 @@ class TestPaginationCycleDetection:
             async def returning_constant_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListToolsResult:
                 result = await original(cursor=cursor)
                 result.next_cursor = "stuck"
@@ -292,6 +293,7 @@ class TestPaginationCycleDetection:
             async def returning_constant_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListPromptsResult:
                 result = await original(cursor=cursor)
                 result.next_cursor = "stuck"
@@ -319,6 +321,7 @@ class TestPaginationCycleDetection:
             async def returning_constant_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListResourcesResult:
                 result = await original(cursor=cursor)
                 result.next_cursor = "stuck"
@@ -346,6 +349,7 @@ class TestPaginationCycleDetection:
             async def returning_constant_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListResourceTemplatesResult:
                 result = await original(cursor=cursor)
                 result.next_cursor = "stuck"
@@ -375,6 +379,7 @@ class TestPaginationCycleDetection:
             async def returning_cycling_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListToolsResult:
                 nonlocal call_count
                 result = await original(cursor=cursor)
@@ -407,6 +412,7 @@ class TestPaginationCycleDetection:
             async def returning_empty_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListToolsResult:
                 result = await original(cursor=cursor)
                 result.next_cursor = ""
@@ -435,6 +441,7 @@ class TestPaginationCycleDetection:
             async def returning_unique_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListToolsResult:
                 nonlocal call_count
                 result = await original(cursor=cursor)
@@ -465,6 +472,7 @@ class TestPaginationCycleDetection:
             async def returning_unique_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListResourcesResult:
                 nonlocal call_count
                 result = await original(cursor=cursor)
@@ -495,6 +503,7 @@ class TestPaginationCycleDetection:
             async def returning_unique_cursor(
                 *,
                 cursor: str | None = None,
+                cache_mode: str = "use",
             ) -> mcp_types.ListPromptsResult:
                 nonlocal call_count
                 result = await original(cursor=cursor)

--- a/tests/server/test_server_docket.py
+++ b/tests/server/test_server_docket.py
@@ -3,7 +3,6 @@
 import asyncio
 from contextlib import asynccontextmanager
 
-import pytest
 from docket import Docket
 from docket.worker import Worker
 from fastmcp_tasks.dependencies import CurrentDocket, CurrentWorker
@@ -14,16 +13,6 @@ from fastmcp.server.dependencies import get_context
 from fastmcp_tasks import TasksExtension
 
 HUZZAH = "huzzah!"
-
-
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to each test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 async def test_docket_not_initialized_without_task_components():

--- a/tests/tasks/server/conftest.py
+++ b/tests/tasks/server/conftest.py
@@ -9,26 +9,6 @@ from fastmcp.utilities.tests import temporary_settings
 
 
 @pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Reset the shared memory:// Docket server between tests.
-
-    Docket keeps a process-wide ``Docket._memory_server`` singleton for
-    ``memory://`` backends. It persists across tests and across event loops, so a
-    test that inherits a stale server from a previous loop can fail (e.g.
-    ``tasks/get`` raising ``TypeError`` from the dead client). Clearing it before
-    and after each test keeps the task suite isolation-safe rather than
-    order-dependent.
-    """
-    from docket import Docket
-
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-
-
-@pytest.fixture(autouse=True)
 def isolate_settings_home(_settings_home_root: Path):
     """Task-local override of the repo-wide ``isolate_settings_home`` fixture.
 

--- a/tests/tasks/server/test_task_mount.py
+++ b/tests/tasks/server/test_task_mount.py
@@ -44,16 +44,6 @@ from tests.tasks.task_helpers import (
 )
 
 
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Reset the shared memory:// Docket server between tests for isolation."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-
-
 @pytest.fixture
 def child_server() -> FastMCP:
     mcp = FastMCP("child-server")

--- a/tests/tasks/server/test_task_proxy.py
+++ b/tests/tasks/server/test_task_proxy.py
@@ -8,7 +8,6 @@ client opts the tasks extension in for the request.
 """
 
 import pytest
-from docket import Docket
 from fastmcp_tasks.models import CreateTaskResult
 
 from fastmcp import FastMCP
@@ -22,16 +21,6 @@ from tests.tasks.task_helpers import (
     auth_scope,
     running_task_server,
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to each test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 async def call_tool_with_optin(server: FastMCP, name: str, arguments: dict):

--- a/tests/tasks/server/test_task_return_types.py
+++ b/tests/tasks/server/test_task_return_types.py
@@ -16,7 +16,6 @@ from uuid import UUID
 
 import mcp_types
 import pytest
-from docket import Docket
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
@@ -29,16 +28,6 @@ from tests.tasks.task_helpers import (
     run_task,
     running_task_server,
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_docket_memory_server():
-    """Force a fresh memory:// Docket server bound to each test's event loop."""
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
-    yield
-    if hasattr(Docket, "_memory_server"):
-        delattr(Docket, "_memory_server")
 
 
 def _sync_result_to_wire(result: ToolResult) -> dict[str, Any]:


### PR DESCRIPTION
Updates `published-docs` to the current `main` tree so the beta 5 changelog and the client docs from #4936 (`list_tools` on the tools page, `Client` restored in the SDK reference generator) reach gofastmcp.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
