### PR TITLE
docs: publish main to published-docs (SDK reference with client modules)

### DIFF
--- a/docs/python-sdk-pages.json
+++ b/docs/python-sdk-pages.json
@@ -1,5 +1,4 @@
 [
-  "python-sdk/fastmcp-cli",
   "python-sdk/fastmcp-decorators",
   "python-sdk/fastmcp-dependencies",
   "python-sdk/fastmcp-exceptions",
@@ -21,6 +20,107 @@
     ]
   },
   {
+    "group": "fastmcp.cli",
+    "pages": [
+      "python-sdk/fastmcp-cli-__init__",
+      "python-sdk/fastmcp-cli-apps_dev",
+      "python-sdk/fastmcp-cli-auth",
+      "python-sdk/fastmcp-cli-cimd",
+      "python-sdk/fastmcp-cli-cli",
+      "python-sdk/fastmcp-cli-client",
+      {
+        "group": "deploy",
+        "pages": [
+          "python-sdk/fastmcp-cli-deploy-__init__",
+          "python-sdk/fastmcp-cli-deploy-authentication",
+          "python-sdk/fastmcp-cli-deploy-command",
+          "python-sdk/fastmcp-cli-deploy-configuration",
+          "python-sdk/fastmcp-cli-deploy-credentials",
+          "python-sdk/fastmcp-cli-deploy-horizon_client",
+          "python-sdk/fastmcp-cli-deploy-output",
+          "python-sdk/fastmcp-cli-deploy-state"
+        ]
+      },
+      "python-sdk/fastmcp-cli-discovery",
+      "python-sdk/fastmcp-cli-generate",
+      {
+        "group": "install",
+        "pages": [
+          "python-sdk/fastmcp-cli-install-__init__",
+          "python-sdk/fastmcp-cli-install-claude_code",
+          "python-sdk/fastmcp-cli-install-claude_desktop",
+          "python-sdk/fastmcp-cli-install-cursor",
+          "python-sdk/fastmcp-cli-install-gemini_cli",
+          "python-sdk/fastmcp-cli-install-goose",
+          "python-sdk/fastmcp-cli-install-mcp_json",
+          "python-sdk/fastmcp-cli-install-shared",
+          "python-sdk/fastmcp-cli-install-stdio"
+        ]
+      },
+      "python-sdk/fastmcp-cli-run"
+    ]
+  },
+  {
+    "group": "fastmcp.client",
+    "pages": [
+      {
+        "group": "auth",
+        "pages": [
+          "python-sdk/fastmcp-client-auth-bearer",
+          "python-sdk/fastmcp-client-auth-client_credentials",
+          "python-sdk/fastmcp-client-auth-oauth"
+        ]
+      },
+      "python-sdk/fastmcp-client-caching",
+      "python-sdk/fastmcp-client-client",
+      "python-sdk/fastmcp-client-dependencies",
+      "python-sdk/fastmcp-client-elicitation",
+      "python-sdk/fastmcp-client-extension_hooks",
+      "python-sdk/fastmcp-client-group",
+      "python-sdk/fastmcp-client-logging",
+      "python-sdk/fastmcp-client-messages",
+      {
+        "group": "mixins",
+        "pages": [
+          "python-sdk/fastmcp-client-mixins-__init__",
+          "python-sdk/fastmcp-client-mixins-prompts",
+          "python-sdk/fastmcp-client-mixins-resources",
+          "python-sdk/fastmcp-client-mixins-tools"
+        ]
+      },
+      "python-sdk/fastmcp-client-oauth_callback",
+      "python-sdk/fastmcp-client-progress",
+      "python-sdk/fastmcp-client-roots",
+      {
+        "group": "sampling",
+        "pages": [
+          "python-sdk/fastmcp-client-sampling-__init__",
+          {
+            "group": "handlers",
+            "pages": [
+              "python-sdk/fastmcp-client-sampling-handlers-anthropic",
+              "python-sdk/fastmcp-client-sampling-handlers-google_genai",
+              "python-sdk/fastmcp-client-sampling-handlers-openai"
+            ]
+          }
+        ]
+      },
+      "python-sdk/fastmcp-client-telemetry",
+      {
+        "group": "transports",
+        "pages": [
+          "python-sdk/fastmcp-client-transports-base",
+          "python-sdk/fastmcp-client-transports-config",
+          "python-sdk/fastmcp-client-transports-http",
+          "python-sdk/fastmcp-client-transports-inference",
+          "python-sdk/fastmcp-client-transports-memory",
+          "python-sdk/fastmcp-client-transports-sse",
+          "python-sdk/fastmcp-client-transports-stdio"
+        ]
+      }
+    ]
+  },
+  {
     "group": "fastmcp.experimental",
     "pages": [
       {
@@ -29,6 +129,13 @@
           "python-sdk/fastmcp-experimental-transforms-code_mode"
         ]
       }
+    ]
+  },
+  {
+    "group": "fastmcp.prompts",
+    "pages": [
+      "python-sdk/fastmcp-prompts-base",
+      "python-sdk/fastmcp-prompts-function_prompt"
     ]
   },
   {
@@ -44,6 +151,60 @@
   {
     "group": "fastmcp.server",
     "pages": [
+      {
+        "group": "auth",
+        "pages": [
+          "python-sdk/fastmcp-server-auth-auth",
+          "python-sdk/fastmcp-server-auth-cimd",
+          {
+            "group": "handlers",
+            "pages": [
+              "python-sdk/fastmcp-server-auth-handlers-authorize"
+            ]
+          },
+          "python-sdk/fastmcp-server-auth-identity_assertion",
+          "python-sdk/fastmcp-server-auth-jwt_issuer",
+          "python-sdk/fastmcp-server-auth-middleware",
+          {
+            "group": "oauth_proxy",
+            "pages": [
+              "python-sdk/fastmcp-server-auth-oauth_proxy-__init__",
+              "python-sdk/fastmcp-server-auth-oauth_proxy-consent",
+              "python-sdk/fastmcp-server-auth-oauth_proxy-models",
+              "python-sdk/fastmcp-server-auth-oauth_proxy-proxy",
+              "python-sdk/fastmcp-server-auth-oauth_proxy-ui",
+              "python-sdk/fastmcp-server-auth-oauth_proxy-upstream"
+            ]
+          },
+          "python-sdk/fastmcp-server-auth-oidc_proxy",
+          {
+            "group": "providers",
+            "pages": [
+              "python-sdk/fastmcp-server-auth-providers-auth0",
+              "python-sdk/fastmcp-server-auth-providers-aws",
+              "python-sdk/fastmcp-server-auth-providers-azure",
+              "python-sdk/fastmcp-server-auth-providers-clerk",
+              "python-sdk/fastmcp-server-auth-providers-debug",
+              "python-sdk/fastmcp-server-auth-providers-descope",
+              "python-sdk/fastmcp-server-auth-providers-discord",
+              "python-sdk/fastmcp-server-auth-providers-github",
+              "python-sdk/fastmcp-server-auth-providers-google",
+              "python-sdk/fastmcp-server-auth-providers-huggingface",
+              "python-sdk/fastmcp-server-auth-providers-in_memory",
+              "python-sdk/fastmcp-server-auth-providers-introspection",
+              "python-sdk/fastmcp-server-auth-providers-jwt",
+              "python-sdk/fastmcp-server-auth-providers-keycloak",
+              "python-sdk/fastmcp-server-auth-providers-oci",
+              "python-sdk/fastmcp-server-auth-providers-propelauth",
+              "python-sdk/fastmcp-server-auth-providers-scalekit",
+              "python-sdk/fastmcp-server-auth-providers-supabase",
+              "python-sdk/fastmcp-server-auth-providers-workos"
+            ]
+          },
+          "python-sdk/fastmcp-server-auth-redirect_validation",
+          "python-sdk/fastmcp-server-auth-ssrf"
+        ]
+      },
       "python-sdk/fastmcp-server-caching",
       "python-sdk/fastmcp-server-completions",
       "python-sdk/fastmcp-server-context",
@@ -54,13 +215,117 @@
       "python-sdk/fastmcp-server-http",
       "python-sdk/fastmcp-server-lifespan",
       "python-sdk/fastmcp-server-low_level",
-      "python-sdk/fastmcp-server-mixins",
-      "python-sdk/fastmcp-server-providers",
+      {
+        "group": "middleware",
+        "pages": [
+          "python-sdk/fastmcp-server-middleware-authorization",
+          "python-sdk/fastmcp-server-middleware-caching",
+          "python-sdk/fastmcp-server-middleware-dereference",
+          "python-sdk/fastmcp-server-middleware-error_handling",
+          "python-sdk/fastmcp-server-middleware-logging",
+          "python-sdk/fastmcp-server-middleware-middleware",
+          "python-sdk/fastmcp-server-middleware-ping",
+          "python-sdk/fastmcp-server-middleware-rate_limiting",
+          "python-sdk/fastmcp-server-middleware-response_limiting",
+          "python-sdk/fastmcp-server-middleware-timing",
+          "python-sdk/fastmcp-server-middleware-tool_injection"
+        ]
+      },
+      {
+        "group": "mixins",
+        "pages": [
+          "python-sdk/fastmcp-server-mixins-__init__",
+          "python-sdk/fastmcp-server-mixins-lifespan",
+          "python-sdk/fastmcp-server-mixins-mcp_operations",
+          "python-sdk/fastmcp-server-mixins-transport"
+        ]
+      },
+      {
+        "group": "providers",
+        "pages": [
+          "python-sdk/fastmcp-server-providers-__init__",
+          "python-sdk/fastmcp-server-providers-addressing",
+          "python-sdk/fastmcp-server-providers-aggregate",
+          "python-sdk/fastmcp-server-providers-base",
+          "python-sdk/fastmcp-server-providers-fastmcp_provider",
+          "python-sdk/fastmcp-server-providers-filesystem",
+          "python-sdk/fastmcp-server-providers-filesystem_discovery",
+          {
+            "group": "local_provider",
+            "pages": [
+              "python-sdk/fastmcp-server-providers-local_provider-__init__",
+              {
+                "group": "decorators",
+                "pages": [
+                  "python-sdk/fastmcp-server-providers-local_provider-decorators-__init__",
+                  "python-sdk/fastmcp-server-providers-local_provider-decorators-prompts",
+                  "python-sdk/fastmcp-server-providers-local_provider-decorators-resources",
+                  "python-sdk/fastmcp-server-providers-local_provider-decorators-tools"
+                ]
+              },
+              "python-sdk/fastmcp-server-providers-local_provider-local_provider"
+            ]
+          },
+          {
+            "group": "openapi",
+            "pages": [
+              "python-sdk/fastmcp-server-providers-openapi-__init__",
+              "python-sdk/fastmcp-server-providers-openapi-components",
+              "python-sdk/fastmcp-server-providers-openapi-provider",
+              "python-sdk/fastmcp-server-providers-openapi-routing"
+            ]
+          },
+          "python-sdk/fastmcp-server-providers-prefab_payload",
+          "python-sdk/fastmcp-server-providers-prefab_synthesis",
+          "python-sdk/fastmcp-server-providers-proxy",
+          {
+            "group": "skills",
+            "pages": [
+              "python-sdk/fastmcp-server-providers-skills-__init__",
+              "python-sdk/fastmcp-server-providers-skills-claude_provider",
+              "python-sdk/fastmcp-server-providers-skills-directory_provider",
+              "python-sdk/fastmcp-server-providers-skills-skill_provider",
+              "python-sdk/fastmcp-server-providers-skills-vendor_providers"
+            ]
+          },
+          "python-sdk/fastmcp-server-providers-wrapped_provider"
+        ]
+      },
       "python-sdk/fastmcp-server-server",
       "python-sdk/fastmcp-server-session_scoped_event_store",
       "python-sdk/fastmcp-server-sessions",
       "python-sdk/fastmcp-server-telemetry",
-      "python-sdk/fastmcp-server-transforms"
+      {
+        "group": "transforms",
+        "pages": [
+          "python-sdk/fastmcp-server-transforms-__init__",
+          "python-sdk/fastmcp-server-transforms-catalog",
+          "python-sdk/fastmcp-server-transforms-namespace",
+          "python-sdk/fastmcp-server-transforms-prompts_as_tools",
+          "python-sdk/fastmcp-server-transforms-resources_as_tools",
+          {
+            "group": "search",
+            "pages": [
+              "python-sdk/fastmcp-server-transforms-search-__init__",
+              "python-sdk/fastmcp-server-transforms-search-base",
+              "python-sdk/fastmcp-server-transforms-search-bm25",
+              "python-sdk/fastmcp-server-transforms-search-regex"
+            ]
+          },
+          "python-sdk/fastmcp-server-transforms-tool_transform",
+          "python-sdk/fastmcp-server-transforms-version_filter",
+          "python-sdk/fastmcp-server-transforms-visibility"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "fastmcp.tools",
+    "pages": [
+      "python-sdk/fastmcp-tools-base",
+      "python-sdk/fastmcp-tools-function_parsing",
+      "python-sdk/fastmcp-tools-function_tool",
+      "python-sdk/fastmcp-tools-tool_transform"
     ]
   },
   {
@@ -109,7 +374,18 @@
         ]
       },
       "python-sdk/fastmcp-utilities-mime",
-      "python-sdk/fastmcp-utilities-openapi",
+      {
+        "group": "openapi",
+        "pages": [
+          "python-sdk/fastmcp-utilities-openapi-__init__",
+          "python-sdk/fastmcp-utilities-openapi-director",
+          "python-sdk/fastmcp-utilities-openapi-formatters",
+          "python-sdk/fastmcp-utilities-openapi-json_schema_converter",
+          "python-sdk/fastmcp-utilities-openapi-models",
+          "python-sdk/fastmcp-utilities-openapi-parser",
+          "python-sdk/fastmcp-utilities-openapi-schemas"
+        ]
+      },
       "python-sdk/fastmcp-utilities-pagination",
       "python-sdk/fastmcp-utilities-prefab",
       "python-sdk/fastmcp-utilities-skills",

--- a/docs/python-sdk/fastmcp-cli-__init__.mdx
+++ b/docs/python-sdk/fastmcp-cli-__init__.mdx
@@ -1,6 +1,6 @@
 ---
-title: cli
-sidebarTitle: cli
+title: __init__
+sidebarTitle: __init__
 ---
 
 # `fastmcp.cli`

--- a/docs/python-sdk/fastmcp-cli-apps_dev.mdx
+++ b/docs/python-sdk/fastmcp-cli-apps_dev.mdx
@@ -1,0 +1,47 @@
+---
+title: apps_dev
+sidebarTitle: apps_dev
+---
+
+# `fastmcp.cli.apps_dev`
+
+
+Dev server for previewing FastMCPApp UIs locally.
+
+Starts the user's MCP server on a configurable port, then starts a lightweight
+Starlette dev server that:
+
+  - Serves a Prefab-based tool picker at GET /
+  - Proxies /mcp to the user's server (avoids browser CORS restrictions)
+  - Serves the AppBridge host page at GET /launch
+
+The host page uses @modelcontextprotocol/ext-apps to connect to the MCP server
+and render the selected UI tool inside an iframe.
+
+Startup sequence
+----------------
+1. Download ext-apps app-bridge.js from npm and patch its bare
+   ``@modelcontextprotocol/sdk/…`` imports to use concrete esm.sh URLs.
+2. Detect the exact Zod v4 module URL that esm.sh serves for that SDK version
+   and build an import-map entry that redirects the broken ``v4.mjs`` (which
+   only re-exports ``{z, default}``) to ``v4/classic/index.mjs`` (which
+   correctly exports every named Zod v4 function).  Import maps apply to the
+   full module graph in the document, including cross-origin esm.sh modules.
+3. Serve both the patched JS and the import-map JSON from the dev server.
+
+
+## Functions
+
+### `run_dev_apps` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/apps_dev.py#L1726" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_dev_apps(server_spec: str) -> None
+```
+
+
+Start the full dev environment for a FastMCPApp server.
+
+Starts the user's MCP server on *mcp_port*, starts the Prefab dev UI
+on *dev_port* (with an /mcp proxy to the user's server), then opens
+the browser.
+

--- a/docs/python-sdk/fastmcp-cli-auth.mdx
+++ b/docs/python-sdk/fastmcp-cli-auth.mdx
@@ -1,0 +1,9 @@
+---
+title: auth
+sidebarTitle: auth
+---
+
+# `fastmcp.cli.auth`
+
+
+Authentication-related CLI commands.

--- a/docs/python-sdk/fastmcp-cli-cimd.mdx
+++ b/docs/python-sdk/fastmcp-cli-cimd.mdx
@@ -1,0 +1,43 @@
+---
+title: cimd
+sidebarTitle: cimd
+---
+
+# `fastmcp.cli.cimd`
+
+
+CIMD (Client ID Metadata Document) CLI commands.
+
+## Functions
+
+### `create_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cimd.py#L32" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_command() -> None
+```
+
+
+Generate a CIMD document for hosting.
+
+Create a Client ID Metadata Document that you can host at an HTTPS URL.
+The URL where you host this document becomes your client_id.
+
+After creating the document, host it at an HTTPS URL with a non-root path,
+for example: https://myapp.example.com/oauth/client.json
+
+
+### `validate_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cimd.py#L144" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_command(url: Annotated[str, cyclopts.Parameter(help='URL of the CIMD document to validate')]) -> None
+```
+
+
+Validate a hosted CIMD document.
+
+Fetches the document from the given URL and validates:
+- URL is valid CIMD URL (HTTPS, non-root path)
+- Document is valid JSON
+- Document conforms to CIMD schema
+- client_id in document matches the URL
+

--- a/docs/python-sdk/fastmcp-cli-cli.mdx
+++ b/docs/python-sdk/fastmcp-cli-cli.mdx
@@ -1,0 +1,146 @@
+---
+title: cli
+sidebarTitle: cli
+---
+
+# `fastmcp.cli.cli`
+
+
+FastMCP CLI tools using Cyclopts.
+
+## Functions
+
+### `with_argv` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cli.py#L76" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+with_argv(args: list[str] | None)
+```
+
+
+Temporarily replace sys.argv if args provided.
+
+This context manager is used at the CLI boundary to inject
+server arguments when needed, without mutating sys.argv deep
+in the source loading logic.
+
+Args are provided without the script name, so we preserve sys.argv[0]
+and replace the rest.
+
+
+### `version` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cli.py#L99" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+version()
+```
+
+
+Display version information and platform details.
+
+
+### `inspector` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cli.py#L145" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+inspector(server_spec: str | None = None) -> None
+```
+
+
+Run an MCP server with the MCP Inspector for development.
+
+**Args:**
+- `server_spec`: Python file to run, optionally with \:object suffix, or None to auto-detect fastmcp.json
+
+
+### `apps` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cli.py#L340" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+apps(server_spec: str) -> None
+```
+
+
+Preview a FastMCPApp UI in the browser.
+
+Starts the MCP server from SERVER_SPEC on --mcp-port, launches a local
+dev UI on --dev-port with a tool picker and AppBridge host, then opens
+the browser automatically.
+
+Requires fastmcp[apps] to be installed (prefab-ui).
+
+
+### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cli.py#L410" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(server_spec: str | None = None, *server_args: str) -> None
+```
+
+
+Run an MCP server or connect to a remote one.
+
+The server can be specified in several ways:
+1. Module approach: "server.py" - runs the module directly, looking for an object named 'mcp', 'server', or 'app'
+2. Import approach: "server.py:app" - imports and runs the specified server object
+3. URL approach: "http://server-url" - connects to a remote server and creates a proxy
+4. MCPConfig file: "mcp.json" - runs as a proxy server for the MCP Servers in the MCPConfig file
+5. FastMCP config: "fastmcp.json" - runs server using FastMCP configuration
+6. No argument: looks for fastmcp.json in current directory
+7. Module mode: "-m my_module" - runs the module directly via python -m
+
+Server arguments can be passed after -- :
+fastmcp run server.py -- --config config.json --debug
+
+**Args:**
+- `server_spec`: Python file, object specification (file\:obj), config file, URL, or None to auto-detect
+
+
+### `inspect` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cli.py#L791" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+inspect(server_spec: str | None = None) -> None
+```
+
+
+Inspect an MCP server and display information or generate a JSON report.
+
+This command analyzes an MCP server. Without flags, it displays a text summary.
+Use --format to output complete JSON data.
+
+**Examples:**
+
+# Show text summary
+fastmcp inspect server.py
+
+# Output FastMCP format JSON to stdout
+fastmcp inspect server.py --format fastmcp
+
+# Save MCP protocol format to file (format required with -o)
+fastmcp inspect server.py --format mcp -o manifest.json
+
+# Inspect from fastmcp.json configuration
+fastmcp inspect fastmcp.json
+fastmcp inspect  # auto-detect fastmcp.json
+
+**Args:**
+- `server_spec`: Python file to inspect, optionally with \:object suffix, or fastmcp.json
+
+
+### `prepare` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/cli.py#L1033" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+prepare(config_path: Annotated[str | None, cyclopts.Parameter(help='Path to fastmcp.json configuration file')] = None, output_dir: Annotated[str | None, cyclopts.Parameter(help='Directory to create the persistent environment in')] = None, skip_source: Annotated[bool, cyclopts.Parameter(help='Skip source preparation (e.g., git clone)')] = False) -> None
+```
+
+
+Prepare a FastMCP project by creating a persistent uv environment.
+
+This command creates a persistent uv project with all dependencies installed:
+- Creates a pyproject.toml with dependencies from the config
+- Installs all Python packages into a .venv
+- Prepares the source (git clone, download, etc.) unless --skip-source
+
+After running this command, you can use:
+fastmcp run &lt;config&gt; --project &lt;output-dir&gt;
+
+This is useful for:
+- CI/CD pipelines with separate build and run stages
+- Docker images where you prepare during build
+- Production deployments where you want fast startup times
+

--- a/docs/python-sdk/fastmcp-cli-client.mdx
+++ b/docs/python-sdk/fastmcp-cli-client.mdx
@@ -1,0 +1,135 @@
+---
+title: client
+sidebarTitle: client
+---
+
+# `fastmcp.cli.client`
+
+
+Client-side CLI commands for querying and invoking MCP servers.
+
+## Functions
+
+### `resolve_server_spec` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/client.py#L43" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+resolve_server_spec(server_spec: str | None) -> str | dict[str, Any] | ClientTransport
+```
+
+
+Turn CLI inputs into something ``Client()`` accepts.
+
+Exactly one of ``server_spec`` or ``command`` should be provided.
+
+Resolution order for ``server_spec``:
+1. URLs (``http://``, ``https://``) — passed through as-is.
+   If ``--transport`` is ``sse``, the URL is rewritten to end with ``/sse``
+   so ``infer_transport`` picks the right transport.
+2. Existing file paths, or strings ending in ``.py``/``.js``/``.json``.
+3. Anything else — name-based resolution via ``resolve_name``.
+
+When ``command`` is provided, the string is shell-split into a
+``StdioTransport(command, args)``.
+
+
+### `coerce_value` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/client.py#L264" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+coerce_value(raw: str, schema: dict[str, Any]) -> Any
+```
+
+
+Coerce a string CLI value according to a JSON-Schema type hint.
+
+
+### `parse_tool_arguments` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/client.py#L298" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+parse_tool_arguments(raw_args: tuple[str, ...], input_json: str | None, input_schema: dict[str, Any]) -> dict[str, Any]
+```
+
+
+Build a tool-call argument dict from CLI inputs.
+
+A single JSON object argument is treated as the full argument dict.
+``--input-json`` provides the base dict; ``key=value`` pairs override.
+Values are coerced using the tool's ``inputSchema``.
+
+
+### `format_tool_signature` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/client.py#L370" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+format_tool_signature(tool: mcp_types.Tool) -> str
+```
+
+
+Build ``name(param: type, ...) -> return_type`` from a tool's JSON schemas.
+
+
+### `list_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/client.py#L641" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_command(server_spec: Annotated[str | None, cyclopts.Parameter(help='Server URL, Python file, MCPConfig JSON, or .js file')] = None) -> None
+```
+
+
+List tools available on an MCP server.
+
+**Examples:**
+
+fastmcp list http://localhost:8000/mcp
+fastmcp list server.py
+fastmcp list mcp.json --json
+fastmcp list --command 'npx -y @mcp/server' --resources
+fastmcp list http://server/mcp --transport sse
+
+
+### `call_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/client.py#L796" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+call_command(server_spec: Annotated[str | None, cyclopts.Parameter(help='Server URL, Python file, MCPConfig JSON, or .js file')] = None, target: Annotated[str, cyclopts.Parameter(help='Tool name, resource URI, or prompt name (with --prompt)')] = '', *arguments: str) -> None
+```
+
+
+Call a tool, read a resource, or get a prompt on an MCP server.
+
+By default the target is treated as a tool name. If the target
+contains ``://`` it is treated as a resource URI. Pass ``--prompt``
+to treat it as a prompt name.
+
+Arguments are passed as key=value pairs. Use --input-json for complex
+or nested arguments.
+
+**Examples:**
+
+```
+fastmcp call server.py greet name=World
+fastmcp call server.py resource://docs/readme
+fastmcp call server.py analyze --prompt data='[1,2,3]'
+fastmcp call http://server/mcp create --input-json '{"tags": ["a","b"]}'
+```
+
+
+### `discover_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/client.py#L897" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+discover_command() -> None
+```
+
+
+Discover MCP servers configured in editor and project configs.
+
+Scans Claude Desktop, Claude Code, Cursor, Gemini CLI, Goose, and
+project-level mcp.json files for MCP server definitions.
+
+Discovered server names can be used directly with ``fastmcp list``
+and ``fastmcp call`` instead of specifying a URL or file path.
+
+**Examples:**
+
+fastmcp discover
+fastmcp discover --source claude-code
+fastmcp discover --source cursor --source gemini --json
+fastmcp list weather
+fastmcp call cursor:weather get_forecast city=London
+

--- a/docs/python-sdk/fastmcp-cli-deploy-__init__.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-__init__.mdx
@@ -1,0 +1,9 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.cli.deploy`
+
+
+Horizon deployment support for the FastMCP CLI.

--- a/docs/python-sdk/fastmcp-cli-deploy-authentication.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-authentication.mdx
@@ -1,0 +1,51 @@
+---
+title: authentication
+sidebarTitle: authentication
+---
+
+# `fastmcp.cli.deploy.authentication`
+
+
+Horizon device authorization workflow.
+
+## Functions
+
+### `poll_device_authorization` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/authentication.py#L32" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+poll_device_authorization(client: HorizonClient, authorization: DeviceAuthorization) -> SecretStr
+```
+
+
+Poll at the server interval until the device request completes.
+
+
+### `authorize_device` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/authentication.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+authorize_device(client: HorizonClient) -> SecretStr
+```
+
+
+Create, present, and complete a Horizon device authorization.
+
+
+## Classes
+
+### `DeviceAuthorizationError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/authentication.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Device authorization did not complete.
+
+
+### `DeviceAuthorizationDeniedError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/authentication.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The user denied the device authorization request.
+
+
+### `DeviceAuthorizationExpiredError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/authentication.py#L28" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The device authorization request expired.
+

--- a/docs/python-sdk/fastmcp-cli-deploy-command.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-command.mdx
@@ -1,0 +1,41 @@
+---
+title: command
+sidebarTitle: command
+---
+
+# `fastmcp.cli.deploy.command`
+
+
+Public Prefect Horizon authentication commands.
+
+## Functions
+
+### `login` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/command.py#L195" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+login() -> None
+```
+
+
+Sign in to Prefect Horizon.
+
+
+### `whoami` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/command.py#L303" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+whoami() -> None
+```
+
+
+Show the current Prefect Horizon user.
+
+
+### `logout` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/command.py#L353" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+logout() -> None
+```
+
+
+Revoke the current Horizon key and remove the local credential.
+

--- a/docs/python-sdk/fastmcp-cli-deploy-configuration.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-configuration.mdx
@@ -1,0 +1,50 @@
+---
+title: configuration
+sidebarTitle: configuration
+---
+
+# `fastmcp.cli.deploy.configuration`
+
+
+Global non-secret configuration for the FastMCP CLI.
+
+## Classes
+
+### `HorizonConfiguration` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/configuration.py#L18" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `validate_api_origin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/configuration.py#L26" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_api_origin(cls, value: str) -> str
+```
+
+### `ConfigurationStore` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/configuration.py#L30" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Persist the Horizon API origin without organization state.
+
+
+**Methods:**
+
+#### `load` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/configuration.py#L40" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load(self) -> HorizonConfiguration
+```
+
+#### `save` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/configuration.py#L49" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+save(self, configuration: HorizonConfiguration) -> None
+```
+
+#### `set_api_origin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/configuration.py#L55" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_api_origin(self, api_origin: str) -> HorizonConfiguration
+```
+
+Set the origin and clear credentials before an origin change.
+

--- a/docs/python-sdk/fastmcp-cli-deploy-credentials.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-credentials.mdx
@@ -1,0 +1,95 @@
+---
+title: credentials
+sidebarTitle: credentials
+---
+
+# `fastmcp.cli.deploy.credentials`
+
+
+Restricted Horizon credential storage and resolution.
+
+## Functions
+
+### `resolve_credential` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L130" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+resolve_credential(store: CredentialStore) -> ResolvedCredential
+```
+
+
+Resolve environment, stored, then interactive credentials.
+
+
+### `revoke_and_clear_credential` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L161" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+revoke_and_clear_credential(client: HorizonClient, store: CredentialStore) -> None
+```
+
+
+Attempt remote revocation and always remove the stored credential.
+
+
+## Classes
+
+### `AuthenticationRequiredError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L33" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+No Horizon credential is available without interactive authorization.
+
+
+### `AuthState` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L37" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `require_nonempty_api_key` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L45" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+require_nonempty_api_key(cls, value: SecretStr) -> SecretStr
+```
+
+### `ResolvedCredential` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L52" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `CredentialStore` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Persist the active personal Horizon API key.
+
+
+**Methods:**
+
+#### `load` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L67" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load(self) -> SecretStr | None
+```
+
+#### `save` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L71" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+save(self, api_key: SecretStr | str) -> None
+```
+
+#### `save_for_origin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L84" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+save_for_origin(self, api_key: SecretStr | str) -> None
+```
+
+Save a key only while its issuing Horizon origin is active.
+
+
+#### `clear_if_matches` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+clear_if_matches(self, api_key: SecretStr | str) -> None
+```
+
+Clear a key only while its Horizon origin and value are active.
+
+
+#### `clear` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/credentials.py#L126" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+clear(self) -> None
+```

--- a/docs/python-sdk/fastmcp-cli-deploy-horizon_client.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-horizon_client.mdx
@@ -1,0 +1,111 @@
+---
+title: horizon_client
+sidebarTitle: horizon_client
+---
+
+# `fastmcp.cli.deploy.horizon_client`
+
+
+Typed HTTP client for the Horizon control plane.
+
+## Functions
+
+### `normalize_api_origin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L129" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+normalize_api_origin(value: str) -> str
+```
+
+
+Validate and normalize a Horizon API origin.
+
+
+## Classes
+
+### `HorizonError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L33" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A safe Horizon client error.
+
+
+### `HorizonUnavailableError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L37" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The Horizon API could not be reached.
+
+
+### `HorizonUnauthorizedError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L41" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The Horizon credential was rejected.
+
+
+### `HorizonResponseError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L45" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Horizon returned an unexpected response.
+
+
+### `DeviceAuthorization` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L60" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `DeviceAccessToken` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L69" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `require_nonempty_access_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L75" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+require_nonempty_access_token(cls, value: SecretStr) -> SecretStr
+```
+
+### `HorizonUser` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L85" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `HorizonOrganization` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `DeviceMetadata` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L112" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `DeviceTokenPoll` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L120" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `HorizonClient` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L150" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Call the Horizon routes used by FastMCP CLI authentication.
+
+
+**Methods:**
+
+#### `aclose` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L188" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+aclose(self) -> None
+```
+
+#### `create_device_authorization` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L242" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_device_authorization(self, metadata: DeviceMetadata | None = None) -> DeviceAuthorization
+```
+
+#### `exchange_device_authorization` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L262" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+exchange_device_authorization(self, device_code: str) -> DeviceTokenPoll
+```
+
+#### `get_current_user` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L287" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_current_user(self) -> HorizonUser
+```
+
+#### `list_organizations` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L297" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_organizations(self) -> tuple[HorizonOrganization, ...]
+```
+
+#### `revoke_current_api_key` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/horizon_client.py#L326" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+revoke_current_api_key(self) -> None
+```

--- a/docs/python-sdk/fastmcp-cli-deploy-output.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-output.mdx
@@ -1,0 +1,81 @@
+---
+title: output
+sidebarTitle: output
+---
+
+# `fastmcp.cli.deploy.output`
+
+
+Stable terminal and JSON output for Horizon CLI commands.
+
+## Functions
+
+### `emit_device_challenge` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/output.py#L84" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+emit_device_challenge(authorization: DeviceAuthorization) -> None
+```
+
+
+Show a device challenge before polling starts.
+
+
+### `start_device_approval_status` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/output.py#L129" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+start_device_approval_status() -> Status | None
+```
+
+
+Start the terminal spinner while the browser approval is pending.
+
+
+### `stop_device_approval_status` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/output.py#L142" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+stop_device_approval_status(status: Status | None) -> None
+```
+
+
+Stop a device approval spinner when one is active.
+
+
+### `emit_identity` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/output.py#L148" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+emit_identity(command: Literal['login', 'whoami'], user: HorizonUser) -> None
+```
+
+
+Show the authenticated user.
+
+
+### `emit_environment_logout` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/output.py#L182" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+emit_environment_logout() -> None
+```
+
+
+Explain why logout cannot change an environment credential.
+
+
+### `emit_logout` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/output.py#L216" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+emit_logout() -> None
+```
+
+
+Show a successful local logout result.
+
+
+### `emit_error` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/output.py#L257" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+emit_error(command: CommandName, category: ErrorCategory, message: str) -> None
+```
+
+
+Show a stable expected command failure.
+

--- a/docs/python-sdk/fastmcp-cli-deploy-state.mdx
+++ b/docs/python-sdk/fastmcp-cli-deploy-state.mdx
@@ -1,0 +1,59 @@
+---
+title: state
+sidebarTitle: state
+---
+
+# `fastmcp.cli.deploy.state`
+
+
+Versioned JSON state helpers for the FastMCP CLI.
+
+## Functions
+
+### `state_lock` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/state.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+state_lock(directory: Path) -> Iterator[None]
+```
+
+
+Lock related CLI state changes across processes.
+
+
+### `read_state` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/state.py#L145" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read_state(path: Path, model: type[ModelT]) -> ModelT | None
+```
+
+
+Read and validate a versioned JSON state file.
+
+
+### `write_state` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/state.py#L169" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+write_state(path: Path, data: dict[str, Any]) -> None
+```
+
+
+Write JSON through a restricted temporary file and atomic replacement.
+
+
+### `remove_state` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/state.py#L221" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+remove_state(path: Path) -> None
+```
+
+
+Remove a state file when it exists.
+
+
+## Classes
+
+### `StateFileError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/deploy/state.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A CLI state file could not be read or written safely.
+

--- a/docs/python-sdk/fastmcp-cli-discovery.mdx
+++ b/docs/python-sdk/fastmcp-cli-discovery.mdx
@@ -1,0 +1,71 @@
+---
+title: discovery
+sidebarTitle: discovery
+---
+
+# `fastmcp.cli.discovery`
+
+
+Discover MCP servers configured in editor config files.
+
+Scans filesystem-readable config files from editors like Claude Desktop,
+Claude Code, Cursor, Gemini CLI, and Goose, as well as project-level
+``mcp.json`` files. Each discovered server can be resolved by name
+(or ``source:name``) so the CLI can connect without requiring a URL
+or file path.
+
+
+## Functions
+
+### `discover_servers` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/discovery.py#L323" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+discover_servers(start_dir: Path | None = None) -> list[DiscoveredServer]
+```
+
+
+Run all scanners and return the combined results.
+
+Duplicate names across sources are preserved — callers can
+use :pyattr:`DiscoveredServer.qualified_name` to disambiguate.
+
+
+### `resolve_name` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/discovery.py#L340" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+resolve_name(name: str, start_dir: Path | None = None) -> ClientTransport
+```
+
+
+Resolve a server name (or ``source:name``) to a transport.
+
+Raises :class:`ValueError` when the name is not found or is ambiguous.
+
+
+## Classes
+
+### `DiscoveredServer` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/discovery.py#L37" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A single MCP server found in an editor or project config.
+
+
+**Methods:**
+
+#### `qualified_name` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/discovery.py#L46" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+qualified_name(self) -> str
+```
+
+Fully qualified ``source:name`` identifier.
+
+
+#### `transport_summary` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/discovery.py#L51" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+transport_summary(self) -> str
+```
+
+Human-readable one-liner describing the transport.
+

--- a/docs/python-sdk/fastmcp-cli-generate.mdx
+++ b/docs/python-sdk/fastmcp-cli-generate.mdx
@@ -1,0 +1,66 @@
+---
+title: generate
+sidebarTitle: generate
+---
+
+# `fastmcp.cli.generate`
+
+
+Generate a standalone CLI script and agent skill from an MCP server.
+
+## Functions
+
+### `serialize_transport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/generate.py#L122" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+serialize_transport(resolved: str | dict[str, Any] | ClientTransport) -> tuple[str, set[str]]
+```
+
+
+Serialize a resolved transport to a Python expression string.
+
+Returns ``(expression, extra_imports)`` where *extra_imports* is a set of
+import lines needed by the expression.
+
+
+### `generate_cli_script` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/generate.py#L283" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate_cli_script(server_name: str, server_spec: str, transport_code: str, extra_imports: set[str], tools: list[mcp_types.Tool]) -> str
+```
+
+
+Generate the full CLI script source code.
+
+
+### `generate_skill_content` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/generate.py#L619" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate_skill_content(server_name: str, cli_filename: str, tools: list[mcp_types.Tool]) -> str
+```
+
+
+Generate a SKILL.md file for a generated CLI script.
+
+
+### `generate_cli_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/generate.py#L670" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate_cli_command(server_spec: Annotated[str, cyclopts.Parameter(help='Server URL, Python file, MCPConfig JSON, discovered name, or .js file')], output: Annotated[str, cyclopts.Parameter(help='Output file path (default: cli.py)')] = 'cli.py') -> None
+```
+
+
+Generate a standalone CLI script from an MCP server.
+
+Connects to the server, reads its tools/resources/prompts, and writes
+a Python script that can invoke them directly. Also generates a SKILL.md
+agent skill file unless --no-skill is passed.
+
+**Examples:**
+
+fastmcp generate-cli weather
+fastmcp generate-cli weather my_cli.py
+fastmcp generate-cli http://localhost:8000/mcp
+fastmcp generate-cli server.py output.py -f
+fastmcp generate-cli weather --no-skill
+

--- a/docs/python-sdk/fastmcp-cli-install-__init__.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-__init__.mdx
@@ -1,0 +1,9 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.cli.install`
+
+
+Install subcommands for FastMCP CLI using Cyclopts.

--- a/docs/python-sdk/fastmcp-cli-install-claude_code.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-claude_code.mdx
@@ -1,0 +1,71 @@
+---
+title: claude_code
+sidebarTitle: claude_code
+---
+
+# `fastmcp.cli.install.claude_code`
+
+
+Claude Code integration for FastMCP install using Cyclopts.
+
+## Functions
+
+### `find_claude_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/claude_code.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+find_claude_command() -> str | None
+```
+
+
+Find the Claude Code CLI command.
+
+Checks common installation locations since 'claude' is often a shell alias
+that doesn't work with subprocess calls.
+
+
+### `check_claude_code_available` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/claude_code.py#L68" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+check_claude_code_available() -> bool
+```
+
+
+Check if Claude Code CLI is available.
+
+
+### `install_claude_code` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/claude_code.py#L73" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_claude_code(file: Path, server_object: str | None, name: str) -> bool
+```
+
+
+Install FastMCP server in Claude Code.
+
+**Args:**
+- `file`: Path to the server file
+- `server_object`: Optional server object name (for \:object suffix)
+- `name`: Name for the server in Claude Code
+- `with_editable`: Optional list of directories to install in editable mode
+- `with_packages`: Optional list of additional packages to install
+- `env_vars`: Optional dictionary of environment variables
+- `python_version`: Optional Python version to use
+- `with_requirements`: Optional requirements file to install from
+- `project`: Optional project directory to run within
+
+**Returns:**
+- True if installation was successful, False otherwise
+
+
+### `claude_code_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/claude_code.py#L155" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+claude_code_command(server_spec: str) -> None
+```
+
+
+Install an MCP server in Claude Code.
+
+**Args:**
+- `server_spec`: Python file to install, optionally with \:object suffix
+

--- a/docs/python-sdk/fastmcp-cli-install-claude_desktop.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-claude_desktop.mdx
@@ -1,0 +1,62 @@
+---
+title: claude_desktop
+sidebarTitle: claude_desktop
+---
+
+# `fastmcp.cli.install.claude_desktop`
+
+
+Claude Desktop integration for FastMCP install using Cyclopts.
+
+## Functions
+
+### `get_claude_config_path` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/claude_desktop.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_claude_config_path(config_path: Path | None = None) -> Path | None
+```
+
+
+Get the Claude config directory based on platform.
+
+**Args:**
+- `config_path`: Optional custom path to the Claude Desktop config directory
+
+
+### `install_claude_desktop` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/claude_desktop.py#L49" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_claude_desktop(file: Path, server_object: str | None, name: str) -> bool
+```
+
+
+Install FastMCP server in Claude Desktop.
+
+**Args:**
+- `file`: Path to the server file
+- `server_object`: Optional server object name (for \:object suffix)
+- `name`: Name for the server in Claude's config
+- `with_editable`: Optional list of directories to install in editable mode
+- `with_packages`: Optional list of additional packages to install
+- `env_vars`: Optional dictionary of environment variables
+- `python_version`: Optional Python version to use
+- `with_requirements`: Optional requirements file to install from
+- `project`: Optional project directory to run within
+- `config_path`: Optional custom path to Claude Desktop config directory
+
+**Returns:**
+- True if installation was successful, False otherwise
+
+
+### `claude_desktop_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/claude_desktop.py#L139" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+claude_desktop_command(server_spec: str) -> None
+```
+
+
+Install an MCP server in Claude Desktop.
+
+**Args:**
+- `server_spec`: Python file to install, optionally with \:object suffix
+

--- a/docs/python-sdk/fastmcp-cli-install-cursor.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-cursor.mdx
@@ -1,0 +1,107 @@
+---
+title: cursor
+sidebarTitle: cursor
+---
+
+# `fastmcp.cli.install.cursor`
+
+
+Cursor integration for FastMCP install using Cyclopts.
+
+## Functions
+
+### `generate_cursor_deeplink` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/cursor.py#L22" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate_cursor_deeplink(server_name: str, server_config: StdioMCPServer) -> str
+```
+
+
+Generate a Cursor deeplink for installing the MCP server.
+
+**Args:**
+- `server_name`: Name of the server
+- `server_config`: Server configuration
+
+**Returns:**
+- Deeplink URL that can be clicked to install the server
+
+
+### `open_deeplink` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/cursor.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+open_deeplink(deeplink: str) -> bool
+```
+
+
+Attempt to open a Cursor deeplink URL using the system's default handler.
+
+**Args:**
+- `deeplink`: The deeplink URL to open
+
+**Returns:**
+- True if the command succeeded, False otherwise
+
+
+### `install_cursor_workspace` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/cursor.py#L59" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_cursor_workspace(file: Path, server_object: str | None, name: str, workspace_path: Path) -> bool
+```
+
+
+Install FastMCP server to workspace-specific Cursor configuration.
+
+**Args:**
+- `file`: Path to the server file
+- `server_object`: Optional server object name (for \:object suffix)
+- `name`: Name for the server in Cursor
+- `workspace_path`: Path to the workspace directory
+- `with_editable`: Optional list of directories to install in editable mode
+- `with_packages`: Optional list of additional packages to install
+- `env_vars`: Optional dictionary of environment variables
+- `python_version`: Optional Python version to use
+- `with_requirements`: Optional requirements file to install from
+- `project`: Optional project directory to run within
+
+**Returns:**
+- True if installation was successful, False otherwise
+
+
+### `install_cursor` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/cursor.py#L143" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_cursor(file: Path, server_object: str | None, name: str) -> bool
+```
+
+
+Install FastMCP server in Cursor.
+
+**Args:**
+- `file`: Path to the server file
+- `server_object`: Optional server object name (for \:object suffix)
+- `name`: Name for the server in Cursor
+- `with_editable`: Optional list of directories to install in editable mode
+- `with_packages`: Optional list of additional packages to install
+- `env_vars`: Optional dictionary of environment variables
+- `python_version`: Optional Python version to use
+- `with_requirements`: Optional requirements file to install from
+- `project`: Optional project directory to run within
+- `workspace`: Optional workspace directory for project-specific installation
+
+**Returns:**
+- True if installation was successful, False otherwise
+
+
+### `cursor_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/cursor.py#L228" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+cursor_command(server_spec: str) -> None
+```
+
+
+Install an MCP server in Cursor.
+
+**Args:**
+- `server_spec`: Python file to install, optionally with \:object suffix
+

--- a/docs/python-sdk/fastmcp-cli-install-gemini_cli.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-gemini_cli.mdx
@@ -1,0 +1,68 @@
+---
+title: gemini_cli
+sidebarTitle: gemini_cli
+---
+
+# `fastmcp.cli.install.gemini_cli`
+
+
+Gemini CLI integration for FastMCP install using Cyclopts.
+
+## Functions
+
+### `find_gemini_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/gemini_cli.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+find_gemini_command() -> str | None
+```
+
+
+Find the Gemini CLI command.
+
+
+### `check_gemini_cli_available` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/gemini_cli.py#L64" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+check_gemini_cli_available() -> bool
+```
+
+
+Check if Gemini CLI is available.
+
+
+### `install_gemini_cli` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/gemini_cli.py#L69" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_gemini_cli(file: Path, server_object: str | None, name: str) -> bool
+```
+
+
+Install FastMCP server in Gemini CLI.
+
+**Args:**
+- `file`: Path to the server file
+- `server_object`: Optional server object name (for \:object suffix)
+- `name`: Name for the server in Gemini CLI
+- `with_editable`: Optional list of directories to install in editable mode
+- `with_packages`: Optional list of additional packages to install
+- `env_vars`: Optional dictionary of environment variables
+- `python_version`: Optional Python version to use
+- `with_requirements`: Optional requirements file to install from
+- `project`: Optional project directory to run within
+
+**Returns:**
+- True if installation was successful, False otherwise
+
+
+### `gemini_cli_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/gemini_cli.py#L152" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+gemini_cli_command(server_spec: str) -> None
+```
+
+
+Install an MCP server in Gemini CLI.
+
+**Args:**
+- `server_spec`: Python file to install, optionally with \:object suffix
+

--- a/docs/python-sdk/fastmcp-cli-install-goose.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-goose.mdx
@@ -1,0 +1,67 @@
+---
+title: goose
+sidebarTitle: goose
+---
+
+# `fastmcp.cli.install.goose`
+
+
+Goose integration for FastMCP install using Cyclopts.
+
+## Functions
+
+### `generate_goose_deeplink` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/goose.py#L29" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate_goose_deeplink(name: str, command: str, args: list[str]) -> str
+```
+
+
+Generate a Goose deeplink for installing an MCP extension.
+
+**Args:**
+- `name`: Human-readable display name for the extension.
+- `command`: The executable command (e.g. "uv").
+- `args`: Arguments to the command.
+- `description`: Short description shown in Goose.
+
+**Returns:**
+- A goose://extension?... deeplink URL.
+
+
+### `install_goose` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/goose.py#L85" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_goose(file: Path, server_object: str | None, name: str) -> bool
+```
+
+
+Install FastMCP server in Goose via deeplink.
+
+**Args:**
+- `file`: Path to the server file.
+- `server_object`: Optional server object name (for \:object suffix).
+- `name`: Name for the extension in Goose.
+- `with_packages`: Optional list of additional packages to install.
+- `python_version`: Optional Python version to use.
+
+**Returns:**
+- True if installation was successful, False otherwise.
+
+
+### `goose_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/goose.py#L135" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+goose_command(server_spec: str) -> None
+```
+
+
+Install an MCP server in Goose.
+
+Uses uvx to run the server. Environment variables are not included
+in the deeplink; use `fastmcp install mcp-json` to generate a full
+config for manual installation.
+
+**Args:**
+- `server_spec`: Python file to install, optionally with \:object suffix
+

--- a/docs/python-sdk/fastmcp-cli-install-mcp_json.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-mcp_json.mdx
@@ -1,0 +1,49 @@
+---
+title: mcp_json
+sidebarTitle: mcp_json
+---
+
+# `fastmcp.cli.install.mcp_json`
+
+
+MCP configuration JSON generation for FastMCP install using Cyclopts.
+
+## Functions
+
+### `install_mcp_json` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/mcp_json.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_mcp_json(file: Path, server_object: str | None, name: str) -> bool
+```
+
+
+Generate MCP configuration JSON for manual installation.
+
+**Args:**
+- `file`: Path to the server file
+- `server_object`: Optional server object name (for \:object suffix)
+- `name`: Name for the server in MCP config
+- `with_editable`: Optional list of directories to install in editable mode
+- `with_packages`: Optional list of additional packages to install
+- `env_vars`: Optional dictionary of environment variables
+- `copy`: If True, copy to clipboard instead of printing to stdout
+- `python_version`: Optional Python version to use
+- `with_requirements`: Optional requirements file to install from
+- `project`: Optional project directory to run within
+
+**Returns:**
+- True if generation was successful, False otherwise
+
+
+### `mcp_json_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/mcp_json.py#L98" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+mcp_json_command(server_spec: str) -> None
+```
+
+
+Generate MCP configuration JSON for manual installation.
+
+**Args:**
+- `server_spec`: Python file to install, optionally with \:object suffix
+

--- a/docs/python-sdk/fastmcp-cli-install-shared.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-shared.mdx
@@ -1,0 +1,62 @@
+---
+title: shared
+sidebarTitle: shared
+---
+
+# `fastmcp.cli.install.shared`
+
+
+Shared utilities for install commands.
+
+## Functions
+
+### `validate_server_name` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/shared.py#L28" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_server_name(name: str) -> str
+```
+
+
+Validate that a server name is safe for use as a subprocess argument.
+
+Raises SystemExit if the name contains shell metacharacters.
+
+
+### `parse_env_var` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/shared.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+parse_env_var(env_var: str) -> tuple[str, str]
+```
+
+
+Parse environment variable string in format KEY=VALUE.
+
+
+### `process_common_args` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/shared.py#L58" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+process_common_args(server_spec: str, server_name: str | None, with_packages: list[str] | None, env_vars: list[str] | None, env_file: Path | None) -> tuple[Path, str | None, str, list[str], dict[str, str] | None]
+```
+
+
+Process common arguments shared by all install commands.
+
+Handles both fastmcp.json config files and traditional file.py:object syntax.
+
+
+### `open_deeplink` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/shared.py#L174" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+open_deeplink(url: str) -> bool
+```
+
+
+Attempt to open a deeplink URL using the system's default handler.
+
+**Args:**
+- `url`: The deeplink URL to open.
+- `expected_scheme`: The URL scheme to validate (e.g. "cursor", "goose").
+
+**Returns:**
+- True if the command succeeded, False otherwise.
+

--- a/docs/python-sdk/fastmcp-cli-install-stdio.mdx
+++ b/docs/python-sdk/fastmcp-cli-install-stdio.mdx
@@ -1,0 +1,50 @@
+---
+title: stdio
+sidebarTitle: stdio
+---
+
+# `fastmcp.cli.install.stdio`
+
+
+Stdio command generation for FastMCP install using Cyclopts.
+
+## Functions
+
+### `install_stdio` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/stdio.py#L21" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+install_stdio(file: Path, server_object: str | None) -> bool
+```
+
+
+Generate the stdio command for running a FastMCP server.
+
+**Args:**
+- `file`: Path to the server file
+- `server_object`: Optional server object name (for \:object suffix)
+- `with_editable`: Optional list of directories to install in editable mode
+- `with_packages`: Optional list of additional packages to install
+- `copy`: If True, copy to clipboard instead of printing to stdout
+- `python_version`: Optional Python version to use
+- `with_requirements`: Optional requirements file to install from
+- `project`: Optional project directory to run within
+
+**Returns:**
+- True if generation was successful, False otherwise
+
+
+### `stdio_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/install/stdio.py#L78" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+stdio_command(server_spec: str) -> None
+```
+
+
+Generate the stdio command for running a FastMCP server.
+
+Outputs the shell command that an MCP host would use to start this server
+over stdio transport. Useful for manual configuration or debugging.
+
+**Args:**
+- `server_spec`: Python file to run, optionally with \:object suffix
+

--- a/docs/python-sdk/fastmcp-cli-run.mdx
+++ b/docs/python-sdk/fastmcp-cli-run.mdx
@@ -1,0 +1,136 @@
+---
+title: run
+sidebarTitle: run
+---
+
+# `fastmcp.cli.run`
+
+
+FastMCP run command implementation with enhanced type hints.
+
+## Functions
+
+### `is_url` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L84" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_url(path: str) -> bool
+```
+
+
+Check if a string is a URL.
+
+
+### `create_client_server` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L90" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_client_server(url: str) -> Any
+```
+
+
+Create a FastMCP server from a client URL.
+
+**Args:**
+- `url`: The URL to connect to
+
+**Returns:**
+- A FastMCP server instance
+
+
+### `create_mcp_config_server` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L115" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_mcp_config_server(mcp_config_path: Path) -> FastMCP[None]
+```
+
+
+Create a FastMCP server from a MCPConfig.
+
+
+### `load_mcp_server_config` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L124" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_mcp_server_config(config_path: Path) -> MCPServerConfig
+```
+
+
+Load a FastMCP configuration from a fastmcp.json file.
+
+**Args:**
+- `config_path`: Path to fastmcp.json file
+
+**Returns:**
+- MCPServerConfig object
+
+
+### `run_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L141" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_command(server_spec: str, transport: TransportType | None = None, host: str | None = None, port: int | None = None, path: str | None = None, log_level: LogLevelType | None = None, server_args: list[str] | None = None, show_banner: bool = True, use_direct_import: bool = False, skip_source: bool = False, stateless: bool = False) -> None
+```
+
+
+Run a MCP server or connect to a remote one.
+
+**Args:**
+- `server_spec`: Python file, object specification (file\:obj), config file, or URL
+- `transport`: Transport protocol to use
+- `host`: Host to bind to when using http transport
+- `port`: Port to bind to when using http transport
+- `path`: Path to bind to when using http transport
+- `log_level`: Log level
+- `server_args`: Additional arguments to pass to the server
+- `show_banner`: Whether to show the server banner
+- `use_direct_import`: Whether to use direct import instead of subprocess
+- `skip_source`: Whether to skip source preparation step
+- `stateless`: Whether to run in stateless mode (no session)
+
+
+### `run_module_command` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L277" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_module_command(module_name: str) -> None
+```
+
+
+Run a Python module directly using ``python -m <module>``.
+
+When ``-m`` is used, the module manages its own server startup.
+No server-object discovery or transport overrides are applied.
+
+**Args:**
+- `module_name`: Dotted module name (e.g. ``my_package``).
+- `env_command_builder`: An optional callable that wraps a command list
+with environment setup (e.g. ``UVEnvironment.build_command``).
+- `extra_args`: Extra arguments forwarded after the module name.
+
+
+### `run_v1_server_async` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L316" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_v1_server_async(server: SDKServer, host: str | None = None, port: int | None = None, transport: TransportType | None = None) -> None
+```
+
+
+Run a FastMCP 1.x server using async methods.
+
+**Args:**
+- `server`: FastMCP 1.x server instance
+- `host`: Host to bind to
+- `port`: Port to bind to
+- `transport`: Transport protocol to use
+
+
+### `run_with_reload` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/cli/run.py#L384" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_with_reload(cmd: list[str], reload_dirs: list[Path] | None = None, is_stdio: bool = False) -> None
+```
+
+
+Run a command with file watching and auto-reload.
+
+**Args:**
+- `cmd`: Command to run as subprocess (should include --no-reload)
+- `reload_dirs`: Directories to watch for changes (default\: cwd)
+- `is_stdio`: Whether this is stdio transport
+

--- a/docs/python-sdk/fastmcp-client-auth-bearer.mdx
+++ b/docs/python-sdk/fastmcp-client-auth-bearer.mdx
@@ -1,0 +1,18 @@
+---
+title: bearer
+sidebarTitle: bearer
+---
+
+# `fastmcp.client.auth.bearer`
+
+## Classes
+
+### `BearerAuth` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/bearer.py#L11" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `auth_flow` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/bearer.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+auth_flow(self, request)
+```

--- a/docs/python-sdk/fastmcp-client-auth-client_credentials.mdx
+++ b/docs/python-sdk/fastmcp-client-auth-client_credentials.mdx
@@ -1,0 +1,66 @@
+---
+title: client_credentials
+sidebarTitle: client_credentials
+---
+
+# `fastmcp.client.auth.client_credentials`
+
+
+Machine-to-machine (M2M) OAuth client authentication for FastMCP.
+
+These providers authenticate a FastMCP client to a protected MCP server without
+a browser, using the OAuth 2.0 ``client_credentials`` grant:
+
+- `ClientCredentialsOAuthProvider` authenticates with a ``client_id`` and
+  ``client_secret`` (the common M2M case).
+- `PrivateKeyJWTOAuthProvider` authenticates with an RFC 7523 ``private_key_jwt``
+  client assertion (workload identity federation, or a locally signed JWT).
+
+Both are thin wrappers over the MCP SDK's client-credentials providers. Like the
+interactive `OAuth` provider, they can be constructed without an ``mcp_url`` and
+bound to the server URL automatically when passed to `Client(auth=...)`.
+
+
+## Classes
+
+### `ClientCredentialsOAuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/client_credentials.py#L164" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth ``client_credentials`` provider using a client ID and secret.
+
+This is the standard machine-to-machine flow: the client exchanges its
+``client_id`` and ``client_secret`` at the authorization server's token
+endpoint for an access token, which is then attached to every request. The
+token endpoint is discovered from the MCP server's OAuth metadata, so callers
+provide the MCP server URL rather than a raw token endpoint.
+
+
+**Methods:**
+
+#### `async_auth_flow` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/client_credentials.py#L258" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+async_auth_flow(self, request: httpx2.Request) -> AsyncGenerator[httpx2.Request, httpx2.Response]
+```
+
+### `PrivateKeyJWTOAuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/client_credentials.py#L281" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth ``client_credentials`` provider using ``private_key_jwt`` (RFC 7523).
+
+Instead of a shared client secret, the client authenticates to the token
+endpoint with a signed JWT assertion. The ``assertion_provider`` callback
+receives the authorization server's issuer identifier (the required JWT
+audience) and returns the assertion. Use
+`SignedJWTParameters.create_assertion_provider()` to sign locally with a
+private key, `static_assertion_provider()` for a pre-built JWT, or supply your
+own callback for workload identity federation.
+
+
+**Methods:**
+
+#### `async_auth_flow` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/client_credentials.py#L384" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+async_auth_flow(self, request: httpx2.Request) -> AsyncGenerator[httpx2.Request, httpx2.Response]
+```

--- a/docs/python-sdk/fastmcp-client-auth-oauth.mdx
+++ b/docs/python-sdk/fastmcp-client-auth-oauth.mdx
@@ -1,0 +1,116 @@
+---
+title: oauth
+sidebarTitle: oauth
+---
+
+# `fastmcp.client.auth.oauth`
+
+## Functions
+
+### `check_if_auth_required` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L58" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+check_if_auth_required(mcp_url: str, httpx_kwargs: dict[str, Any] | None = None) -> bool
+```
+
+
+Check if the MCP endpoint requires authentication by making a test request.
+
+**Returns:**
+- True if auth appears to be required, False otherwise
+
+
+## Classes
+
+### `ClientNotFoundError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L50" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Raised when OAuth client credentials are not found on the server.
+
+
+### `ExpiredClientRegistrationError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L54" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Raised when dynamic registration returns an expired client secret.
+
+
+### `TokenStorageAdapter` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L88" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `clear` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L135" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+clear(self) -> None
+```
+
+#### `get_tokens` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L144" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tokens(self) -> OAuthToken | None
+```
+
+#### `set_tokens` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L148" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_tokens(self, tokens: OAuthToken) -> None
+```
+
+#### `get_token_expiry` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L168" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_token_expiry(self) -> float | None
+```
+
+#### `get_client_info` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L178" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_client_info(self) -> OAuthClientInformationFull | None
+```
+
+#### `set_client_info` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L184" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_client_info(self, client_info: OAuthClientInformationFull) -> None
+```
+
+### `OAuth` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L202" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth client provider for MCP servers with browser-based authentication.
+
+This class provides OAuth authentication for FastMCP clients by opening
+a browser for user authorization and running a local callback server.
+
+
+**Methods:**
+
+#### `redirect_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L381" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+redirect_handler(self, authorization_url: str) -> None
+```
+
+Open browser for authorization, with pre-flight check for invalid client.
+
+
+#### `callback_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L402" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+callback_handler(self) -> AuthorizationCodeResult
+```
+
+Handle OAuth callback and return the authorization code result.
+
+
+#### `async_auth_flow` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/auth/oauth.py#L446" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+async_auth_flow(self, request: httpx2.Request) -> AsyncGenerator[httpx2.Request, httpx2.Response]
+```
+
+HTTPX auth flow with automatic retry on stale cached credentials.
+
+If the OAuth flow fails due to invalid/stale client credentials,
+clears the cache and retries once with fresh registration.
+

--- a/docs/python-sdk/fastmcp-client-caching.mdx
+++ b/docs/python-sdk/fastmcp-client-caching.mdx
@@ -1,0 +1,102 @@
+---
+title: caching
+sidebarTitle: caching
+---
+
+# `fastmcp.client.caching`
+
+
+A client response cache store backed by AsyncKeyValue.
+
+The MCP SDK's client response cache (SEP-2549) reads and writes through a
+pluggable `ResponseCacheStore` protocol; the default is a per-client in-memory
+LRU. This module adapts that protocol onto the `AsyncKeyValue` key-value
+abstraction FastMCP already uses for its other state-management surfaces (the
+event store, the OAuth proxy, the response-caching middleware), so a fleet of
+FastMCP clients — for example a set of proxy replicas — can share one
+Redis-backed response cache.
+
+Because a shared store mingles cached responses across principals, the SDK
+requires an explicit `partition` on any custom store (and FastMCP additionally
+requires a `target_id`). The partition is folded into every stored key so
+entries can never collide or leak across authorization contexts, and the
+adapter round-trips each result through a small type-tagged envelope validated
+against an allowlist of cacheable result models — a stored value that names an
+unknown type is treated as a miss, never imported by name.
+
+Example:
+    ```python
+    from fastmcp import Client
+    from fastmcp.client.caching import KeyValueResponseCacheStore
+    from mcp.client.caching import CacheConfig
+    from key_value.aio.stores.redis import RedisStore
+
+    store = KeyValueResponseCacheStore(storage=RedisStore(url="redis://localhost"))
+    config = CacheConfig(store=store, partition="tenant-a", target_id="weather-api")
+    client = Client("https://example.com/mcp", mode="auto", cache=config)
+    ```
+
+
+## Classes
+
+### `KeyValueResponseCacheStore` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/caching.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A `ResponseCacheStore` backed by any `AsyncKeyValue` store.
+
+Implements the SDK client response cache contract (`get`/`set`/`delete`/
+`clear`) over the key-value abstraction FastMCP already uses elsewhere, so a
+distributed deployment can point every client at one shared backend (memory,
+Redis, etc.). Pass an instance as `CacheConfig(store=...)`; the SDK requires
+an explicit `partition` on any custom store, and FastMCP additionally
+requires a `target_id`.
+
+Each adapter instance owns one collection (`collection`), so `clear()` only
+affects its own namespace and never another tenant's data. `clear()` needs
+the backend to support collection destruction or key enumeration; against a
+backend that supports neither it is a no-op and entries age out by TTL (a
+warning is logged once).
+
+The SDK wraps every store call defensively — a raised operation degrades to
+a cache miss rather than failing the request — so this adapter does not
+re-wrap its own operations.
+
+**Args:**
+- `storage`: The `AsyncKeyValue` backend. Defaults to an in-process `MemoryStore`.
+- `collection`: Collection namespace for this adapter's entries.
+
+
+**Methods:**
+
+#### `get` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/caching.py#L152" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get(self, key: CacheKey) -> CacheEntry | None
+```
+
+#### `set` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/caching.py#L166" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set(self, key: CacheKey, entry: CacheEntry) -> None
+```
+
+#### `delete` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/caching.py#L182" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+delete(self, key: CacheKey) -> None
+```
+
+#### `clear` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/caching.py#L185" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+clear(self) -> None
+```
+
+Clear this adapter's collection only.
+
+Prefers deleting each enumerated key (which leaves the collection
+usable), and falls back to whole-collection destruction. Against a
+backend that supports neither, this is a no-op (entries age out by TTL)
+and a warning is logged once. Either path is scoped to this adapter's
+own collection, so a shared store's other tenants are never touched.
+

--- a/docs/python-sdk/fastmcp-client-client.mdx
+++ b/docs/python-sdk/fastmcp-client-client.mdx
@@ -1,0 +1,394 @@
+---
+title: client
+sidebarTitle: client
+---
+
+# `fastmcp.client.client`
+
+## Classes
+
+### `ClientSessionState` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L219" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Holds all session-related state for a Client instance.
+
+This allows clean separation of configuration (which is copied) from
+session state (which should be fresh for each new client instance).
+
+
+### `CallToolResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L252" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Parsed result from a tool call.
+
+
+### `Client` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L262" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+MCP client that delegates connection management to a Transport instance.
+
+The Client class is responsible for MCP protocol logic, while the Transport
+handles connection establishment and management. Client provides methods for
+working with resources, prompts, tools and other MCP capabilities.
+
+This client supports reentrant context managers (multiple concurrent
+`async with client:` blocks) using reference counting and background session
+management. This allows efficient session reuse in any scenario with
+nested or concurrent client usage.
+
+MCP SDK 1.10 introduced automatic list_tools() calls during call_tool()
+execution. This created a race condition where events could be reset while
+other tasks were waiting on them, causing deadlocks. The issue was exposed
+in proxy scenarios but affects any reentrant usage.
+
+The solution uses reference counting to track active context managers,
+a background task to manage the session lifecycle, events to coordinate
+between tasks, and ensures all session state changes happen within a lock.
+Events are only created when needed, never reset outside locks.
+
+This design prevents race conditions where tasks wait on events that get
+replaced by other tasks, ensuring reliable coordination in concurrent scenarios.
+
+**Args:**
+- `transport`: 
+Connection source specification, which can be\:
+
+    - ClientTransport\: Direct transport instance
+    - FastMCP\: In-process FastMCP server
+    - AnyUrl or str\: URL to connect to
+    - Path\: File path for local socket
+    - MCPConfig\: MCP server configuration
+    - dict\: Transport configuration
+- `roots`: Optional RootsList or RootsHandler for filesystem access
+- `sampling_handler`: Optional handler for sampling requests
+- `log_handler`: Optional handler for log messages
+- `message_handler`: Optional handler for protocol messages
+- `progress_handler`: Optional handler for progress notifications
+- `timeout`: Optional timeout for requests (seconds or timedelta)
+- `init_timeout`: Optional timeout for initial connection (seconds or timedelta).
+Set to 0 to disable. If None, uses the value in the FastMCP global settings.
+- `mode`: Protocol-era negotiation at connect time. `"auto"` (the default) probes
+`server/discover` and negotiates the modern era, denylist-falling-back to the
+initialize handshake for any server that is not positive evidence of a modern
+peer — safe against a mixed fleet of legacy and modern servers. `"legacy"`
+forces the initialize handshake, byte-identical to pre-v4 behavior; opt into it
+to pin the old handshake. A modern version string (e.g. `"2026-07-28"`) adopts
+that version directly without a probe.
+- `prior_discover`: A previously obtained `DiscoverResult` to adopt when `mode` is a
+version pin, reused instead of synthesizing a minimal one. Ignored otherwise.
+- `input_required_max_rounds`: Cap on `InputRequiredResult` (SEP-2322) retry rounds
+for `call_tool` / `get_prompt` / `read_resource` before the driver gives up.
+Only reachable on 2026-era servers that emit `InputRequiredResult`.
+- `cache`: Client-side response caching (SEP-2549), opt-in. `None` (default) and
+`False` disable it; `True` enables the default in-memory store honoring
+server `ttlMs`/`cacheScope` hints; a `CacheConfig` customizes it. Honoring is
+modern-only, so a cache is inert on legacy connections. A custom `CacheConfig`
+store requires `target_id`, since FastMCP transports expose no server URL to
+derive a shared-store identity from.
+- `extensions`: Opt-in client extensions (SEP-2133), a sequence of
+`mcp.client.extension.ClientExtension` instances. Each contributes its
+capability advertisement, its result claims, and its notification bindings,
+all of which are threaded into the underlying session. User-supplied
+notification bindings compose with FastMCP's internal task-status binding
+rather than replacing it. A claimed `call_tool` result is resolved
+transparently through the owning extension's resolver. For an advertise-only
+entry, use `mcp.client.advertise(identifier, settings)`.
+- `result_claims`: Additional `ResultClaim`s (SEP-2133) keyed by the identifier of
+an extension already advertised through `extensions`, merged with that
+extension's own claims. Rarely needed directly; prefer declaring claims on
+the extension itself. Claimed shapes are modern-only and inert on a legacy
+connection.
+
+**Examples:**
+
+```python
+# Connect to FastMCP server
+client = Client("http://localhost:8080")
+
+async with client:
+    # List available resources
+    resources = await client.list_resources()
+
+    # Call a tool
+    result = await client.call_tool("my_tool", {"param": "value"})
+```
+
+
+**Methods:**
+
+#### `session` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L651" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+session(self) -> ClientSession
+```
+
+Get the current active session. Raises RuntimeError if not connected.
+
+
+#### `prior_discover` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L661" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+prior_discover(self) -> mcp_types.DiscoverResult | None
+```
+
+The configured result to adopt when `mode` pins a modern version.
+
+
+#### `initialize_result` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L666" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+initialize_result(self) -> mcp_types.InitializeResult | None
+```
+
+Get the result of the initialization request.
+
+`None` on a modern (`server/discover`) connection, which negotiates via a
+`DiscoverResult` rather than an `InitializeResult`. Use `protocol_version`,
+`server_info`, `server_capabilities`, and `instructions` for era-neutral
+access to the negotiated server metadata.
+
+
+#### `protocol_version` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L677" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+protocol_version(self) -> str | None
+```
+
+The negotiated protocol version, or `None` when disconnected.
+
+Set during connect-time negotiation regardless of era: the initialize
+handshake, `server/discover`, or a direct version pin all populate it.
+
+
+#### `server_capabilities` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L687" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+server_capabilities(self) -> mcp_types.ServerCapabilities | None
+```
+
+The server's advertised capabilities, or `None` when disconnected.
+
+Populated from whichever negotiation result the era produced (the
+`InitializeResult` on legacy, the `DiscoverResult` on modern).
+
+
+#### `server_info` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L697" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+server_info(self) -> mcp_types.Implementation | None
+```
+
+The session's server identity, or `None` when disconnected.
+
+Populated from whichever negotiation result the era produced (the
+`InitializeResult` on legacy, the `DiscoverResult` on modern). A directly
+pinned modern version uses a synthesized identity with an empty name.
+
+
+#### `instructions` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L708" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+instructions(self) -> str | None
+```
+
+The server's instructions, or `None` when absent or disconnected.
+
+Populated from whichever negotiation result the era produced (the
+`InitializeResult` on legacy, the `DiscoverResult` on modern).
+
+
+#### `set_roots` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L717" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_roots(self, roots: RootsList | RootsHandler) -> None
+```
+
+Set the roots for the client. This does not automatically call `send_roots_list_changed`.
+
+
+#### `set_sampling_callback` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L721" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_sampling_callback(self, sampling_callback: SamplingHandler, sampling_capabilities: mcp_types.SamplingCapability | None = None) -> None
+```
+
+Set the sampling callback for the client.
+
+
+#### `set_elicitation_callback` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L736" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_elicitation_callback(self, elicitation_callback: ElicitationHandler) -> None
+```
+
+Set the elicitation callback for the client.
+
+
+#### `is_connected` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L747" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_connected(self) -> bool
+```
+
+Check if the client is currently connected.
+
+
+#### `new` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L751" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+new(self) -> Client[ClientTransportT]
+```
+
+Create a new client instance with the same configuration but fresh session state.
+
+This creates a new client with the same transport, handlers, and configuration,
+but with no active session. Useful for creating independent sessions that don't
+share state with the original client.
+
+**Returns:**
+- A new Client instance with the same configuration but disconnected state.
+
+
+#### `initialize` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L891" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+initialize(self, timeout: datetime.timedelta | float | int | None = None) -> mcp_types.InitializeResult
+```
+
+Send an initialize request to the server.
+
+This method performs the MCP initialization handshake with the server,
+exchanging capabilities and server information. It is idempotent - calling
+it multiple times returns the cached result from the first call.
+
+The initialization happens automatically when entering the client context
+manager unless `auto_initialize=False` was set during client construction.
+Manual calls to this method are only needed when auto-initialization is disabled.
+
+With `mode="auto"` or a pinned modern version, connect-time negotiation may adopt
+the modern `server/discover` era, which has no `InitializeResult`; in that case
+this method raises. Read `protocol_version`, `server_info`,
+`server_capabilities`, and `instructions` instead, or use `mode="legacy"`
+when you need the handshake result.
+
+**Args:**
+- `timeout`: Optional timeout for the initialization request (seconds or timedelta).
+If None, uses the client's init_timeout setting.
+
+**Returns:**
+- The server's initialization response containing server info,
+capabilities, protocol version, and optional instructions.
+
+**Raises:**
+- `RuntimeError`: If the client is not connected, initialization times out, or the
+negotiated era carries no `InitializeResult` (a modern `discover` connection).
+
+
+#### `close` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1363" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+close(self)
+```
+
+#### `ping` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1369" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+ping(self) -> bool
+```
+
+Send a ping request.
+
+
+#### `cancel` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1374" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+cancel(self, request_id: str | int, reason: str | None = None) -> None
+```
+
+Send a cancellation notification for an in-progress request.
+
+
+#### `progress` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1389" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+progress(self, progress_token: str | int, progress: float, total: float | None = None, message: str | None = None) -> None
+```
+
+Send a progress notification.
+
+
+#### `set_logging_level` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1403" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_logging_level(self, level: mcp_types.LoggingLevel) -> None
+```
+
+Send a logging/setLevel request.
+
+Handshake-era servers only. `logging/setLevel` asks the server to
+remember a level for the rest of the session, and the 2026-07-28
+protocol has no session to remember it in — the method is absent from
+that era's registry. Log *notifications* are unaffected: they ride the
+request's own stream, so a server's `ctx.info()` still reaches you.
+Filter by level on the receiving side instead, in your `log_handler`.
+
+
+#### `send_roots_list_changed` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1426" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+send_roots_list_changed(self) -> None
+```
+
+Send a roots/list_changed notification.
+
+
+#### `complete_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1434" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+complete_mcp(self, ref: mcp_types.ResourceTemplateReference | mcp_types.PromptReference, argument: dict[str, str], context_arguments: dict[str, Any] | None = None) -> mcp_types.CompleteResult
+```
+
+Send a completion request and return the complete MCP protocol result.
+
+**Args:**
+- `ref`: The reference to complete.
+- `argument`: Arguments to pass to the completion request.
+- `context_arguments`: Optional context arguments to
+include with the completion request. Defaults to None.
+
+**Returns:**
+- mcp_types.CompleteResult: The complete response object from the protocol,
+containing the completion and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `complete` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1465" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+complete(self, ref: mcp_types.ResourceTemplateReference | mcp_types.PromptReference, argument: dict[str, str], context_arguments: dict[str, Any] | None = None) -> mcp_types.Completion
+```
+
+Send a completion request to the server.
+
+**Args:**
+- `ref`: The reference to complete.
+- `argument`: Arguments to pass to the completion request.
+- `context_arguments`: Optional context arguments to
+include with the completion request. Defaults to None.
+
+**Returns:**
+- mcp_types.Completion: The completion object.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `generate_name` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/client.py#L1492" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate_name(cls, name: str | None = None) -> str
+```

--- a/docs/python-sdk/fastmcp-client-dependencies.mdx
+++ b/docs/python-sdk/fastmcp-client-dependencies.mdx
@@ -1,0 +1,24 @@
+---
+title: dependencies
+sidebarTitle: dependencies
+---
+
+# `fastmcp.client.dependencies`
+
+
+Client-side dependency helpers.
+
+## Functions
+
+### `get_http_headers` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/dependencies.py#L19" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_http_headers(include_all: bool = False, include: set[str] | None = None) -> dict[str, str]
+```
+
+
+Return HTTP headers from an ambient server request, when available.
+
+The standalone client package has no server request context. When the full
+FastMCP package is installed, delegate to its request-aware implementation.
+

--- a/docs/python-sdk/fastmcp-client-elicitation.mdx
+++ b/docs/python-sdk/fastmcp-client-elicitation.mdx
@@ -1,0 +1,18 @@
+---
+title: elicitation
+sidebarTitle: elicitation
+---
+
+# `fastmcp.client.elicitation`
+
+## Functions
+
+### `create_elicitation_callback` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/elicitation.py#L38" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_elicitation_callback(elicitation_handler: ElicitationHandler) -> ElicitationFnT
+```
+
+## Classes
+
+### `ElicitResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/elicitation.py#L22" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>

--- a/docs/python-sdk/fastmcp-client-extension_hooks.mdx
+++ b/docs/python-sdk/fastmcp-client-extension_hooks.mdx
@@ -1,0 +1,58 @@
+---
+title: extension_hooks
+sidebarTitle: extension_hooks
+---
+
+# `fastmcp.client.extension_hooks`
+
+
+Registry for FastMCP-internal client extensions (SEP-2133).
+
+Core ships the client wiring for opt-in extensions but no extension of its own.
+A companion package (``fastmcp-tasks``) provides an extension the ``Client``
+folds in automatically once the package is imported — so a caller that uses
+tasks (importing ``fastmcp_tasks`` for ``call_tool_task``, or to register the
+server extension) gets transparent client task support without passing anything
+per ``Client``. The package cannot reach into core's ``Client`` constructor, so
+core exposes this hook instead: the package registers a factory on import, and
+``Client`` folds the factory's extension in alongside the user's own.
+
+This mirrors the server-side ``set_background_context_factory`` hook: core
+declares the extension point, the tasks package fills it. Task support is
+opt-in — with ``fastmcp_tasks`` unimported the registry is empty and ``Client``
+behaves exactly as core alone, so a plain ``from fastmcp import Client`` never
+advertises the tasks capability and the server never runs its calls as tasks.
+
+A factory receives the client's elicitation callback (so a task resolver can
+answer in-task input prompts) and returns a ``ClientExtension`` to register, or
+``None`` to contribute nothing for this client.
+
+
+## Functions
+
+### `register_internal_client_extension_factory` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/extension_hooks.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+register_internal_client_extension_factory(factory: InternalClientExtensionFactory) -> None
+```
+
+
+Register a factory whose extension every ``Client`` folds in automatically.
+
+Idempotent: registering the same factory object twice is a no-op, so a
+package importing more than once does not double-register.
+
+
+### `build_internal_client_extensions` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/extension_hooks.py#L54" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+build_internal_client_extensions(elicitation_callback: ElicitationFnT | None) -> list[ClientExtension]
+```
+
+
+Build the internal extensions to fold into a ``Client`` under construction.
+
+Each registered factory is invoked with the client's elicitation callback;
+factories that return ``None`` contribute nothing. Empty when no companion
+package has registered a factory (plain core, or ``fastmcp_tasks`` unimported).
+

--- a/docs/python-sdk/fastmcp-client-group.mdx
+++ b/docs/python-sdk/fastmcp-client-group.mdx
@@ -1,0 +1,110 @@
+---
+title: group
+sidebarTitle: group
+---
+
+# `fastmcp.client.group`
+
+
+Coordination of independent MCP client connections.
+
+## Classes
+
+### `ToolRoute` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The client and upstream name behind a public group tool name.
+
+
+### `ClientGroup` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L31" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Coordinate independent clients without introducing a proxy server.
+
+Each client retains its own transport, session, capabilities, and protocol
+version. The group only combines tool discovery and routes tool calls.
+
+Callers may manage the clients' connections themselves or use the group as
+a convenience context manager. Entering an already-connected FastMCP client
+is safe because client contexts are reference counted.
+
+
+**Methods:**
+
+#### `clients` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L53" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+clients(self) -> Mapping[str, Client[Any]]
+```
+
+The group's clients, keyed by server name.
+
+Read-only: membership is fixed at construction, since discovered routes
+hold the client that advertised each tool and would silently go stale
+if the mapping were swapped underneath them.
+
+
+#### `from_config` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L63" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_config(cls, config: MCPConfig | dict[str, Any]) -> ClientGroup
+```
+
+Create one independent client for each configured server.
+
+A server entry may include a FastMCP-specific ``mode`` field. It applies
+only to that server; entries without one use ``default_mode``.
+
+
+#### `protocol_versions` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L88" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+protocol_versions(self) -> dict[str, str | None]
+```
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L152" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self) -> list[mcp_types.Tool]
+```
+
+List tools from every client with namespaced names.
+
+An explicit call is the group's catalog-refresh mechanism, so it
+defaults to `cache_mode="refresh"`: a client-side response cache
+(SEP-2549) is repopulated rather than served, and the routes reflect
+what every server advertises now. Pass `cache_mode="use"` to allow
+cache hits when staleness within the server's hint is acceptable.
+
+
+#### `resolve_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L189" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+resolve_tool(self, name: str) -> ToolRoute
+```
+
+Resolve a public tool name to its client and upstream identity.
+
+A known route only requires its own client to be connected; one dead
+server does not couple failures onto calls routed to healthy servers.
+Loading the catalog (the first resolution, or after a refresh) still
+requires every client, since discovery queries them all.
+
+
+#### `call_tool_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L224" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+call_tool_mcp(self, name: str, arguments: dict[str, Any] | None = None) -> mcp_types.CallToolResult
+```
+
+Call a namespaced tool and return its raw MCP result.
+
+
+#### `call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/group.py#L243" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> CallToolResult
+```
+
+Call a namespaced tool through the client that advertised it.
+

--- a/docs/python-sdk/fastmcp-client-logging.mdx
+++ b/docs/python-sdk/fastmcp-client-logging.mdx
@@ -1,0 +1,24 @@
+---
+title: logging
+sidebarTitle: logging
+---
+
+# `fastmcp.client.logging`
+
+## Functions
+
+### `default_log_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/logging.py#L17" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_log_handler(message: LogMessage) -> None
+```
+
+
+Default handler that properly routes server log messages to appropriate log levels.
+
+
+### `create_log_callback` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/logging.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_log_callback(handler: LogHandler | None = None) -> LoggingFnT
+```

--- a/docs/python-sdk/fastmcp-client-messages.mdx
+++ b/docs/python-sdk/fastmcp-client-messages.mdx
@@ -1,0 +1,89 @@
+---
+title: messages
+sidebarTitle: messages
+---
+
+# `fastmcp.client.messages`
+
+## Classes
+
+### `MessageHandler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L11" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+This class is used to handle MCP messages sent to the client: notifications
+and transport-level exceptions. Users can override any of the hooks.
+
+Server-initiated *requests* (ping, sampling, roots) never reach this
+handler: the stable MCP SDK v2's `message_handler` contract only delivers
+`ServerNotification | Exception`, so a request has no wire path here.
+Those are answered through the `Client`'s dedicated callbacks instead —
+`sampling_handler=`, `roots=`, and `elicitation_handler=`.
+
+
+**Methods:**
+
+#### `dispatch` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L26" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+dispatch(self, message: Message) -> None
+```
+
+#### `on_message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L54" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_message(self, message: Message) -> None
+```
+
+#### `on_notification` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_notification(self, message: mcp_types.ServerNotification) -> None
+```
+
+#### `on_exception` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L60" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_exception(self, message: Exception) -> None
+```
+
+#### `on_progress` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L63" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_progress(self, message: mcp_types.ProgressNotification) -> None
+```
+
+#### `on_logging_message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L66" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_logging_message(self, message: mcp_types.LoggingMessageNotification) -> None
+```
+
+#### `on_tool_list_changed` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L71" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_tool_list_changed(self, message: mcp_types.ToolListChangedNotification) -> None
+```
+
+#### `on_resource_list_changed` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L76" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_resource_list_changed(self, message: mcp_types.ResourceListChangedNotification) -> None
+```
+
+#### `on_prompt_list_changed` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L81" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_prompt_list_changed(self, message: mcp_types.PromptListChangedNotification) -> None
+```
+
+#### `on_resource_updated` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L86" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_resource_updated(self, message: mcp_types.ResourceUpdatedNotification) -> None
+```
+
+#### `on_cancelled` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/messages.py#L91" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_cancelled(self, message: mcp_types.CancelledNotification) -> None
+```

--- a/docs/python-sdk/fastmcp-client-mixins-__init__.mdx
+++ b/docs/python-sdk/fastmcp-client-mixins-__init__.mdx
@@ -1,0 +1,9 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.client.mixins`
+
+
+Client mixins for FastMCP.

--- a/docs/python-sdk/fastmcp-client-mixins-prompts.mdx
+++ b/docs/python-sdk/fastmcp-client-mixins-prompts.mdx
@@ -1,0 +1,108 @@
+---
+title: prompts
+sidebarTitle: prompts
+---
+
+# `fastmcp.client.mixins.prompts`
+
+
+Prompt-related methods for FastMCP Client.
+
+## Classes
+
+### `ClientPromptsMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/prompts.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin providing prompt-related methods for Client.
+
+
+**Methods:**
+
+#### `list_prompts_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/prompts.py#L28" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_prompts_mcp(self: Client) -> mcp_types.ListPromptsResult
+```
+
+Send a prompts/list request and return the complete MCP protocol result.
+
+**Args:**
+- `cursor`: Optional pagination cursor from a previous request's nextCursor.
+- `cache_mode`: Response-cache behavior (only active with a cache and a modern
+connection). See `list_tools_mcp`.
+
+**Returns:**
+- mcp_types.ListPromptsResult: The complete response object from the protocol,
+containing the list of prompts and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/prompts.py#L72" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_prompts(self: Client, max_pages: int = AUTO_PAGINATION_MAX_PAGES) -> list[mcp_types.Prompt]
+```
+
+Retrieve all prompts available on the server.
+
+This method automatically fetches all pages if the server paginates results,
+returning the complete list. For manual pagination control (e.g., to handle
+large result sets incrementally), use list_prompts_mcp() with the cursor parameter.
+
+**Args:**
+- `max_pages`: Maximum number of pages to fetch before raising. Defaults to 250.
+
+**Returns:**
+- list\[mcp_types.Prompt]: A list of all Prompt objects.
+
+**Raises:**
+- `RuntimeError`: If the page limit is reached before pagination completes.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `get_prompt_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/prompts.py#L120" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_prompt_mcp(self: Client, name: str, arguments: dict[str, Any] | None = None, meta: dict[str, Any] | None = None) -> mcp_types.GetPromptResult
+```
+
+Send a prompts/get request and return the complete MCP protocol result.
+
+**Args:**
+- `name`: The name of the prompt to retrieve.
+- `arguments`: Arguments to pass to the prompt. Defaults to None.
+- `meta`: Request metadata (e.g., for SEP-1686 tasks). Defaults to None.
+
+**Returns:**
+- mcp_types.GetPromptResult: The complete response object from the protocol,
+containing the prompt messages and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/prompts.py#L186" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_prompt(self: Client, name: str, arguments: dict[str, Any] | None = None) -> mcp_types.GetPromptResult
+```
+
+Retrieve a rendered prompt message list from the server.
+
+**Args:**
+- `name`: The name of the prompt to retrieve.
+- `arguments`: Arguments to pass to the prompt. Defaults to None.
+- `version`: Specific prompt version to get. If None, gets highest version.
+- `meta`: Optional request-level metadata.
+
+**Returns:**
+- mcp_types.GetPromptResult: The complete response object.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+

--- a/docs/python-sdk/fastmcp-client-mixins-resources.mdx
+++ b/docs/python-sdk/fastmcp-client-mixins-resources.mdx
@@ -1,0 +1,153 @@
+---
+title: resources
+sidebarTitle: resources
+---
+
+# `fastmcp.client.mixins.resources`
+
+
+Resource-related methods for FastMCP Client.
+
+## Classes
+
+### `ClientResourcesMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/resources.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin providing resource-related methods for Client.
+
+
+**Methods:**
+
+#### `list_resources_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/resources.py#L28" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resources_mcp(self: Client) -> mcp_types.ListResourcesResult
+```
+
+Send a resources/list request and return the complete MCP protocol result.
+
+**Args:**
+- `cursor`: Optional pagination cursor from a previous request's nextCursor.
+- `cache_mode`: Response-cache behavior (only active with a cache and a modern
+connection). See `list_tools_mcp`.
+
+**Returns:**
+- mcp_types.ListResourcesResult: The complete response object from the protocol,
+containing the list of resources and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/resources.py#L72" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resources(self: Client, max_pages: int = AUTO_PAGINATION_MAX_PAGES) -> list[mcp_types.Resource]
+```
+
+Retrieve all resources available on the server.
+
+This method automatically fetches all pages if the server paginates results,
+returning the complete list. For manual pagination control (e.g., to handle
+large result sets incrementally), use list_resources_mcp() with the cursor parameter.
+
+**Args:**
+- `max_pages`: Maximum number of pages to fetch before raising. Defaults to 250.
+
+**Returns:**
+- list\[mcp_types.Resource]: A list of all Resource objects.
+
+**Raises:**
+- `RuntimeError`: If the page limit is reached before pagination completes.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `list_resource_templates_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/resources.py#L119" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resource_templates_mcp(self: Client) -> mcp_types.ListResourceTemplatesResult
+```
+
+Send a resources/listResourceTemplates request and return the complete MCP protocol result.
+
+**Args:**
+- `cursor`: Optional pagination cursor from a previous request's nextCursor.
+- `cache_mode`: Response-cache behavior (only active with a cache and a modern
+connection). See `list_tools_mcp`.
+
+**Returns:**
+- mcp_types.ListResourceTemplatesResult: The complete response object from the protocol,
+containing the list of resource templates and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/resources.py#L166" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resource_templates(self: Client, max_pages: int = AUTO_PAGINATION_MAX_PAGES) -> list[mcp_types.ResourceTemplate]
+```
+
+Retrieve all resource templates available on the server.
+
+This method automatically fetches all pages if the server paginates results,
+returning the complete list. For manual pagination control (e.g., to handle
+large result sets incrementally), use list_resource_templates_mcp() with the
+cursor parameter.
+
+**Args:**
+- `max_pages`: Maximum number of pages to fetch before raising. Defaults to 250.
+
+**Returns:**
+- list\[mcp_types.ResourceTemplate]: A list of all ResourceTemplate objects.
+
+**Raises:**
+- `RuntimeError`: If the page limit is reached before pagination completes.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `read_resource_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/resources.py#L215" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read_resource_mcp(self: Client, uri: AnyUrl | str, meta: dict[str, Any] | None = None) -> mcp_types.ReadResourceResult
+```
+
+Send a resources/read request and return the complete MCP protocol result.
+
+**Args:**
+- `uri`: The URI of the resource to read. Can be a string or an AnyUrl object.
+- `meta`: Request metadata (e.g., for SEP-1686 tasks). Defaults to None.
+
+**Returns:**
+- mcp_types.ReadResourceResult: The complete response object from the protocol,
+containing the resource contents and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `read_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/resources.py#L267" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read_resource(self: Client, uri: AnyUrl | str) -> list[mcp_types.TextResourceContents | mcp_types.BlobResourceContents]
+```
+
+Read the contents of a resource or resolved template.
+
+**Args:**
+- `uri`: The URI of the resource to read. Can be a string or an AnyUrl object.
+- `version`: Specific version to read. If None, reads highest version.
+- `meta`: Optional request-level metadata.
+
+**Returns:**
+- list\[mcp_types.TextResourceContents | mcp_types.BlobResourceContents]:
+A list of content objects.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+

--- a/docs/python-sdk/fastmcp-client-mixins-tools.mdx
+++ b/docs/python-sdk/fastmcp-client-mixins-tools.mdx
@@ -1,0 +1,137 @@
+---
+title: tools
+sidebarTitle: tools
+---
+
+# `fastmcp.client.mixins.tools`
+
+
+Tool-related methods for FastMCP Client.
+
+## Classes
+
+### `ClientToolsMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/tools.py#L29" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin providing tool-related methods for Client.
+
+
+**Methods:**
+
+#### `list_tools_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/tools.py#L34" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools_mcp(self: Client) -> mcp_types.ListToolsResult
+```
+
+Send a tools/list request and return the complete MCP protocol result.
+
+**Args:**
+- `cursor`: Optional pagination cursor from a previous request's nextCursor.
+- `cache_mode`: Response-cache behavior for this call (only active when the
+client was built with a cache and the connection is modern). `"use"`
+(default) serves and stores; `"refresh"` stores without serving;
+`"bypass"` skips the cache. A cursor page always skips the cache.
+
+**Returns:**
+- mcp_types.ListToolsResult: The complete response object from the protocol,
+containing the list of tools and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/tools.py#L90" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self: Client, max_pages: int = AUTO_PAGINATION_MAX_PAGES) -> list[mcp_types.Tool]
+```
+
+Retrieve all tools available on the server.
+
+This method automatically fetches all pages if the server paginates results,
+returning the complete list. For manual pagination control (e.g., to handle
+large result sets incrementally), use list_tools_mcp() with the cursor parameter.
+
+**Args:**
+- `max_pages`: Maximum number of pages to fetch before raising. Defaults to 250.
+- `cache_mode`: Response-cache behavior for the first page (only active when
+the client was built with a cache and the connection is modern).
+`"use"` (default) serves and stores; `"refresh"` stores without
+serving; `"bypass"` skips the cache. Subsequent cursor pages always
+skip the cache.
+
+**Returns:**
+- list\[mcp_types.Tool]: A list of all Tool objects.
+
+**Raises:**
+- `RuntimeError`: If the page limit is reached before pagination completes.
+- `MCPError`: If the request results in a TimeoutError | JSONRPCError
+
+
+#### `call_tool_mcp` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/tools.py#L146" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+call_tool_mcp(self: Client, name: str, arguments: dict[str, Any], progress_handler: ProgressHandler | None = None, timeout: datetime.timedelta | float | int | None = None, meta: dict[str, Any] | None = None) -> mcp_types.CallToolResult
+```
+
+Send a tools/call request and return the complete MCP protocol result.
+
+This method returns the raw CallToolResult object, which includes an isError flag
+and other metadata. It does not raise an exception if the tool call results in an error.
+
+**Args:**
+- `name`: The name of the tool to call.
+- `arguments`: Arguments to pass to the tool.
+- `timeout`: The timeout for the tool call. Defaults to None.
+- `progress_handler`: The progress handler to use for the tool call. Defaults to None.
+- `meta`: Additional metadata to include with the request.
+This is useful for passing contextual information (like user IDs, trace IDs, or preferences)
+that shouldn't be tool arguments but may influence server-side processing. The server
+can access this via `context.request_context.meta`. Defaults to None.
+
+**Returns:**
+- mcp_types.CallToolResult: The complete response object from the protocol,
+containing the tool result and any additional metadata.
+
+**Raises:**
+- `RuntimeError`: If called while the client is not connected.
+- `MCPError`: If the tool call requests results in a TimeoutError | JSONRPCError
+
+
+#### `call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/mixins/tools.py#L281" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+call_tool(self: Client, name: str, arguments: dict[str, Any] | None = None) -> CallToolResult
+```
+
+Call a tool on the server.
+
+Unlike call_tool_mcp, this method raises a ToolError if the tool call results in an error.
+
+**Args:**
+- `name`: The name of the tool to call.
+- `arguments`: Arguments to pass to the tool. Defaults to None.
+- `version`: Specific tool version to call. If None, calls highest version.
+- `timeout`: The timeout for the tool call. Defaults to None.
+- `progress_handler`: The progress handler to use for the tool call. Defaults to None.
+- `raise_on_error`: Whether to raise an exception if the tool call results in an error. Defaults to True.
+- `meta`: Additional metadata to include with the request.
+This is useful for passing contextual information (like user IDs, trace IDs, or preferences)
+that shouldn't be tool arguments but may influence server-side processing. The server
+can access this via `context.request_context.meta`. Defaults to None.
+
+**Returns:**
+- The content returned by the tool. If the tool returns
+structured outputs, they are returned as a dataclass (if an output
+schema is available) or a dictionary; otherwise, a list of content
+blocks is returned. Note: to receive both structured and
+unstructured outputs, use call_tool_mcp instead and access the
+raw result object.
+
+**Raises:**
+- `ToolError`: If the tool call results in an error.
+- `MCPError`: If the tool call request results in a TimeoutError | JSONRPCError
+- `RuntimeError`: If called while the client is not connected.
+

--- a/docs/python-sdk/fastmcp-client-oauth_callback.mdx
+++ b/docs/python-sdk/fastmcp-client-oauth_callback.mdx
@@ -1,0 +1,70 @@
+---
+title: oauth_callback
+sidebarTitle: oauth_callback
+---
+
+# `fastmcp.client.oauth_callback`
+
+
+
+OAuth callback server for handling authorization code flows.
+
+This module provides a reusable callback server that can handle OAuth redirects
+and display styled responses to users.
+
+
+## Functions
+
+### `create_callback_html` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/oauth_callback.py#L34" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_callback_html(message: str, is_success: bool = True, title: str = 'FastMCP OAuth', server_url: str | None = None) -> str
+```
+
+
+Create a styled HTML response for OAuth callbacks.
+
+
+### `create_oauth_callback_server` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/oauth_callback.py#L114" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_oauth_callback_server(port: int, host: str = '127.0.0.1', callback_path: str = '/callback', server_url: str | None = None, result_container: OAuthCallbackResult | None = None, result_ready: anyio.Event | None = None) -> Server
+```
+
+
+Create an OAuth callback server.
+
+**Args:**
+- `port`: The port to run the server on
+- `callback_path`: The path to listen for OAuth redirects on
+- `server_url`: Optional server URL to display in success messages
+- `result_container`: Optional container to store callback results
+- `result_ready`: Optional event to signal when callback is received
+
+**Returns:**
+- Configured uvicorn Server instance (not yet running)
+
+
+## Classes
+
+### `CallbackResponse` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/oauth_callback.py#L80" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `from_dict` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/oauth_callback.py#L92" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_dict(cls, data: dict[str, str]) -> CallbackResponse
+```
+
+#### `to_dict` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/oauth_callback.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+to_dict(self) -> dict[str, str]
+```
+
+### `OAuthCallbackResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/oauth_callback.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Container for OAuth callback results, used with anyio.Event for async coordination.
+

--- a/docs/python-sdk/fastmcp-client-progress.mdx
+++ b/docs/python-sdk/fastmcp-client-progress.mdx
@@ -1,0 +1,25 @@
+---
+title: progress
+sidebarTitle: progress
+---
+
+# `fastmcp.client.progress`
+
+## Functions
+
+### `default_progress_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/progress.py#L12" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_progress_handler(progress: float, total: float | None, message: str | None) -> None
+```
+
+
+Default handler for progress notifications.
+
+Logs progress updates at debug level, properly handling missing total or message values.
+
+**Args:**
+- `progress`: Current progress value
+- `total`: Optional total expected value
+- `message`: Optional status message
+

--- a/docs/python-sdk/fastmcp-client-roots.mdx
+++ b/docs/python-sdk/fastmcp-client-roots.mdx
@@ -1,0 +1,20 @@
+---
+title: roots
+sidebarTitle: roots
+---
+
+# `fastmcp.client.roots`
+
+## Functions
+
+### `convert_roots_list` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/roots.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+convert_roots_list(roots: RootsList) -> list[mcp_types.Root]
+```
+
+### `create_roots_callback` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/roots.py#L34" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_roots_callback(handler: RootsList | RootsHandler) -> ListRootsFnT
+```

--- a/docs/python-sdk/fastmcp-client-sampling-__init__.mdx
+++ b/docs/python-sdk/fastmcp-client-sampling-__init__.mdx
@@ -1,0 +1,14 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.client.sampling`
+
+## Functions
+
+### `create_sampling_callback` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/sampling/__init__.py#L44" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_sampling_callback(sampling_handler: SamplingHandler) -> SamplingFnT
+```

--- a/docs/python-sdk/fastmcp-client-sampling-handlers-anthropic.mdx
+++ b/docs/python-sdk/fastmcp-client-sampling-handlers-anthropic.mdx
@@ -1,0 +1,17 @@
+---
+title: anthropic
+sidebarTitle: anthropic
+---
+
+# `fastmcp.client.sampling.handlers.anthropic`
+
+
+Anthropic sampling handler for FastMCP.
+
+## Classes
+
+### `AnthropicSamplingHandler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/sampling/handlers/anthropic.py#L72" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Sampling handler that uses the Anthropic API.
+

--- a/docs/python-sdk/fastmcp-client-sampling-handlers-google_genai.mdx
+++ b/docs/python-sdk/fastmcp-client-sampling-handlers-google_genai.mdx
@@ -1,0 +1,17 @@
+---
+title: google_genai
+sidebarTitle: google_genai
+---
+
+# `fastmcp.client.sampling.handlers.google_genai`
+
+
+Google GenAI sampling handler with tool support for FastMCP 3.0.
+
+## Classes
+
+### `GoogleGenaiSamplingHandler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/sampling/handlers/google_genai.py#L58" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Sampling handler that uses the Google GenAI API with tool support.
+

--- a/docs/python-sdk/fastmcp-client-sampling-handlers-openai.mdx
+++ b/docs/python-sdk/fastmcp-client-sampling-handlers-openai.mdx
@@ -1,0 +1,17 @@
+---
+title: openai
+sidebarTitle: openai
+---
+
+# `fastmcp.client.sampling.handlers.openai`
+
+
+OpenAI sampling handler for FastMCP.
+
+## Classes
+
+### `OpenAISamplingHandler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/sampling/handlers/openai.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Sampling handler that uses the OpenAI API.
+

--- a/docs/python-sdk/fastmcp-client-telemetry.mdx
+++ b/docs/python-sdk/fastmcp-client-telemetry.mdx
@@ -1,0 +1,23 @@
+---
+title: telemetry
+sidebarTitle: telemetry
+---
+
+# `fastmcp.client.telemetry`
+
+
+Client-side telemetry helpers.
+
+## Functions
+
+### `client_span` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/telemetry.py#L13" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+client_span(name: str, method: str, component_key: str, session_id: str | None = None, resource_uri: str | None = None, tool_name: str | None = None, prompt_name: str | None = None) -> Generator[Span, None, None]
+```
+
+
+Create a CLIENT span with standard MCP attributes.
+
+Automatically records any exception on the span and sets error status.
+

--- a/docs/python-sdk/fastmcp-client-transports-base.mdx
+++ b/docs/python-sdk/fastmcp-client-transports-base.mdx
@@ -1,0 +1,95 @@
+---
+title: base
+sidebarTitle: base
+---
+
+# `fastmcp.client.transports.base`
+
+## Classes
+
+### `ClientSessionKwargs` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/base.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Keyword arguments for the MCP ClientSession constructor.
+
+
+### `TransportOptions` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/base.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+How one client wants its connection built.
+
+These belong to the client rather than to the transport, so a transport
+shared between clients doesn't leak one client's settings to another.
+Different client layers may own different fields; a layer that adds its
+settings must preserve the existing options rather than replace the bundle.
+
+**Attributes:**
+- `session_class`: The ClientSession class to instantiate. Proxies supply a
+session that skips output-schema validation, since they relay
+results rather than consume them.
+- `forward_incoming_headers`: Whether to forward eligible inbound HTTP
+headers upstream, including authorization. Hop-specific HTTP headers
+and MCP transport, routing, and event-stream state are excluded
+because each backend connection owns that state. Only appropriate
+for proxies; honored by the HTTP and SSE transports and ignored by
+the others.
+- `backend_mode`: The connect `mode` to give backend clients that a wrapping
+transport builds on this client's behalf, so a chain of connections
+speaks one protocol era end to end. `None` leaves each backend
+client at its own default. Honored by `MCPConfigTransport`, whose
+multi-server form mounts a proxy per configured server and resolves
+one shared era for the aggregate; ignored by transports that connect
+to a single backend directly, since those carry the connecting
+client's own session and era.
+
+
+### `ClientTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/base.py#L80" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Abstract base class for different MCP client transport mechanisms.
+
+A Transport is responsible for establishing and managing connections
+to an MCP server, and providing a ClientSession within an async context.
+
+
+**Methods:**
+
+#### `connect_session` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/base.py#L98" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+connect_session(self, **session_kwargs: Unpack[SessionKwargs]) -> AsyncIterator[ClientSession]
+```
+
+Establishes a connection and yields an active ClientSession.
+
+The ClientSession is *not* expected to be initialized in this context manager.
+
+The session is guaranteed to be valid only within the scope of the
+async context manager. Connection setup and teardown are handled
+within this context.
+
+**Args:**
+- `transport_options`: How the connecting client wants this connection
+               built. Defaults apply when omitted. A transport
+               that wraps others must pass this along.
+- `**session_kwargs`: Keyword arguments to pass to the ClientSession
+              constructor (e.g., callbacks, timeouts).
+
+
+#### `close` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/base.py#L130" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+close(self)
+```
+
+Close the transport.
+
+
+#### `get_session_id` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/base.py#L133" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_session_id(self) -> str | None
+```
+
+Get the session ID for this transport, if available.
+

--- a/docs/python-sdk/fastmcp-client-transports-config.mdx
+++ b/docs/python-sdk/fastmcp-client-transports-config.mdx
@@ -1,0 +1,87 @@
+---
+title: config
+sidebarTitle: config
+---
+
+# `fastmcp.client.transports.config`
+
+## Classes
+
+### `MCPConfigTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/config.py#L35" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport for connecting to one or more MCP servers defined in an MCPConfig.
+
+This transport provides a unified interface to multiple MCP servers defined in an MCPConfig
+object or dictionary matching the MCPConfig schema. It supports two key scenarios:
+
+1. If the MCPConfig contains exactly one server, it creates a direct transport to that server.
+2. If the MCPConfig contains multiple servers, it creates a composite client by mounting
+   all servers on a single FastMCP instance, with each server's name, by default, used as its mounting prefix.
+
+In the multiserver case, tools are accessible with the prefix pattern `{server_name}_{tool_name}`
+and resources with the pattern `protocol://{server_name}/path/to/resource`.
+
+This is particularly useful for creating clients that need to interact with multiple specialized
+MCP servers through a single interface, simplifying client code.
+
+**Examples:**
+
+```python
+from fastmcp import Client
+
+# Create a config with multiple servers
+config = {
+    "mcpServers": {
+        "weather": {
+            "url": "https://weather-api.example.com/mcp",
+            "transport": "http"
+        },
+        "calendar": {
+            "url": "https://calendar-api.example.com/mcp",
+            "transport": "http"
+        }
+    }
+}
+
+# Create a client with the config
+client = Client(config)
+
+async with client:
+    # Access tools with prefixes
+    weather = await client.call_tool("weather_get_forecast", {"city": "London"})
+    events = await client.call_tool("calendar_list_events", {"date": "2023-06-01"})
+
+    # Access resources with prefixed URIs
+    icons = await client.read_resource("weather://weather/icons/sunny")
+```
+
+
+**Methods:**
+
+#### `legacy_only` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/config.py#L116" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+legacy_only(self) -> bool
+```
+
+Whether the connected composite resolved to the legacy protocol era.
+
+A single-server config delegates directly to the underlying transport
+(no proxy), so it inherits that transport's era capability. A
+multi-server config resolves this value while connecting its backends:
+all-modern backends leave the composite modern-capable, while any
+legacy backend moves every leg to the handshake era.
+
+
+#### `connect_session` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/config.py#L130" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+connect_session(self, **session_kwargs: Unpack[SessionKwargs]) -> AsyncIterator[ClientSession]
+```
+
+#### `close` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/config.py#L329" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+close(self)
+```

--- a/docs/python-sdk/fastmcp-client-transports-http.mdx
+++ b/docs/python-sdk/fastmcp-client-transports-http.mdx
@@ -1,0 +1,37 @@
+---
+title: http
+sidebarTitle: http
+---
+
+# `fastmcp.client.transports.http`
+
+
+Streamable HTTP transport for FastMCP Client.
+
+## Classes
+
+### `StreamableHttpTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/http.py#L31" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport implementation that connects to an MCP server via Streamable HTTP Requests.
+
+
+**Methods:**
+
+#### `connect_session` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/http.py#L156" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+connect_session(self, **session_kwargs: Unpack[SessionKwargs]) -> AsyncIterator[ClientSession]
+```
+
+#### `get_session_id` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/http.py#L227" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_session_id(self) -> str | None
+```
+
+#### `close` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/http.py#L230" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+close(self)
+```

--- a/docs/python-sdk/fastmcp-client-transports-inference.mdx
+++ b/docs/python-sdk/fastmcp-client-transports-inference.mdx
@@ -1,0 +1,56 @@
+---
+title: inference
+sidebarTitle: inference
+---
+
+# `fastmcp.client.transports.inference`
+
+## Functions
+
+### `infer_transport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/inference.py#L65" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+infer_transport(transport: ClientTransport | FastMCP | SDKServer | AnyUrl | Path | MCPConfig | dict[str, Any] | str) -> ClientTransport
+```
+
+
+Infer the appropriate transport type from the given transport argument.
+
+This function attempts to infer the correct transport type from the provided
+argument, handling various input types and converting them to the appropriate
+ClientTransport subclass.
+
+The function supports these input types:
+- ClientTransport: Used directly without modification
+- FastMCP or SDKServer: Creates an in-memory FastMCPTransport
+- Path or str (file path): Creates PythonStdioTransport (.py) or NodeStdioTransport (.js)
+- AnyUrl or str (URL): Creates StreamableHttpTransport (default) or SSETransport (for /sse endpoints)
+- MCPConfig or dict: Creates MCPConfigTransport, potentially connecting to multiple servers
+
+For HTTP URLs, they are assumed to be Streamable HTTP URLs unless they end in `/sse`.
+
+For MCPConfig with multiple servers, a composite client is created where each server
+is mounted with its name as prefix. This allows accessing tools and resources from multiple
+servers through a single unified client interface, using naming patterns like
+`servername_toolname` for tools and `protocol://servername/path` for resources.
+If the MCPConfig contains only one server, a direct connection is established without prefixing.
+
+**Examples:**
+
+```python
+# Connect to a local Python script
+transport = infer_transport("my_script.py")
+
+# Connect to a remote server via HTTP
+transport = infer_transport("http://example.com/mcp")
+
+# Connect to multiple servers using MCPConfig
+config = {
+    "mcpServers": {
+        "weather": {"url": "http://weather.example.com/mcp"},
+        "calendar": {"url": "http://calendar.example.com/mcp"}
+    }
+}
+transport = infer_transport(config)
+```
+

--- a/docs/python-sdk/fastmcp-client-transports-memory.mdx
+++ b/docs/python-sdk/fastmcp-client-transports-memory.mdx
@@ -1,0 +1,28 @@
+---
+title: memory
+sidebarTitle: memory
+---
+
+# `fastmcp.client.transports.memory`
+
+## Classes
+
+### `FastMCPTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/memory.py#L37" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+In-memory transport for FastMCP servers.
+
+This transport connects directly to a FastMCP server instance in the same
+Python process. It works with both FastMCP servers and the SDK's own
+high-level `MCPServer` from the low-level MCP SDK. This is particularly
+useful for unit tests or scenarios where client and server run in the same
+runtime.
+
+
+**Methods:**
+
+#### `connect_session` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/memory.py#L58" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+connect_session(self, **session_kwargs: Unpack[SessionKwargs]) -> AsyncIterator[ClientSession]
+```

--- a/docs/python-sdk/fastmcp-client-transports-sse.mdx
+++ b/docs/python-sdk/fastmcp-client-transports-sse.mdx
@@ -1,0 +1,25 @@
+---
+title: sse
+sidebarTitle: sse
+---
+
+# `fastmcp.client.transports.sse`
+
+
+Server-Sent Events (SSE) transport for FastMCP Client.
+
+## Classes
+
+### `SSETransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/sse.py#L33" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport implementation that connects to an MCP server via Server-Sent Events.
+
+
+**Methods:**
+
+#### `connect_session` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/sse.py#L132" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+connect_session(self, **session_kwargs: Unpack[SessionKwargs]) -> AsyncIterator[ClientSession]
+```

--- a/docs/python-sdk/fastmcp-client-transports-stdio.mdx
+++ b/docs/python-sdk/fastmcp-client-transports-stdio.mdx
@@ -1,0 +1,79 @@
+---
+title: stdio
+sidebarTitle: stdio
+---
+
+# `fastmcp.client.transports.stdio`
+
+## Classes
+
+### `StdioTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L25" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Base transport for connecting to an MCP server via subprocess with stdio.
+
+This is a base class that can be subclassed for specific command-based
+transports like Python, Node, Uvx, etc.
+
+
+**Methods:**
+
+#### `connect_session` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L78" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+connect_session(self, **session_kwargs: Unpack[SessionKwargs]) -> AsyncIterator[ClientSession]
+```
+
+#### `connect` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L97" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+connect(self, **session_kwargs: Unpack[SessionKwargs]) -> ClientSession | None
+```
+
+#### `disconnect` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L169" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+disconnect(self)
+```
+
+#### `close` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L218" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+close(self)
+```
+
+### `PythonStdioTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L291" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport for running Python scripts.
+
+
+### `FastMCPStdioTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L344" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport for running FastMCP servers using the FastMCP CLI.
+
+
+### `NodeStdioTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L373" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport for running Node.js scripts.
+
+
+### `UvStdioTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L426" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport for running commands via the uv tool.
+
+
+### `UvxStdioTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L503" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport for running commands via the uvx tool.
+
+
+### `NpxStdioTransport` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/stdio.py#L568" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transport for running commands via the npx tool.
+

--- a/docs/python-sdk/fastmcp-prompts-base.mdx
+++ b/docs/python-sdk/fastmcp-prompts-base.mdx
@@ -1,0 +1,137 @@
+---
+title: base
+sidebarTitle: base
+---
+
+# `fastmcp.prompts.base`
+
+
+Base classes for FastMCP prompts.
+
+## Classes
+
+### `Message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L38" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Wrapper for prompt message with auto-serialization.
+
+Accepts any content - strings pass through, other types
+(dict, list, BaseModel) are JSON-serialized to text.
+
+
+**Methods:**
+
+#### `to_mcp_prompt_message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L93" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+to_mcp_prompt_message(self) -> PromptMessage
+```
+
+Convert to MCP PromptMessage.
+
+
+### `PromptArgument` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L98" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+An argument that can be passed to a prompt.
+
+
+### `PromptResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L110" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Canonical result type for prompt rendering.
+
+Provides explicit control over prompt responses: multiple messages,
+roles, and metadata at both the message and result level.
+
+
+**Methods:**
+
+#### `to_mcp_prompt_result` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L182" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+to_mcp_prompt_result(self) -> GetPromptResult
+```
+
+Convert to MCP GetPromptResult.
+
+
+### `InputRequiredPromptResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L192" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The full result of a single multi-round-trip prompt leg (SEP-2322).
+
+`InputRequiredResult` is a result type, not a `tools/call` feature: any
+request may resolve to one. When a prompt returns an `InputRequiredResult`
+from its body to ask the client for input, that ask is the legitimate
+result of this `prompts/get` — so FastMCP wraps it in this `PromptResult`
+subclass, mirroring `InputRequiredToolResult`, and it flows through the
+middleware chain as an ordinary return value.
+
+Invariant: the wrapped `InputRequiredResult` is never rendered as prompt
+messages. `messages` is always empty; the wire handler (`_on_get_prompt`)
+reads `.input_required` and returns it to the runner.
+
+
+### `Prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L224" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A prompt template that can be rendered with parameters.
+
+
+**Methods:**
+
+#### `to_mcp_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L236" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+to_mcp_prompt(self, **overrides: Any) -> SDKPrompt
+```
+
+Convert the prompt to an MCP prompt.
+
+
+#### `from_function` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L262" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_function(cls, fn: Callable[..., Any]) -> FunctionPrompt
+```
+
+Create a Prompt from a function.
+
+The function can return:
+- str: wrapped as single user Message
+- list\[Message | str]: converted to list\[Message]
+- PromptResult: used directly
+
+
+#### `render` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L296" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+render(self, arguments: dict[str, Any] | None = None) -> str | list[Message | str] | PromptResult
+```
+
+Render the prompt with arguments.
+
+Subclasses must implement this method. Return one of:
+- str: Wrapped as single user Message
+- list\[Message | str]: Converted to list\[Message]
+- PromptResult: Used directly
+
+
+#### `convert_result` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L309" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+convert_result(self, raw_value: Any) -> PromptResult
+```
+
+Convert a raw return value to PromptResult.
+
+**Raises:**
+- `TypeError`: for unsupported types
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/base.py#L364" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```

--- a/docs/python-sdk/fastmcp-prompts-function_prompt.mdx
+++ b/docs/python-sdk/fastmcp-prompts-function_prompt.mdx
@@ -1,0 +1,76 @@
+---
+title: function_prompt
+sidebarTitle: function_prompt
+---
+
+# `fastmcp.prompts.function_prompt`
+
+
+Standalone @prompt decorator for FastMCP.
+
+## Functions
+
+### `prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/function_prompt.py#L395" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+prompt(name_or_fn: str | Callable[..., Any] | None = None) -> Any
+```
+
+
+Standalone decorator to mark a function as an MCP prompt.
+
+Returns the original function with metadata attached. Register with a server
+using mcp.add_prompt().
+
+
+## Classes
+
+### `DecoratedPrompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/function_prompt.py#L43" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Protocol for functions decorated with @prompt.
+
+
+### `PromptMeta` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/function_prompt.py#L52" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Metadata attached to functions by the @prompt decorator.
+
+
+### `FunctionPrompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/function_prompt.py#L67" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A prompt that is a function.
+
+
+**Methods:**
+
+#### `from_function` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/function_prompt.py#L73" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_function(cls, fn: Callable[..., Any]) -> FunctionPrompt
+```
+
+Create a Prompt from a function.
+
+**Args:**
+- `fn`: The function to wrap
+- `metadata`: PromptMeta object with all configuration. If provided,
+individual parameters must not be passed.
+- `name, title, etc.`: Individual parameters for backwards compatibility.
+Cannot be used together with metadata parameter.
+
+The function can return:
+- str: wrapped as single user Message
+- list\[Message | str]: converted to list\[Message]
+- PromptResult: used directly
+
+
+#### `render` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/prompts/function_prompt.py#L313" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+render(self, arguments: dict[str, Any] | None = None) -> PromptResult
+```
+
+Render the prompt with arguments.
+

--- a/docs/python-sdk/fastmcp-server-auth-auth.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-auth.mdx
@@ -1,0 +1,452 @@
+---
+title: auth
+sidebarTitle: auth
+---
+
+# `fastmcp.server.auth.auth`
+
+## Classes
+
+### `AccessToken` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L58" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+AccessToken that includes all JWT claims.
+
+
+### `TokenHandler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L64" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+TokenHandler that returns MCP-compliant error responses.
+
+This handler addresses two SDK issues:
+
+1. Error code: The SDK returns `unauthorized_client` for client authentication
+   failures, but RFC 6749 Section 5.2 requires `invalid_client` with HTTP 401.
+   This distinction matters for client re-registration behavior.
+
+2. Status code: The SDK returns HTTP 400 for all token errors including
+   `invalid_grant` (expired/invalid tokens). However, the MCP spec requires:
+   "Invalid or expired tokens MUST receive a HTTP 401 response."
+
+This handler transforms responses to be compliant with both OAuth 2.1 and MCP specs.
+
+
+**Methods:**
+
+#### `handle` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L80" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+handle(self, request: Any)
+```
+
+Wrap SDK handle() and transform auth error responses.
+
+The SEP-990 jwt-bearer (ID-JAG) grant is dispatched here rather than by
+the SDK. The SDK requires a confidential client (a stored client_secret)
+before it will call `exchange_identity_assertion`. FastMCP OAuth-proxy
+clients are always public (`token_endpoint_auth_method="none"`, no stored
+secret), and in the proxy trust model the ID-JAG — validated against a
+trusted issuer — is the authoritative grant, not a per-client secret.
+So when identity assertion is enabled we authenticate the client and
+dispatch the grant ourselves, without the SDK's confidential precondition.
+
+
+### `PrivateKeyJWTClientAuthenticator` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L219" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Client authenticator with private_key_jwt support for CIMD clients.
+
+Extends the SDK's ClientAuthenticator to add support for the `private_key_jwt`
+authentication method per RFC 7523. This is required for CIMD (Client ID Metadata
+Document) clients that use asymmetric keys for authentication.
+
+The authenticator:
+1. Delegates to SDK for standard methods (client_secret_basic, client_secret_post, none)
+2. Adds private_key_jwt handling for CIMD clients
+3. Validates JWT assertions against client's JWKS
+
+
+**Methods:**
+
+#### `authenticate_request` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L249" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+authenticate_request(self, request: Request) -> OAuthClientInformationFull
+```
+
+Authenticate a client from an HTTP request.
+
+Extends SDK authentication to support private_key_jwt for CIMD clients.
+Delegates to SDK for client_secret_basic (Authorization header) and
+client_secret_post (form body) authentication.
+
+
+### `AuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L300" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Base class for all FastMCP authentication providers.
+
+This class provides a unified interface for all authentication providers,
+whether they are simple token verifiers or full OAuth authorization servers.
+All providers must be able to verify tokens and can optionally provide
+custom authentication routes.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L340" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a bearer token and return access info if valid.
+
+All auth providers must implement token verification.
+
+**Args:**
+- `token`: The token string to validate
+
+**Returns:**
+- AccessToken object if valid, None if invalid or expired
+
+
+#### `scopes_supported` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L354" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+scopes_supported(self) -> list[str]
+```
+
+Scopes advertised in protected resource metadata.
+
+
+#### `challenge_scopes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L359" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+challenge_scopes(self) -> list[str]
+```
+
+Scopes clients must request to access this resource.
+
+
+#### `get_challenge_scopes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L363" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_challenge_scopes(self, required_scopes: list[str] | None = None) -> list[str]
+```
+
+Translate validation scopes into scopes clients should request.
+
+Providers whose authorization server uses a different scope format can
+override this method to translate any effective set of validation scopes.
+
+
+#### `set_mcp_path` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L373" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_mcp_path(self, mcp_path: str | None) -> None
+```
+
+Set the MCP endpoint path and compute resource URL.
+
+This method is called by get_routes() to configure the expected
+resource URL before route creation. Subclasses can override to
+perform additional initialization that depends on knowing the
+MCP endpoint path.
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L387" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get all routes for this authentication provider.
+
+This includes both well-known discovery routes and operational routes.
+Each provider is responsible for creating whatever routes it needs:
+- TokenVerifier: typically no routes (default implementation)
+- RemoteAuthProvider: protected resource metadata routes
+- OAuthProvider: full OAuth authorization server routes
+- Custom providers: whatever routes they need
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+This is used to advertise the resource URL in metadata, but the
+provider does not create the actual MCP endpoint route.
+
+**Returns:**
+- List of all routes for this provider (excluding the MCP endpoint itself)
+
+
+#### `get_well_known_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L410" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_well_known_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get well-known discovery routes for this authentication provider.
+
+This is a utility method that filters get_routes() to return only
+well-known discovery routes (those starting with /.well-known/).
+
+Well-known routes provide OAuth metadata and discovery endpoints that
+clients use to discover authentication capabilities. These routes should
+be mounted at the root level of the application to comply with RFC 8414
+and RFC 9728.
+
+Common well-known routes:
+- /.well-known/oauth-authorization-server (authorization server metadata)
+- /.well-known/oauth-protected-resource/* (protected resource metadata)
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+This is used to construct path-scoped well-known URLs.
+
+**Returns:**
+- List of well-known discovery routes (typically mounted at root level)
+
+
+#### `get_middleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L442" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_middleware(self) -> list
+```
+
+Get HTTP application-level middleware for this auth provider.
+
+**Returns:**
+- List of Starlette Middleware instances to apply to the HTTP app
+
+
+### `TokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L479" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Base class for token verifiers (Resource Servers).
+
+This class provides token verification capability without OAuth server functionality.
+Token verifiers typically don't provide authentication routes by default.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L510" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a bearer token and return access info if valid.
+
+
+### `RemoteAuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L515" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Authentication provider for resource servers that verify tokens from known authorization servers.
+
+This provider composes a TokenVerifier with authorization server metadata to create
+standardized OAuth 2.0 Protected Resource endpoints (RFC 9728). Perfect for:
+- JWT verification with known issuers
+- Remote token introspection services
+- Any resource server that knows where its tokens come from
+
+Use this when you have token verification logic and want to advertise
+the authorization servers that issue valid tokens.
+
+
+**Methods:**
+
+#### `scopes_supported` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L575" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+scopes_supported(self) -> list[str]
+```
+
+Scopes advertised in protected resource metadata.
+
+
+#### `get_challenge_scopes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L581" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_challenge_scopes(self, required_scopes: list[str] | None = None) -> list[str]
+```
+
+Translate effective validation scopes for the authorization server.
+
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L598" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify token using the configured token verifier.
+
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L602" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get routes for this provider.
+
+Creates protected resource metadata routes (RFC 9728).
+
+
+### `MultiAuth` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L636" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Composes an optional auth server with additional token verifiers.
+
+Use this when a single server needs to accept tokens from multiple sources.
+For example, an OAuth proxy for interactive clients combined with a JWT
+verifier for machine-to-machine tokens.
+
+Token verification tries the server first (if present), then each verifier
+in order, returning the first successful result. Routes and OAuth metadata
+come from the server; verifiers contribute only token verification.
+
+
+**Methods:**
+
+#### `scopes_supported` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L730" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+scopes_supported(self) -> list[str]
+```
+
+Scopes advertised by the delegated auth server.
+
+
+#### `get_challenge_scopes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L736" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_challenge_scopes(self, required_scopes: list[str] | None = None) -> list[str]
+```
+
+Translate effective scopes through an unambiguous auth source.
+
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L751" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a token by trying the server, then each verifier in order.
+
+Each source is tried independently. If a source raises an exception,
+it is logged and treated as a non-match so that remaining sources
+still get a chance to verify the token.
+
+
+#### `set_mcp_path` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L772" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_mcp_path(self, mcp_path: str | None) -> None
+```
+
+Propagate MCP path to the server and all verifiers.
+
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L780" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Delegate route creation to the server.
+
+
+#### `get_well_known_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L786" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_well_known_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Delegate well-known route creation to the server.
+
+This ensures that server-specific well-known route logic (e.g.,
+OAuthProvider's RFC 8414 path-aware discovery) is preserved.
+
+
+### `OAuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L797" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth Authorization Server provider.
+
+This class provides full OAuth server functionality including client registration,
+authorization flows, token issuance, and token verification.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L869" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a bearer token and return access info if valid.
+
+This method implements the TokenVerifier protocol by delegating
+to our existing load_access_token method.
+
+**Args:**
+- `token`: The token string to validate
+
+**Returns:**
+- AccessToken object if valid, None if invalid or expired
+
+
+#### `scopes_supported` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L885" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+scopes_supported(self) -> list[str]
+```
+
+Scopes advertised by this authorization server.
+
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L894" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get OAuth authorization server routes and optional protected resource routes.
+
+This method creates the full set of OAuth routes including:
+- Standard OAuth authorization server routes (/.well-known/oauth-authorization-server, /authorize, /token, etc.)
+- Optional protected resource routes
+
+**Returns:**
+- List of OAuth routes
+
+
+#### `get_well_known_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/auth.py#L996" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_well_known_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get well-known discovery routes with RFC 8414 path-aware support.
+
+Overrides the base implementation to support path-aware authorization
+server metadata discovery per RFC 8414. If issuer_url has a path component,
+the authorization server metadata route is adjusted to include that path.
+
+For example, if issuer_url is "http://example.com/api", the discovery
+endpoint will be at "/.well-known/oauth-authorization-server/api" instead
+of just "/.well-known/oauth-authorization-server".
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+
+**Returns:**
+- List of well-known discovery routes
+

--- a/docs/python-sdk/fastmcp-server-auth-cimd.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-cimd.mdx
@@ -1,0 +1,245 @@
+---
+title: cimd
+sidebarTitle: cimd
+---
+
+# `fastmcp.server.auth.cimd`
+
+
+CIMD (Client ID Metadata Document) support for FastMCP.
+
+.. warning::
+    **Beta Feature**: CIMD support is currently in beta. The API may change
+    in future releases. Please report any issues you encounter.
+
+CIMD is a simpler alternative to Dynamic Client Registration where clients
+host a static JSON document at an HTTPS URL, and that URL becomes their
+client_id. See the IETF draft: draft-parecki-oauth-client-id-metadata-document
+
+This module provides:
+- CIMDDocument: Pydantic model for CIMD document validation
+- CIMDFetcher: Fetch and validate CIMD documents with SSRF protection
+- CIMDClientManager: Manages CIMD client operations
+
+
+## Classes
+
+### `CIMDDocument` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+CIMD document per draft-parecki-oauth-client-id-metadata-document.
+
+The client metadata document is a JSON document containing OAuth client
+metadata. The client_id property MUST match the URL where this document
+is hosted.
+
+Key constraint: token_endpoint_auth_method MUST NOT use shared secrets
+(client_secret_post, client_secret_basic, client_secret_jwt).
+
+redirect_uris is required and must contain at least one entry.
+
+
+**Methods:**
+
+#### `validate_auth_method` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L137" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_auth_method(cls, v: str) -> str
+```
+
+Ensure no shared-secret auth methods are used.
+
+
+#### `validate_redirect_uris` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L149" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_redirect_uris(cls, v: list[str]) -> list[str]
+```
+
+Ensure redirect_uris is non-empty and each entry is a valid URI.
+
+
+### `CIMDValidationError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L166" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Raised when CIMD document validation fails.
+
+
+### `CIMDFetchError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L170" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Raised when CIMD document fetching fails.
+
+
+### `CIMDFetcher` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L198" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Fetch and validate CIMD documents with SSRF protection.
+
+Delegates HTTP fetching to ssrf_safe_fetch_response, which provides DNS
+pinning, IP validation, size limits, and timeout enforcement. Documents are
+cached using HTTP caching semantics (Cache-Control/ETag/Last-Modified), with
+a TTL fallback when response headers do not define caching behavior.
+
+
+**Methods:**
+
+#### `is_cimd_client_id` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L298" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_cimd_client_id(self, client_id: str) -> bool
+```
+
+Check if a client_id looks like a CIMD URL.
+
+CIMD URLs must be HTTPS with a host and non-root path.
+
+
+#### `fetch` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L315" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+fetch(self, client_id_url: str) -> CIMDDocument
+```
+
+Fetch and validate a CIMD document with SSRF protection.
+
+Uses ssrf_safe_fetch_response for the HTTP layer, which provides:
+- HTTPS only, DNS resolution with IP validation
+- DNS pinning (connects to validated IP directly)
+- Blocks private/loopback/link-local/multicast IPs
+- Response size limit and timeout enforcement
+- Redirects disabled
+
+**Args:**
+- `client_id_url`: The URL to fetch (also the expected client_id)
+
+**Returns:**
+- Validated CIMDDocument
+
+**Raises:**
+- `CIMDValidationError`: If document is invalid or URL blocked
+- `CIMDFetchError`: If document cannot be fetched
+
+
+#### `validate_redirect_uri` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L456" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_redirect_uri(self, doc: CIMDDocument, redirect_uri: str) -> bool
+```
+
+Validate that a redirect_uri is allowed by the CIMD document.
+
+Uses component-level matching (scheme, host, port, path) which correctly
+handles RFC 8252 §7.3 loopback port flexibility and wildcard patterns.
+
+**Args:**
+- `doc`: The CIMD document
+- `redirect_uri`: The redirect URI to validate
+
+**Returns:**
+- True if valid, False otherwise
+
+
+### `CIMDAssertionValidator` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L484" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Validates JWT assertions for private_key_jwt CIMD clients.
+
+Implements RFC 7523 (JSON Web Token (JWT) Profile for OAuth 2.0 Client
+Authentication and Authorization Grants) for CIMD client authentication.
+
+JTI replay protection uses TTL-based caching to ensure proper security:
+- JTIs are cached with expiration matching the JWT's exp claim
+- Expired JTIs are automatically cleaned up
+- Maximum assertion lifetime is enforced (5 minutes)
+
+
+**Methods:**
+
+#### `validate_assertion` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L527" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_assertion(self, assertion: str, client_id: str, token_endpoint: str, cimd_doc: CIMDDocument) -> bool
+```
+
+Validate JWT assertion from client.
+
+**Args:**
+- `assertion`: The JWT assertion string
+- `client_id`: Expected client_id (must match iss and sub claims)
+- `token_endpoint`: Token endpoint URL (must match aud claim)
+- `cimd_doc`: CIMD document containing JWKS for key verification
+
+**Returns:**
+- True if valid
+
+**Raises:**
+- `ValueError`: If validation fails
+
+
+### `CIMDClientManager` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L703" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Manages all CIMD client operations for OAuth proxy.
+
+This class encapsulates:
+- CIMD client detection
+- Document fetching and validation
+- Synthetic OAuth client creation
+- Private key JWT assertion validation
+
+This allows the OAuth proxy to delegate all CIMD-specific logic to a
+single, focused manager class.
+
+
+**Methods:**
+
+#### `is_cimd_client_id` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L737" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_cimd_client_id(self, client_id: str) -> bool
+```
+
+Check if client_id is a CIMD URL.
+
+**Args:**
+- `client_id`: Client ID to check
+
+**Returns:**
+- True if client_id is an HTTPS URL (CIMD format)
+
+
+#### `get_client` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L748" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_client(self, client_id_url: str)
+```
+
+Fetch CIMD document and create synthetic OAuth client.
+
+**Args:**
+- `client_id_url`: HTTPS URL pointing to CIMD document
+
+**Returns:**
+- OAuthProxyClient with CIMD document attached, or None if fetch fails
+
+
+#### `validate_private_key_jwt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/cimd.py#L797" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_private_key_jwt(self, assertion: str, client, token_endpoint: str) -> bool
+```
+
+Validate JWT assertion for private_key_jwt auth.
+
+**Args:**
+- `assertion`: JWT assertion string from client
+- `client`: OAuth proxy client (must have cimd_document)
+- `token_endpoint`: Token endpoint URL for aud validation
+
+**Returns:**
+- True if assertion is valid
+
+**Raises:**
+- `ValueError`: If client doesn't have CIMD document or validation fails
+

--- a/docs/python-sdk/fastmcp-server-auth-handlers-authorize.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-handlers-authorize.mdx
@@ -1,0 +1,83 @@
+---
+title: authorize
+sidebarTitle: authorize
+---
+
+# `fastmcp.server.auth.handlers.authorize`
+
+
+Enhanced authorization handler with improved error responses.
+
+This module provides an enhanced authorization handler that wraps the MCP SDK's
+AuthorizationHandler to provide better error messages when clients attempt to
+authorize with unregistered client IDs.
+
+The enhancement adds:
+- Content negotiation: HTML for browsers, JSON for API clients
+- Enhanced JSON responses with registration endpoint hints
+- Styled HTML error pages with registration links/forms
+- Link headers pointing to registration endpoints
+
+
+## Functions
+
+### `create_unregistered_client_html` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/handlers/authorize.py#L43" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_unregistered_client_html(client_id: str, registration_endpoint: str, discovery_endpoint: str, server_name: str | None = None, server_icon_url: str | None = None, title: str = 'Client Not Registered') -> str
+```
+
+
+Create styled HTML error page for unregistered client attempts.
+
+**Args:**
+- `client_id`: The unregistered client ID that was provided
+- `registration_endpoint`: URL of the registration endpoint
+- `discovery_endpoint`: URL of the OAuth metadata discovery endpoint
+- `server_name`: Optional server name for branding
+- `server_icon_url`: Optional server icon URL
+- `title`: Page title
+
+**Returns:**
+- HTML string for the error page
+
+
+## Classes
+
+### `AuthorizationHandler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/handlers/authorize.py#L163" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Authorization handler with enhanced error responses for unregistered clients.
+
+This handler extends the MCP SDK's AuthorizationHandler to provide better UX
+when clients attempt to authorize without being registered. It implements
+content negotiation to return:
+
+- HTML error pages for browser requests
+- Enhanced JSON with registration hints for API clients
+- Link headers pointing to registration endpoints
+
+This maintains OAuth 2.1 compliance (returns 400 for invalid client_id)
+while providing actionable guidance to fix the error.
+
+
+**Methods:**
+
+#### `handle` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/handlers/authorize.py#L207" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+handle(self, request: Request) -> Response
+```
+
+Handle authorization request with enhanced error responses.
+
+This method extends the SDK's authorization handler and intercepts
+errors for unregistered clients to provide better error responses
+based on the client's Accept header.
+
+**Args:**
+- `request`: The authorization request
+
+**Returns:**
+- Response (redirect on success, error response on failure)
+

--- a/docs/python-sdk/fastmcp-server-auth-identity_assertion.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-identity_assertion.mdx
@@ -1,0 +1,125 @@
+---
+title: identity_assertion
+sidebarTitle: identity_assertion
+---
+
+# `fastmcp.server.auth.identity_assertion`
+
+
+Server-side identity assertion (ID-JAG) support for FastMCP (SEP-990).
+
+.. warning::
+    **Beta Feature**: Identity assertion support is currently in beta. The API
+    may change in future releases. Please report any issues you encounter.
+
+SEP-990 defines an enterprise "on-behalf-of" flow. A corporate identity provider
+(Okta, Entra, etc.) issues an *ID-JAG* (Identity Assertion JWT Authorization
+Grant) that asserts an employee's identity to a specific MCP authorization
+server. The client presents that ID-JAG at the token endpoint using the RFC 7523
+``urn:ietf:params:oauth:grant-type:jwt-bearer`` grant (the RFC 8693 token-exchange
+profile). This module validates the assertion and lets the authorization server
+mint a short-lived access token carrying the asserted subject, with no refresh
+token — the client re-exchanges a fresh ID-JAG instead, and revocation lives at
+the IdP.
+
+This module provides:
+
+- ``IdentityAssertion``: a small pydantic config model attached to ``OAuthProxy``
+  via the ``identity_assertion`` parameter.
+- ``IdentityAssertionValidator``: validates an ID-JAG per RFC 7523 §3 and the
+  SEP-990 processing rules, reusing FastMCP's :class:`JWTVerifier` for signature,
+  issuer, audience, and expiry checks, and enforcing ``typ``, ``sub`` presence,
+  and ``jti`` replay protection on top.
+
+
+## Functions
+
+### `normalize_resource_url` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/identity_assertion.py#L474" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+normalize_resource_url(url: str) -> str
+```
+
+
+Normalize a resource URL by removing query parameters and trailing slashes.
+
+RFC 8707 allows clients to include query parameters in resource URLs, but
+the server's configured resource URL typically doesn't include them. This
+normalizes both sides for comparison by stripping query and fragment.
+
+
+### `server_url_has_query` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/identity_assertion.py#L487" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+server_url_has_query(url: str) -> bool
+```
+
+
+Check if a URL has query parameters.
+
+
+## Classes
+
+### `IdentityAssertion` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/identity_assertion.py#L60" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration for server-side identity assertion (ID-JAG) support.
+
+When attached to an :class:`~fastmcp.server.auth.oauth_proxy.OAuthProxy` via the
+``identity_assertion`` parameter, the proxy's token endpoint accepts the RFC 7523
+``jwt-bearer`` grant carrying an ID-JAG issued by one of the ``trusted_issuers``,
+and mints a short-lived FastMCP access token for the asserted subject.
+
+
+### `IdentityAssertionError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/identity_assertion.py#L183" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Raised when an ID-JAG fails validation.
+
+The message is for server-side logging only; the token endpoint maps this to a
+generic OAuth error response and does not leak the detail to the client.
+
+
+### `IdentityAssertionValidator` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/identity_assertion.py#L191" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Validates ID-JAG assertions for the SEP-990 jwt-bearer grant.
+
+Reuses :class:`JWTVerifier` for signature, issuer, audience, and expiry checks
+(with JWKS fetching and caching), and layers on the SEP-990 processing rules
+that the generic verifier does not cover: the ``typ`` JOSE header, a mandatory
+``sub``, and ``jti`` replay rejection.
+
+JTI replay protection mirrors :class:`CIMDAssertionValidator`: seen ``jti``
+values are cached until the assertion would expire anyway, with periodic
+cleanup and an emergency size cap. Like CIMD, the cache is per-process, so
+replay protection is not shared across horizontally-scaled workers or
+replicas; see the identity-assertion docs for the deployment caveat.
+
+
+**Methods:**
+
+#### `validate` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/identity_assertion.py#L327" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate(self, assertion: str) -> dict
+```
+
+Validate an ID-JAG and return its claims.
+
+**Args:**
+- `assertion`: The compact-serialized ID-JAG JWT.
+- `client_id`: The authenticated client presenting the assertion. Must
+match the assertion's signed `client_id` claim — checked before
+the jti is recorded as consumed, so an assertion presented by
+the wrong client is rejected without burning it for the right
+one.
+- `resource_url`: This server's resource URL, if configured. Must match
+the assertion's signed `resource` claim, for the same reason.
+
+**Returns:**
+- The verified claims (including `sub`, `iss`, and any `resource`/`scope`).
+
+**Raises:**
+- `IdentityAssertionError`: If the assertion is invalid for any reason.
+

--- a/docs/python-sdk/fastmcp-server-auth-jwt_issuer.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-jwt_issuer.mdx
@@ -1,0 +1,114 @@
+---
+title: jwt_issuer
+sidebarTitle: jwt_issuer
+---
+
+# `fastmcp.server.auth.jwt_issuer`
+
+
+JWT token issuance and verification for FastMCP OAuth Proxy.
+
+This module implements the token factory pattern for OAuth proxies, where the proxy
+issues its own JWT tokens to clients instead of forwarding upstream provider tokens.
+This maintains proper OAuth 2.0 token audience boundaries.
+
+
+## Functions
+
+### `derive_jwt_key` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/jwt_issuer.py#L39" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+derive_jwt_key() -> bytes
+```
+
+
+Derive JWT signing key from a high-entropy or low-entropy key material and server salt.
+
+
+## Classes
+
+### `JWTIssuer` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/jwt_issuer.py#L79" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Issues and validates FastMCP-signed JWT tokens using HS256.
+
+This issuer creates JWT tokens for MCP clients with proper audience claims,
+maintaining OAuth 2.0 token boundaries. Tokens are signed with HS256 using
+a key derived from the upstream client secret.
+
+
+**Methods:**
+
+#### `issue_access_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/jwt_issuer.py#L105" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+issue_access_token(self, client_id: str, scopes: list[str], jti: str, expires_in: int = 3600, upstream_claims: dict[str, Any] | None = None, subject: str | None = None, extra_claims: dict[str, Any] | None = None) -> str
+```
+
+Issue a minimal FastMCP access token.
+
+FastMCP tokens are reference tokens containing only the minimal claims
+needed for validation and lookup. The JTI maps to the upstream token
+which contains actual user identity and authorization data.
+
+**Args:**
+- `client_id`: MCP client ID
+- `scopes`: Token scopes
+- `jti`: Unique token identifier (maps to upstream token)
+- `expires_in`: Token lifetime in seconds
+- `upstream_claims`: Optional claims from upstream IdP token to include
+- `subject`: Optional `sub` claim. Set for self-contained tokens (e.g.
+minted from an ID-JAG) where the subject is carried directly in
+the token rather than looked up via a JTI mapping.
+- `extra_claims`: Optional additional top-level claims to embed. Used to
+mark self-contained tokens (e.g. the ID-JAG issuer/marker) so
+`load_access_token` can validate them without a JTI mapping.
+
+**Returns:**
+- Signed JWT token
+
+
+#### `issue_refresh_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/jwt_issuer.py#L175" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+issue_refresh_token(self, client_id: str, scopes: list[str], jti: str, expires_in: int, upstream_claims: dict[str, Any] | None = None) -> str
+```
+
+Issue a minimal FastMCP refresh token.
+
+FastMCP refresh tokens are reference tokens containing only the minimal
+claims needed for validation and lookup. The JTI maps to the upstream
+token which contains actual user identity and authorization data.
+
+**Args:**
+- `client_id`: MCP client ID
+- `scopes`: Token scopes
+- `jti`: Unique token identifier (maps to upstream token)
+- `expires_in`: Token lifetime in seconds (should match upstream refresh expiry)
+- `upstream_claims`: Optional claims from upstream IdP token to include
+
+**Returns:**
+- Signed JWT token
+
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/jwt_issuer.py#L232" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str, expected_token_use: str = 'access') -> dict[str, Any]
+```
+
+Verify and decode a FastMCP token.
+
+Validates JWT signature, expiration, issuer, audience, and token type.
+
+**Args:**
+- `token`: JWT token to verify
+- `expected_token_use`: Expected token type ("access" or "refresh").
+Defaults to "access", which rejects refresh tokens.
+
+**Returns:**
+- Decoded token payload
+
+**Raises:**
+- `JoseError`: If token is invalid, expired, or has wrong claims
+

--- a/docs/python-sdk/fastmcp-server-auth-middleware.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-middleware.mdx
@@ -1,0 +1,33 @@
+---
+title: middleware
+sidebarTitle: middleware
+---
+
+# `fastmcp.server.auth.middleware`
+
+
+Enhanced authentication middleware with better error messages.
+
+This module provides enhanced versions of MCP SDK authentication middleware
+that return more helpful error messages for developers troubleshooting
+authentication issues.
+
+Implements RFC 6750 §3.1 compliance by distinguishing between missing
+authentication (no error attribute) and invalid authentication (with error).
+
+
+## Classes
+
+### `RequireAuthMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/middleware.py#L27" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Enhanced authentication middleware with detailed error messages.
+
+Extends the SDK's RequireAuthMiddleware to provide more actionable
+error messages when authentication fails. This helps developers
+understand what went wrong and how to fix it.
+
+Also implements RFC 6750 §3.1 compliance by distinguishing between
+missing authentication (initial discovery) and invalid authentication
+(token validation failure).
+

--- a/docs/python-sdk/fastmcp-server-auth-oauth_proxy-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-oauth_proxy-__init__.mdx
@@ -1,0 +1,16 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.server.auth.oauth_proxy`
+
+
+OAuth Proxy Provider for FastMCP.
+
+This package provides OAuth proxy functionality split across multiple modules:
+- models: Pydantic models and constants
+- ui: HTML generation functions
+- consent: Consent management mixin
+- proxy: Main OAuthProxy class
+

--- a/docs/python-sdk/fastmcp-server-auth-oauth_proxy-consent.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-oauth_proxy-consent.mdx
@@ -1,0 +1,28 @@
+---
+title: consent
+sidebarTitle: consent
+---
+
+# `fastmcp.server.auth.oauth_proxy.consent`
+
+
+OAuth Proxy Consent Management.
+
+This module contains consent management functionality for the OAuth proxy.
+The ConsentMixin class provides methods for handling user consent flows,
+cookie management, and consent page rendering.
+
+
+## Classes
+
+### `ConsentMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/consent.py#L76" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin class providing consent management functionality for OAuthProxy.
+
+This mixin contains all methods related to:
+- Cookie signing and verification
+- Consent page rendering
+- Consent approval/denial handling
+- URI normalization for consent tracking
+

--- a/docs/python-sdk/fastmcp-server-auth-oauth_proxy-models.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-oauth_proxy-models.mdx
@@ -1,0 +1,121 @@
+---
+title: models
+sidebarTitle: models
+---
+
+# `fastmcp.server.auth.oauth_proxy.models`
+
+
+OAuth Proxy Models and Constants.
+
+This module contains all Pydantic models and constants used by the OAuth proxy.
+
+
+## Classes
+
+### `OAuthTransaction` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L44" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth transaction state for consent flow.
+
+Stored server-side to track active authorization flows with client context.
+Includes CSRF tokens for consent protection per MCP security best practices.
+
+
+### `ConsentCSRFToken` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L70" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+One CSRF token issued for one render of the consent page.
+
+Stored under a key derived from the token itself rather than on the
+transaction. Every render of a consent page issues its own token, and two
+renders can be in flight at once (a reload, a browser preload, an extension
+re-fetching the URL). Appending to a list on the transaction loses one of
+them whenever that happens: `AsyncKeyValue` has no compare-and-swap, so two
+handlers read the same transaction, each append their own token, and the
+second write drops the first. Giving each token its own key makes the
+writes independent, which holds across processes sharing one backend.
+
+
+### `ClientCode` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L87" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Client authorization code with PKCE and upstream tokens.
+
+Stored server-side after upstream IdP callback. Contains the upstream
+tokens bound to the client's PKCE challenge for secure token exchange.
+
+
+### `UpstreamTokenSet` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L105" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Stored upstream OAuth tokens from identity provider.
+
+These tokens are obtained from the upstream provider (Google, GitHub, etc.)
+and stored in plaintext within this model. Encryption is handled transparently
+at the storage layer via FernetEncryptionWrapper. Tokens are never exposed to MCP clients.
+
+
+### `JTIMapping` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L127" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Maps FastMCP token JTI to upstream token ID.
+
+This allows stateless JWT validation while still being able to look up
+the corresponding upstream token when tools need to access upstream APIs.
+
+
+### `RefreshTokenMetadata` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L139" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Metadata for a refresh token, stored keyed by token hash.
+
+We store only metadata (not the token itself) for security - if storage
+is compromised, attackers get hashes they can't reverse into usable tokens.
+
+
+### `ProxyDCRClient` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L208" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Client for DCR proxy with configurable redirect URI validation.
+
+This special client class is critical for the OAuth proxy to work correctly
+with Dynamic Client Registration (DCR). Here's why it exists:
+
+Problem:
+--------
+When MCP clients use OAuth, they dynamically register with random localhost
+ports (e.g., http://localhost:55454/callback). The OAuth proxy needs to:
+1. Accept these dynamic redirect URIs from clients based on configured patterns
+2. Use its own fixed redirect URI with the upstream provider (Google, GitHub, etc.)
+3. Forward the authorization code back to the client's dynamic URI
+
+Solution:
+---------
+This class validates redirect URIs against configurable patterns,
+while the proxy internally uses its own fixed redirect URI with the upstream
+provider. This allows the flow to work even when clients reconnect with
+different ports or when tokens are cached.
+
+Without proper validation, clients could get "Redirect URI not registered" errors
+when trying to authenticate with cached tokens, or security vulnerabilities could
+arise from accepting arbitrary redirect URIs.
+
+
+**Methods:**
+
+#### `validate_redirect_uri` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py#L256" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl
+```
+
+Validate redirect URI against proxy patterns and optionally CIMD redirect_uris.
+
+For CIMD clients: validates against BOTH the CIMD document's redirect_uris
+AND the proxy's allowed patterns (if configured). Both must pass.
+
+For DCR clients: validates against proxy patterns when configured. Without
+proxy patterns, validates against registered redirect_uris while allowing
+loopback ports to vary for MCP client compatibility.
+

--- a/docs/python-sdk/fastmcp-server-auth-oauth_proxy-proxy.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-oauth_proxy-proxy.mdx
@@ -1,0 +1,381 @@
+---
+title: proxy
+sidebarTitle: proxy
+---
+
+# `fastmcp.server.auth.oauth_proxy.proxy`
+
+
+OAuth Proxy Provider for FastMCP.
+
+This provider acts as a transparent proxy to an upstream OAuth Authorization Server,
+handling Dynamic Client Registration locally while forwarding all other OAuth flows.
+This enables authentication with upstream providers that don't support DCR or have
+restricted client registration policies.
+
+Key features:
+- Proxies authorization and token endpoints to upstream server
+- Implements local Dynamic Client Registration with fixed upstream credentials
+- Validates tokens using upstream JWKS
+- Maintains minimal local state for bookkeeping
+- Enhanced logging with request correlation
+
+This implementation is based on the OAuth 2.1 specification and is designed for
+production use with enterprise identity providers.
+
+
+## Classes
+
+### `OAuthProxy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L190" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth provider that presents a DCR-compliant interface while proxying to non-DCR IDPs.
+
+Purpose
+-------
+MCP clients expect OAuth providers to support Dynamic Client Registration (DCR),
+where clients can register themselves dynamically and receive unique credentials.
+Most enterprise IDPs (Google, GitHub, Azure AD, etc.) don't support DCR and require
+pre-registered OAuth applications with fixed credentials.
+
+This proxy bridges that gap by:
+- Presenting a full DCR-compliant OAuth interface to MCP clients
+- Translating DCR registration requests to use pre-configured upstream credentials
+- Proxying all OAuth flows to the upstream IDP with appropriate translations
+- Managing the state and security requirements of both protocols
+
+Architecture Overview
+--------------------
+The proxy maintains a single OAuth app registration with the upstream provider
+while allowing unlimited MCP clients to register and authenticate dynamically.
+It implements the complete OAuth 2.1 + DCR specification for clients while
+translating to whatever OAuth variant the upstream provider requires.
+
+Key Translation Challenges Solved
+---------------------------------
+1. Dynamic Client Registration:
+   - MCP clients expect to register dynamically and get unique credentials
+   - Upstream IDPs require pre-registered apps with fixed credentials
+   - Solution: Accept DCR requests, return shared upstream credentials
+
+2. Dynamic Redirect URIs:
+   - MCP clients use random localhost ports that change between sessions
+   - Upstream IDPs require fixed, pre-registered redirect URIs
+   - Solution: Use proxy's fixed callback URL with upstream, forward to client's dynamic URI
+
+3. Authorization Code Mapping:
+   - Upstream returns codes for the proxy's redirect URI
+   - Clients expect codes for their own redirect URIs
+   - Solution: Exchange upstream code server-side, issue new code to client
+
+4. State Parameter Collision:
+   - Both client and proxy need to maintain state through the flow
+   - Only one state parameter available in OAuth
+   - Solution: Use transaction ID as state with upstream, preserve client's state
+
+5. Token Management:
+   - Clients may expect different token formats/claims than upstream provides
+   - Need to track tokens for revocation and refresh
+   - Solution: Store token relationships, forward upstream tokens transparently
+
+OAuth Flow Implementation
+------------------------
+1. Client Registration (DCR):
+   - Accept any client registration request
+   - Store ProxyDCRClient that accepts dynamic redirect URIs
+
+2. Authorization:
+   - Store transaction mapping client details to proxy flow
+   - Redirect to upstream with proxy's fixed redirect URI
+   - Use transaction ID as state parameter with upstream
+
+3. Upstream Callback:
+   - Exchange upstream authorization code for tokens (server-side)
+   - Generate new authorization code bound to client's PKCE challenge
+   - Redirect to client's original dynamic redirect URI
+
+4. Token Exchange:
+   - Validate client's code and PKCE verifier
+   - Return previously obtained upstream tokens
+   - Clean up one-time use authorization code
+
+5. Token Refresh:
+   - Forward refresh requests to upstream
+   - Handle token rotation if upstream issues new refresh token
+   - Update local token mappings
+
+State Management
+---------------
+The proxy maintains minimal but crucial state via pluggable storage (client_storage):
+- _oauth_transactions: Active authorization flows with client context
+- _client_codes: Authorization codes with PKCE challenges and upstream tokens
+- _jti_mapping_store: Maps FastMCP token JTIs to upstream token IDs
+- _refresh_token_store: Refresh token metadata (keyed by token hash)
+
+All state is stored in the configured client_storage backend (Redis, disk, etc.)
+enabling horizontal scaling across multiple instances.
+
+Security Considerations
+----------------------
+- Refresh tokens stored by hash only (defense in depth if storage compromised)
+- PKCE enforced end-to-end (client to proxy, proxy to upstream)
+- Authorization codes are single-use with short expiry
+- Transaction IDs are cryptographically random
+- All state is cleaned up after use to prevent replay
+- Token validation delegates to upstream provider
+
+Provider Compatibility
+---------------------
+Works with any OAuth 2.0 provider that supports:
+- Authorization code flow
+- Fixed redirect URI (configured in provider's app settings)
+- Standard token endpoint
+
+Handles provider-specific requirements:
+- Google: Ensures minimum scope requirements
+- GitHub: Compatible with OAuth Apps and GitHub Apps
+- Azure AD: Handles tenant-specific endpoints
+- Generic: Works with any spec-compliant provider
+
+
+**Methods:**
+
+#### `update_default_scopes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L740" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+update_default_scopes(self, scopes: list[str]) -> None
+```
+
+Update the default scopes advertised to clients and used for DCR/CIMD fallback.
+
+Use this method when the available scope set is determined after provider
+initialization (e.g., after tool registration widens the required scopes).
+
+This updates all internal state derived from scopes:
+- The default scope string used for DCR client registration fallback
+- The CIMD manager's default scope (if CIMD is enabled)
+- The client registration options default_scopes and valid_scopes (if registration options exist)
+
+**Args:**
+- `scopes`: The new list of valid scopes to advertise and use as defaults.
+
+
+#### `set_mcp_path` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L766" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_mcp_path(self, mcp_path: str | None) -> None
+```
+
+Set the MCP endpoint path and create JWTIssuer with correct audience.
+
+This method is called by get_routes() to configure the resource URL
+and create the JWTIssuer. The JWT audience is set to the full resource
+URL (e.g., http://localhost:8000/mcp) to ensure tokens are bound to
+this specific MCP endpoint.
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+
+
+#### `jwt_issuer` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L792" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+jwt_issuer(self) -> JWTIssuer
+```
+
+Get the JWT issuer, ensuring it has been initialized.
+
+The JWT issuer is created when set_mcp_path() is called (via get_routes()).
+This property ensures a clear error if used before initialization.
+
+
+#### `token_endpoint_url` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L806" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+token_endpoint_url(self) -> str
+```
+
+The token endpoint URL, as advertised in the authorization server metadata.
+
+A CIMD `private_key_jwt` assertion is bound to this URL as its `aud`, so
+it must match the advertised `token_endpoint` byte-for-byte. The SDK's
+`build_metadata` builds that URL by stripping any trailing slash from
+`base_url` first, so this does too: pydantic renders a bare-authority
+`base_url` with a trailing slash, which would otherwise expect an `aud`
+of `https://example.com//token`.
+
+
+#### `get_client` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L919" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_client(self, client_id: str) -> OAuthClientInformationFull | None
+```
+
+Get client information by ID. This is generally the random ID
+provided to the DCR client during registration, not the upstream client ID.
+
+For unregistered clients, returns None (which will raise an error in the SDK).
+CIMD clients (URL-based client IDs) are looked up through the bounded
+in-process document cache rather than persisted in the DCR client store.
+
+
+#### `register_client` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L977" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+register_client(self, client_info: OAuthClientInformationFull) -> None
+```
+
+Register a client locally
+
+When a client registers, we create a ProxyDCRClient that is more
+forgiving about validating redirect URIs, since the DCR client's
+redirect URI will likely be localhost or unknown to the proxied IDP. The
+proxied IDP only knows about this server's fixed redirect URI.
+
+
+#### `authorize` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L1109" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str
+```
+
+Start OAuth transaction and route through consent interstitial.
+
+Flow:
+1. Validate client's resource matches server's resource URL (security check)
+2. Store transaction with client details and PKCE (if forwarding)
+3. Return local /consent URL; browser visits consent first
+4. Consent handler redirects to upstream IdP if approved/already approved
+
+If consent is disabled (require_authorization_consent=False or "external"),
+skip the consent screen and redirect directly to the upstream IdP. In
+"remember" mode, still route through /consent so the cookie lookup and
+Sec-Fetch-Site gating can run.
+
+
+#### `load_authorization_code` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L1240" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_authorization_code(self, client: OAuthClientInformationFull, authorization_code: str) -> AuthorizationCode | None
+```
+
+Load authorization code for validation.
+
+Look up our client code and return authorization code object
+with PKCE challenge for validation.
+
+
+#### `exchange_authorization_code` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L1288" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+exchange_authorization_code(self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode) -> OAuthToken
+```
+
+Exchange authorization code for FastMCP-issued tokens.
+
+Implements the token factory pattern:
+1. Retrieves upstream tokens from stored authorization code
+2. Extracts user identity from upstream token
+3. Encrypts and stores upstream tokens
+4. Issues FastMCP-signed JWT tokens
+5. Returns FastMCP tokens (NOT upstream tokens)
+
+PKCE validation is handled by the MCP framework before this method is called.
+
+
+#### `exchange_identity_assertion` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L1510" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+exchange_identity_assertion(self, client: OAuthClientInformationFull, params: IdentityAssertionParams) -> OAuthToken
+```
+
+Exchange a SEP-990 ID-JAG for a short-lived FastMCP access token.
+
+Validates the ID-JAG against the configured trusted issuers (signature,
+`iss`, `aud`, `exp`, `typ`, `sub`, and `jti` replay), then mints a
+self-contained FastMCP access token carrying the asserted subject. No
+refresh token is issued — the client re-exchanges a fresh assertion.
+
+**Raises:**
+- `TokenError`: ``invalid_grant`` if the assertion is rejected, or
+``unsupported_grant_type`` if identity assertion is not configured.
+
+
+#### `load_refresh_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L1722" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_refresh_token(self, client: OAuthClientInformationFull, refresh_token: str) -> RefreshToken | None
+```
+
+Load refresh token metadata from distributed storage.
+
+Looks up by token hash and reconstructs the RefreshToken object.
+Validates that the token belongs to the requesting client.
+
+
+#### `exchange_refresh_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L1758" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+exchange_refresh_token(self, client: OAuthClientInformationFull, refresh_token: RefreshToken, scopes: list[str]) -> OAuthToken
+```
+
+Exchange FastMCP refresh token for new FastMCP access token.
+
+Implements two-tier refresh:
+1. Verify FastMCP refresh token
+2. Look up upstream token via JTI mapping
+3. Refresh upstream token with upstream provider
+4. Update stored upstream token
+5. Issue new FastMCP access token
+6. Keep same FastMCP refresh token (unless upstream rotates)
+
+
+#### `load_access_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L2135" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_access_token(self, token: str) -> AccessToken | None
+```
+
+Validate FastMCP JWT by swapping for upstream token.
+
+This implements the token swap pattern:
+1. Verify FastMCP JWT signature (proves it's our token)
+2. Look up upstream token via JTI mapping
+3. Decrypt upstream token
+4. Validate upstream token with provider (GitHub API, JWT validation, etc.)
+5. If upstream validation fails, attempt transparent refresh
+6. Return upstream validation result
+
+The FastMCP JWT is a reference token - all authorization data comes
+from validating the upstream token via the TokenVerifier.
+
+
+#### `revoke_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L2318" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+revoke_token(self, token: AccessToken | RefreshToken) -> None
+```
+
+Revoke token locally and with upstream server if supported.
+
+For refresh tokens, removes from local storage by hash.
+For all tokens, attempts upstream revocation if endpoint is configured.
+Access token JTI mappings expire via TTL.
+
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py#L2386" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get OAuth routes with custom handlers for better error UX.
+
+This method creates standard OAuth routes and replaces:
+- /authorize endpoint: Enhanced error responses for unregistered clients
+- /token endpoint: OAuth 2.1 compliant error codes
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+This is used to advertise the resource URL in metadata.
+

--- a/docs/python-sdk/fastmcp-server-auth-oauth_proxy-ui.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-oauth_proxy-ui.mdx
@@ -1,0 +1,50 @@
+---
+title: ui
+sidebarTitle: ui
+---
+
+# `fastmcp.server.auth.oauth_proxy.ui`
+
+
+OAuth Proxy UI Generation Functions.
+
+This module contains HTML generation functions for consent and error pages.
+
+
+## Functions
+
+### `create_consent_html` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/ui.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_consent_html(client_id: str, redirect_uri: str, scopes: list[str], txn_id: str, csrf_token: str, client_name: str | None = None, title: str = 'Application Access Request', server_name: str | None = None, server_icon_url: str | None = None, server_website_url: str | None = None, client_website_url: str | None = None, csp_policy: str | None = None, is_cimd_client: bool = False, cimd_domain: str | None = None) -> str
+```
+
+
+Create a styled HTML consent page for OAuth authorization requests.
+
+**Args:**
+- `csp_policy`: Content Security Policy override.
+If None, uses the built-in CSP policy with appropriate directives.
+If empty string "", disables CSP entirely (no meta tag is rendered).
+If a non-empty string, uses that as the CSP policy value.
+
+
+### `create_error_html` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/ui.py#L215" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_error_html(error_title: str, error_message: str, error_details: dict[str, str] | None = None, server_name: str | None = None, server_icon_url: str | None = None) -> str
+```
+
+
+Create a styled HTML error page for OAuth errors.
+
+**Args:**
+- `error_title`: The error title (e.g., "OAuth Error", "Authorization Failed")
+- `error_message`: The main error message to display
+- `error_details`: Optional dictionary of error details to show (e.g., `{"Error Code"\: "invalid_client"}`)
+- `server_name`: Optional server name to display
+- `server_icon_url`: Optional URL to server icon/logo
+
+**Returns:**
+- Complete HTML page as a string
+

--- a/docs/python-sdk/fastmcp-server-auth-oauth_proxy-upstream.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-oauth_proxy-upstream.mdx
@@ -1,0 +1,73 @@
+---
+title: upstream
+sidebarTitle: upstream
+---
+
+# `fastmcp.server.auth.oauth_proxy.upstream`
+
+
+httpx2-based upstream OAuth2 token client.
+
+Replaces `authlib.integrations.httpx_client.AsyncOAuth2Client` for the OAuth
+proxy's upstream token-endpoint calls. authlib's httpx integration imports the
+legacy `httpx` package — which authlib does not declare as a dependency and
+FastMCP no longer ships — so importing it on a clean install fails.
+
+This module reimplements the narrow surface the proxy uses (`fetch_token`,
+`refresh_token`, `client_secret`, `aclose`) on `httpx2.AsyncClient`, preserving
+authlib's wire behavior exactly:
+
+- form-encoded POST token requests with authlib's default headers
+- `client_secret_basic` (latin-1 basic auth, authlib-style), `client_secret_post`,
+  and `none` client authentication methods
+- falsy parameters dropped from the request body
+- `expires_at` computed onto the returned token dict
+- the previous refresh token injected into the response when the server does
+  not rotate it
+- `OAuthError` (authlib's httpx-free core error class) raised for RFC 6749
+  error responses, and 5xx responses raised as HTTP status errors
+
+
+## Classes
+
+### `AsyncOAuth2Client` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/upstream.py#L40" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Minimal async OAuth2 client for upstream token-endpoint interactions.
+
+Drop-in replacement for the slice of authlib's `AsyncOAuth2Client` that
+`OAuthProxy` uses. Subclasses of `OAuthProxy` that override
+`_create_upstream_oauth_client` may return any object with the same
+`fetch_token`/`refresh_token`/`client_secret`/`aclose` surface.
+
+
+**Methods:**
+
+#### `aclose` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/upstream.py#L63" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+aclose(self) -> None
+```
+
+#### `fetch_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/upstream.py#L111" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+fetch_token(self, url: str, **params: Any) -> dict[str, Any]
+```
+
+Exchange an authorization grant for tokens at the token endpoint.
+
+Falsy parameters are dropped from the request body, matching authlib.
+
+
+#### `refresh_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oauth_proxy/upstream.py#L126" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+refresh_token(self, url: str, **params: Any) -> dict[str, Any]
+```
+
+Fetch a new access token using a refresh token.
+
+If the server does not rotate the refresh token, the previous one is
+injected into the returned dict, matching authlib.
+

--- a/docs/python-sdk/fastmcp-server-auth-oidc_proxy.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-oidc_proxy.mdx
@@ -1,0 +1,82 @@
+---
+title: oidc_proxy
+sidebarTitle: oidc_proxy
+---
+
+# `fastmcp.server.auth.oidc_proxy`
+
+
+OIDC Proxy Provider for FastMCP.
+
+This provider acts as a transparent proxy to an upstream OIDC compliant Authorization
+Server. It leverages the OAuthProxy class to handle Dynamic Client Registration and
+forwarding of all OAuth flows.
+
+This implementation is based on:
+    OpenID Connect Discovery 1.0 - https://openid.net/specs/openid-connect-discovery-1_0.html
+    OAuth 2.0 Authorization Server Metadata - https://datatracker.ietf.org/doc/html/rfc8414
+
+
+## Classes
+
+### `OIDCConfiguration` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py#L36" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OIDC Configuration.
+
+
+**Methods:**
+
+#### `get_oidc_configuration` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py#L151" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_oidc_configuration(cls, config_url: AnyHttpUrl) -> Self
+```
+
+Get the OIDC configuration for the specified config URL.
+
+**Args:**
+- `config_url`: The OIDC config URL
+- `strict`: The strict flag for the configuration
+- `timeout_seconds`: HTTP request timeout in seconds
+
+
+### `OIDCProxy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py#L181" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth provider that wraps OAuthProxy to provide configuration via an OIDC configuration URL.
+
+This provider makes it easier to add OAuth protection for any upstream provider
+that is OIDC compliant.
+
+
+**Methods:**
+
+#### `get_oidc_configuration` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py#L507" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_oidc_configuration(self, config_url: AnyHttpUrl, strict: bool | None, timeout_seconds: int | None) -> OIDCConfiguration
+```
+
+Gets the OIDC configuration for the specified configuration URL.
+
+**Args:**
+- `config_url`: The OIDC configuration URL
+- `strict`: The strict flag for the configuration
+- `timeout_seconds`: HTTP request timeout in seconds
+
+
+#### `get_token_verifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/oidc_proxy.py#L524" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_token_verifier(self) -> TokenVerifier
+```
+
+Creates the token verifier for the specified OIDC configuration and arguments.
+
+**Args:**
+- `algorithm`: Optional token verifier algorithm
+- `audience`: Optional token verifier audience
+- `required_scopes`: Optional token verifier required_scopes
+- `timeout_seconds`: HTTP request timeout in seconds
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-auth0.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-auth0.mdx
@@ -1,0 +1,97 @@
+---
+title: auth0
+sidebarTitle: auth0
+---
+
+# `fastmcp.server.auth.providers.auth0`
+
+
+Auth0 OAuth providers for FastMCP.
+
+This module provides two Auth0 integrations:
+
+- ``Auth0Provider`` — OAuth proxy for fixed Auth0 application credentials
+- ``Auth0MCPProvider`` — resource server for Auth0 Auth for MCP (DCR/CIMD)
+
+Example (OAuth proxy):
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.auth0 import Auth0Provider
+
+    auth = Auth0Provider(
+        config_url="https://auth0.config.url",
+        client_id="your-auth0-client-id",
+        client_secret="your-auth0-client-secret",
+        audience="your-auth0-api-audience",
+        base_url="http://localhost:8000",
+    )
+
+    mcp = FastMCP("My Protected Server", auth=auth)
+    ```
+
+Example (Auth for MCP):
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.auth0 import Auth0MCPProvider
+
+    auth = Auth0MCPProvider(
+        config_url="https://your-tenant.auth0.com/.well-known/openid-configuration",
+        base_url="http://127.0.0.1:8000",
+    )
+
+    mcp = FastMCP("My MCP Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `Auth0Provider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/auth0.py#L61" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+An Auth0 provider implementation for FastMCP.
+
+This provider is a complete Auth0 integration that's ready to use with
+just the configuration URL, client ID, client secret, audience, and base URL.
+
+
+### `Auth0JWTVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/auth0.py#L191" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+JWT verifier for Auth0 MCP access tokens.
+
+Auth0's ``rfc9068_profile_authz`` token dialect exposes API permissions in
+the ``permissions`` claim. Standard OAuth ``scope``/``scp`` claims are checked
+first; ``permissions`` is included when present.
+
+
+### `Auth0MCPProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/auth0.py#L209" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Auth0 resource server provider for Auth for MCP (DCR/CIMD).
+
+FastMCP validates access tokens issued by Auth0 while Auth0 handles OAuth,
+dynamic client registration, and CIMD approval in the tenant dashboard.
+
+Enable the Resource Parameter Compatibility Profile in Auth0 and create an
+API whose identifier matches this server's resource URL (logged at startup).
+
+
+**Methods:**
+
+#### `set_mcp_path` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/auth0.py#L286" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_mcp_path(self, mcp_path: str | None) -> None
+```
+
+Bind the default verifier's audience to this server's resource URL.
+
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/auth0.py#L303" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Protected resource routes plus Auth0 authorization server metadata.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-aws.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-aws.mdx
@@ -1,0 +1,87 @@
+---
+title: aws
+sidebarTitle: aws
+---
+
+# `fastmcp.server.auth.providers.aws`
+
+
+AWS Cognito OAuth provider for FastMCP.
+
+This module provides a complete AWS Cognito OAuth integration that's ready to use
+with a user pool ID, domain prefix, client ID and client secret. It handles all
+the complexity of AWS Cognito's OAuth flow, token validation, and user management.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.aws_cognito import AWSCognitoProvider
+
+    # Simple AWS Cognito OAuth protection
+    auth = AWSCognitoProvider(
+        user_pool_id="your-user-pool-id",
+        aws_region="eu-central-1",
+        client_id="your-cognito-client-id",
+        client_secret="your-cognito-client-secret"
+    )
+
+    mcp = FastMCP("My Protected Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `AWSCognitoTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/aws.py#L43" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier for Cognito access tokens.
+
+Cognito access tokens use a ``client_id`` claim instead of the
+standard ``aud`` claim.  This subclass passes ``audience=None``
+to the parent (skipping the ``aud`` check) and validates the
+``client_id`` claim directly.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/aws.py#L56" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify token and filter claims to Cognito-specific subset.
+
+
+### `AWSCognitoProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/aws.py#L94" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Complete AWS Cognito OAuth provider for FastMCP.
+
+This provider makes it trivial to add AWS Cognito OAuth protection to any
+FastMCP server using OIDC Discovery. Just provide your Cognito User Pool details,
+client credentials, and a base URL, and you're ready to go.
+
+Features:
+- Automatic OIDC Discovery from AWS Cognito User Pool
+- Automatic JWT token validation via Cognito's public keys
+- Cognito-specific claim filtering (sub, username, cognito:groups)
+- Support for Cognito User Pools
+
+
+**Methods:**
+
+#### `get_token_verifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/aws.py#L239" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_token_verifier(self) -> AWSCognitoTokenVerifier
+```
+
+Creates a Cognito-specific token verifier with claim filtering.
+
+**Args:**
+- `algorithm`: Optional token verifier algorithm
+- `audience`: Optional token verifier audience
+- `required_scopes`: Optional token verifier required_scopes
+- `timeout_seconds`: HTTP request timeout in seconds
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-azure.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-azure.mdx
@@ -1,0 +1,230 @@
+---
+title: azure
+sidebarTitle: azure
+---
+
+# `fastmcp.server.auth.providers.azure`
+
+
+Azure (Microsoft Entra) OAuth provider for FastMCP.
+
+This provider implements Azure/Microsoft Entra ID OAuth authentication
+using the OAuth Proxy pattern for non-DCR OAuth flows.
+
+
+## Functions
+
+### `EntraOBOToken` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L871" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+EntraOBOToken(scopes: list[str]) -> str
+```
+
+
+Exchange the user's Entra token for a downstream API token via OBO.
+
+This dependency performs a Microsoft Entra On-Behalf-Of (OBO) token exchange,
+allowing your MCP server to call downstream APIs (like Microsoft Graph) on
+behalf of the authenticated user.
+
+**Args:**
+- `scopes`: The scopes to request for the downstream API. For Microsoft Graph,
+use scopes like ["https\://graph.microsoft.com/Mail.Read"] or
+["https\://graph.microsoft.com/.default"].
+
+**Returns:**
+- A dependency that resolves to the downstream API access token string
+
+**Raises:**
+- `ImportError`: If fastmcp[azure] is not installed
+- `RuntimeError`: If no access token is available, provider is not Azure,
+or OBO exchange fails
+
+
+## Classes
+
+### `AzureProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L39" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Azure (Microsoft Entra) OAuth provider for FastMCP.
+
+This provider implements Azure/Microsoft Entra ID authentication using the
+OAuth Proxy pattern. It supports both organizational accounts and personal
+Microsoft accounts depending on the tenant configuration.
+
+Scope Handling:
+- required_scopes: Provide unprefixed scope names (e.g., ["read", "write"])
+  → Automatically prefixed with identifier_uri during initialization
+  → Validated on all tokens and advertised to MCP clients
+- additional_authorize_scopes: Provide full format (e.g., ["User.Read"])
+  → NOT prefixed, NOT validated, NOT advertised to clients
+  → Used to request Microsoft Graph or other upstream API permissions
+
+Features:
+- OAuth proxy to Azure/Microsoft identity platform
+- JWT validation using tenant issuer and JWKS
+- Supports tenant configurations: specific tenant ID, "organizations", or "consumers"
+- Custom API scopes and Microsoft Graph scopes in a single provider
+
+Setup:
+1. Create an App registration in Azure Portal
+2. Configure Web platform redirect URI: http://localhost:8000/auth/callback (or your custom path)
+3. Add an Application ID URI under "Expose an API" (defaults to api://{client_id})
+4. Add custom scopes (e.g., "read", "write") under "Expose an API"
+5. Set access token version to 2 in the App manifest: "requestedAccessTokenVersion": 2
+6. Create a client secret
+7. Get Application (client) ID, Directory (tenant) ID, and client secret
+
+
+**Methods:**
+
+#### `from_b2c` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L297" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_b2c(cls, **kwargs: Any) -> AzureProvider
+```
+
+Create an AzureProvider pre-configured for Azure AD B2C.
+
+Derives authority host, tenant path, and identifier URI from
+`tenant_name` and `policy_name`, then delegates to the standard
+constructor. Returns a plain `AzureProvider` instance.
+
+B2C issuer validation is disabled by default (`token_issuer=None`)
+because B2C issuers embed the tenant GUID. Pass an explicit
+`token_issuer` string once you know the real `iss` value.
+
+Azure AD B2C does **not** support OBO.
+
+**Args:**
+- `tenant_name`: Short B2C tenant name without `.onmicrosoft.com`
+(e.g. `"mytenant"`).
+- `policy_name`: User-flow or custom-policy name
+(e.g. `"B2C_1_susi"`).
+- `client_id`: Application (client) ID from the B2C app registration.
+- `client_secret`: Client secret from the B2C app registration.
+- `required_scopes`: Custom API scope names without prefix
+(e.g. `["mcp-access"]`).
+- `base_url`: Public base URL of this server.
+- `custom_domain`: Custom domain for the B2C authority
+(e.g. `"auth.mycompany.com"`). Defaults to
+`{tenant_name}.b2clogin.com`.
+- `identifier_uri`: Application ID URI. Defaults to
+`https\://{tenant_name}.onmicrosoft.com/{client_id}`.
+- `token_issuer`: Expected `iss` claim. `None` (default) disables
+issuer validation.
+- `**kwargs`: Forwarded to `AzureProvider.__init__`.
+
+
+#### `authorize` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L375" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str
+```
+
+Start OAuth transaction and redirect to Azure AD.
+
+Override parent's authorize method to filter out the 'resource' parameter
+which is not supported by Azure AD v2.0 endpoints. The v2.0 endpoints use
+scopes to determine the resource/audience instead of a separate parameter.
+
+**Args:**
+- `client`: OAuth client information
+- `params`: Authorization parameters from the client
+
+**Returns:**
+- Authorization URL to redirect the user to Azure AD
+
+
+#### `get_obo_credential` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L629" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_obo_credential(self, user_assertion: str) -> OnBehalfOfCredential
+```
+
+Get a cached or new OnBehalfOfCredential for OBO token exchange.
+
+Credentials are cached by user assertion so the Azure SDK's internal
+token cache can avoid redundant OBO exchanges when the same user
+calls multiple tools with the same scopes.
+
+**Args:**
+- `user_assertion`: The user's access token to exchange via OBO.
+
+**Returns:**
+- A configured OnBehalfOfCredential ready for get_token() calls.
+
+**Raises:**
+- `NotImplementedError`: If OBO is not supported (e.g. Azure AD B2C).
+- `ImportError`: If azure-identity is not installed (requires fastmcp[azure]).
+
+
+#### `close_obo_credentials` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L686" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+close_obo_credentials(self) -> None
+```
+
+Close all cached OBO credentials.
+
+
+### `AzureJWTVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L697" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+JWT verifier pre-configured for Azure AD / Microsoft Entra ID.
+
+Auto-configures JWKS URI, issuer, audience, and scope handling from your
+Azure app registration details. Designed for Managed Identity and other
+token-verification-only scenarios where AzureProvider's full OAuth proxy
+isn't needed.
+
+Handles Azure's scope format automatically:
+- Validates tokens using short-form scopes (what Azure puts in ``scp`` claims)
+- Advertises full-URI scopes in OAuth metadata (what clients need to request)
+
+Example::
+
+    from fastmcp.server.auth import RemoteAuthProvider
+    from fastmcp.server.auth.providers.azure import AzureJWTVerifier
+    from pydantic import AnyHttpUrl
+
+    verifier = AzureJWTVerifier(
+        client_id="your-client-id",
+        tenant_id="your-tenant-id",
+        required_scopes=["access_as_user"],
+    )
+
+    auth = RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[
+            AnyHttpUrl("https://login.microsoftonline.com/your-tenant-id/v2.0")
+        ],
+        base_url="https://my-server.com",
+    )
+
+
+**Methods:**
+
+#### `scopes_supported` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L777" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+scopes_supported(self) -> list[str]
+```
+
+Return scopes with Azure URI prefix for OAuth metadata.
+
+Azure tokens contain short-form scopes (e.g., ``read``) in the ``scp``
+claim, but clients must request full URI scopes (e.g.,
+``api://client-id/read``) from the Azure authorization endpoint. This
+property returns the full-URI form for OAuth metadata while
+``required_scopes`` retains the short form for token validation.
+
+
+#### `get_challenge_scopes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/azure.py#L788" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_challenge_scopes(self, required_scopes: list[str] | None = None) -> list[str]
+```
+
+Prefix any effective validation scopes for Azure authorization.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-clerk.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-clerk.mdx
@@ -1,0 +1,94 @@
+---
+title: clerk
+sidebarTitle: clerk
+---
+
+# `fastmcp.server.auth.providers.clerk`
+
+
+Clerk OAuth provider for FastMCP.
+
+This module provides a complete Clerk OAuth integration that's ready to use
+with a Clerk domain, client ID, and client secret. It handles all the complexity
+of Clerk's OAuth/OIDC flow, token validation, and user management.
+
+Clerk uses standard OIDC endpoints derived from the instance domain
+(e.g., ``https://<instance>.clerk.accounts.dev``). Token verification is
+performed via the introspection endpoint (RFC 7662) for security-critical
+checks (active status, audience, scopes), followed by the userinfo endpoint
+for profile enrichment. Userinfo failure is non-fatal.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.clerk import ClerkProvider
+
+    auth = ClerkProvider(
+        domain="saving-primate-16.clerk.accounts.dev",
+        client_id="your-clerk-client-id",
+        client_secret="your-clerk-client-secret",
+        base_url="https://my-server.com",
+    )
+
+    mcp = FastMCP("My Protected Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `ClerkTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/clerk.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier for Clerk OAuth tokens.
+
+Clerk issues standard OIDC tokens. Verification uses the introspection
+endpoint (RFC 7662) as the primary security gate — it confirms the token
+is active and provides metadata (scopes, expiry, audience). The userinfo
+endpoint is called second for profile enrichment (name, email, picture)
+and its failure is non-fatal.
+
+When a ``client_id`` is configured, the audience from introspection is
+validated against it. When ``required_scopes`` are configured,
+introspection must return the token's scopes — the verifier will not
+assume scopes when introspection is unavailable.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/clerk.py#L94" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a Clerk OAuth token via introspection and userinfo.
+
+Calls the introspection endpoint first to validate the token and
+retrieve auth metadata (active status, scopes, expiry, audience).
+If the token passes security checks, the userinfo endpoint is called
+for profile enrichment. Userinfo failure is non-fatal.
+
+When a ``client_id`` is configured, the token's audience must match it.
+When ``required_scopes`` are configured, introspection must confirm
+them; tokens are rejected if scope information is unavailable.
+
+
+### `ClerkProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/clerk.py#L241" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Complete Clerk OAuth provider for FastMCP.
+
+This provider makes it trivial to add Clerk OAuth protection to any
+FastMCP server. Provide your Clerk instance domain, OAuth app credentials,
+and a base URL, and you're ready to go.
+
+Clerk uses standard OIDC endpoints derived from the instance domain.
+All endpoint URLs are constructed automatically from the domain parameter.
+
+Features:
+- Transparent OAuth proxy to Clerk
+- Automatic token validation via Clerk's userinfo & introspection APIs
+- User information extraction from Clerk's OIDC claims
+- PKCE support (S256)
+- Minimal configuration required
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-debug.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-debug.mdx
@@ -1,0 +1,70 @@
+---
+title: debug
+sidebarTitle: debug
+---
+
+# `fastmcp.server.auth.providers.debug`
+
+
+Debug token verifier for testing and special cases.
+
+This module provides a flexible token verifier that delegates validation
+to a custom callable. Useful for testing, development, or scenarios where
+standard verification isn't possible (like opaque tokens without introspection).
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.debug import DebugTokenVerifier
+
+    # Accept all tokens (default - useful for testing)
+    auth = DebugTokenVerifier()
+
+    # Custom sync validation logic
+    auth = DebugTokenVerifier(validate=lambda token: token.startswith("valid-"))
+
+    # Custom async validation logic
+    async def check_cache(token: str) -> bool:
+        return await redis.exists(f"token:{token}")
+
+    auth = DebugTokenVerifier(validate=check_cache)
+
+    mcp = FastMCP("My Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `DebugTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/debug.py#L40" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier with custom validation logic.
+
+This verifier delegates token validation to a user-provided callable.
+By default, it accepts all non-empty tokens (useful for testing).
+
+Use cases:
+- Testing: Accept any token without real verification
+- Development: Custom validation logic for prototyping
+- Opaque tokens: When you have tokens with no introspection endpoint
+
+WARNING: This bypasses standard security checks. Only use in controlled
+environments or when you understand the security implications.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/debug.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify token using custom validation logic.
+
+**Args:**
+- `token`: The token string to validate
+
+**Returns:**
+- AccessToken if validation succeeds, None otherwise
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-descope.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-descope.mdx
@@ -1,0 +1,43 @@
+---
+title: descope
+sidebarTitle: descope
+---
+
+# `fastmcp.server.auth.providers.descope`
+
+
+Descope authentication provider for FastMCP.
+
+This module provides DescopeProvider - a complete authentication solution that integrates
+with Descope's OAuth 2.1 and OpenID Connect services, supporting Dynamic Client Registration (DCR)
+for seamless MCP client authentication.
+
+
+## Classes
+
+### `DescopeProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/descope.py#L79" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Descope metadata provider for Dynamic Client Registration (DCR).
+
+The provider accepts either a resource-specific Descope MCP Server URL such
+as `/v1/apps/agentic/P.../M.../.well-known/openid-configuration` or a
+project-level inbound app URL such as
+`/v1/apps/P.../.well-known/openid-configuration`.
+
+When neither `scopes_supported` nor `required_scopes` is provided, advertised
+scopes are discovered lazily from the OpenID configuration. Use
+`scopes_supported` and `required_scopes` together when the scopes clients
+should request differ from the scopes enforced during token validation.
+
+See [Descope's inbound app documentation](https://docs.descope.com/identity-federation/inbound-apps/creating-inbound-apps#method-2-dynamic-client-registration-dcr)
+for DCR setup instructions.
+
+
+**Methods:**
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/descope.py#L267" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```

--- a/docs/python-sdk/fastmcp-server-auth-providers-discord.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-discord.mdx
@@ -1,0 +1,66 @@
+---
+title: discord
+sidebarTitle: discord
+---
+
+# `fastmcp.server.auth.providers.discord`
+
+
+Discord OAuth provider for FastMCP.
+
+This module provides a complete Discord OAuth integration that's ready to use
+with just a client ID and client secret. It handles all the complexity of
+Discord's OAuth flow, token validation, and user management.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.discord import DiscordProvider
+
+    # Simple Discord OAuth protection
+    auth = DiscordProvider(
+        client_id="your-discord-client-id",
+        client_secret="your-discord-client-secret"
+    )
+
+    mcp = FastMCP("My Protected Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `DiscordTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/discord.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier for Discord OAuth tokens.
+
+Discord OAuth tokens are opaque (not JWTs), so we verify them
+by calling Discord's tokeninfo API to check if they're valid and get user info.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/discord.py#L72" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify Discord OAuth token by calling Discord's tokeninfo API.
+
+
+### `DiscordProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/discord.py#L166" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Complete Discord OAuth provider for FastMCP.
+
+This provider makes it trivial to add Discord OAuth protection to any
+FastMCP server. Just provide your Discord OAuth app credentials and
+a base URL, and you're ready to go.
+
+Features:
+- Transparent OAuth proxy to Discord
+- Automatic token validation via Discord's API
+- User information extraction from Discord APIs
+- Minimal configuration required
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-github.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-github.mdx
@@ -1,0 +1,70 @@
+---
+title: github
+sidebarTitle: github
+---
+
+# `fastmcp.server.auth.providers.github`
+
+
+GitHub OAuth provider for FastMCP.
+
+This module provides a complete GitHub OAuth integration that's ready to use
+with just a client ID and client secret. It handles all the complexity of
+GitHub's OAuth flow, token validation, and user management.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.github import GitHubProvider
+
+    # Simple GitHub OAuth protection
+    auth = GitHubProvider(
+        client_id="your-github-client-id",
+        client_secret="your-github-client-secret"
+    )
+
+    mcp = FastMCP("My Protected Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `GitHubTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/github.py#L41" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier for GitHub OAuth tokens.
+
+GitHub OAuth tokens are opaque (not JWTs), so we verify them
+by calling GitHub's API to check if they're valid and get user info.
+
+Caching is disabled by default.  Set ``cache_ttl_seconds`` to a positive
+integer to cache successful verification results and avoid repeated
+GitHub API calls for the same token.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/github.py#L91" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify GitHub OAuth token by calling GitHub API.
+
+
+### `GitHubProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/github.py#L188" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Complete GitHub OAuth provider for FastMCP.
+
+This provider makes it trivial to add GitHub OAuth protection to any
+FastMCP server. Just provide your GitHub OAuth app credentials and
+a base URL, and you're ready to go.
+
+Features:
+- Transparent OAuth proxy to GitHub
+- Automatic token validation via GitHub API
+- User information extraction
+- Minimal configuration required
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-google.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-google.mdx
@@ -1,0 +1,74 @@
+---
+title: google
+sidebarTitle: google
+---
+
+# `fastmcp.server.auth.providers.google`
+
+
+Google OAuth provider for FastMCP.
+
+This module provides a complete Google OAuth integration that's ready to use
+with just a client ID and client secret. It handles all the complexity of
+Google's OAuth flow, token validation, and user management.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.google import GoogleProvider
+
+    # Simple Google OAuth protection
+    auth = GoogleProvider(
+        client_id="your-google-client-id.apps.googleusercontent.com",
+        client_secret="your-google-client-secret"
+    )
+
+    mcp = FastMCP("My Protected Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `GoogleTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/google.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier for Google OAuth tokens.
+
+Google OAuth tokens are opaque (not JWTs), so we verify them by calling
+Google's tokeninfo endpoint with the access token as a query parameter.
+This returns the OAuth app ID (``aud``), granted scopes, and expiry time.
+User profile data (name, picture, etc.) is fetched separately from the
+v2 userinfo endpoint when the token is valid.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/google.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a Google OAuth token using the tokeninfo endpoint.
+
+Calls ``https://oauth2.googleapis.com/tokeninfo?access_token=TOKEN``
+to validate the token and retrieve the OAuth app ID (``aud``), granted
+scopes, and expiry time.  On success, fetches user profile data from
+the v2 userinfo endpoint to populate name, picture, and locale claims.
+
+
+### `GoogleProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/google.py#L225" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Complete Google OAuth provider for FastMCP.
+
+This provider makes it trivial to add Google OAuth protection to any
+FastMCP server. Just provide your Google OAuth app credentials and
+a base URL, and you're ready to go.
+
+Features:
+- Transparent OAuth proxy to Google
+- Automatic token validation via Google's tokeninfo API
+- User information extraction from Google APIs
+- Minimal configuration required
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-huggingface.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-huggingface.mdx
@@ -1,0 +1,37 @@
+---
+title: huggingface
+sidebarTitle: huggingface
+---
+
+# `fastmcp.server.auth.providers.huggingface`
+
+
+Hugging Face OAuth provider for FastMCP.
+
+## Classes
+
+### `HuggingFaceTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/huggingface.py#L56" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier for Hugging Face OAuth access tokens.
+
+Hugging Face OAuth access tokens are opaque, so validation is performed by
+calling Hugging Face's userinfo endpoint.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/huggingface.py#L74" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a Hugging Face OAuth token using the userinfo endpoint.
+
+
+### `HuggingFaceProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/huggingface.py#L175" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Complete Hugging Face OAuth provider for FastMCP.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-in_memory.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-in_memory.mdx
@@ -1,0 +1,96 @@
+---
+title: in_memory
+sidebarTitle: in_memory
+---
+
+# `fastmcp.server.auth.providers.in_memory`
+
+## Classes
+
+### `InMemoryOAuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L31" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+An in-memory OAuth provider for testing purposes.
+It simulates the OAuth 2.1 flow locally without external calls.
+
+
+**Methods:**
+
+#### `get_client` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L70" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_client(self, client_id: str) -> OAuthClientInformationFull | None
+```
+
+#### `register_client` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L73" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+register_client(self, client_info: OAuthClientInformationFull) -> None
+```
+
+#### `authorize` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L97" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str
+```
+
+Simulates user authorization and generates an authorization code.
+Returns a redirect URI with the code and state.
+
+
+#### `load_authorization_code` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L154" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_authorization_code(self, client: OAuthClientInformationFull, authorization_code: str) -> AuthorizationCode | None
+```
+
+#### `exchange_authorization_code` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L167" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+exchange_authorization_code(self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode) -> OAuthToken
+```
+
+#### `load_refresh_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L220" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_refresh_token(self, client: OAuthClientInformationFull, refresh_token: str) -> RefreshToken | None
+```
+
+#### `exchange_refresh_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L235" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+exchange_refresh_token(self, client: OAuthClientInformationFull, refresh_token: RefreshToken, scopes: list[str]) -> OAuthToken
+```
+
+#### `load_access_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L292" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_access_token(self, token: str) -> AccessToken | None
+```
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L303" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a bearer token and return access info if valid.
+
+This method implements the TokenVerifier protocol by delegating
+to our existing load_access_token method.
+
+**Args:**
+- `token`: The token string to validate
+
+**Returns:**
+- AccessToken object if valid, None if invalid or expired
+
+
+#### `revoke_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/in_memory.py#L360" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+revoke_token(self, token: AccessToken | RefreshToken) -> None
+```
+
+Revokes an access or refresh token and its counterpart.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-introspection.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-introspection.mdx
@@ -1,0 +1,82 @@
+---
+title: introspection
+sidebarTitle: introspection
+---
+
+# `fastmcp.server.auth.providers.introspection`
+
+
+OAuth 2.0 Token Introspection (RFC 7662) provider for FastMCP.
+
+This module provides token verification for opaque tokens using the OAuth 2.0
+Token Introspection protocol defined in RFC 7662. It allows FastMCP servers to
+validate tokens issued by authorization servers that don't use JWT format.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
+
+    # Verify opaque tokens via RFC 7662 introspection
+    verifier = IntrospectionTokenVerifier(
+        introspection_url="https://auth.example.com/oauth/introspect",
+        client_id="your-client-id",
+        client_secret="your-client-secret",
+        required_scopes=["read", "write"]
+    )
+
+    mcp = FastMCP("My Protected Server", auth=verifier)
+    ```
+
+
+## Classes
+
+### `IntrospectionTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/introspection.py#L45" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OAuth 2.0 Token Introspection verifier (RFC 7662).
+
+This verifier validates opaque tokens by calling an OAuth 2.0 token introspection
+endpoint. Unlike JWT verification which is stateless, token introspection requires
+a network call to the authorization server for each token validation.
+
+The verifier authenticates to the introspection endpoint using either:
+- HTTP Basic Auth (client_secret_basic, default): credentials in Authorization header
+- POST body authentication (client_secret_post): credentials in request body
+
+Both methods are specified in RFC 6749 (OAuth 2.0) and RFC 7662 (Token Introspection).
+
+Use this when:
+- Your authorization server issues opaque (non-JWT) tokens
+- You need to validate tokens from Auth0, Okta, Keycloak, or other OAuth servers
+- Your tokens require real-time revocation checking
+- Your authorization server supports RFC 7662 introspection
+
+Caching is disabled by default to preserve real-time revocation semantics.
+Set ``cache_ttl_seconds`` to enable caching and reduce load on the
+introspection endpoint (e.g., ``cache_ttl_seconds=300`` for 5 minutes).
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/introspection.py#L179" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a bearer token using OAuth 2.0 Token Introspection (RFC 7662).
+
+This method makes a POST request to the introspection endpoint with the token,
+authenticated using the configured client authentication method (client_secret_basic
+or client_secret_post).
+
+Results are cached in-memory to reduce load on the introspection endpoint.
+Cache TTL and size are configurable via constructor parameters.
+
+**Args:**
+- `token`: The opaque token string to validate
+
+**Returns:**
+- AccessToken object if valid and active, None if invalid, inactive, or expired
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-jwt.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-jwt.mdx
@@ -1,0 +1,147 @@
+---
+title: jwt
+sidebarTitle: jwt
+---
+
+# `fastmcp.server.auth.providers.jwt`
+
+
+TokenVerifier implementations for FastMCP.
+
+## Classes
+
+### `JWKData` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L74" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+JSON Web Key data structure.
+
+
+### `JWKSData` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L89" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+JSON Web Key Set data structure.
+
+
+### `RSAKeyPair` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+RSA key pair for JWT testing.
+
+
+**Methods:**
+
+#### `generate` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L103" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate(cls) -> RSAKeyPair
+```
+
+Generate an RSA key pair for testing.
+
+**Returns:**
+- Generated key pair
+
+
+#### `create_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L138" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_token(self, subject: str = 'fastmcp-user', issuer: str = 'https://fastmcp.example.com', audience: str | list[str] | None = None, scopes: list[str] | None = None, expires_in_seconds: int = 3600, additional_claims: dict[str, Any] | None = None, kid: str | None = None) -> str
+```
+
+Generate a test JWT token for testing purposes.
+
+**Args:**
+- `subject`: Subject claim (usually user ID)
+- `issuer`: Issuer claim
+- `audience`: Audience claim - can be a string or list of strings (optional)
+- `scopes`: List of scopes to include
+- `expires_in_seconds`: Token expiration time in seconds
+- `additional_claims`: Any additional claims to include
+- `kid`: Key ID to include in header
+
+
+### `JWTVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L205" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+JWT token verifier supporting asymmetric (RSA/ECDSA/EdDSA) and symmetric (HMAC) algorithms.
+
+This verifier validates JWT tokens using various signing algorithms:
+- **Asymmetric algorithms** (RS256/384/512, ES256/384/512, PS256/384/512,
+  Ed25519, Ed448, and legacy EdDSA):
+  Uses public/private key pairs. Ideal for external clients and services where
+  only the authorization server has the private key.
+- **Symmetric algorithms** (HS256/384/512): Uses a shared secret for both
+  signing and verification. Perfect for internal microservices and trusted
+  environments where the secret can be securely shared.
+
+Use this when:
+- You have JWT tokens issued by an external service (asymmetric)
+- You need JWKS support for automatic key rotation (asymmetric)
+- You have internal microservices sharing a secret key (symmetric)
+- Your tokens contain standard OAuth scopes and claims
+
+
+**Methods:**
+
+#### `load_access_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L485" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+load_access_token(self, token: str) -> AccessToken | None
+```
+
+Validate a JWT bearer token and return an AccessToken when the token is valid.
+
+**Args:**
+- `token`: The JWT bearer token string to validate.
+
+**Returns:**
+- AccessToken | None: An AccessToken populated from token claims if the token is valid; `None` if the token is expired, has an invalid signature or format, fails issuer/audience/scope validation, or any other validation error occurs.
+
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L628" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify a bearer token and return access info if valid.
+
+This method implements the TokenVerifier protocol by delegating
+to our existing load_access_token method.
+
+**Args:**
+- `token`: The JWT token string to validate
+
+**Returns:**
+- AccessToken object if valid, None if invalid or expired
+
+
+### `StaticTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L644" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Simple static token verifier for testing and development.
+
+This verifier validates tokens against a predefined dictionary of valid token
+strings and their associated claims. When a token string matches a key in the
+dictionary, the verifier returns the corresponding claims as if the token was
+validated by a real authorization server.
+
+Use this when:
+- You're developing or testing locally without a real OAuth server
+- You need predictable tokens for automated testing
+- You want to simulate different users/scopes without complex setup
+- You're prototyping and need simple API key-style authentication
+
+WARNING: Never use this in production - tokens are stored in plain text!
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/jwt.py#L678" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify token against static token dictionary.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-keycloak.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-keycloak.mdx
@@ -1,0 +1,20 @@
+---
+title: keycloak
+sidebarTitle: keycloak
+---
+
+# `fastmcp.server.auth.providers.keycloak`
+
+
+Keycloak authentication provider for FastMCP.
+
+## Classes
+
+### `KeycloakAuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/keycloak.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Keycloak authentication provider using Dynamic Client Registration (DCR).
+
+Requires Keycloak 26.6.0 or later, which includes the fix for DCR compatibility
+with MCP clients (https://github.com/keycloak/keycloak/pull/45309).
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-oci.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-oci.mdx
@@ -1,0 +1,97 @@
+---
+title: oci
+sidebarTitle: oci
+---
+
+# `fastmcp.server.auth.providers.oci`
+
+
+OCI OIDC provider for FastMCP.
+
+The pull request for the provider is submitted to fastmcp.
+
+This module provides OIDC Implementation to integrate MCP servers with OCI.
+You only need OCI Identity Domain's discovery URL, client ID, client secret, and base URL.
+
+Post Authentication, you get OCI IAM domain access token. That is not authorized to invoke OCI control plane.
+You need to exchange the IAM domain access token for OCI UPST token to invoke OCI control plane APIs.
+The sample code below has get_oci_signer function that returns OCI TokenExchangeSigner object.
+You can use the signer object to create OCI service object.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.oci import OCIProvider
+    from fastmcp.server.dependencies import get_access_token
+    from fastmcp.utilities.logging import get_logger
+
+    import os
+
+    import oci
+    from oci.auth.signers import TokenExchangeSigner
+
+    logger = get_logger(__name__)
+
+    # Load configuration from environment
+    config_url = os.environ.get("OCI_CONFIG_URL")  # OCI IAM Domain OIDC discovery URL
+    client_id = os.environ.get("OCI_CLIENT_ID")  # Client ID configured for the OCI IAM Domain Integrated Application
+    client_secret = os.environ.get("OCI_CLIENT_SECRET")  # Client secret configured for the OCI IAM Domain Integrated Application
+    iam_guid = os.environ.get("OCI_IAM_GUID")  # IAM GUID configured for the OCI IAM Domain
+
+    # Simple OCI OIDC protection
+    auth = OCIProvider(
+        config_url=config_url,  # config URL is the OCI IAM Domain OIDC discovery URL
+        client_id=client_id,  # This is same as the client ID configured for the OCI IAM Domain Integrated Application
+        client_secret=client_secret,  # This is same as the client secret configured for the OCI IAM Domain Integrated Application
+        required_scopes=["openid", "profile", "email"],
+        redirect_path="/auth/callback",
+        base_url="http://localhost:8000",
+    )
+
+    # NOTE: For production use, replace this with a thread-safe cache implementation
+    # such as threading.Lock-protected dict or a proper caching library
+    _global_token_cache = {}  # In memory cache for OCI session token signer
+
+    def get_oci_signer() -> TokenExchangeSigner:
+
+        authntoken = get_access_token()
+        tokenID = authntoken.claims.get("jti")
+        token = authntoken.token
+
+        # Check if the signer exists for the token ID in memory cache
+        cached_signer = _global_token_cache.get(tokenID)
+        logger.debug(f"Global cached signer: {cached_signer}")
+        if cached_signer:
+            logger.debug(f"Using globally cached signer for token ID: {tokenID}")
+            return cached_signer
+
+        # If the signer is not yet created for the token then create new OCI signer object
+        logger.debug(f"Creating new signer for token ID: {tokenID}")
+        signer = TokenExchangeSigner(
+            jwt_or_func=token,
+            oci_domain_id=iam_guid.split(".")[0] if iam_guid else None,  # This is same as IAM GUID configured for the OCI IAM Domain
+            client_id=client_id,  # This is same as the client ID configured for the OCI IAM Domain Integrated Application
+            client_secret=client_secret,  # This is same as the client secret configured for the OCI IAM Domain Integrated Application
+        )
+        logger.debug(f"Signer {signer} created for token ID: {tokenID}")
+
+        #Cache the signer object in memory cache
+        _global_token_cache[tokenID] = signer
+        logger.debug(f"Signer cached for token ID: {tokenID}")
+
+        return signer
+
+    mcp = FastMCP("My Protected Server", auth=auth)
+    ```
+
+
+## Classes
+
+### `OCIProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/oci.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+An OCI IAM Domain provider implementation for FastMCP.
+
+This provider is a complete OCI integration that's ready to use with
+just the configuration URL, client ID, client secret, and base URL.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-propelauth.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-propelauth.mdx
@@ -1,0 +1,69 @@
+---
+title: propelauth
+sidebarTitle: propelauth
+---
+
+# `fastmcp.server.auth.providers.propelauth`
+
+
+PropelAuth authentication provider for FastMCP.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth.providers.propelauth import PropelAuthProvider
+
+    auth = PropelAuthProvider(
+        auth_url="https://auth.yourdomain.com",
+        introspection_client_id="your-client-id",
+        introspection_client_secret="your-client-secret",
+        base_url="https://your-fastmcp-server.com",
+        required_scopes=["read:user_data"],
+    )
+
+    mcp = FastMCP("My App", auth=auth)
+    ```
+
+
+## Classes
+
+### `PropelAuthTokenIntrospectionOverrides` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/propelauth.py#L36" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `PropelAuthProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/propelauth.py#L43" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+PropelAuth resource server provider using OAuth 2.1 token introspection.
+
+This provider validates access tokens via PropelAuth's introspection endpoint
+and forwards authorization server metadata for OAuth discovery.
+
+For detailed setup instructions, see:
+https://docs.propelauth.com/mcp-authentication/overview
+
+
+**Methods:**
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/propelauth.py#L141" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get routes for this provider.
+
+Includes the standard routes from the RemoteAuthProvider (protected resource metadata routes (RFC 9728)),
+and creates an authorization server metadata route that forwards to PropelAuth's route
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+This is used to advertise the resource URL in metadata.
+
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/propelauth.py#L185" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify token and check the ``aud`` claim against the configured resource.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-scalekit.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-scalekit.mdx
@@ -1,0 +1,61 @@
+---
+title: scalekit
+sidebarTitle: scalekit
+---
+
+# `fastmcp.server.auth.providers.scalekit`
+
+
+Scalekit authentication provider for FastMCP.
+
+This module provides ScalekitProvider - a complete authentication solution that integrates
+with Scalekit's OAuth 2.1 and OpenID Connect services, supporting Resource Server
+authentication for seamless MCP client authentication.
+
+
+## Classes
+
+### `ScalekitProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/scalekit.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Scalekit resource server provider for OAuth 2.1 authentication.
+
+This provider implements Scalekit integration using resource server pattern.
+FastMCP acts as a protected resource server that validates access tokens issued
+by Scalekit's authorization server.
+
+IMPORTANT SETUP REQUIREMENTS:
+
+1. Create an MCP Server in Scalekit Dashboard:
+   - Go to your [Scalekit Dashboard](https://app.scalekit.com/)
+   - Navigate to MCP Servers section
+   - Register a new MCP Server with appropriate scopes
+   - Ensure the Resource Identifier matches exactly what you configure as MCP URL
+   - Note the Resource ID
+
+2. Environment Configuration:
+   - Set SCALEKIT_ENVIRONMENT_URL (e.g., https://your-env.scalekit.com)
+   - Set SCALEKIT_RESOURCE_ID from your created resource
+   - Set BASE_URL to your FastMCP server's public URL
+
+For detailed setup instructions, see:
+https://docs.scalekit.com/mcp/overview/
+
+
+**Methods:**
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/scalekit.py#L163" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get OAuth routes including Scalekit authorization server metadata forwarding.
+
+This returns the standard protected resource routes plus an authorization server
+metadata endpoint that forwards Scalekit's OAuth metadata to clients.
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+This is used to advertise the resource URL in metadata.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-supabase.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-supabase.mdx
@@ -1,0 +1,67 @@
+---
+title: supabase
+sidebarTitle: supabase
+---
+
+# `fastmcp.server.auth.providers.supabase`
+
+
+Supabase authentication provider for FastMCP.
+
+This module provides SupabaseProvider - a complete authentication solution that integrates
+with Supabase Auth's JWT verification, supporting Dynamic Client Registration (DCR)
+for seamless MCP client authentication.
+
+
+## Classes
+
+### `SupabaseProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/supabase.py#L25" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Supabase metadata provider for DCR (Dynamic Client Registration).
+
+This provider implements Supabase Auth integration using metadata forwarding.
+This approach allows Supabase to handle the OAuth flow directly while FastMCP acts
+as a resource server, verifying JWTs issued by Supabase Auth.
+
+IMPORTANT SETUP REQUIREMENTS:
+
+1. Supabase Project Setup:
+   - Create a Supabase project at https://supabase.com
+   - Note your project URL (e.g., "https://abc123.supabase.co")
+   - Configure your JWT algorithm in Supabase Auth settings (RS256 or ES256)
+   - Asymmetric keys (RS256/ES256) are recommended for production
+
+2. JWT Verification:
+   - FastMCP verifies JWTs using the JWKS endpoint at {project_url}{auth_route}/.well-known/jwks.json
+   - JWTs are issued by {project_url}{auth_route}
+   - Default auth_route is "/auth/v1" (can be customized for self-hosted setups)
+   - Tokens are cached for up to 10 minutes by Supabase's edge servers
+   - Algorithm must match your Supabase Auth configuration
+
+3. Authorization:
+   - Supabase uses Row Level Security (RLS) policies for database authorization
+   - OAuth-level scopes are an upcoming feature in Supabase Auth
+   - Both approaches will be supported once scope handling is available
+
+For detailed setup instructions, see:
+https://supabase.com/docs/guides/auth/jwts
+
+
+**Methods:**
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/supabase.py#L137" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get OAuth routes including Supabase authorization server metadata forwarding.
+
+This returns the standard protected resource routes plus an authorization server
+metadata endpoint that forwards Supabase's OAuth metadata to clients.
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+This is used to advertise the resource URL in metadata.
+

--- a/docs/python-sdk/fastmcp-server-auth-providers-workos.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-providers-workos.mdx
@@ -1,0 +1,123 @@
+---
+title: workos
+sidebarTitle: workos
+---
+
+# `fastmcp.server.auth.providers.workos`
+
+
+WorkOS authentication providers for FastMCP.
+
+This module provides two WorkOS authentication strategies:
+
+1. WorkOSProvider - OAuth proxy for WorkOS Connect applications (non-DCR)
+2. AuthKitProvider - DCR-compliant provider for WorkOS AuthKit
+
+Choose based on your WorkOS setup and authentication requirements.
+
+
+## Classes
+
+### `WorkOSTokenVerifier` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/workos.py#L31" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token verifier for WorkOS OAuth tokens.
+
+WorkOS AuthKit tokens are opaque, so we verify them by calling
+the /oauth2/userinfo endpoint to check validity and get user info.
+
+
+**Methods:**
+
+#### `verify_token` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/workos.py#L61" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+verify_token(self, token: str) -> AccessToken | None
+```
+
+Verify WorkOS OAuth token by calling userinfo endpoint.
+
+
+### `WorkOSProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/workos.py#L127" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Complete WorkOS OAuth provider for FastMCP.
+
+This provider implements WorkOS AuthKit OAuth using the OAuth Proxy pattern.
+It provides OAuth2 authentication for users through WorkOS Connect applications.
+
+Features:
+- Transparent OAuth proxy to WorkOS AuthKit
+- Automatic token validation via userinfo endpoint
+- User information extraction from ID tokens
+- Support for standard OAuth scopes (openid, profile, email)
+
+Setup Requirements:
+1. Create a WorkOS Connect application in your dashboard
+2. Note your AuthKit domain (e.g., "https://your-app.authkit.app")
+3. Configure redirect URI as: http://localhost:8000/auth/callback
+4. Note your Client ID and Client Secret
+
+
+### `AuthKitProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/workos.py#L293" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+AuthKit metadata provider for DCR (Dynamic Client Registration).
+
+This provider implements AuthKit integration using metadata forwarding
+instead of OAuth proxying. This is the recommended approach for WorkOS DCR
+as it allows WorkOS to handle the OAuth flow directly while FastMCP acts
+as a resource server.
+
+IMPORTANT SETUP REQUIREMENTS:
+
+1. Enable Dynamic Client Registration in WorkOS Dashboard:
+   - Go to Applications → Configuration
+   - Toggle "Dynamic Client Registration" to enabled
+
+2. Configure your FastMCP server URL as a callback:
+   - Add your server URL to the Redirects tab in WorkOS dashboard
+   - Example: https://your-fastmcp-server.com/oauth2/callback
+
+For detailed setup instructions, see:
+https://workos.com/docs/authkit/mcp/integrating/token-verification
+
+Token audience is bound to this server automatically: when the MCP
+mount path becomes known (typically at ``http_app()`` construction),
+``JWTVerifier.audience`` is set to the resource URL advertised in
+``.well-known/oauth-protected-resource``. Enable Resource Indicators
+(RFC 8707) in your WorkOS Dashboard and list that same URL — AuthKit
+will then mint tokens with the matching ``aud`` claim.
+
+
+**Methods:**
+
+#### `set_mcp_path` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/workos.py#L396" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+set_mcp_path(self, mcp_path: str | None) -> None
+```
+
+Bind the default verifier's audience to this server's resource URL.
+
+AuthKit with Resource Indicators (RFC 8707) mints tokens whose ``aud``
+claim equals the resource URL the client requested — which is the URL
+we advertise in ``.well-known/oauth-protected-resource``. Binding the
+audience here keeps validation in lock-step with what clients are sent.
+
+
+#### `get_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/providers/workos.py#L418" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_routes(self, mcp_path: str | None = None) -> list[Route]
+```
+
+Get OAuth routes including AuthKit authorization server metadata forwarding.
+
+This returns the standard protected resource routes plus an authorization server
+metadata endpoint that forwards AuthKit's OAuth metadata to clients.
+
+**Args:**
+- `mcp_path`: The path where the MCP endpoint is mounted (e.g., "/mcp")
+This is used to advertise the resource URL in metadata.
+

--- a/docs/python-sdk/fastmcp-server-auth-redirect_validation.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-redirect_validation.mdx
@@ -1,0 +1,221 @@
+---
+title: redirect_validation
+sidebarTitle: redirect_validation
+---
+
+# `fastmcp.server.auth.redirect_validation`
+
+
+Utilities for validating client redirect URIs in OAuth flows.
+
+This module provides secure redirect URI validation with wildcard support,
+protecting against userinfo-based bypass attacks like http://localhost@evil.com.
+
+
+## Functions
+
+### `add_query_params` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/redirect_validation.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+add_query_params(url: str, params: dict[str, str]) -> str
+```
+
+
+Append query parameters to a URL while preserving existing parameters.
+
+The existing query string is appended to verbatim rather than decoded
+and re-serialized, since registered redirect URIs may carry opaque or
+signed query strings whose exact bytes matter to the receiving client
+(for example, a valueless `?flag` must not become `?flag=`, and
+non-UTF-8 percent-encoded sequences must not be replaced).
+
+
+### `replace_query_param` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/redirect_validation.py#L38" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+replace_query_param(url: str, key: str, value: str) -> str
+```
+
+
+Replace the first occurrence of `key` in a URL's query string in place.
+
+Like `add_query_params`, this does not round-trip the query through
+`parse_qsl`/`urlencode`: every segment other than the matched one is
+passed through byte-for-byte, so opaque or non-UTF-8 percent-encoded
+values elsewhere in the query are left untouched. Only the matched
+segment's encoding is replaced (with `key=value`, freshly
+`urlencode`d). If `key` is not present, it is appended, matching
+`add_query_params`'s behavior.
+
+
+### `build_client_redirect` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/redirect_validation.py#L68" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+build_client_redirect(url: str, params: dict[str, str]) -> str
+```
+
+
+Build a client-facing authorization redirect that carries exactly one `iss`.
+
+Every redirect this server sends back to an OAuth client from the
+authorization endpoint -- success (carrying `code`) or error (carrying
+`error`) -- must carry the proxy's RFC 9207 issuer exactly once (RFC
+6749 §3.1 forbids a response parameter from appearing more than once).
+A registered redirect_uri can legitimately carry its own `iss` query
+parameter already (e.g. `https://client.example/callback?iss=tenant`),
+so blindly appending the server's issuer on top of that would duplicate
+it -- this is what every client-facing redirect site must get right,
+and the reason this helper exists instead of five call sites each
+reimplementing the same invariant by hand.
+
+`params` is appended to `url` via `add_query_params` (verbatim, without
+re-encoding the existing query -- see that function's docstring), and
+`iss` is then set idempotently via `replace_query_param`: an existing
+occurrence -- whether contributed by the registered redirect_uri or
+already present in `url` -- is overwritten with the canonical value;
+otherwise `iss` is appended.
+
+`iss` is keyword-only and required so a caller cannot forget to pass
+it. `params` must not itself contain an `"iss"` key -- pass it via the
+`iss` keyword instead, so there is exactly one place the value can come
+from.
+
+**Args:**
+- `url`: The redirect target -- normally the client's registered
+redirect_uri.
+- `params`: The response parameters to append (e.g. `code`/`state`, or
+`error`/`error_description`). Must not include `"iss"`.
+- `iss`: The canonical RFC 9207 issuer, byte-for-byte equal to the
+discovery document's `issuer` (`str(self.base_url)` /
+`self._issuer` -- never the rstripped `self._base_url`).
+
+**Returns:**
+- `url` with `params` appended and exactly one `iss` query parameter
+- set to `iss`.
+
+
+### `is_loopback_host` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/redirect_validation.py#L174" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_loopback_host(host: str | None) -> bool
+```
+
+
+Check if a host is a loopback address.
+
+Per RFC 8252 §7.3, loopback covers the whole reserved loopback range, not
+just the two familiar literals: IPv4 `127.0.0.0/8` (so `127.0.0.2` and
+`127.5.5.5` are loopback just as much as `127.0.0.1`) and IPv6 `::1`. IP
+hosts are therefore classified with `ipaddress.ip_address().is_loopback`
+rather than string equality — checking only `127.0.0.1` would let a web
+client register `https://127.0.0.2/callback` and slip past the
+non-loopback requirement.
+
+Names are handled per RFC 6761 §6.3, which reserves the entire `localhost`
+namespace for the local machine: the exact name `localhost` *and* any
+subdomain of it (`app.localhost`, `api.app.localhost`). `.localhost` is a
+reserved TLD that cannot be registered, so a subdomain of it always resolves
+to the loopback interface and must count as loopback in both directions —
+otherwise a web client could register `https://app.localhost/callback` and
+slip past the non-loopback requirement, while a native client using
+`http://app.localhost:3000/callback` would be wrongly rejected.
+
+The suffix test is anchored on a leading dot so it cannot be spoofed by a
+registrable domain: `localhost.evil.com` and `notlocalhost` are ordinary
+public names and are *not* loopback.
+
+Hosts are also normalized before classification: bracketed IPv6 literals
+(`[::1]`) are unwrapped, and a single trailing dot (the absolute/FQDN form,
+e.g. `localhost.` or `127.0.0.1.`) is stripped, since it denotes the same
+host. Non-IP hosts fall through to the name check without raising.
+
+
+### `matches_allowed_pattern` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/redirect_validation.py#L302" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+matches_allowed_pattern(uri: str, pattern: str) -> bool
+```
+
+
+Securely check if a URI matches an allowed pattern with wildcard support.
+
+This function parses both the URI and pattern as URLs, comparing each
+component separately to prevent bypass attacks like userinfo injection.
+
+Patterns support wildcards:
+- http://localhost:* matches any localhost port
+- http://127.0.0.1:* matches any 127.0.0.1 port
+- https://*.example.com/* matches any subdomain of example.com
+- https://app.example.com/auth/* matches any path under /auth/
+
+Security: Rejects URIs with userinfo (user:pass@host) which could bypass
+naive string matching (e.g., http://localhost@evil.com).
+
+**Args:**
+- `uri`: The redirect URI to validate
+- `pattern`: The allowed pattern (may contain wildcards)
+
+**Returns:**
+- True if the URI matches the pattern
+
+
+### `is_redirect_uri_allowed_for_application_type` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/redirect_validation.py#L369" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_redirect_uri_allowed_for_application_type(redirect_uri: str | AnyUrl, application_type: str | None) -> bool
+```
+
+
+Check a redirect URI against RFC 7591 / SEP-837 `application_type` rules.
+
+`application_type` governs which redirect URIs a Dynamically Registered
+Client may use (RFC 7591 §2, OpenID Connect Dynamic Client Registration §2):
+
+- `"web"` clients must use `https` redirect URIs on a non-loopback host.
+  Loopback `http`, `https://localhost`, and app/custom schemes are rejected.
+  This is the restriction SEP-837 actually asks for.
+- `"native"` clients keep every scheme FastMCP already allowed, except that
+  `http` is restricted to loopback hosts (RFC 8252 §7.3, any port). App and
+  private-use schemes pass through untouched: `vscode://`,
+  `com.example.app:/callback`, `myapp://callback`, `urn:ietf:wg:oauth:2.0:oob`.
+
+Deliberately absent: any attempt to classify a native client's scheme as
+"private-use" versus "a network transport". There is no sound test. The IANA
+registry cannot separate them — `vscode` is registered *because* it is an
+app-dispatch scheme, alongside transports like `coap` and `smb` — and
+reverse-domain notation fails too, since `iris.beep` and
+`microsoft.windows.camera` are registered while `myapp` is not. Every
+formulation either rejects schemes real MCP clients depend on or admits the
+ones it meant to exclude, so native scheme filtering is left to the
+unsafe-scheme check below.
+
+Unsafe browser schemes (`javascript:`, `data:`, `file:`, `vbscript:`) are
+always rejected regardless of `application_type`. That check predates this
+function and is unchanged by it.
+
+The MCP SDK defaults `application_type` to `"native"` because MCP clients
+typically register loopback redirect URIs, so omitting the field preserves
+the behavior clients relied on before this check existed. `None` — which a
+registered-client record carries when the field was never set — is treated
+the same way.
+
+
+### `validate_redirect_uri` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/redirect_validation.py#L427" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_redirect_uri(redirect_uri: str | AnyUrl | None, allowed_patterns: list[str] | None) -> bool
+```
+
+
+Validate a redirect URI against allowed patterns.
+
+**Args:**
+- `redirect_uri`: The redirect URI to validate
+- `allowed_patterns`: List of allowed patterns. If None, ordinary URIs are allowed
+             for DCR compatibility, while unsafe browser schemes are rejected.
+             If empty list, no URIs are allowed.
+             To restrict to localhost only, explicitly pass DEFAULT_LOCALHOST_PATTERNS.
+
+**Returns:**
+- True if the redirect URI is allowed
+

--- a/docs/python-sdk/fastmcp-server-auth-ssrf.mdx
+++ b/docs/python-sdk/fastmcp-server-auth-ssrf.mdx
@@ -1,0 +1,183 @@
+---
+title: ssrf
+sidebarTitle: ssrf
+---
+
+# `fastmcp.server.auth.ssrf`
+
+
+SSRF-safe HTTP utilities for FastMCP.
+
+This module provides SSRF-protected HTTP fetching with:
+- DNS resolution and IP validation before requests
+- DNS pinning to prevent rebinding TOCTOU attacks
+- Support for both CIMD and JWKS fetches
+
+When ``FASTMCP_SSRF_TRUST_PROXY`` is set, DNS resolution and the IP blocklist are
+skipped and a single request is made to the hostname URL through the configured
+HTTPS_PROXY/ALL_PROXY, delegating DNS and egress to that trusted proxy (the scheme
+and hostname checks still apply). The proxy URL is read from the environment and
+passed to httpx2 explicitly with ``trust_env`` disabled, so the request is provably
+routed through the proxy rather than predicted to be — NO_PROXY is not evaluated in
+this mode. If no proxy is configured, the fetch is refused rather than sent direct
+with the blocklist disabled.
+
+
+## Functions
+
+### `format_ip_for_url` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L55" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+format_ip_for_url(ip_str: str) -> str
+```
+
+
+Format IP address for use in URL (bracket IPv6 addresses).
+
+IPv6 addresses must be bracketed in URLs to distinguish the address from
+the port separator. For example: https://[2001:db8::1]:443/path
+
+**Args:**
+- `ip_str`: IP address string
+
+**Returns:**
+- IP string suitable for URL (IPv6 addresses are bracketed)
+
+
+### `is_ip_allowed` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L137" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_ip_allowed(ip_str: str) -> bool
+```
+
+
+Check if an IP address is allowed (must be globally routable unicast).
+
+Uses ip.is_global which catches:
+- Private (10.x, 172.16-31.x, 192.168.x)
+- Loopback (127.x, ::1)
+- Link-local (169.254.x, fe80::) - includes AWS metadata!
+- Reserved, unspecified
+- RFC6598 Carrier-Grade NAT (100.64.0.0/10) - can point to internal networks
+- IPv6 transition forms that embed blocked IPv4 targets
+
+Additionally blocks multicast addresses (not caught by is_global).
+
+**Args:**
+- `ip_str`: IP address string to check
+
+**Returns:**
+- True if the IP is allowed (public unicast internet), False if blocked
+
+
+### `resolve_hostname` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L175" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+resolve_hostname(hostname: str, port: int = 443) -> list[str]
+```
+
+
+Resolve hostname to IP addresses using DNS.
+
+**Args:**
+- `hostname`: Hostname to resolve
+- `port`: Port number (used for getaddrinfo)
+
+**Returns:**
+- List of resolved IP addresses
+
+**Raises:**
+- `SSRFError`: If resolution fails
+
+
+### `validate_url` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L274" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+validate_url(url: str, require_path: bool = False) -> ValidatedURL
+```
+
+
+Validate URL for SSRF and resolve to IPs.
+
+**Args:**
+- `url`: URL to validate
+- `require_path`: If True, require non-root path (for CIMD)
+
+**Returns:**
+- ValidatedURL with resolved IPs
+
+**Raises:**
+- `SSRFError`: If the URL is invalid, resolves to blocked IPs, or proxy-trust
+mode is enabled but no configured proxy will route the request.
+
+
+### `ssrf_safe_fetch` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L370" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+ssrf_safe_fetch(url: str) -> bytes
+```
+
+
+Fetch URL with comprehensive SSRF protection and DNS pinning.
+
+Security measures:
+1. HTTPS only
+2. DNS resolution with IP validation
+3. Connects to validated IP directly (DNS pinning prevents rebinding)
+4. Response size limit
+5. Redirects disabled
+6. Overall timeout
+
+**Args:**
+- `url`: URL to fetch
+- `require_path`: If True, require non-root path
+- `max_size`: Maximum response size in bytes (default 5KB)
+- `timeout`: Per-operation timeout in seconds
+- `overall_timeout`: Overall timeout for entire operation
+
+**Returns:**
+- Response body as bytes
+
+**Raises:**
+- `SSRFError`: If SSRF validation fails
+- `SSRFFetchError`: If fetch fails
+
+
+### `ssrf_safe_fetch_response` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L413" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+ssrf_safe_fetch_response(url: str) -> SSRFFetchResponse
+```
+
+
+Fetch URL with SSRF protection and return response metadata.
+
+This is equivalent to :func:`ssrf_safe_fetch` but returns response headers
+and status code, and supports conditional request headers.
+
+
+## Classes
+
+### `SSRFError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Raised when an SSRF protection check fails.
+
+
+### `SSRFFetchError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Raised when SSRF-safe fetch fails.
+
+
+### `ValidatedURL` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L205" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A URL that has been validated for SSRF with resolved IPs.
+
+
+### `SSRFFetchResponse` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/auth/ssrf.py#L217" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Response payload from an SSRF-safe fetch.
+

--- a/docs/python-sdk/fastmcp-server-middleware-authorization.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-authorization.mdx
@@ -1,0 +1,116 @@
+---
+title: authorization
+sidebarTitle: authorization
+---
+
+# `fastmcp.server.middleware.authorization`
+
+
+Authorization middleware for FastMCP.
+
+This module provides middleware-based authorization using callable auth checks.
+AuthMiddleware applies auth checks globally to all components on the server.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.auth import require_scopes, restrict_tag
+    from fastmcp.server.middleware import AuthMiddleware
+
+    # Require specific scope for all components
+    mcp = FastMCP(middleware=[
+        AuthMiddleware(auth=require_scopes("api"))
+    ])
+
+    # Tag-based: components tagged "admin" require "admin" scope
+    mcp = FastMCP(middleware=[
+        AuthMiddleware(auth=restrict_tag("admin", scopes=["admin"]))
+    ])
+    ```
+
+
+## Classes
+
+### `AuthMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L82" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Global authorization middleware using callable checks.
+
+This middleware applies auth checks to all components (tools, resources,
+prompts) on the server. It uses the same callable API as component-level
+auth checks.
+
+The middleware:
+- Filters tools/resources/prompts from list responses based on auth checks
+- Checks auth before tool execution, resource read, and prompt render
+- Skips all auth checks for STDIO transport (no OAuth concept)
+
+**Args:**
+- `auth`: A single auth check function or list of check functions.
+All checks must pass for authorization to succeed (AND logic).
+
+
+**Methods:**
+
+#### `on_list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L170" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_tools(self, context: MiddlewareContext[mt.ListToolsRequest], call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]]) -> Sequence[Tool]
+```
+
+Filter tools/list response based on auth checks.
+
+
+#### `on_call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L198" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_call_tool(self, context: MiddlewareContext[mt.CallToolRequestParams], call_next: CallNext[mt.CallToolRequestParams, ToolResult]) -> ToolResult
+```
+
+Check auth before tool execution.
+
+
+#### `on_list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L256" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resources(self, context: MiddlewareContext[mt.ListResourcesRequest], call_next: CallNext[mt.ListResourcesRequest, Sequence[Resource]]) -> Sequence[Resource]
+```
+
+Filter resources/list response based on auth checks.
+
+
+#### `on_read_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L283" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_read_resource(self, context: MiddlewareContext[mt.ReadResourceRequestParams], call_next: CallNext[mt.ReadResourceRequestParams, ResourceResult]) -> ResourceResult
+```
+
+Check auth before resource read.
+
+
+#### `on_list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L344" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resource_templates(self, context: MiddlewareContext[mt.ListResourceTemplatesRequest], call_next: CallNext[mt.ListResourceTemplatesRequest, Sequence[ResourceTemplate]]) -> Sequence[ResourceTemplate]
+```
+
+Filter resource templates/list response based on auth checks.
+
+
+#### `on_list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L373" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_prompts(self, context: MiddlewareContext[mt.ListPromptsRequest], call_next: CallNext[mt.ListPromptsRequest, Sequence[Prompt]]) -> Sequence[Prompt]
+```
+
+Filter prompts/list response based on auth checks.
+
+
+#### `on_get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/authorization.py#L400" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_get_prompt(self, context: MiddlewareContext[mt.GetPromptRequestParams], call_next: CallNext[mt.GetPromptRequestParams, PromptResult]) -> PromptResult
+```
+
+Check auth before prompt render.
+

--- a/docs/python-sdk/fastmcp-server-middleware-caching.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-caching.mdx
@@ -1,0 +1,225 @@
+---
+title: caching
+sidebarTitle: caching
+---
+
+# `fastmcp.server.middleware.caching`
+
+
+A middleware for response caching.
+
+## Classes
+
+### `CacheableResourceContent` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L85" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A wrapper for ResourceContent that can be cached.
+
+
+### `CacheableResourceResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L93" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A wrapper for ResourceResult that can be cached.
+
+
+**Methods:**
+
+#### `get_size` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L99" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_size(self) -> int
+```
+
+#### `wrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L103" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap(cls, value: ResourceResult) -> Self
+```
+
+#### `unwrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L114" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+unwrap(self) -> ResourceResult
+```
+
+### `CacheableToolResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L126" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `wrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L133" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap(cls, value: ToolResult) -> Self
+```
+
+#### `unwrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L141" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+unwrap(self) -> ToolResult
+```
+
+### `CacheableMessage` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L150" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A wrapper for Message that can be cached.
+
+
+### `CacheablePromptResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L162" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A wrapper for PromptResult that can be cached.
+
+
+**Methods:**
+
+#### `get_size` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L169" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_size(self) -> int
+```
+
+#### `wrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L173" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap(cls, value: PromptResult) -> Self
+```
+
+#### `unwrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L182" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+unwrap(self) -> PromptResult
+```
+
+### `SharedMethodSettings` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L193" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Shared config for a cache method.
+
+
+### `ListToolsSettings` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L200" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration options for Tool-related caching.
+
+
+### `ListResourcesSettings` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L204" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration options for Resource-related caching.
+
+
+### `ListPromptsSettings` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L208" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration options for Prompt-related caching.
+
+
+### `CallToolSettings` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L212" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration options for Tool-related caching.
+
+
+### `ReadResourceSettings` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L219" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration options for Resource-related caching.
+
+
+### `GetPromptSettings` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L223" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration options for Prompt-related caching.
+
+
+### `ResponseCachingStatistics` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L227" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `ResponseCachingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L236" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The response caching middleware offers a simple way to cache responses to mcp methods. The Middleware
+supports cache invalidation via notifications from the server. The Middleware implements TTL-based caching
+but cache implementations may offer additional features like LRU eviction, size limits, and more.
+
+When items are retrieved from the cache they will no longer be the original objects, but rather no-op objects
+this means that response caching may not be compatible with other middleware that expects original subclasses.
+
+Notes:
+- Caches `tools/call`, `resources/read`, `prompts/get`, `tools/list`, `resources/list`, and `prompts/list` requests.
+- Cache keys are derived from the method name, arguments, and the caller's
+  access token. Entries are partitioned per-token so that responses filtered
+  by per-component authorization (e.g. `auth=require_scopes(...)`) cannot
+  leak across users with different permissions. Unauthenticated callers
+  (including STDIO) share a single anonymous partition.
+
+
+**Methods:**
+
+#### `on_list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L346" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_tools(self, context: MiddlewareContext[mcp_types.ListToolsRequest], call_next: CallNext[mcp_types.ListToolsRequest, Sequence[Tool]]) -> Sequence[Tool]
+```
+
+List tools from the cache, if caching is enabled, and the result is in the cache. Otherwise,
+otherwise call the next middleware and store the result in the cache if caching is enabled.
+
+
+#### `on_list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L379" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resources(self, context: MiddlewareContext[mcp_types.ListResourcesRequest], call_next: CallNext[mcp_types.ListResourcesRequest, Sequence[Resource]]) -> Sequence[Resource]
+```
+
+List resources from the cache, if caching is enabled, and the result is in the cache. Otherwise,
+otherwise call the next middleware and store the result in the cache if caching is enabled.
+
+
+#### `on_list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L412" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_prompts(self, context: MiddlewareContext[mcp_types.ListPromptsRequest], call_next: CallNext[mcp_types.ListPromptsRequest, Sequence[Prompt]]) -> Sequence[Prompt]
+```
+
+List prompts from the cache, if caching is enabled, and the result is in the cache. Otherwise,
+otherwise call the next middleware and store the result in the cache if caching is enabled.
+
+
+#### `on_call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L443" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_call_tool(self, context: MiddlewareContext[mcp_types.CallToolRequestParams], call_next: CallNext[mcp_types.CallToolRequestParams, ToolResult]) -> ToolResult
+```
+
+Call a tool from the cache, if caching is enabled, and the result is in the cache. Otherwise,
+otherwise call the next middleware and store the result in the cache if caching is enabled.
+
+
+#### `on_read_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L507" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_read_resource(self, context: MiddlewareContext[mcp_types.ReadResourceRequestParams], call_next: CallNext[mcp_types.ReadResourceRequestParams, ResourceResult]) -> ResourceResult
+```
+
+Read a resource from the cache, if caching is enabled, and the result is in the cache. Otherwise,
+otherwise call the next middleware and store the result in the cache if caching is enabled.
+
+
+#### `on_get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L548" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_get_prompt(self, context: MiddlewareContext[mcp_types.GetPromptRequestParams], call_next: CallNext[mcp_types.GetPromptRequestParams, PromptResult]) -> PromptResult
+```
+
+Get a prompt from the cache, if caching is enabled, and the result is in the cache. Otherwise,
+otherwise call the next middleware and store the result in the cache if caching is enabled.
+
+
+#### `statistics` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/caching.py#L600" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+statistics(self) -> ResponseCachingStatistics
+```
+
+Get the statistics for the cache.
+

--- a/docs/python-sdk/fastmcp-server-middleware-dereference.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-dereference.mdx
@@ -1,0 +1,35 @@
+---
+title: dereference
+sidebarTitle: dereference
+---
+
+# `fastmcp.server.middleware.dereference`
+
+
+Middleware that dereferences $ref in JSON schemas before sending to clients.
+
+## Classes
+
+### `DereferenceRefsMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/dereference.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Dereferences $ref in component schemas before sending to clients.
+
+Some MCP clients (e.g., VS Code Copilot) don't handle JSON Schema $ref
+properly. This middleware inlines all $ref definitions so schemas are
+self-contained. Enabled by default via ``FastMCP(dereference_schemas=True)``.
+
+
+**Methods:**
+
+#### `on_list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/dereference.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_tools(self, context: MiddlewareContext[mt.ListToolsRequest], call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]]) -> Sequence[Tool]
+```
+
+#### `on_list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/dereference.py#L33" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resource_templates(self, context: MiddlewareContext[mt.ListResourceTemplatesRequest], call_next: CallNext[mt.ListResourceTemplatesRequest, Sequence[ResourceTemplate]]) -> Sequence[ResourceTemplate]
+```

--- a/docs/python-sdk/fastmcp-server-middleware-error_handling.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-error_handling.mdx
@@ -1,0 +1,60 @@
+---
+title: error_handling
+sidebarTitle: error_handling
+---
+
+# `fastmcp.server.middleware.error_handling`
+
+
+Error handling middleware for consistent error responses and tracking.
+
+## Classes
+
+### `ErrorHandlingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/error_handling.py#L17" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that provides consistent error handling and logging.
+
+Catches exceptions, logs them appropriately, and converts them to
+proper MCP error responses. Also tracks error patterns for monitoring.
+
+
+**Methods:**
+
+#### `on_message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/error_handling.py#L109" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_message(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Handle errors for all messages.
+
+
+#### `get_error_stats` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/error_handling.py#L120" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_error_stats(self) -> dict[str, int]
+```
+
+Get error statistics for monitoring.
+
+
+### `RetryMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/error_handling.py#L125" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that implements automatic retry logic for failed requests.
+
+Retries requests that fail with transient errors, using exponential
+backoff to avoid overwhelming the server or external dependencies.
+
+
+**Methods:**
+
+#### `on_request` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/error_handling.py#L191" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_request(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Implement retry logic for requests.
+

--- a/docs/python-sdk/fastmcp-server-middleware-logging.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-logging.mdx
@@ -1,0 +1,58 @@
+---
+title: logging
+sidebarTitle: logging
+---
+
+# `fastmcp.server.middleware.logging`
+
+
+Comprehensive logging middleware for FastMCP servers.
+
+## Functions
+
+### `default_serializer` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/logging.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_serializer(data: Any) -> str
+```
+
+
+The default serializer for Payloads in the logging middleware.
+
+
+## Classes
+
+### `BaseLoggingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/logging.py#L20" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Base class for logging middleware.
+
+
+**Methods:**
+
+#### `on_message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/logging.py#L124" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_message(self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]) -> Any
+```
+
+Log messages for configured methods.
+
+
+### `LoggingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/logging.py#L148" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that provides comprehensive request and response logging.
+
+Logs all MCP messages with configurable detail levels. Useful for debugging,
+monitoring, and understanding server usage patterns.
+
+
+### `StructuredLoggingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/logging.py#L203" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that provides structured JSON logging for better log analysis.
+
+Outputs structured logs that are easier to parse and analyze with log
+aggregation tools like ELK stack, Splunk, or cloud logging services.
+

--- a/docs/python-sdk/fastmcp-server-middleware-middleware.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-middleware.mdx
@@ -1,0 +1,134 @@
+---
+title: middleware
+sidebarTitle: middleware
+---
+
+# `fastmcp.server.middleware.middleware`
+
+## Functions
+
+### `mark_interior_dispatched` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L67" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+mark_interior_dispatched() -> None
+```
+
+
+Record that an interior component middleware chain ran for this message.
+
+
+### `make_middleware_wrapper` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L113" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+make_middleware_wrapper(middleware: Middleware, call_next: CallNext[T, R]) -> CallNext[T, R]
+```
+
+
+Create a wrapper that applies a single middleware to a context. The
+closure bakes in the middleware and call_next function, so it can be
+passed to other functions that expect a call_next function.
+
+
+### `make_handler_wrapper` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L126" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+make_handler_wrapper(handler: Callable[..., Awaitable[Any]], call_next: CallNext[Any, Any]) -> CallNext[Any, Any]
+```
+
+## Classes
+
+### `CallNext` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L89" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `MiddlewareContext` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L94" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Unified context for all middleware operations.
+
+
+**Methods:**
+
+#### `copy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L109" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+copy(self, **kwargs: Any) -> MiddlewareContext[T]
+```
+
+### `Middleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L136" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Base class for FastMCP middleware with dispatching hooks.
+
+
+**Methods:**
+
+#### `on_message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L204" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_message(self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]) -> Any
+```
+
+#### `on_request` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L211" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_request(self, context: MiddlewareContext[mt.Request[Any, Any]], call_next: CallNext[mt.Request[Any, Any], Any]) -> Any
+```
+
+#### `on_notification` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L218" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_notification(self, context: MiddlewareContext[mt.Notification[Any, Any]], call_next: CallNext[mt.Notification[Any, Any], Any]) -> Any
+```
+
+#### `on_initialize` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L225" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_initialize(self, context: MiddlewareContext[mt.InitializeRequest], call_next: CallNext[mt.InitializeRequest, mt.InitializeResult | None]) -> mt.InitializeResult | None
+```
+
+#### `on_discover` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L232" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_discover(self, context: MiddlewareContext[mt.DiscoverRequest], call_next: CallNext[mt.DiscoverRequest, mt.DiscoverResult | dict[str, Any]]) -> mt.DiscoverResult | dict[str, Any]
+```
+
+#### `on_call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L239" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_call_tool(self, context: MiddlewareContext[mt.CallToolRequestParams], call_next: CallNext[mt.CallToolRequestParams, ToolResult]) -> ToolResult
+```
+
+#### `on_read_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L246" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_read_resource(self, context: MiddlewareContext[mt.ReadResourceRequestParams], call_next: CallNext[mt.ReadResourceRequestParams, ResourceResult]) -> ResourceResult
+```
+
+#### `on_get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L253" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_get_prompt(self, context: MiddlewareContext[mt.GetPromptRequestParams], call_next: CallNext[mt.GetPromptRequestParams, PromptResult]) -> PromptResult
+```
+
+#### `on_list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L260" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_tools(self, context: MiddlewareContext[mt.ListToolsRequest], call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]]) -> Sequence[Tool]
+```
+
+#### `on_list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L267" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resources(self, context: MiddlewareContext[mt.ListResourcesRequest], call_next: CallNext[mt.ListResourcesRequest, Sequence[Resource]]) -> Sequence[Resource]
+```
+
+#### `on_list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L274" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resource_templates(self, context: MiddlewareContext[mt.ListResourceTemplatesRequest], call_next: CallNext[mt.ListResourceTemplatesRequest, Sequence[ResourceTemplate]]) -> Sequence[ResourceTemplate]
+```
+
+#### `on_list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/middleware.py#L283" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_prompts(self, context: MiddlewareContext[mt.ListPromptsRequest], call_next: CallNext[mt.ListPromptsRequest, Sequence[Prompt]]) -> Sequence[Prompt]
+```

--- a/docs/python-sdk/fastmcp-server-middleware-ping.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-ping.mdx
@@ -1,0 +1,32 @@
+---
+title: ping
+sidebarTitle: ping
+---
+
+# `fastmcp.server.middleware.ping`
+
+
+Ping middleware for keeping client connections alive.
+
+## Classes
+
+### `PingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/ping.py#L12" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that sends periodic pings to keep client connections alive.
+
+Starts a background ping task on first message from each session. The task
+sends server-to-client pings at the configured interval until the session
+ends.
+
+
+**Methods:**
+
+#### `on_message` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/ping.py#L44" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_message(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Start ping task on first message from a connection.
+

--- a/docs/python-sdk/fastmcp-server-middleware-rate_limiting.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-rate_limiting.mdx
@@ -1,0 +1,97 @@
+---
+title: rate_limiting
+sidebarTitle: rate_limiting
+---
+
+# `fastmcp.server.middleware.rate_limiting`
+
+
+Rate limiting middleware for protecting FastMCP servers from abuse.
+
+## Classes
+
+### `RateLimitError` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Error raised when rate limit is exceeded.
+
+
+### `TokenBucketRateLimiter` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L22" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Token bucket implementation for rate limiting.
+
+
+**Methods:**
+
+#### `consume` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L38" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+consume(self, tokens: int = 1) -> bool
+```
+
+Try to consume tokens from the bucket.
+
+**Args:**
+- `tokens`: Number of tokens to consume
+
+**Returns:**
+- True if tokens were available and consumed, False otherwise
+
+
+### `SlidingWindowRateLimiter` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L61" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Sliding window rate limiter implementation.
+
+
+**Methods:**
+
+#### `is_allowed` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L76" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_allowed(self) -> bool
+```
+
+Check if a request is allowed.
+
+
+### `RateLimitingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L92" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that implements rate limiting to prevent server abuse.
+
+Uses a token bucket algorithm by default, allowing for burst traffic
+while maintaining a sustainable long-term rate.
+
+
+**Methods:**
+
+#### `on_request` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L158" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_request(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Apply rate limiting to requests.
+
+
+### `SlidingWindowRateLimitingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L176" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that implements sliding window rate limiting.
+
+Uses a sliding window approach which provides more precise rate limiting
+but uses more memory to track individual request timestamps.
+
+
+**Methods:**
+
+#### `on_request` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/rate_limiting.py#L231" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_request(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Apply sliding window rate limiting to requests.
+

--- a/docs/python-sdk/fastmcp-server-middleware-response_limiting.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-response_limiting.mdx
@@ -1,0 +1,41 @@
+---
+title: response_limiting
+sidebarTitle: response_limiting
+---
+
+# `fastmcp.server.middleware.response_limiting`
+
+
+Response limiting middleware for controlling tool response sizes.
+
+## Classes
+
+### `ResponseLimitingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/response_limiting.py#L22" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that limits the response size of tool calls.
+
+Intercepts tool call responses and enforces size limits. If a response
+exceeds the limit, it extracts text content, truncates it, and returns
+a single TextContent block.
+
+
+**Methods:**
+
+#### `on_list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/response_limiting.py#L105" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_tools(self, context: MiddlewareContext[mt.ListToolsRequest], call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]]) -> Sequence[Tool]
+```
+
+Hide schemas for tools whose response shape may be truncated to text.
+
+
+#### `on_call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/response_limiting.py#L119" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_call_tool(self, context: MiddlewareContext[mt.CallToolRequestParams], call_next: CallNext[mt.CallToolRequestParams, ToolResult]) -> ToolResult
+```
+
+Intercept tool calls and limit response size.
+

--- a/docs/python-sdk/fastmcp-server-middleware-timing.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-timing.mdx
@@ -1,0 +1,105 @@
+---
+title: timing
+sidebarTitle: timing
+---
+
+# `fastmcp.server.middleware.timing`
+
+
+Timing middleware for measuring and logging request performance.
+
+## Classes
+
+### `TimingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L10" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Middleware that logs the execution time of requests.
+
+Only measures and logs timing for request messages (not notifications).
+Provides insights into performance characteristics of your MCP server.
+
+
+**Methods:**
+
+#### `on_request` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L39" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_request(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time request execution and log the results.
+
+
+### `DetailedTimingMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L60" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Enhanced timing middleware with per-operation breakdowns.
+
+Provides detailed timing information for different types of MCP operations,
+allowing you to identify performance bottlenecks in specific operations.
+
+
+**Methods:**
+
+#### `on_call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L111" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_call_tool(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time tool execution.
+
+
+#### `on_read_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L118" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_read_resource(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time resource reading.
+
+
+#### `on_get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L127" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_get_prompt(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time prompt retrieval.
+
+
+#### `on_list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L134" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_tools(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time tool listing.
+
+
+#### `on_list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L140" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resources(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time resource listing.
+
+
+#### `on_list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L146" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_resource_templates(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time resource template listing.
+
+
+#### `on_list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/timing.py#L152" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_prompts(self, context: MiddlewareContext, call_next: CallNext) -> Any
+```
+
+Time prompt listing.
+

--- a/docs/python-sdk/fastmcp-server-middleware-tool_injection.mdx
+++ b/docs/python-sdk/fastmcp-server-middleware-tool_injection.mdx
@@ -1,0 +1,37 @@
+---
+title: tool_injection
+sidebarTitle: tool_injection
+---
+
+# `fastmcp.server.middleware.tool_injection`
+
+
+A middleware for injecting tools into the MCP server context.
+
+## Classes
+
+### `ToolInjectionMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/tool_injection.py#L16" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A middleware for injecting tools into the context.
+
+
+**Methods:**
+
+#### `on_list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/tool_injection.py#L27" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_list_tools(self, context: MiddlewareContext[mcp_types.ListToolsRequest], call_next: CallNext[mcp_types.ListToolsRequest, Sequence[Tool]]) -> Sequence[Tool]
+```
+
+Inject tools into the response.
+
+
+#### `on_call_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/middleware/tool_injection.py#L36" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_call_tool(self, context: MiddlewareContext[mcp_types.CallToolRequestParams], call_next: CallNext[mcp_types.CallToolRequestParams, ToolResult]) -> ToolResult
+```
+
+Intercept tool calls to injected tools.
+

--- a/docs/python-sdk/fastmcp-server-mixins-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-mixins-__init__.mdx
@@ -1,6 +1,6 @@
 ---
-title: mixins
-sidebarTitle: mixins
+title: __init__
+sidebarTitle: __init__
 ---
 
 # `fastmcp.server.mixins`

--- a/docs/python-sdk/fastmcp-server-mixins-lifespan.mdx
+++ b/docs/python-sdk/fastmcp-server-mixins-lifespan.mdx
@@ -1,0 +1,34 @@
+---
+title: lifespan
+sidebarTitle: lifespan
+---
+
+# `fastmcp.server.mixins.lifespan`
+
+
+Lifespan infrastructure for FastMCP Server.
+
+## Classes
+
+### `LifespanMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/lifespan.py#L39" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin providing lifespan infrastructure for FastMCP.
+
+
+**Methods:**
+
+#### `docket` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/lifespan.py#L43" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+docket(self: FastMCP) -> Docket | None
+```
+
+The Docket instance owned by this server, if the tasks extension is active.
+
+Returns the Docket that the tasks extension initialized as the root of a
+runtime tree, or None when no task backend is running. Mounted children do
+not own their own Docket — they share the root's via ``_current_docket``
+ContextVar inheritance — so accessing ``.docket`` on a mounted child
+returns None even while its tasks run on the root's Docket.
+

--- a/docs/python-sdk/fastmcp-server-mixins-mcp_operations.mdx
+++ b/docs/python-sdk/fastmcp-server-mixins-mcp_operations.mdx
@@ -1,0 +1,23 @@
+---
+title: mcp_operations
+sidebarTitle: mcp_operations
+---
+
+# `fastmcp.server.mixins.mcp_operations`
+
+
+MCP protocol handler setup and wire-format handlers for FastMCP Server.
+
+## Classes
+
+### `MCPOperationsMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/mcp_operations.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin providing MCP protocol handler setup and wire-format handlers.
+
+Handlers are registered via ``add_request_handler(method, params_type,
+handler)`` on the low-level SDK server. Each adapter takes
+``(ctx: ServerRequestContext, params)`` and returns the bare SDK result
+model (no ``ServerResult`` wrapping — the SDK v2 runner serializes the
+result itself).
+

--- a/docs/python-sdk/fastmcp-server-mixins-transport.mdx
+++ b/docs/python-sdk/fastmcp-server-mixins-transport.mdx
@@ -1,0 +1,151 @@
+---
+title: transport
+sidebarTitle: transport
+---
+
+# `fastmcp.server.mixins.transport`
+
+
+Transport-related methods for FastMCP Server.
+
+## Classes
+
+### `TransportMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/transport.py#L68" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin providing transport-related methods for FastMCP.
+
+Includes HTTP/stdio/SSE transport handling and custom HTTP routes.
+
+
+**Methods:**
+
+#### `run_async` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/transport.py#L74" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_async(self: FastMCP, transport: Transport | None = None, show_banner: bool | None = None, **transport_kwargs: Any) -> None
+```
+
+Run the FastMCP server asynchronously.
+
+**Args:**
+- `transport`: Transport protocol to use ("stdio", "http", "sse", or "streamable-http")
+- `show_banner`: Whether to display the server banner. If None, uses the
+FASTMCP_SHOW_SERVER_BANNER setting (default\: True).
+
+
+#### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/transport.py#L108" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(self: FastMCP, transport: Transport | None = None, show_banner: bool | None = None, **transport_kwargs: Any) -> None
+```
+
+Run the FastMCP server. Note this is a synchronous function.
+
+**Args:**
+- `transport`: Transport protocol to use ("http", "stdio", "sse", or "streamable-http")
+- `show_banner`: Whether to display the server banner. If None, uses the
+FASTMCP_SHOW_SERVER_BANNER setting (default\: True).
+
+
+#### `custom_route` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/transport.py#L131" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+custom_route(self: FastMCP, path: str, methods: list[str], name: str | None = None, include_in_schema: bool = True) -> Callable[[Callable[[Request], Awaitable[Response]]], Callable[[Request], Awaitable[Response]]]
+```
+
+Decorator to register a custom HTTP route on the FastMCP server.
+
+Allows adding arbitrary HTTP endpoints outside the standard MCP protocol,
+which can be useful for OAuth callbacks, health checks, or admin APIs.
+The handler function must be an async function that accepts a Starlette
+Request and returns a Response.
+
+**Args:**
+- `path`: URL path for the route (e.g., "/auth/callback")
+- `methods`: List of HTTP methods to support (e.g., ["GET", "POST"])
+- `name`: Optional name for the route (to reference this route with
+Starlette's reverse URL lookup feature)
+- `include_in_schema`: Whether to include in OpenAPI schema, defaults to True
+
+
+#### `run_stdio_async` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/transport.py#L215" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_stdio_async(self: FastMCP, show_banner: bool = True, log_level: str | None = None, stateless: bool = False) -> None
+```
+
+Run the server using stdio transport.
+
+**Args:**
+- `show_banner`: Whether to display the server banner
+- `log_level`: Log level for the server
+- `stateless`: Whether to run in stateless mode (no session initialization)
+
+
+#### `run_http_async` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/transport.py#L258" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run_http_async(self: FastMCP, show_banner: bool = True, transport: Literal['http', 'streamable-http', 'sse'] = 'http', host: str | None = None, port: int | None = None, log_level: str | None = None, path: str | None = None, uvicorn_config: dict[str, Any] | None = None, middleware: list[ASGIMiddleware] | None = None, json_response: bool | None = None, stateless_http: bool | None = None, stateless: bool | None = None, host_origin_protection: HostOriginProtection | None = None, allowed_hosts: list[str] | None = None, allowed_origins: list[str] | None = None, sockets: list[socket.socket] | None = None) -> None
+```
+
+Run the server using HTTP transport.
+
+**Args:**
+- `transport`: Transport protocol to use - "http" (default), "streamable-http", or "sse"
+- `host`: Host address to bind to (defaults to settings.host)
+- `port`: Port to bind to (defaults to settings.port)
+- `log_level`: Log level for the server (defaults to settings.log_level)
+- `path`: Path for the endpoint (defaults to settings.streamable_http_path or settings.sse_path)
+- `uvicorn_config`: Additional configuration for the Uvicorn server
+- `middleware`: A list of middleware to apply to the app
+- `json_response`: Whether to use JSON response format (defaults to settings.json_response)
+- `stateless_http`: Whether to use stateless HTTP (defaults to settings.stateless_http)
+- `stateless`: Alias for stateless_http for CLI consistency
+- `host_origin_protection`: Whether to validate Host and Origin headers
+before requests reach the MCP endpoint. Defaults to
+settings.http_host_origin_protection. "auto" protects
+localhost-bound servers and explicit host/origin allowlists.
+- `allowed_hosts`: Additional hostnames that may appear in the Host header.
+- `allowed_origins`: Additional browser origins trusted by the request guard.
+Configure CORS separately when browser JavaScript must read
+cross-origin responses.
+- `sockets`: Pre-bound sockets to pass to Uvicorn
+
+
+#### `http_app` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/mixins/transport.py#L372" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+http_app(self: FastMCP, path: str | None = None, middleware: list[ASGIMiddleware] | None = None, json_response: bool | None = None, stateless_http: bool | None = None, transport: Literal['http', 'streamable-http', 'sse'] = 'http', event_store: EventStore | None = None, retry_interval: int | None = None, host_origin_protection: HostOriginProtection | None = None, allowed_hosts: list[str] | None = None, allowed_origins: list[str] | None = None, session_idle_timeout: float | None = None) -> StarletteWithLifespan
+```
+
+Create a Starlette app using the specified HTTP transport.
+
+**Args:**
+- `path`: The path for the HTTP endpoint
+- `middleware`: A list of middleware to apply to the app
+- `json_response`: Whether to use JSON response format
+- `stateless_http`: Whether to use stateless mode (new transport per request)
+- `transport`: Transport protocol to use - "http", "streamable-http", or "sse"
+- `event_store`: Optional event store for SSE polling/resumability. When set,
+enables clients to reconnect and resume receiving events after
+server-initiated disconnections. Only used with streamable-http transport.
+- `retry_interval`: Optional retry interval in milliseconds for SSE polling.
+Controls how quickly clients should reconnect after server-initiated
+disconnections. Requires event_store to be set. Only used with
+streamable-http transport.
+- `host_origin_protection`: Whether to validate Host and Origin headers
+before requests reach the MCP endpoint. Defaults to
+settings.http_host_origin_protection. "auto" protects
+localhost-bound servers and explicit host/origin allowlists.
+- `allowed_hosts`: Additional hostnames that may appear in the Host header.
+- `allowed_origins`: Additional browser origins trusted by the request guard.
+Configure CORS separately when browser JavaScript must read
+cross-origin responses.
+- `session_idle_timeout`: Maximum time in seconds a streamable-HTTP
+session may remain idle before it is terminated. When None,
+falls back to the ``http_session_idle_timeout`` setting.
+
+**Returns:**
+- A Starlette application configured with the specified transport
+

--- a/docs/python-sdk/fastmcp-server-providers-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-__init__.mdx
@@ -1,6 +1,6 @@
 ---
-title: providers
-sidebarTitle: providers
+title: __init__
+sidebarTitle: __init__
 ---
 
 # `fastmcp.server.providers`

--- a/docs/python-sdk/fastmcp-server-providers-addressing.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-addressing.mdx
@@ -1,0 +1,88 @@
+---
+title: addressing
+sidebarTitle: addressing
+---
+
+# `fastmcp.server.providers.addressing`
+
+
+Deterministic tool hashing for backend-tool routing and per-tool resources.
+
+Each FastMCPApp backend tool gets a deterministic hash computed from its
+app name + tool name. The hash serves two purposes:
+
+1. **Backend-tool routing.** Tools with ``"app"`` in their visibility are
+   callable via ``<hash>_<local_name>``. The dispatcher parses the prefix,
+   then walks providers recursively (same pattern as the old ``get_app_tool``)
+   to find a tool whose stored hash matches.
+
+2. **Per-tool Prefab renderer URIs.** Each prefab tool gets a unique renderer
+   resource at ``ui://prefab/tool/<hash>/renderer.html``. ``list_resources``
+   and ``read_resource`` synthesize these on demand from the tool's meta.
+
+The hash is computed at registration time from ``(app_name, tool_name)`` —
+both known at that moment — and stored in ``meta["fastmcp"]["tool_hash"]``.
+Deterministic across replicas (same code → same hash), no registry walk
+needed.
+
+The key is deliberately public. Keys prefixed with ``_`` inside the
+``fastmcp`` meta namespace are stripped at every serialization boundary
+(see ``FastMCPComponent.get_meta``) because they hold process-local state
+such as enabled/disabled marks. The hash is the opposite: a stable
+identity that intermediaries need in order to recognize a tool they are
+forwarding, so it must survive the wire.
+
+
+## Functions
+
+### `hash_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/addressing.py#L39" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+hash_tool(app_name: str, tool_name: str) -> str
+```
+
+
+Deterministic hex hash for a tool in an app.
+
+Same inputs on every replica produce the same output.
+
+
+### `hashed_backend_name` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/addressing.py#L48" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+hashed_backend_name(app_name: str, tool_name: str) -> str
+```
+
+
+Format the universal name for a backend tool: ``<hash>_<local_name>``.
+
+
+### `parse_hashed_backend_name` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/addressing.py#L53" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+parse_hashed_backend_name(name: str) -> tuple[str, str] | None
+```
+
+
+Parse ``<HASH_LENGTH hex>_<rest>`` → ``(hash, local_tool_name)`` or None.
+
+
+### `hashed_resource_uri` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/addressing.py#L65" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+hashed_resource_uri(app_name: str, tool_name: str) -> str
+```
+
+
+Per-tool Prefab renderer resource URI.
+
+
+### `parse_hashed_resource_uri` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/addressing.py#L70" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+parse_hashed_resource_uri(uri: str) -> str | None
+```
+
+
+Extract the hash from a Prefab renderer URI, or None.
+

--- a/docs/python-sdk/fastmcp-server-providers-aggregate.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-aggregate.mdx
@@ -1,0 +1,114 @@
+---
+title: aggregate
+sidebarTitle: aggregate
+---
+
+# `fastmcp.server.providers.aggregate`
+
+
+AggregateProvider for combining multiple providers into one.
+
+This module provides `AggregateProvider`, a utility class that presents
+multiple providers as a single unified provider. Useful when you want to
+combine custom providers without creating a full FastMCP server.
+
+Example:
+    ```python
+    from fastmcp.server.providers import AggregateProvider
+
+    # Combine multiple providers into one
+    combined = AggregateProvider()
+    combined.add_provider(provider1)
+    combined.add_provider(provider2, namespace="api")  # Tools become "api_foo"
+
+    # Use like any other provider
+    tools = await combined.list_tools()
+    ```
+
+
+## Classes
+
+### `AggregateProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/aggregate.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Utility provider that combines multiple providers into one.
+
+Components are aggregated from all providers. For get_* operations,
+providers are queried in parallel and the highest version is returned.
+
+When adding providers with a namespace, wrap_transform() is used to apply
+the Namespace transform. This means namespace transformation is handled
+by the wrapped provider, not by AggregateProvider.
+
+Errors from individual providers are logged and skipped by default. Set
+``provider_error_strategy="raise"`` to fail the aggregate operation when
+any provider fails.
+
+
+**Methods:**
+
+#### `add_provider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/aggregate.py#L90" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+add_provider(self, provider: Provider) -> None
+```
+
+Add a provider with optional namespace.
+
+If the provider is a FastMCP server, it's automatically wrapped in
+FastMCPProvider to ensure middleware is invoked correctly.
+
+**Args:**
+- `provider`: The provider to add.
+- `namespace`: Optional namespace prefix. When set\:
+- Tools become "namespace_toolname"
+- Resources become "protocol\://namespace/path"
+- Prompts become "namespace_promptname"
+
+
+#### `get_app_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/aggregate.py#L208" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_app_tool(self, app_name: str, tool_name: str) -> Tool | None
+```
+
+Query all child providers for an app tool.
+
+
+#### `get_tool_by_hash` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/aggregate.py#L223" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None
+```
+
+Query all child providers for a tool matching a hash.
+
+The hash identifies a tool by app name and registered name, with no
+mount-point component, so composing one app into two branches yields
+two distinct tools claiming the same identity. That is ambiguous
+rather than resolvable: picking either one silently routes a UI's
+call into the wrong branch. Raise instead.
+
+An ambiguity raised by a child is a verdict, not a provider failure,
+so it propagates whatever the error strategy is. Swallowing it would
+turn a duplicated app into "unknown tool", which sends whoever hits
+it looking for a missing registration instead of a duplicate one.
+
+
+#### `get_tasks` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/aggregate.py#L332" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tasks(self) -> Sequence[FastMCPComponent]
+```
+
+Get all task-eligible components from all providers.
+
+
+#### `lifespan` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/aggregate.py#L345" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+lifespan(self) -> AsyncIterator[None]
+```
+
+Combine lifespans of all providers.
+

--- a/docs/python-sdk/fastmcp-server-providers-base.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-base.mdx
@@ -1,0 +1,334 @@
+---
+title: base
+sidebarTitle: base
+---
+
+# `fastmcp.server.providers.base`
+
+
+Base Provider class for dynamic MCP components.
+
+This module provides the `Provider` abstraction for providing tools,
+resources, and prompts dynamically at runtime.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.providers import Provider
+    from fastmcp.tools import Tool
+
+    class DatabaseProvider(Provider):
+        def __init__(self, db_url: str):
+            super().__init__()
+            self.db = Database(db_url)
+
+        async def _list_tools(self) -> list[Tool]:
+            rows = await self.db.fetch("SELECT * FROM tools")
+            return [self._make_tool(row) for row in rows]
+
+        async def _get_tool(self, name: str) -> Tool | None:
+            row = await self.db.fetchone("SELECT * FROM tools WHERE name = ?", name)
+            return self._make_tool(row) if row else None
+
+    mcp = FastMCP("Server", providers=[DatabaseProvider(db_url)])
+    ```
+
+
+## Classes
+
+### `Provider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Base class for dynamic component providers.
+
+Subclass and override whichever methods you need. Default implementations
+return empty lists / None, so you only need to implement what your provider
+supports.
+
+
+**Methods:**
+
+#### `transforms` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L82" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+transforms(self) -> list[Transform]
+```
+
+All transforms applied to components from this provider.
+
+
+#### `add_transform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L86" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+add_transform(self, transform: Transform) -> None
+```
+
+Add a transform to this provider.
+
+Transforms modify components (tools, resources, prompts) as they flow
+through the provider. They're applied in order - first added is innermost.
+
+**Args:**
+- `transform`: The transform to add.
+
+
+#### `wrap_transform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L106" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap_transform(self, transform: Transform) -> Provider
+```
+
+Return a new provider with this transform applied (immutable).
+
+Unlike add_transform() which mutates this provider, wrap_transform()
+returns a new provider that wraps this one. The original provider
+is unchanged.
+
+This is useful when you want to apply transforms without side effects,
+such as adding the same provider to multiple aggregators with different
+namespaces.
+
+**Args:**
+- `transform`: The transform to apply.
+
+**Returns:**
+- A new provider that wraps this one with the transform applied.
+
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L142" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self) -> Sequence[Tool]
+```
+
+List tools with all transforms applied.
+
+Applies transforms sequentially: base → transforms (in order).
+Each transform receives the result from the previous transform.
+Components may be marked as disabled but are NOT filtered here -
+filtering happens at the server level to allow session transforms to override.
+
+**Returns:**
+- Transformed sequence of tools (including disabled ones).
+
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L158" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, version: VersionSpec | None = None) -> Tool | None
+```
+
+Get tool by transformed name with all transforms applied.
+
+Note: This method does NOT filter disabled components. The Server
+(FastMCP) performs enabled filtering after all transforms complete,
+allowing session-level transforms to override provider-level disables.
+
+**Args:**
+- `name`: The transformed tool name to look up.
+- `version`: Optional version filter. If None, returns highest version.
+
+**Returns:**
+- The tool if found (may be marked disabled), None if not found.
+
+
+#### `get_app_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L187" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_app_tool(self, app_name: str, tool_name: str) -> Tool | None
+```
+
+Look up an app-visible tool by original name, bypassing transforms.
+
+Searches for a tool named ``tool_name`` tagged with the given app
+name.  Skips the transform chain entirely.
+
+**Returns:**
+- The tool if found and tagged with the given app name, else None.
+
+
+#### `get_tool_by_hash` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L213" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None
+```
+
+Look up an app-visible tool by its deterministic hash.
+
+Same recursive-walk semantics as ``get_app_tool`` but matches on
+``meta["fastmcp"]["tool_hash"]`` instead of the app name tag.
+Used by the dispatcher when receiving hashed backend-tool calls.
+
+
+#### `list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L238" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resources(self) -> Sequence[Resource]
+```
+
+List resources with all transforms applied.
+
+Components may be marked as disabled but are NOT filtered here.
+
+
+#### `get_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L248" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource(self, uri: str, version: VersionSpec | None = None) -> Resource | None
+```
+
+Get resource by transformed URI with all transforms applied.
+
+Note: This method does NOT filter disabled components. The Server
+(FastMCP) performs enabled filtering after all transforms complete.
+
+**Args:**
+- `uri`: The transformed resource URI to look up.
+- `version`: Optional version filter. If None, returns highest version.
+
+**Returns:**
+- The resource if found (may be marked disabled), None if not found.
+
+
+#### `list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L278" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resource_templates(self) -> Sequence[ResourceTemplate]
+```
+
+List resource templates with all transforms applied.
+
+Components may be marked as disabled but are NOT filtered here.
+
+
+#### `get_resource_template` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L288" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource_template(self, uri: str, version: VersionSpec | None = None) -> ResourceTemplate | None
+```
+
+Get resource template by transformed URI with all transforms applied.
+
+Note: This method does NOT filter disabled components. The Server
+(FastMCP) performs enabled filtering after all transforms complete.
+
+**Args:**
+- `uri`: The transformed template URI to look up.
+- `version`: Optional version filter. If None, returns highest version.
+
+**Returns:**
+- The template if found (may be marked disabled), None if not found.
+
+
+#### `list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L321" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_prompts(self) -> Sequence[Prompt]
+```
+
+List prompts with all transforms applied.
+
+Components may be marked as disabled but are NOT filtered here.
+
+
+#### `get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L331" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_prompt(self, name: str, version: VersionSpec | None = None) -> Prompt | None
+```
+
+Get prompt by transformed name with all transforms applied.
+
+Note: This method does NOT filter disabled components. The Server
+(FastMCP) performs enabled filtering after all transforms complete.
+
+**Args:**
+- `name`: The transformed prompt name to look up.
+- `version`: Optional version filter. If None, returns highest version.
+
+**Returns:**
+- The prompt if found (may be marked disabled), None if not found.
+
+
+#### `get_tasks` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L492" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tasks(self) -> Sequence[FastMCPComponent]
+```
+
+Return components that should be registered as background tasks.
+
+Override to customize which components are task-eligible.
+Default calls list_* methods, applies provider transforms, and filters
+for components with task_config.mode != 'forbidden'.
+
+Used by the server during startup to register functions with Docket.
+
+
+#### `lifespan` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L544" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+lifespan(self) -> AsyncIterator[None]
+```
+
+User-overridable lifespan for custom setup and teardown.
+
+Override this method to perform provider-specific initialization
+like opening database connections, setting up external resources,
+or other state management needed for the provider's lifetime.
+
+The lifespan scope matches the server's lifespan - code before yield
+runs at startup, code after yield runs at shutdown.
+
+
+#### `enable` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L573" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+enable(self) -> Self
+```
+
+Enable components matching all specified criteria.
+
+Adds a visibility transform that marks matching components as enabled.
+Later transforms override earlier ones, so enable after disable makes
+the component enabled.
+
+With only=True, switches to allowlist mode - first disables everything,
+then enables matching components.
+
+**Args:**
+- `names`: Component names or URIs to enable.
+- `keys`: Component keys to enable (e.g., {"tool\:my_tool@v1"}).
+- `version`: Component version spec to enable (e.g., VersionSpec(eq="v1") or
+VersionSpec(gte="v2")). Unversioned components will not match.
+- `tags`: Enable components with these tags.
+- `components`: Component types to include (e.g., {"tool", "prompt"}).
+- `only`: If True, ONLY enable matching components (allowlist mode).
+
+**Returns:**
+- Self for method chaining.
+
+
+#### `disable` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/base.py#L622" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+disable(self) -> Self
+```
+
+Disable components matching all specified criteria.
+
+Adds a visibility transform that marks matching components as disabled.
+Components can be re-enabled by calling enable() with matching criteria
+(the later transform wins).
+
+**Args:**
+- `names`: Component names or URIs to disable.
+- `keys`: Component keys to disable (e.g., {"tool\:my_tool@v1"}).
+- `version`: Component version spec to disable (e.g., VersionSpec(eq="v1") or
+VersionSpec(gte="v2")). Unversioned components will not match.
+- `tags`: Disable components with these tags.
+- `components`: Component types to include (e.g., {"tool", "prompt"}).
+
+**Returns:**
+- Self for method chaining.
+

--- a/docs/python-sdk/fastmcp-server-providers-fastmcp_provider.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-fastmcp_provider.mdx
@@ -1,0 +1,232 @@
+---
+title: fastmcp_provider
+sidebarTitle: fastmcp_provider
+---
+
+# `fastmcp.server.providers.fastmcp_provider`
+
+
+FastMCPProvider for wrapping FastMCP servers as providers.
+
+This module provides the `FastMCPProvider` class that wraps a FastMCP server
+and exposes its components through the Provider interface.
+
+It also provides FastMCPProvider* component classes that delegate execution to
+the wrapped server's middleware, ensuring middleware runs when components are
+executed.
+
+
+## Classes
+
+### `FastMCPProviderTool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L37" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Tool that delegates execution to a wrapped server's middleware.
+
+When `run()` is called, this tool invokes the wrapped server's
+`_call_tool_middleware()` method, ensuring the server's middleware
+chain is executed.
+
+
+**Methods:**
+
+#### `wrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L59" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap(cls, server: Any, tool: Tool) -> FastMCPProviderTool
+```
+
+Wrap a Tool to delegate execution to the server's middleware.
+
+
+#### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L101" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(self, arguments: dict[str, Any]) -> ToolResult
+```
+
+Delegate to the child server's call_tool().
+
+This is called when the tool is used within a TransformedTool
+forwarding function or other contexts.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L114" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `FastMCPProviderResource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L121" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Resource that delegates reading to a wrapped server's read_resource().
+
+When `read()` is called, this resource invokes the wrapped server's
+`read_resource()` method, ensuring the server's middleware chain is executed.
+
+
+**Methods:**
+
+#### `wrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L142" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap(cls, server: Any, resource: Resource) -> FastMCPProviderResource
+```
+
+Wrap a Resource to delegate reading to the server's middleware.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L176" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `FastMCPProviderPrompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L183" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Prompt that delegates rendering to a wrapped server's render_prompt().
+
+When `render()` is called, this prompt invokes the wrapped server's
+`render_prompt()` method, ensuring the server's middleware chain is executed.
+
+
+**Methods:**
+
+#### `wrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L204" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap(cls, server: Any, prompt: Prompt) -> FastMCPProviderPrompt
+```
+
+Wrap a Prompt to delegate rendering to the server's middleware.
+
+
+#### `render` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L238" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+render(self, arguments: dict[str, Any] | None = None) -> PromptResult
+```
+
+Delegate to the child server's render_prompt().
+
+This is called when the prompt is used within a transformed context
+or other contexts.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L251" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `FastMCPProviderResourceTemplate` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L258" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Resource template that creates FastMCPProviderResources.
+
+When `create_resource()` is called, this template creates a
+FastMCPProviderResource that will invoke the wrapped server's middleware
+when read.
+
+
+**Methods:**
+
+#### `wrap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L280" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+wrap(cls, server: Any, template: ResourceTemplate) -> FastMCPProviderResourceTemplate
+```
+
+Wrap a ResourceTemplate to create FastMCPProviderResources.
+
+
+#### `create_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L302" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_resource(self, uri: str, params: dict[str, Any]) -> Resource
+```
+
+Create a FastMCPProviderResource for the given URI.
+
+The `uri` is the external/transformed URI (e.g., with namespace prefix).
+We use `_original_uri_template` with `params` to construct the internal
+URI that the nested server understands.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L344" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `FastMCPProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L356" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider that wraps a FastMCP server.
+
+This provider enables mounting one FastMCP server onto another, exposing
+the mounted server's tools, resources, and prompts through the parent
+server.
+
+Components returned by this provider are wrapped in FastMCPProvider*
+classes that delegate execution to the wrapped server's middleware chain.
+This ensures middleware runs when components are executed.
+
+
+**Methods:**
+
+#### `get_app_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L431" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_app_tool(self, app_name: str, tool_name: str) -> Tool | None
+```
+
+Delegate to nested server's get_app_tool, wrapping for middleware.
+
+
+#### `get_tool_by_hash` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L442" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None
+```
+
+Delegate to nested server's get_tool_by_hash, wrapping for middleware.
+
+
+#### `get_tasks` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L541" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tasks(self) -> Sequence[FastMCPComponent]
+```
+
+Return task-eligible components from the mounted server.
+
+Returns the child's ACTUAL components (not wrapped) so their actual
+functions get registered with Docket. Gets components with child
+server's transforms applied, then applies this provider's transforms
+for correct registration keys.
+
+
+#### `lifespan` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py#L582" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+lifespan(self) -> AsyncIterator[None]
+```
+
+Start the mounted server's lifespan.
+
+Sets ``_lifespan_root_active=True`` to signal to the wrapped server's
+``_docket_lifespan`` that it is running below an existing root in the
+same runtime tree, then delegates to its full ``_lifespan_manager``.
+The root's Docket / Worker / SharedContext are reused through
+ContextVars (``_current_docket`` etc.); the mounted server's user
+lifespan, ``_lifespan_result`` cache, and its own sub-providers
+(nested mounts) all run normally.
+
+The flag is reset as soon as ``_lifespan_manager`` finishes entering,
+so it doesn't leak into the caller's async scope. Unrelated servers
+entered later in the same task (e.g. siblings via ``AsyncExitStack``)
+correctly see no active root and start their own infrastructure.
+

--- a/docs/python-sdk/fastmcp-server-providers-filesystem.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-filesystem.mdx
@@ -1,0 +1,54 @@
+---
+title: filesystem
+sidebarTitle: filesystem
+---
+
+# `fastmcp.server.providers.filesystem`
+
+
+FileSystemProvider for filesystem-based component discovery.
+
+FileSystemProvider scans a directory for Python files, imports them, and
+registers any Tool, Resource, ResourceTemplate, or Prompt objects found.
+
+Components are created using the standalone decorators from fastmcp.tools,
+fastmcp.resources, and fastmcp.prompts:
+
+Example:
+    ```python
+    # In mcp/tools.py
+    from fastmcp.tools import tool
+
+    @tool
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    # In main.py
+    from pathlib import Path
+
+    from fastmcp import FastMCP
+    from fastmcp.server.providers import FileSystemProvider
+
+    mcp = FastMCP("MyServer", providers=[FileSystemProvider(Path(__file__).parent / "mcp")])
+    ```
+
+
+## Classes
+
+### `FileSystemProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/filesystem.py#L48" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider that discovers components from the filesystem.
+
+Scans a directory for Python files and registers any Tool, Resource,
+ResourceTemplate, or Prompt objects found. Components are created using
+the standalone decorators:
+- @tool from fastmcp.tools
+- @resource from fastmcp.resources
+- @prompt from fastmcp.prompts
+
+**Args:**
+- `root`: Root directory to scan. Defaults to current directory.
+- `reload`: If True, re-scan files on every request (dev mode).
+Defaults to False (scan once at init, cache results).
+

--- a/docs/python-sdk/fastmcp-server-providers-filesystem_discovery.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-filesystem_discovery.mdx
@@ -1,0 +1,109 @@
+---
+title: filesystem_discovery
+sidebarTitle: filesystem_discovery
+---
+
+# `fastmcp.server.providers.filesystem_discovery`
+
+
+File discovery and module import utilities for filesystem-based routing.
+
+This module provides functions to:
+1. Discover Python files in a directory tree
+2. Import modules (as packages if __init__.py exists, else directly)
+3. Extract decorated components (Tool, Resource, Prompt objects) from imported modules
+
+
+## Functions
+
+### `discover_files` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py#L35" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+discover_files(root: Path) -> list[Path]
+```
+
+
+Recursively discover all Python files under a directory.
+
+Excludes __init__.py files (they're for package structure, not components).
+
+**Args:**
+- `root`: Root directory to scan.
+
+**Returns:**
+- List of .py file paths, sorted for deterministic order.
+
+
+### `import_module_from_file` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py#L140" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+import_module_from_file(file_path: Path, provider_root: Path | None = None) -> ModuleType
+```
+
+
+Import a Python file as a module.
+
+If the file is part of a package (directory has __init__.py), imports
+it as a proper package member (relative imports work). Otherwise,
+imports directly using spec_from_file_location.
+
+sys.path is modified only for the duration of the import and restored
+immediately after, so no permanent pollution occurs.
+
+**Args:**
+- `file_path`: Path to the Python file.
+- `provider_root`: The provider's root directory. Prevents package root
+discovery from walking above this boundary into ancestor packages.
+
+**Returns:**
+- The imported module.
+
+**Raises:**
+- `ImportError`: If the module cannot be imported.
+
+
+### `extract_components` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py#L285" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+extract_components(module: ModuleType) -> list[FastMCPComponent]
+```
+
+
+Extract all MCP components from a module.
+
+Scans all module attributes for instances of Tool, Resource,
+ResourceTemplate, or Prompt objects created by standalone decorators,
+or functions decorated with @tool/@resource/@prompt that have __fastmcp__ metadata.
+
+**Args:**
+- `module`: The imported module to scan.
+
+**Returns:**
+- List of component objects (Tool, Resource, ResourceTemplate, Prompt).
+
+
+### `discover_and_import` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py#L404" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+discover_and_import(root: Path) -> DiscoveryResult
+```
+
+
+Discover files, import modules, and extract components.
+
+This is the main entry point for filesystem-based discovery.
+
+**Args:**
+- `root`: Root directory to scan.
+
+**Returns:**
+- DiscoveryResult with components and any failed files.
+
+
+## Classes
+
+### `DiscoveryResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/filesystem_discovery.py#L27" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Result of filesystem discovery.
+

--- a/docs/python-sdk/fastmcp-server-providers-local_provider-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-local_provider-__init__.mdx
@@ -1,0 +1,13 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.server.providers.local_provider`
+
+
+LocalProvider for locally-defined MCP components.
+
+This module provides the `LocalProvider` class that manages tools, resources,
+templates, and prompts registered via decorators or direct methods.
+

--- a/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-__init__.mdx
@@ -1,0 +1,13 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.server.providers.local_provider.decorators`
+
+
+Decorator mixins for LocalProvider.
+
+This module provides mixin classes that add decorator functionality
+to LocalProvider for tools, resources, templates, and prompts.
+

--- a/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-prompts.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-prompts.mdx
@@ -1,0 +1,80 @@
+---
+title: prompts
+sidebarTitle: prompts
+---
+
+# `fastmcp.server.providers.local_provider.decorators.prompts`
+
+
+Prompt decorator mixin for LocalProvider.
+
+This module provides the PromptDecoratorMixin class that adds prompt
+registration functionality to LocalProvider.
+
+
+## Classes
+
+### `PromptDecoratorMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/prompts.py#L27" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin class providing prompt decorator functionality for LocalProvider.
+
+This mixin contains all methods related to:
+- Prompt registration via add_prompt()
+- Prompt decorator (@provider.prompt)
+
+
+**Methods:**
+
+#### `add_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/prompts.py#L35" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+add_prompt(self: LocalProvider, prompt: Prompt | Callable[..., Any]) -> Prompt
+```
+
+Add a prompt to this provider's storage.
+
+Accepts either a Prompt object or a decorated function with __fastmcp__ metadata.
+
+
+#### `prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/prompts.py#L70" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+prompt(self: LocalProvider, name_or_fn: F) -> F
+```
+
+#### `prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/prompts.py#L86" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+prompt(self: LocalProvider, name_or_fn: str | None = None) -> Callable[[F], F]
+```
+
+#### `prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/prompts.py#L101" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+prompt(self: LocalProvider, name_or_fn: str | AnyFunction | None = None) -> Callable[[AnyFunction], FunctionPrompt] | FunctionPrompt | partial[Callable[[AnyFunction], FunctionPrompt] | FunctionPrompt]
+```
+
+Decorator to register a prompt.
+
+This decorator supports multiple calling patterns:
+- @provider.prompt (without parentheses)
+- @provider.prompt() (with empty parentheses)
+- @provider.prompt("custom_name") (with name as first argument)
+- @provider.prompt(name="custom_name") (with name as keyword argument)
+- provider.prompt(function, name="custom_name") (direct function call)
+
+**Args:**
+- `name_or_fn`: Either a function (when used as @prompt), a string name, or None
+- `name`: Optional name for the prompt (keyword-only, alternative to name_or_fn)
+- `title`: Optional title for the prompt
+- `description`: Optional description of what the prompt does
+- `icons`: Optional icons for the prompt
+- `tags`: Optional set of tags for categorizing the prompt
+- `enabled`: Whether the prompt is enabled (default True). If False, adds to blocklist.
+- `meta`: Optional meta information about the prompt
+- `auth`: Optional authorization checks for the prompt
+
+**Returns:**
+- The registered FunctionPrompt or a decorator function.
+

--- a/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-resources.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-resources.mdx
@@ -1,0 +1,76 @@
+---
+title: resources
+sidebarTitle: resources
+---
+
+# `fastmcp.server.providers.local_provider.decorators.resources`
+
+
+Resource decorator mixin for LocalProvider.
+
+This module provides the ResourceDecoratorMixin class that adds resource
+and template registration functionality to LocalProvider.
+
+
+## Classes
+
+### `ResourceDecoratorMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/resources.py#L32" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin class providing resource decorator functionality for LocalProvider.
+
+This mixin contains all methods related to:
+- Resource registration via add_resource()
+- Resource template registration via add_template()
+- Resource decorator (@provider.resource)
+
+
+**Methods:**
+
+#### `add_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/resources.py#L41" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+add_resource(self: LocalProvider, resource: Resource | ResourceTemplate | Callable[..., Any]) -> Resource | ResourceTemplate
+```
+
+Add a resource to this provider's storage.
+
+Accepts either a Resource/ResourceTemplate object or a decorated function with __fastmcp__ metadata.
+
+
+#### `add_template` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/resources.py#L102" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+add_template(self: LocalProvider, template: ResourceTemplate) -> ResourceTemplate
+```
+
+Add a resource template to this provider's storage.
+
+
+#### `resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/resources.py#L108" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+resource(self: LocalProvider, uri: str) -> Callable[[F], F]
+```
+
+Decorator to register a function as a resource.
+
+If the URI contains parameters (e.g. "resource://{param}") or the function
+has parameters, it will be registered as a template resource.
+
+**Args:**
+- `uri`: URI for the resource (e.g. "resource\://my-resource" or "resource\://{param}")
+- `name`: Optional name for the resource
+- `title`: Optional title for the resource
+- `description`: Optional description of the resource
+- `icons`: Optional icons for the resource
+- `mime_type`: Optional MIME type for the resource
+- `tags`: Optional set of tags for categorizing the resource
+- `enabled`: Whether the resource is enabled (default True). If False, adds to blocklist.
+- `annotations`: Optional annotations about the resource's behavior
+- `meta`: Optional meta information about the resource
+- `auth`: Optional authorization checks for the resource
+
+**Returns:**
+- A decorator function.
+

--- a/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-tools.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-local_provider-decorators-tools.mdx
@@ -1,0 +1,82 @@
+---
+title: tools
+sidebarTitle: tools
+---
+
+# `fastmcp.server.providers.local_provider.decorators.tools`
+
+
+Tool decorator mixin for LocalProvider.
+
+This module provides the ToolDecoratorMixin class that adds tool
+registration functionality to LocalProvider.
+
+
+## Classes
+
+### `ToolDecoratorMixin` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py#L104" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mixin class providing tool decorator functionality for LocalProvider.
+
+This mixin contains all methods related to:
+- Tool registration via add_tool()
+- Tool decorator (@provider.tool)
+
+
+**Methods:**
+
+#### `add_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py#L112" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+add_tool(self: LocalProvider, tool: Tool | Callable[..., Any]) -> Tool
+```
+
+Add a tool to this provider's storage.
+
+Accepts either a Tool object or a decorated function with __fastmcp__ metadata.
+
+
+#### `tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py#L163" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+tool(self: LocalProvider, name_or_fn: F) -> F
+```
+
+#### `tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py#L184" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+tool(self: LocalProvider, name_or_fn: str | None = None) -> Callable[[F], F]
+```
+
+#### `tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/decorators/tools.py#L207" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+tool(self: LocalProvider, name_or_fn: str | AnyFunction | None = None) -> Callable[[AnyFunction], FunctionTool] | FunctionTool | partial[Callable[[AnyFunction], FunctionTool] | FunctionTool]
+```
+
+Decorator to register a tool.
+
+This decorator supports multiple calling patterns:
+- @provider.tool (without parentheses)
+- @provider.tool() (with empty parentheses)
+- @provider.tool("custom_name") (with name as first argument)
+- @provider.tool(name="custom_name") (with name as keyword argument)
+- provider.tool(function, name="custom_name") (direct function call)
+
+**Args:**
+- `name_or_fn`: Either a function (when used as @tool), a string name, or None
+- `name`: Optional name for the tool (keyword-only, alternative to name_or_fn)
+- `title`: Optional title for the tool
+- `description`: Optional description of what the tool does
+- `icons`: Optional icons for the tool
+- `tags`: Optional set of tags for categorizing the tool
+- `output_schema`: Optional JSON schema for the tool's output
+- `annotations`: Optional annotations about the tool's behavior
+- `meta`: Optional meta information about the tool
+- `enabled`: Whether the tool is enabled (default True). If False, adds to blocklist.
+- `task`: Optional task configuration for background execution
+
+**Returns:**
+- The registered FunctionTool or a decorator function.
+

--- a/docs/python-sdk/fastmcp-server-providers-local_provider-local_provider.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-local_provider-local_provider.mdx
@@ -1,0 +1,125 @@
+---
+title: local_provider
+sidebarTitle: local_provider
+---
+
+# `fastmcp.server.providers.local_provider.local_provider`
+
+
+LocalProvider for locally-defined MCP components.
+
+This module provides the `LocalProvider` class that manages tools, resources,
+templates, and prompts registered via decorators or direct methods.
+
+LocalProvider can be used standalone and attached to multiple servers:
+
+```python
+from fastmcp.server.providers import LocalProvider
+
+# Create a reusable provider with tools
+provider = LocalProvider()
+
+@provider.tool
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+# Attach to any server
+from fastmcp import FastMCP
+server1 = FastMCP("Server1", providers=[provider])
+server2 = FastMCP("Server2", providers=[provider])
+```
+
+
+## Classes
+
+### `LocalProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py#L51" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider for locally-defined components.
+
+Supports decorator-based registration (`@provider.tool`, `@provider.resource`,
+`@provider.prompt`) and direct object registration methods.
+
+When used standalone, LocalProvider uses default settings. When attached
+to a FastMCP server via the server's decorators, server-level settings
+like `_tool_serializer` and `_support_tasks_by_default` are injected.
+
+
+**Methods:**
+
+#### `remove_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py#L229" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+remove_tool(self, name: str, version: str | None = None) -> None
+```
+
+Remove tool(s) from this provider's storage.
+
+**Args:**
+- `name`: The tool name.
+- `version`: If None, removes ALL versions. If specified, removes only that version.
+
+**Raises:**
+- `KeyError`: If no matching tool is found.
+
+
+#### `remove_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py#L257" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+remove_resource(self, uri: str, version: str | None = None) -> None
+```
+
+Remove resource(s) from this provider's storage.
+
+**Args:**
+- `uri`: The resource URI.
+- `version`: If None, removes ALL versions. If specified, removes only that version.
+
+**Raises:**
+- `KeyError`: If no matching resource is found.
+
+
+#### `remove_template` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py#L285" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+remove_template(self, uri_template: str, version: str | None = None) -> None
+```
+
+Remove resource template(s) from this provider's storage.
+
+**Args:**
+- `uri_template`: The template URI pattern.
+- `version`: If None, removes ALL versions. If specified, removes only that version.
+
+**Raises:**
+- `KeyError`: If no matching template is found.
+
+
+#### `remove_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py#L315" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+remove_prompt(self, name: str, version: str | None = None) -> None
+```
+
+Remove prompt(s) from this provider's storage.
+
+**Args:**
+- `name`: The prompt name.
+- `version`: If None, removes ALL versions. If specified, removes only that version.
+
+**Raises:**
+- `KeyError`: If no matching prompt is found.
+
+
+#### `get_tasks` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py#L449" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tasks(self) -> Sequence[FastMCPComponent]
+```
+
+Return components eligible for background task execution.
+
+Returns components that have task_config.mode != 'forbidden'.
+This includes both FunctionTool/Resource/Prompt instances created via
+decorators and custom Tool/Resource/Prompt subclasses.
+

--- a/docs/python-sdk/fastmcp-server-providers-openapi-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-openapi-__init__.mdx
@@ -1,0 +1,23 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.server.providers.openapi`
+
+
+OpenAPI provider for FastMCP.
+
+This module provides OpenAPI integration for FastMCP through the Provider pattern.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.providers.openapi import OpenAPIProvider
+    import httpx2
+
+    client = httpx2.AsyncClient(base_url="https://api.example.com")
+    provider = OpenAPIProvider(openapi_spec=spec, client=client)
+    mcp = FastMCP("API Server", providers=[provider])
+    ```
+

--- a/docs/python-sdk/fastmcp-server-providers-openapi-components.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-openapi-components.mdx
@@ -1,0 +1,62 @@
+---
+title: components
+sidebarTitle: components
+---
+
+# `fastmcp.server.providers.openapi.components`
+
+
+OpenAPI component classes: Tool, Resource, and ResourceTemplate.
+
+## Classes
+
+### `OpenAPITool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/components.py#L165" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Tool implementation for OpenAPI endpoints.
+
+
+**Methods:**
+
+#### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/components.py#L197" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(self, arguments: dict[str, Any]) -> ToolResult
+```
+
+Execute the HTTP request using RequestDirector.
+
+
+### `OpenAPIResource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/components.py#L270" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Resource implementation for OpenAPI endpoints.
+
+
+**Methods:**
+
+#### `read` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/components.py#L302" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read(self) -> ResourceResult
+```
+
+Fetch the resource data by making an HTTP request.
+
+
+### `OpenAPIResourceTemplate` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/components.py#L367" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Resource template implementation for OpenAPI endpoints.
+
+
+**Methods:**
+
+#### `create_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/components.py#L399" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_resource(self, uri: str, params: dict[str, Any], context: Context | None = None) -> Resource
+```
+
+Create a resource with the given parameters.
+

--- a/docs/python-sdk/fastmcp-server-providers-openapi-provider.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-openapi-provider.mdx
@@ -1,0 +1,40 @@
+---
+title: provider
+sidebarTitle: provider
+---
+
+# `fastmcp.server.providers.openapi.provider`
+
+
+OpenAPIProvider for creating MCP components from OpenAPI specifications.
+
+## Classes
+
+### `OpenAPIProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/provider.py#L61" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider that creates MCP components from an OpenAPI specification.
+
+Components are created eagerly during initialization by parsing the OpenAPI
+spec. Each component makes HTTP calls to the described API endpoints.
+
+
+**Methods:**
+
+#### `lifespan` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/provider.py#L204" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+lifespan(self) -> AsyncIterator[None]
+```
+
+Manage the lifecycle of the auto-created httpx client.
+
+
+#### `get_tasks` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/provider.py#L454" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tasks(self) -> Sequence[FastMCPComponent]
+```
+
+Return empty list - OpenAPI components don't support tasks.
+

--- a/docs/python-sdk/fastmcp-server-providers-openapi-routing.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-openapi-routing.mdx
@@ -1,0 +1,23 @@
+---
+title: routing
+sidebarTitle: routing
+---
+
+# `fastmcp.server.providers.openapi.routing`
+
+
+Route mapping logic for OpenAPI operations.
+
+## Classes
+
+### `MCPType` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/routing.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Type of FastMCP component to create from a route.
+
+
+### `RouteMap` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/openapi/routing.py#L59" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Mapping configuration for HTTP routes to FastMCP component types.
+

--- a/docs/python-sdk/fastmcp-server-providers-prefab_payload.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-prefab_payload.mdx
@@ -1,0 +1,78 @@
+---
+title: prefab_payload
+sidebarTitle: prefab_payload
+---
+
+# `fastmcp.server.providers.prefab_payload`
+
+
+Late-bound tool names in Prefab UI payloads.
+
+A Prefab UI is serialized during the entry tool's call, deep inside whatever
+composition the server happens to have. At that moment nothing knows what the
+backend tools will be *called* by the time the payload reaches a host: every
+layer above may rename them, and the outermost layer's names are the only ones
+a client can actually invoke.
+
+So the payload leaves the app addressed by identity — ``<hash>_<local_name>``,
+stable everywhere — and every FastMCP server rewrites those references on the
+way out to whatever it lists that tool as. Servers rewrite innermost-first, so
+the edge writes last and wins.
+
+Rewriting a name in place would destroy the identity for the next layer up, so
+the payload carries a name-to-identity map under ``_meta.fastmcp.toolNames``.
+Each layer resolves through the map and updates it. The action objects keep the
+exact shape ``prefab_ui`` defines — only the value of ``tool`` changes, and only
+ever to another valid tool name.
+
+Renderers read ``_meta`` already and ignore keys they don't recognize, so this
+needs no renderer change.
+
+
+## Functions
+
+### `payload_has_identities` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/prefab_payload.py#L83" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+payload_has_identities(payload: Any) -> bool
+```
+
+
+Cheap guard: does this payload carry tool references worth rewriting?
+
+Runs on every tool result, so it must not walk the tree.
+
+
+### `annotate_payload_identities` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/prefab_payload.py#L91" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+annotate_payload_identities(payload: dict[str, Any]) -> dict[str, Any]
+```
+
+
+Record the identity-addressed form of each reference, at serialization.
+
+References start out as ``<hash>_<local_name>``, so the map begins as an
+identity map to itself. Once a later layer rewrites a name, this is the
+only remaining route back: it carries both what the reference points at
+and the address any server can fall back to.
+
+
+### `rewrite_payload_tool_names` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/prefab_payload.py#L115" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+rewrite_payload_tool_names(payload: Any, resolve: IdentityResolver) -> Any
+```
+
+
+Re-address a payload's tool references to this server's own names.
+
+Mutates in place and returns the payload.
+
+A reference this server cannot resolve is restored to its
+identity-addressed form rather than left as-is. Leaving it would strand
+whatever name an inner server chose — a name that is correct there and
+meaningless here — and, unlike the identity form, a stranded name has no
+route back. Restoring keeps the reference resolvable by the dispatcher,
+or by any server further out with a better view.
+

--- a/docs/python-sdk/fastmcp-server-providers-prefab_synthesis.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-prefab_synthesis.mdx
@@ -1,0 +1,58 @@
+---
+title: prefab_synthesis
+sidebarTitle: prefab_synthesis
+---
+
+# `fastmcp.server.providers.prefab_synthesis`
+
+
+On-demand Prefab renderer resource synthesis.
+
+Tools marked as Prefab (via ``app=True``, ``PrefabAppConfig``, etc.) carry
+a placeholder ``meta.ui.resourceUri`` and optionally a hash in
+``meta.fastmcp.tool_hash``. This module synthesizes per-tool renderer
+resources on demand at ``list_resources`` and ``read_resource`` time
+without storing or materializing anything.
+
+Each tool's resource URI is ``ui://prefab/tool/<hash>/renderer.html``
+where the hash comes from the tool's own meta (set at registration from
+the app name + tool name). CSP on the resource is the tool's
+``meta.ui.csp`` merged with the renderer defaults across all four
+``*_domains`` fields.
+
+
+## Functions
+
+### `synthesize_prefab_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/prefab_synthesis.py#L201" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+synthesize_prefab_resources(server: FastMCP) -> list[Resource]
+```
+
+
+Return fresh synthetic Prefab resources for all prefab tools. Pure.
+
+
+### `synthesize_prefab_resource_by_uri` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/prefab_synthesis.py#L216" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+synthesize_prefab_resource_by_uri(server: FastMCP, uri: str) -> Resource | None
+```
+
+
+Intercept a Prefab renderer URI and synthesize on demand.
+
+
+### `rewrite_tool_meta_for_wire` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/prefab_synthesis.py#L229" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+rewrite_tool_meta_for_wire(tool: Tool) -> Tool
+```
+
+
+Return a model_copy with the per-tool URI and CSP stripped.
+
+Reads the hash from the tool's own meta. If no hash is found,
+returns the tool unchanged. Produces a fresh copy — the original
+Tool object is untouched.
+

--- a/docs/python-sdk/fastmcp-server-providers-proxy.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-proxy.mdx
@@ -1,0 +1,419 @@
+---
+title: proxy
+sidebarTitle: proxy
+---
+
+# `fastmcp.server.providers.proxy`
+
+
+ProxyProvider for proxying to remote MCP servers.
+
+This module provides the `ProxyProvider` class that proxies components from
+a remote MCP server via a client factory. It also provides proxy component
+classes that forward execution to remote servers.
+
+
+## Functions
+
+### `default_proxy_roots_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1529" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_proxy_roots_handler(context: ServerRequestContext[Any, Any]) -> RootsList
+```
+
+
+Forward list roots request from remote server to proxy's connected clients.
+
+A handshake-era backend can still issue `roots/list`, and the proxy is that
+backend's client, so it relays the request onto its own front session. This
+reaches the wire through the SDK session rather than a `Context` method:
+`ctx.list_roots()` is not part of FastMCP's server-authoring API, because
+SEP-2577 removed server-initiated requests from the modern protocol. The
+relay exists only for handshake-era interop on both legs.
+
+
+### `default_proxy_sampling_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1547" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_proxy_sampling_handler(messages: list[mcp_types.SamplingMessage], params: mcp_types.CreateMessageRequestParams, context: ServerRequestContext[Any, Any]) -> mcp_types.CreateMessageResult
+```
+
+
+Forward sampling request from remote server to proxy's connected clients.
+
+Relays through the SDK session for the same reason as
+`default_proxy_roots_handler`: server-initiated sampling is not part of
+FastMCP's server-authoring API, and this path only ever runs when both legs
+of the proxy speak the handshake era.
+
+
+### `default_proxy_elicitation_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1581" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_proxy_elicitation_handler(message: str, response_type: type, params: mcp_types.ElicitRequestParams, context: ServerRequestContext[Any, Any]) -> ElicitResult
+```
+
+
+Forward elicitation request from remote server to proxy's connected clients.
+
+
+### `default_proxy_log_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1603" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_proxy_log_handler(message: LogMessage) -> None
+```
+
+
+Forward log notification from remote server to proxy's connected clients.
+
+
+### `default_proxy_progress_handler` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1611" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_proxy_progress_handler(progress: float, total: float | None, message: str | None) -> None
+```
+
+
+Forward progress notification from remote server to proxy's connected clients.
+
+
+## Classes
+
+### `ProxyInitializeMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L268" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Deprecated middleware for forwarding instructions during initialization.
+
+
+**Methods:**
+
+#### `on_initialize` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L281" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_initialize(self, context: MiddlewareContext[mcp_types.InitializeRequest], call_next: CallNext[mcp_types.InitializeRequest, mcp_types.InitializeResult | None]) -> mcp_types.InitializeResult | None
+```
+
+### `ProxyTool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L341" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A Tool that represents and executes a tool on a remote server.
+
+
+**Methods:**
+
+#### `model_copy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L358" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+model_copy(self, **kwargs: Any) -> ProxyTool
+```
+
+Override to preserve _backend_name when name changes.
+
+
+#### `from_mcp_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L368" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_mcp_tool(cls, client_factory: ClientFactoryT, mcp_tool: mcp_types.Tool) -> ProxyTool
+```
+
+Factory method to create a ProxyTool from a raw MCP tool schema.
+
+
+#### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L386" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(self, arguments: dict[str, Any], context: Context | None = None) -> ToolResult
+```
+
+Executes the tool by making a call through the client.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L472" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `ProxyResource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L479" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A Resource that represents and reads a resource from a remote server.
+
+
+**Methods:**
+
+#### `model_copy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L504" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+model_copy(self, **kwargs: Any) -> ProxyResource
+```
+
+Override to preserve _backend_uri when uri changes.
+
+
+#### `from_mcp_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L514" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_mcp_resource(cls, client_factory: ClientFactoryT, mcp_resource: mcp_types.Resource) -> ProxyResource
+```
+
+Factory method to create a ProxyResource from a raw MCP resource schema.
+
+
+#### `read` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L534" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read(self) -> ResourceResult
+```
+
+Read the resource content from the remote server.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L583" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `ProxyTemplate` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L590" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A ResourceTemplate that represents and creates resources from a remote server template.
+
+
+**Methods:**
+
+#### `model_copy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L607" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+model_copy(self, **kwargs: Any) -> ProxyTemplate
+```
+
+Override to preserve _backend_uri_template when uri_template changes.
+
+
+#### `from_mcp_template` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L617" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_mcp_template(cls, client_factory: ClientFactoryT, mcp_template: mcp_types.ResourceTemplate) -> ProxyTemplate
+```
+
+Factory method to create a ProxyTemplate from a raw MCP template schema.
+
+
+#### `create_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L636" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_resource(self, uri: str, params: dict[str, Any], context: Context | None = None) -> ProxyResource
+```
+
+Create a resource from the template by calling the remote server.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L716" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `ProxyPrompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L725" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A Prompt that represents and renders a prompt from a remote server.
+
+
+**Methods:**
+
+#### `model_copy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L742" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+model_copy(self, **kwargs: Any) -> ProxyPrompt
+```
+
+Override to preserve _backend_name when name changes.
+
+
+#### `from_mcp_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L752" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_mcp_prompt(cls, client_factory: ClientFactoryT, mcp_prompt: mcp_types.Prompt) -> ProxyPrompt
+```
+
+Factory method to create a ProxyPrompt from a raw MCP prompt schema.
+
+
+#### `render` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L776" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+render(self, arguments: dict[str, Any]) -> PromptResult
+```
+
+Render the prompt by making a call through the client.
+
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L821" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```
+
+### `ProxyProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L852" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider that proxies to a remote MCP server via a client factory.
+
+This provider fetches components from a remote server and returns Proxy*
+component instances that forward execution to the remote server.
+
+All components returned by this provider have task_config.mode="forbidden"
+because tasks cannot be executed through a proxy.
+
+Component lists (tools, resources, templates, prompts) are cached so that
+individual lookups (e.g. during ``call_tool``) can resolve from the cache
+instead of opening a new backend connection.  The cache stores the
+backend's raw component metadata and is shared across all sessions;
+per-session visibility and auth filtering are applied after cache lookup
+by the server layer.  The cache is refreshed whenever a ``list_*`` call
+is made, and entries expire after ``cache_ttl`` seconds (default 300).
+Set ``cache_ttl=0`` to disable caching.  Disabling is recommended for
+backends whose component lists change dynamically.
+
+
+**Methods:**
+
+#### `get_tool_by_hash` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L955" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool_by_hash(self, tool_hash: str, tool_name: str) -> Tool | None
+```
+
+Resolve an identity against the remote listing.
+
+The base implementation looks the tool up by its registered name,
+which assumes the name survived to here. Across a proxy it need not:
+a backend that mounts its app under a namespace advertises
+``crm_save``, and nothing named ``save`` was ever listed. Matching on
+the identity carried in meta is what the identity is for.
+
+A remote that mounts one app twice sends back two tools claiming one
+identity, exactly as a local composition would. That is refused here
+on the same terms ``AggregateProvider`` refuses it, so a duplicated
+app is caught wherever it is composed rather than only nearby.
+
+
+#### `get_tasks` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1124" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tasks(self) -> Sequence[FastMCPComponent]
+```
+
+Return empty list since proxy components don't support tasks.
+
+Override the base implementation to avoid calling list_tools() during
+server lifespan initialization, which would open the client before any
+context is set. All Proxy* components have task_config.mode="forbidden".
+
+
+### `ProxyMetadataMiddleware` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1179" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Forward optional server metadata from a ``ProxyProvider`` backend.
+
+Instructions and namespaced metadata are forwarded with frontend values
+taking precedence. Protocol versions, capabilities, cache policy, and result
+type are never copied from the backend. ``identity`` controls whether server
+identity remains the gateway's or uses the backend's when available.
+
+
+**Methods:**
+
+#### `on_initialize` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1257" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_initialize(self, context: MiddlewareContext[mcp_types.InitializeRequest], call_next: CallNext[mcp_types.InitializeRequest, mcp_types.InitializeResult | None]) -> mcp_types.InitializeResult | None
+```
+
+#### `on_discover` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1274" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+on_discover(self, context: MiddlewareContext[mcp_types.DiscoverRequest], call_next: CallNext[mcp_types.DiscoverRequest, mcp_types.DiscoverResult | dict[str, Any]]) -> mcp_types.DiscoverResult | dict[str, Any]
+```
+
+### `FastMCPProxy` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1451" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A FastMCP server that acts as a proxy to a remote MCP-compliant server.
+
+This is a convenience wrapper that creates a FastMCP server with a
+ProxyProvider. For more control, use FastMCP with add_provider(ProxyProvider(...)).
+
+
+### `ProxyClient` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1682" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A proxy client that forwards advanced interactions between a remote MCP server and the proxy's connected clients.
+
+Supports forwarding roots, sampling, elicitation, logging, and progress.
+
+The default forwarding handlers must resolve the *proxy's* request context so
+they relay server-initiated requests (roots/sampling/elicitation) back to the
+proxy's own connected client, not to the upstream server they are talking to.
+Under SDK v2 an in-memory backend runs in the same event loop as this client,
+so a naive ``get_context()`` inside a handler can resolve to the backend's
+context and forward the request straight back to the backend — an infinite
+loop. To avoid that, ``ProxyTool.run`` (and the other proxy components) stash
+the proxy-side ``RequestContext`` in ``_proxy_rc_ref`` before each backend
+call, and the handlers are wrapped to restore it before forwarding.
+
+
+**Methods:**
+
+#### `new` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1788" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+new(self) -> ProxyClient[ClientTransportT]
+```
+
+### `StatefulProxyClient` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1798" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A proxy client that provides a stateful client factory for the proxy server.
+
+The stateful proxy client bound its copy to the server session.
+And it will be disconnected when the session is exited.
+
+This is useful to proxy a stateful mcp server such as the Playwright MCP server.
+Note that it is essential to ensure that the proxy server itself is also stateful.
+
+The base ``ProxyClient`` already installs the context-restoring handlers
+(see its docstring); this subclass additionally caches one client per stable
+``Connection`` and forces disconnect when the connection is torn down.
+
+
+**Methods:**
+
+#### `new` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1819" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+new(self) -> StatefulProxyClient[ClientTransportT]
+```
+
+#### `clear` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1830" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+clear(self)
+```
+
+Clear all cached clients and force disconnect them.
+
+
+#### `new_stateful` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/proxy.py#L1836" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+new_stateful(self) -> Client[ClientTransportT]
+```
+
+Create a new stateful proxy client instance with the same configuration.
+
+Use this method as the client factory for stateful proxy server.
+

--- a/docs/python-sdk/fastmcp-server-providers-skills-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-skills-__init__.mdx
@@ -1,0 +1,32 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.server.providers.skills`
+
+
+Skills providers for exposing agent skills as MCP resources.
+
+This module provides a two-layer architecture for skill discovery:
+
+- **SkillProvider**: Handles a single skill folder, exposing its files as resources.
+- **SkillsDirectoryProvider**: Scans a directory, creates a SkillProvider per folder.
+- **Vendor providers**: Platform-specific providers for Claude, Cursor, VS Code, Codex,
+  Gemini, Goose, Copilot, and OpenCode.
+
+Example:
+    ```python
+    from pathlib import Path
+    from fastmcp import FastMCP
+    from fastmcp.server.providers.skills import ClaudeSkillsProvider, SkillProvider
+
+    mcp = FastMCP("Skills Server")
+
+    # Load a single skill
+    mcp.add_provider(SkillProvider(Path.home() / ".claude/skills/pdf-processing"))
+
+    # Or load all skills in a directory
+    mcp.add_provider(ClaudeSkillsProvider())  # Uses ~/.claude/skills/
+    ```
+

--- a/docs/python-sdk/fastmcp-server-providers-skills-claude_provider.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-skills-claude_provider.mdx
@@ -1,0 +1,25 @@
+---
+title: claude_provider
+sidebarTitle: claude_provider
+---
+
+# `fastmcp.server.providers.skills.claude_provider`
+
+
+Claude-specific skills provider for Claude Code skills.
+
+## Classes
+
+### `ClaudeSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/claude_provider.py#L11" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider for Claude Code skills from ~/.claude/skills/.
+
+A convenience subclass that sets the default root to Claude's skills location.
+
+**Args:**
+- `reload`: If True, re-scan on every request. Defaults to False.
+- `supporting_files`: How supporting files are exposed\:
+- "template"\: Accessed via ResourceTemplate, hidden from list_resources().
+- "resources"\: Each file exposed as individual Resource in list_resources().
+

--- a/docs/python-sdk/fastmcp-server-providers-skills-directory_provider.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-skills-directory_provider.mdx
@@ -1,0 +1,31 @@
+---
+title: directory_provider
+sidebarTitle: directory_provider
+---
+
+# `fastmcp.server.providers.skills.directory_provider`
+
+
+Directory scanning provider for discovering multiple skills.
+
+## Classes
+
+### `SkillsDirectoryProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/directory_provider.py#L19" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider that scans directories and creates a SkillProvider per skill folder.
+
+This extends AggregateProvider to combine multiple SkillProviders into one.
+Each subdirectory containing a main file (default: SKILL.md) becomes a skill.
+Can scan multiple root directories - if a skill name appears in multiple roots,
+the first one found wins.
+
+**Args:**
+- `roots`: Root directory(ies) containing skill folders. Can be a single path
+or a sequence of paths.
+- `reload`: If True, re-discover skills on each request. Defaults to False.
+- `main_file_name`: Name of the main skill file. Defaults to "SKILL.md".
+- `supporting_files`: How supporting files are exposed in child SkillProviders\:
+- "template"\: Accessed via ResourceTemplate, hidden from list_resources().
+- "resources"\: Each file exposed as individual Resource in list_resources().
+

--- a/docs/python-sdk/fastmcp-server-providers-skills-skill_provider.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-skills-skill_provider.mdx
@@ -1,0 +1,121 @@
+---
+title: skill_provider
+sidebarTitle: skill_provider
+---
+
+# `fastmcp.server.providers.skills.skill_provider`
+
+
+Basic skill provider for handling a single skill folder.
+
+## Classes
+
+### `SkillResource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L37" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A resource representing a skill's main file or manifest.
+
+
+**Methods:**
+
+#### `get_meta` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L43" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_meta(self) -> dict[str, Any]
+```
+
+#### `read` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L52" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read(self) -> str | bytes | ResourceResult
+```
+
+Read the resource content.
+
+
+### `SkillFileTemplate` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L72" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A template for accessing files within a skill.
+
+
+**Methods:**
+
+#### `read` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read(self, arguments: dict[str, Any]) -> str | bytes | ResourceResult
+```
+
+Read a file from the skill directory.
+
+
+#### `create_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L111" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_resource(self, uri: str, params: dict[str, Any]) -> Resource
+```
+
+Create a resource for the given URI and parameters.
+
+Note: This is not typically used since _read() handles file reading directly.
+Provided for compatibility with the ResourceTemplate interface.
+
+
+### `SkillFileResource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L139" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A resource representing a specific file within a skill.
+
+
+**Methods:**
+
+#### `get_meta` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L145" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_meta(self) -> dict[str, Any]
+```
+
+#### `read` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L153" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+read(self) -> str | bytes | ResourceResult
+```
+
+Read the file content.
+
+
+### `SkillProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L177" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provider that exposes a single skill folder as MCP resources.
+
+Each skill folder must contain a main file (default: SKILL.md) and may
+contain additional supporting files.
+
+Exposes:
+- A Resource for the main file (skill://{name}/SKILL.md)
+- A Resource for the synthetic manifest (skill://{name}/_manifest)
+- Supporting files via ResourceTemplate or Resources (configurable)
+
+**Args:**
+- `skill_path`: Path to the skill directory.
+- `main_file_name`: Name of the main skill file. Defaults to "SKILL.md".
+- `supporting_files`: How supporting files (everything except main file and
+manifest) are exposed to clients\:
+- "template"\: Accessed via ResourceTemplate, hidden from list_resources().
+  Clients discover files by reading the manifest first.
+- "resources"\: Each file exposed as individual Resource in list_resources().
+  Full enumeration upfront.
+
+
+**Methods:**
+
+#### `skill_info` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/skill_provider.py#L269" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+skill_info(self) -> SkillInfo
+```
+
+Get the loaded skill info.
+

--- a/docs/python-sdk/fastmcp-server-providers-skills-vendor_providers.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-skills-vendor_providers.mdx
@@ -1,0 +1,56 @@
+---
+title: vendor_providers
+sidebarTitle: vendor_providers
+---
+
+# `fastmcp.server.providers.skills.vendor_providers`
+
+
+Vendor-specific skills providers for various AI coding platforms.
+
+## Classes
+
+### `CursorSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/vendor_providers.py#L11" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Cursor skills from ~/.cursor/skills/.
+
+
+### `VSCodeSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/vendor_providers.py#L29" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+VS Code skills from ~/.copilot/skills/.
+
+
+### `CodexSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/vendor_providers.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Codex skills from /etc/codex/skills/ and ~/.codex/skills/.
+
+Scans both system-level and user-level directories. System skills take
+precedence if duplicates exist.
+
+
+### `GeminiSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/vendor_providers.py#L73" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Gemini skills from ~/.gemini/skills/.
+
+
+### `GooseSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/vendor_providers.py#L91" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Goose skills from ~/.config/agents/skills/.
+
+
+### `CopilotSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/vendor_providers.py#L109" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+GitHub Copilot skills from ~/.copilot/skills/.
+
+
+### `OpenCodeSkillsProvider` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/providers/skills/vendor_providers.py#L127" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+OpenCode skills from ~/.config/opencode/skills/.
+

--- a/docs/python-sdk/fastmcp-server-providers-wrapped_provider.mdx
+++ b/docs/python-sdk/fastmcp-server-providers-wrapped_provider.mdx
@@ -1,0 +1,13 @@
+---
+title: wrapped_provider
+sidebarTitle: wrapped_provider
+---
+
+# `fastmcp.server.providers.wrapped_provider`
+
+
+WrappedProvider for immutable transform composition.
+
+This module provides `_WrappedProvider`, an internal class that wraps a provider
+with an additional transform. Created by `Provider.wrap_transform()`.
+

--- a/docs/python-sdk/fastmcp-server-transforms-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-__init__.mdx
@@ -1,6 +1,6 @@
 ---
-title: transforms
-sidebarTitle: transforms
+title: __init__
+sidebarTitle: __init__
 ---
 
 # `fastmcp.server.transforms`

--- a/docs/python-sdk/fastmcp-server-transforms-catalog.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-catalog.mdx
@@ -1,0 +1,234 @@
+---
+title: catalog
+sidebarTitle: catalog
+---
+
+# `fastmcp.server.transforms.catalog`
+
+
+Base class for transforms that need to read the real component catalog.
+
+Some transforms replace ``list_tools()`` output with synthetic components
+(e.g. a search interface) while still needing access to the *real*
+(auth-filtered) catalog at call time.  ``CatalogTransform`` provides the
+bypass machinery so subclasses can call ``get_tool_catalog()`` without
+triggering their own replacement logic.
+
+Re-entrancy problem
+-------------------
+
+When a synthetic tool handler calls ``get_tool_catalog()``, that calls
+``ctx.fastmcp.list_tools()`` which re-enters the transform pipeline —
+including *this* transform's ``list_tools()``.  If the subclass overrides
+``list_tools()`` directly, the re-entrant call would hit the subclass's
+replacement logic again (returning synthetic tools instead of the real
+catalog).  A ``super()`` call can't prevent this because Python can't
+short-circuit a method after ``super()`` returns.
+
+Solution: ``CatalogTransform`` owns ``list_tools()`` and uses a
+per-instance ``ContextVar`` to detect re-entrant calls.  During bypass,
+it passes through to the base ``Transform.list_tools()`` (a no-op).
+Otherwise, it delegates to ``transform_tools()`` — the subclass hook
+where replacement logic lives.  Same pattern for resources, prompts,
+and resource templates.
+
+This is *not* the same as the ``Provider._list_tools()`` convention
+(which produces raw components with no arguments).  ``transform_tools()``
+receives the current catalog and returns a transformed version.  The
+distinct name avoids confusion between the two patterns.
+
+Usage::
+
+    class MyTransform(CatalogTransform):
+        async def transform_tools(self, tools):
+            return [self._make_search_tool()]
+
+        def _make_search_tool(self):
+            async def search(ctx: Context = None):
+                real_tools = await self.get_tool_catalog(ctx)
+                ...
+            return Tool.from_function(fn=search, name="search")
+
+
+## Classes
+
+### `CatalogTransform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L66" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transform that needs access to the real component catalog.
+
+Subclasses override ``transform_tools()`` / ``transform_resources()``
+/ ``transform_prompts()`` / ``transform_resource_templates()``
+instead of the ``list_*()`` methods.  The base class owns
+``list_*()`` and handles re-entrant bypass automatically — subclasses
+never see re-entrant calls from ``get_*_catalog()``.
+
+The ``get_*_catalog()`` methods fetch the real (auth-filtered) catalog
+by temporarily setting a bypass flag so that this transform's
+``list_*()`` passes through without calling the subclass hook.
+
+
+**Methods:**
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L90" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+#### `list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resources(self, resources: Sequence[Resource]) -> Sequence[Resource]
+```
+
+#### `list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resource_templates(self, templates: Sequence[ResourceTemplate]) -> Sequence[ResourceTemplate]
+```
+
+#### `list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L107" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_prompts(self, prompts: Sequence[Prompt]) -> Sequence[Prompt]
+```
+
+#### `transform_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L116" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+transform_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+Transform the tool catalog.
+
+Override this method to replace, filter, or augment the tool listing.
+The default implementation passes through unchanged.
+
+Do NOT override ``list_tools()`` directly — the base class uses it
+to handle re-entrant bypass when ``get_tool_catalog()`` reads the
+real catalog.
+
+
+#### `transform_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L128" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+transform_resources(self, resources: Sequence[Resource]) -> Sequence[Resource]
+```
+
+Transform the resource catalog.
+
+Override this method to replace, filter, or augment the resource listing.
+The default implementation passes through unchanged.
+
+Do NOT override ``list_resources()`` directly — the base class uses it
+to handle re-entrant bypass when ``get_resource_catalog()`` reads the
+real catalog.
+
+
+#### `transform_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L142" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+transform_resource_templates(self, templates: Sequence[ResourceTemplate]) -> Sequence[ResourceTemplate]
+```
+
+Transform the resource template catalog.
+
+Override this method to replace, filter, or augment the template listing.
+The default implementation passes through unchanged.
+
+Do NOT override ``list_resource_templates()`` directly — the base class
+uses it to handle re-entrant bypass when
+``get_resource_template_catalog()`` reads the real catalog.
+
+
+#### `transform_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L156" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+transform_prompts(self, prompts: Sequence[Prompt]) -> Sequence[Prompt]
+```
+
+Transform the prompt catalog.
+
+Override this method to replace, filter, or augment the prompt listing.
+The default implementation passes through unchanged.
+
+Do NOT override ``list_prompts()`` directly — the base class uses it
+to handle re-entrant bypass when ``get_prompt_catalog()`` reads the
+real catalog.
+
+
+#### `get_tool_catalog` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L172" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool_catalog(self, ctx: Context) -> Sequence[Tool]
+```
+
+Fetch the real tool catalog, bypassing this transform.
+
+The result is deduplicated by name so that only the highest version
+of each tool is returned — matching what protocol handlers expose
+on the wire.
+
+Tools the model may not see are excluded. A catalog is read by the
+model as tool output rather than advertised as ``tools/list``, so the
+host filtering the spec relies on never applies to it — this is the
+only place the declaration can be enforced.
+
+Visibility is checked after deduplication, on the version a bare name
+actually reaches. Checking first would let a model-visible older
+version advertise a name whose highest version is app-only, and the
+call would run the version nobody was shown.
+
+**Args:**
+- `ctx`: The current request context.
+- `run_middleware`: Whether to run middleware on the inner call.
+Defaults to True because this is typically called from a
+tool handler where list_tools middleware has not yet run.
+
+
+#### `get_resource_catalog` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L205" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource_catalog(self, ctx: Context) -> Sequence[Resource]
+```
+
+Fetch the real resource catalog, bypassing this transform.
+
+**Args:**
+- `ctx`: The current request context.
+- `run_middleware`: Whether to run middleware on the inner call.
+Defaults to True because this is typically called from a
+tool handler where list_resources middleware has not yet run.
+
+
+#### `get_prompt_catalog` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L222" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_prompt_catalog(self, ctx: Context) -> Sequence[Prompt]
+```
+
+Fetch the real prompt catalog, bypassing this transform.
+
+**Args:**
+- `ctx`: The current request context.
+- `run_middleware`: Whether to run middleware on the inner call.
+Defaults to True because this is typically called from a
+tool handler where list_prompts middleware has not yet run.
+
+
+#### `get_resource_template_catalog` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/catalog.py#L239" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource_template_catalog(self, ctx: Context) -> Sequence[ResourceTemplate]
+```
+
+Fetch the real resource template catalog, bypassing this transform.
+
+**Args:**
+- `ctx`: The current request context.
+- `run_middleware`: Whether to run middleware on the inner call.
+Defaults to True because this is typically called from a
+tool handler where list_resource_templates middleware has
+not yet run.
+

--- a/docs/python-sdk/fastmcp-server-transforms-namespace.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-namespace.mdx
@@ -1,0 +1,96 @@
+---
+title: namespace
+sidebarTitle: namespace
+---
+
+# `fastmcp.server.transforms.namespace`
+
+
+Namespace transform for prefixing component names.
+
+## Classes
+
+### `Namespace` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L28" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Prefixes component names with a namespace.
+
+- Tools: name → namespace_name
+- Prompts: name → namespace_name
+- Resources: protocol://path → protocol://namespace/path
+- Resource Templates: same as resources
+
+
+**Methods:**
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L97" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+Prefix tool names with namespace.
+
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L103" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, call_next: GetToolNext) -> Tool | None
+```
+
+Get tool by namespaced name.
+
+
+#### `list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L119" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resources(self, resources: Sequence[Resource]) -> Sequence[Resource]
+```
+
+Add namespace path segment to resource URIs.
+
+
+#### `get_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L126" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource(self, uri: str, call_next: GetResourceNext) -> Resource | None
+```
+
+Get resource by namespaced URI.
+
+
+#### `list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L146" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resource_templates(self, templates: Sequence[ResourceTemplate]) -> Sequence[ResourceTemplate]
+```
+
+Add namespace path segment to template URIs.
+
+
+#### `get_resource_template` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L155" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource_template(self, uri: str, call_next: GetResourceTemplateNext) -> ResourceTemplate | None
+```
+
+Get resource template by namespaced URI.
+
+
+#### `list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L177" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_prompts(self, prompts: Sequence[Prompt]) -> Sequence[Prompt]
+```
+
+Prefix prompt names with namespace.
+
+
+#### `get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/namespace.py#L183" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_prompt(self, name: str, call_next: GetPromptNext) -> Prompt | None
+```
+
+Get prompt by namespaced name.
+

--- a/docs/python-sdk/fastmcp-server-transforms-prompts_as_tools.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-prompts_as_tools.mdx
@@ -1,0 +1,66 @@
+---
+title: prompts_as_tools
+sidebarTitle: prompts_as_tools
+---
+
+# `fastmcp.server.transforms.prompts_as_tools`
+
+
+Transform that exposes prompts as tools.
+
+This transform generates tools for listing and getting prompts, enabling
+clients that only support tools to access prompt functionality.
+
+The generated tools route through `ctx.fastmcp` at runtime, so all server
+middleware (auth, visibility, rate limiting, etc.) applies to prompt
+operations exactly as it would for direct `prompts/get` calls.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.transforms import PromptsAsTools
+
+    mcp = FastMCP("Server")
+    mcp.add_transform(PromptsAsTools(mcp))
+    # Now has list_prompts and get_prompt tools
+    ```
+
+
+## Classes
+
+### `PromptsAsTools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/prompts_as_tools.py#L38" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transform that adds tools for listing and getting prompts.
+
+Generates two tools:
+- `list_prompts`: Lists all prompts
+- `get_prompt`: Gets a specific prompt with optional arguments
+
+The generated tools route through the server at runtime, so auth,
+middleware, and visibility apply automatically.
+
+This transform should be applied to a FastMCP server instance, not
+a raw Provider, because the generated tools need the server's
+middleware chain for auth and visibility filtering.
+
+
+**Methods:**
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/prompts_as_tools.py#L75" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+Add prompt tools to the tool list.
+
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/prompts_as_tools.py#L83" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, call_next: GetToolNext) -> Tool | None
+```
+
+Get a tool by name, including generated prompt tools.
+

--- a/docs/python-sdk/fastmcp-server-transforms-resources_as_tools.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-resources_as_tools.mdx
@@ -1,0 +1,66 @@
+---
+title: resources_as_tools
+sidebarTitle: resources_as_tools
+---
+
+# `fastmcp.server.transforms.resources_as_tools`
+
+
+Transform that exposes resources as tools.
+
+This transform generates tools for listing and reading resources, enabling
+clients that only support tools to access resource functionality.
+
+The generated tools route through `ctx.fastmcp` at runtime, so all server
+middleware (auth, visibility, rate limiting, etc.) applies to resource
+operations exactly as it would for direct `resources/read` calls.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.transforms import ResourcesAsTools
+
+    mcp = FastMCP("Server")
+    mcp.add_transform(ResourcesAsTools(mcp))
+    # Now has list_resources and read_resource tools
+    ```
+
+
+## Classes
+
+### `ResourcesAsTools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/resources_as_tools.py#L41" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Transform that adds tools for listing and reading resources.
+
+Generates two tools:
+- `list_resources`: Lists all resources and templates
+- `read_resource`: Reads a resource by URI
+
+The generated tools route through the server at runtime, so auth,
+middleware, and visibility apply automatically.
+
+This transform should be applied to a FastMCP server instance, not
+a raw Provider, because the generated tools need the server's
+middleware chain for auth and visibility filtering.
+
+
+**Methods:**
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/resources_as_tools.py#L78" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+Add resource tools to the tool list.
+
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/resources_as_tools.py#L86" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, call_next: GetToolNext) -> Tool | None
+```
+
+Get a tool by name, including generated resource tools.
+

--- a/docs/python-sdk/fastmcp-server-transforms-search-__init__.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-search-__init__.mdx
@@ -1,0 +1,23 @@
+---
+title: __init__
+sidebarTitle: __init__
+---
+
+# `fastmcp.server.transforms.search`
+
+
+Search transforms for tool discovery.
+
+Search transforms collapse a large tool catalog into a search interface,
+letting LLMs discover tools on demand instead of seeing the full list.
+
+Example:
+    ```python
+    from fastmcp import FastMCP
+    from fastmcp.server.transforms.search import RegexSearchTransform
+
+    mcp = FastMCP("Server")
+    mcp.add_transform(RegexSearchTransform())
+    # list_tools now returns only search_tools + call_tool
+    ```
+

--- a/docs/python-sdk/fastmcp-server-transforms-search-base.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-search-base.mdx
@@ -1,0 +1,105 @@
+---
+title: base
+sidebarTitle: base
+---
+
+# `fastmcp.server.transforms.search.base`
+
+
+Base class for search transforms.
+
+Search transforms replace ``list_tools()`` output with a small set of
+synthetic tools — a search tool and a call-tool proxy — so LLMs can
+discover tools on demand instead of receiving the full catalog.
+
+All concrete search transforms (``RegexSearchTransform``,
+``BM25SearchTransform``, etc.) inherit from ``BaseSearchTransform`` and
+implement ``_make_search_tool()`` and ``_search()`` to provide their
+specific search strategy.
+
+Example::
+
+    from fastmcp import FastMCP
+    from fastmcp.server.transforms.search import RegexSearchTransform
+
+    mcp = FastMCP("Server")
+
+    @mcp.tool
+    def add(a: int, b: int) -> int: ...
+
+    @mcp.tool
+    def multiply(x: float, y: float) -> float: ...
+
+    # Clients now see only ``search_tools`` and ``call_tool``.
+    # The original tools are discoverable via search.
+    mcp.add_transform(RegexSearchTransform())
+
+
+## Functions
+
+### `serialize_tools_for_output_json` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/search/base.py#L61" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+serialize_tools_for_output_json(tools: Sequence[Tool]) -> list[dict[str, Any]]
+```
+
+
+Serialize tools to the same dict format as ``list_tools`` output.
+
+
+### `serialize_tools_for_output_markdown` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/search/base.py#L140" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+serialize_tools_for_output_markdown(tools: Sequence[Tool]) -> str
+```
+
+
+Serialize tools to compact markdown, using ~65-70% fewer tokens than JSON.
+
+
+## Classes
+
+### `BaseSearchTransform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/search/base.py#L156" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Replace the tool listing with a search interface.
+
+When this transform is active, ``list_tools()`` returns only:
+
+* Any tools listed in ``always_visible`` (pinned).
+* A **search tool** that finds tools matching a query.
+* A **call_tool** proxy that executes tools discovered via search.
+
+Hidden tools remain callable — ``get_tool()`` delegates unknown
+names downstream, so direct calls and the call-tool proxy both work.
+
+Search results respect the full auth pipeline: middleware, visibility
+transforms, and component-level auth checks all apply.
+
+**Args:**
+- `max_results`: Maximum number of tools returned per search.
+- `always_visible`: Tool names that stay in the ``list_tools``
+output alongside the synthetic search/call tools.
+- `search_tool_name`: Name of the generated search tool.
+- `call_tool_name`: Name of the generated call-tool proxy.
+
+
+**Methods:**
+
+#### `transform_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/search/base.py#L201" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+transform_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+Replace the catalog with pinned + synthetic search/call tools.
+
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/search/base.py#L206" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, call_next: GetToolNext) -> Tool | None
+```
+
+Intercept synthetic tool names; delegate everything else.
+

--- a/docs/python-sdk/fastmcp-server-transforms-search-bm25.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-search-bm25.mdx
@@ -1,0 +1,20 @@
+---
+title: bm25
+sidebarTitle: bm25
+---
+
+# `fastmcp.server.transforms.search.bm25`
+
+
+BM25-based search transform.
+
+## Classes
+
+### `BM25SearchTransform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/search/bm25.py#L88" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Search transform using BM25 Okapi relevance ranking.
+
+Maintains an in-memory index that is lazily rebuilt when the tool
+catalog changes (detected via a hash of tool names).
+

--- a/docs/python-sdk/fastmcp-server-transforms-search-regex.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-search-regex.mdx
@@ -1,0 +1,20 @@
+---
+title: regex
+sidebarTitle: regex
+---
+
+# `fastmcp.server.transforms.search.regex`
+
+
+Regex-based search transform.
+
+## Classes
+
+### `RegexSearchTransform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/search/regex.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Search transform using regex pattern matching.
+
+Tools are matched against their name, description, and parameter
+information using ``re.search`` with ``re.IGNORECASE``.
+

--- a/docs/python-sdk/fastmcp-server-transforms-tool_transform.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-tool_transform.mdx
@@ -1,0 +1,40 @@
+---
+title: tool_transform
+sidebarTitle: tool_transform
+---
+
+# `fastmcp.server.transforms.tool_transform`
+
+
+Transform for applying tool transformations.
+
+## Classes
+
+### `ToolTransform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/tool_transform.py#L16" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Applies tool transformations to modify tool schemas.
+
+Wraps ToolTransformConfig to apply argument renames, schema changes,
+hidden arguments, and other transformations at the transform level.
+
+
+**Methods:**
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/tool_transform.py#L64" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+Apply transforms to matching tools.
+
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/tool_transform.py#L75" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, call_next: GetToolNext) -> Tool | None
+```
+
+Get tool by transformed name.
+

--- a/docs/python-sdk/fastmcp-server-transforms-version_filter.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-version_filter.mdx
@@ -1,0 +1,89 @@
+---
+title: version_filter
+sidebarTitle: version_filter
+---
+
+# `fastmcp.server.transforms.version_filter`
+
+
+Version filter transform for filtering components by version range.
+
+## Classes
+
+### `VersionFilter` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Filters components by version range.
+
+When applied to a provider or server, components within the version range
+are visible, and unversioned components are included by default. Within
+that filtered set, the highest version of each component is exposed to
+clients (standard deduplication behavior). Set
+``include_unversioned=False`` to exclude unversioned components.
+
+Parameters mirror comparison operators for clarity:
+
+    # Versions < 3.0 (v1 and v2)
+    server.add_transform(VersionFilter(version_lt="3.0"))
+
+    # Versions >= 2.0 and < 3.0 (only v2.x)
+    server.add_transform(VersionFilter(version_gte="2.0", version_lt="3.0"))
+
+Works with any version string - PEP 440 (1.0, 2.0) or dates (2025-01-01).
+
+**Args:**
+- `version_gte`: Versions >= this value pass through.
+- `version_lt`: Versions < this value pass through.
+- `include_unversioned`: Whether unversioned components (``version=None``)
+should pass through the filter. Defaults to True.
+
+
+**Methods:**
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L80" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L87" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, call_next: GetToolNext) -> Tool | None
+```
+
+#### `list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resources(self, resources: Sequence[Resource]) -> Sequence[Resource]
+```
+
+#### `get_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L103" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource(self, uri: str, call_next: GetResourceNext) -> Resource | None
+```
+
+#### `list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L116" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resource_templates(self, templates: Sequence[ResourceTemplate]) -> Sequence[ResourceTemplate]
+```
+
+#### `get_resource_template` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L125" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource_template(self, uri: str, call_next: GetResourceTemplateNext) -> ResourceTemplate | None
+```
+
+#### `list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L138" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_prompts(self, prompts: Sequence[Prompt]) -> Sequence[Prompt]
+```
+
+#### `get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/version_filter.py#L145" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_prompt(self, name: str, call_next: GetPromptNext) -> Prompt | None
+```

--- a/docs/python-sdk/fastmcp-server-transforms-visibility.mdx
+++ b/docs/python-sdk/fastmcp-server-transforms-visibility.mdx
@@ -1,0 +1,261 @@
+---
+title: visibility
+sidebarTitle: visibility
+---
+
+# `fastmcp.server.transforms.visibility`
+
+
+Visibility transform for marking component visibility state.
+
+Each Visibility instance marks components via internal metadata. Multiple
+visibility transforms can be stacked - later transforms override earlier ones.
+Final filtering happens at the Provider level.
+
+
+## Functions
+
+### `is_enabled` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L285" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+is_enabled(component: FastMCPComponent) -> bool
+```
+
+
+Check if component is enabled.
+
+Returns True if:
+- No visibility mark exists (default is enabled)
+- Visibility mark is True
+
+Returns False if visibility mark is False.
+
+**Args:**
+- `component`: Component to check.
+
+**Returns:**
+- True if component should be enabled/visible to clients.
+
+
+### `get_visibility_rules` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L314" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_visibility_rules(context: Context) -> list[dict[str, Any]]
+```
+
+
+Load visibility rule dicts from session state.
+
+
+### `save_visibility_rules` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L319" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+save_visibility_rules(context: Context, rules: list[dict[str, Any]]) -> None
+```
+
+
+Save visibility rule dicts to session state and send notifications.
+
+**Args:**
+- `context`: The context to save rules for.
+- `rules`: The visibility rules to save.
+- `components`: Optional hint about which component types are affected.
+If None, sends notifications for all types (safe default).
+If provided, only sends notifications for specified types.
+
+
+### `create_visibility_transforms` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L346" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+create_visibility_transforms(rules: list[dict[str, Any]]) -> list[Visibility]
+```
+
+
+Convert rule dicts to Visibility transforms.
+
+
+### `get_session_transforms` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L374" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_session_transforms(context: Context) -> list[Visibility]
+```
+
+
+Get session-specific Visibility transforms from state store.
+
+
+### `enable_components` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L386" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+enable_components(context: Context) -> None
+```
+
+
+Enable components matching criteria for this session only.
+
+Session rules override global transforms. Rules accumulate - each call
+adds a new rule to the session. Later marks override earlier ones
+(Visibility transform semantics).
+
+Sends notifications to this session only: ToolListChangedNotification,
+ResourceListChangedNotification, and PromptListChangedNotification.
+
+**Args:**
+- `context`: The context for this session.
+- `names`: Component names or URIs to match.
+- `keys`: Component keys to match (e.g., {"tool\:my_tool@v1"}).
+- `version`: Component version spec to match.
+- `tags`: Tags to match (component must have at least one).
+- `components`: Component types to match (e.g., {"tool", "prompt"}).
+- `match_all`: If True, matches all components regardless of other criteria.
+
+
+### `disable_components` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L440" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+disable_components(context: Context) -> None
+```
+
+
+Disable components matching criteria for this session only.
+
+Session rules override global transforms. Rules accumulate - each call
+adds a new rule to the session. Later marks override earlier ones
+(Visibility transform semantics).
+
+Sends notifications to this session only: ToolListChangedNotification,
+ResourceListChangedNotification, and PromptListChangedNotification.
+
+**Args:**
+- `context`: The context for this session.
+- `names`: Component names or URIs to match.
+- `keys`: Component keys to match (e.g., {"tool\:my_tool@v1"}).
+- `version`: Component version spec to match.
+- `tags`: Tags to match (component must have at least one).
+- `components`: Component types to match (e.g., {"tool", "prompt"}).
+- `match_all`: If True, matches all components regardless of other criteria.
+
+
+### `reset_visibility` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L494" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+reset_visibility(context: Context) -> None
+```
+
+
+Clear all session visibility rules.
+
+Use this to reset session visibility back to global defaults.
+
+Sends notifications to this session only: ToolListChangedNotification,
+ResourceListChangedNotification, and PromptListChangedNotification.
+
+**Args:**
+- `context`: The context for this session.
+
+
+### `apply_session_transforms` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L511" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+apply_session_transforms(components: Sequence[ComponentT]) -> Sequence[ComponentT]
+```
+
+
+Apply session-specific visibility transforms to components.
+
+This helper applies session-level enable/disable rules by marking
+components with their visibility state. Session transforms override
+global transforms due to mark-based semantics (later marks win).
+
+**Args:**
+- `components`: The components to apply session transforms to.
+
+**Returns:**
+- The components with session transforms applied.
+
+
+## Classes
+
+### `Visibility` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L40" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Sets visibility state on matching components.
+
+Does NOT filter inline - just marks components with visibility state.
+Later transforms in the chain can override earlier marks.
+Final filtering happens at the Provider level after all transforms run.
+
+
+**Methods:**
+
+#### `list_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L210" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]
+```
+
+Mark tools by visibility state.
+
+
+#### `get_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L214" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_tool(self, name: str, call_next: GetToolNext) -> Tool | None
+```
+
+Mark tool if found.
+
+
+#### `list_resources` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L227" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resources(self, resources: Sequence[Resource]) -> Sequence[Resource]
+```
+
+Mark resources by visibility state.
+
+
+#### `get_resource` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L231" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource(self, uri: str, call_next: GetResourceNext) -> Resource | None
+```
+
+Mark resource if found.
+
+
+#### `list_resource_templates` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L248" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_resource_templates(self, templates: Sequence[ResourceTemplate]) -> Sequence[ResourceTemplate]
+```
+
+Mark resource templates by visibility state.
+
+
+#### `get_resource_template` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L254" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_resource_template(self, uri: str, call_next: GetResourceTemplateNext) -> ResourceTemplate | None
+```
+
+Mark resource template if found.
+
+
+#### `list_prompts` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L271" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+list_prompts(self, prompts: Sequence[Prompt]) -> Sequence[Prompt]
+```
+
+Mark prompts by visibility state.
+
+
+#### `get_prompt` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/server/transforms/visibility.py#L275" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_prompt(self, name: str, call_next: GetPromptNext) -> Prompt | None
+```
+
+Mark prompt if found.
+

--- a/docs/python-sdk/fastmcp-tools-base.mdx
+++ b/docs/python-sdk/fastmcp-tools-base.mdx
@@ -1,0 +1,128 @@
+---
+title: base
+sidebarTitle: base
+---
+
+# `fastmcp.tools.base`
+
+## Functions
+
+### `default_serializer` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L72" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+default_serializer(data: Any) -> str
+```
+
+## Classes
+
+### `ToolResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `from_mcp_result` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L160" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_mcp_result(cls, result: CallToolResult) -> ToolResult
+```
+
+Wrap a protocol result while preserving its exact wire representation.
+
+
+#### `to_mcp_result` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L171" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+to_mcp_result(self) -> list[ContentBlock] | tuple[list[ContentBlock], dict[str, Any]] | CallToolResult
+```
+
+### `InputRequiredToolResult` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L193" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+The full result of a single multi-round-trip leg (SEP-2322).
+
+The protocol is stateless: each MRTR leg is a complete request→response
+cycle. When a guard tool returns an `InputRequiredResult` from its body to
+ask the client for input, that ask is the *legitimate result* of this tool
+call — not a pause, not an error, not a third control-flow outcome. FastMCP
+wraps it in this `ToolResult` subclass so it flows through the middleware
+chain as an ordinary return value: `call_next(...)` returns it, default
+middleware completes normally on the leg, and middleware authors can
+identify an ask with a simple `isinstance(result, InputRequiredToolResult)`
+check.
+
+Invariant: the wrapped `InputRequiredResult` is never serialized as tool
+content. `content` is always empty; the wire handler (`_on_call_tool`)
+reads `.input_required` and returns it to the runner as the
+`input_required` result. Do not read `.content` / `.structured_content` on
+this subclass — they carry nothing.
+
+
+### `Tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L231" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Internal tool registration info.
+
+
+**Methods:**
+
+#### `to_mcp_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L268" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+to_mcp_tool(self, **overrides: Any) -> MCPTool
+```
+
+Convert the FastMCP tool to an MCP tool.
+
+
+#### `from_function` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L311" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_function(cls, fn: Callable[..., Any]) -> FunctionTool
+```
+
+Create a Tool from a function.
+
+
+#### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L349" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(self, arguments: dict[str, Any]) -> ToolResult
+```
+
+Run the tool with arguments.
+
+This method is not implemented in the base Tool class and must be
+implemented by subclasses.
+
+`run()` can EITHER return a list of ContentBlocks, or a tuple of
+(list of ContentBlocks, dict of structured output).
+
+A tool that requests client input (SEP-2322 multi-round-trip) does so by
+returning an `InputRequiredResult` from its body; the run machinery wraps
+that in an `InputRequiredToolResult` — a `ToolResult` subclass — so it
+stays inside the declared `ToolResult` result type and flows through the
+middleware chain as an ordinary result (see `FunctionTool.run`).
+
+
+#### `convert_result` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L367" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+convert_result(self, raw_value: Any) -> ToolResult
+```
+
+Convert a raw result to ToolResult.
+
+Handles ToolResult passthrough and converts raw values using the tool's
+attributes (output_schema) for proper conversion.
+
+
+#### `from_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L443" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_tool(cls, tool: Tool | Callable[..., Any]) -> TransformedTool
+```
+
+#### `get_span_attributes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/base.py#L489" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+get_span_attributes(self) -> dict[str, Any]
+```

--- a/docs/python-sdk/fastmcp-tools-function_parsing.mdx
+++ b/docs/python-sdk/fastmcp-tools-function_parsing.mdx
@@ -1,0 +1,21 @@
+---
+title: function_parsing
+sidebarTitle: function_parsing
+---
+
+# `fastmcp.tools.function_parsing`
+
+
+Function introspection and schema generation for FastMCP tools.
+
+## Classes
+
+### `ParsedFunction` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_parsing.py#L240" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `from_function` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_parsing.py#L249" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_function(cls, fn: Callable[..., Any], validate: bool = True, wrap_non_object_output_schema: bool = True) -> ParsedFunction
+```

--- a/docs/python-sdk/fastmcp-tools-function_tool.mdx
+++ b/docs/python-sdk/fastmcp-tools-function_tool.mdx
@@ -1,0 +1,84 @@
+---
+title: function_tool
+sidebarTitle: function_tool
+---
+
+# `fastmcp.tools.function_tool`
+
+
+Standalone @tool decorator for FastMCP.
+
+## Functions
+
+### `tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_tool.py#L548" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+tool(name_or_fn: str | Callable[..., Any] | None = None) -> Any
+```
+
+
+Standalone decorator to mark a function as an MCP tool.
+
+Returns the original function with metadata attached. Register with a server
+using mcp.add_tool().
+
+**Args:**
+- `run_in_thread`: Applies to sync tool functions only. When True (default),
+the sync function is dispatched to a worker thread so it does not
+block the event loop. Set to False to run the function inline on the
+event loop thread — useful for libraries with thread affinity
+(e.g. Windows COM via `uiautomation`/`comtypes`/`pywin32`, `tkinter`,
+some GPU/driver bindings). Ignored for async functions. Cannot be
+combined with `timeout` on a sync function\: inline calls have no
+cancellation checkpoints, so the timeout would be a silent no-op.
+
+
+## Classes
+
+### `DecoratedTool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_tool.py#L143" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Protocol for functions decorated with @tool.
+
+
+### `ToolMeta` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_tool.py#L152" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Metadata attached to functions by the @tool decorator.
+
+
+### `FunctionTool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_tool.py#L198" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+**Methods:**
+
+#### `from_function` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_tool.py#L217" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_function(cls, fn: Callable[..., Any]) -> FunctionTool
+```
+
+Create a FunctionTool from a function.
+
+**Args:**
+- `fn`: The function to wrap
+- `metadata`: ToolMeta object with all configuration. If provided,
+individual parameters must not be passed.
+- `name, title, etc.`: Individual parameters for backwards compatibility.
+Cannot be used together with metadata parameter.
+
+
+#### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/function_tool.py#L367" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(self, arguments: dict[str, Any]) -> ToolResult
+```
+
+Run the tool with arguments.
+
+A tool body may return an `InputRequiredResult` (SEP-2322) to ask the
+client for input. Under the stateless multi-round-trip protocol that ask
+is the full result of this leg, so it is wrapped in an
+`InputRequiredToolResult` (a `ToolResult` subclass) rather than
+serialized as content; the ask flows through the middleware chain as an
+ordinary result and the wire handler returns it to the client unmodified.
+

--- a/docs/python-sdk/fastmcp-tools-tool_transform.mdx
+++ b/docs/python-sdk/fastmcp-tools-tool_transform.mdx
@@ -1,0 +1,307 @@
+---
+title: tool_transform
+sidebarTitle: tool_transform
+---
+
+# `fastmcp.tools.tool_transform`
+
+## Functions
+
+### `forward` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+forward(**kwargs: Any) -> ToolResult
+```
+
+
+Forward to parent tool with argument transformation applied.
+
+This function can only be called from within a transformed tool's custom
+function. It applies argument transformation (renaming, validation) before
+calling the parent tool.
+
+For example, if the parent tool has args `x` and `y`, but the transformed
+tool has args `a` and `b`, and an `transform_args` was provided that maps `x` to
+`a` and `y` to `b`, then `forward(a=1, b=2)` will call the parent tool with
+`x=1` and `y=2`.
+
+**Args:**
+- `**kwargs`: Arguments to forward to the parent tool (using transformed names).
+
+**Returns:**
+- The ToolResult from the parent tool execution.
+
+**Raises:**
+- `RuntimeError`: If called outside a transformed tool context.
+- `TypeError`: If provided arguments don't match the transformed schema.
+
+
+### `forward_raw` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+forward_raw(**kwargs: Any) -> ToolResult
+```
+
+
+Forward directly to parent tool without transformation.
+
+This function bypasses all argument transformation and validation, calling the parent
+tool directly with the provided arguments. Use this when you need to call the parent
+with its original parameter names and structure.
+
+For example, if the parent tool has args `x` and `y`, then `forward_raw(x=1,
+y=2)` will call the parent tool with `x=1` and `y=2`.
+
+**Args:**
+- `**kwargs`: Arguments to pass directly to the parent tool (using original names).
+
+**Returns:**
+- The ToolResult from the parent tool execution.
+
+**Raises:**
+- `RuntimeError`: If called outside a transformed tool context.
+
+
+### `apply_transformations_to_tools` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L1022" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+apply_transformations_to_tools(tools: dict[str, Tool], transformations: dict[str, ToolTransformConfig]) -> dict[str, Tool]
+```
+
+
+Apply a list of transformations to a list of tools. Tools that do not have any transformations
+are left unchanged.
+
+Note: tools dict is keyed by prefixed key (e.g., "tool:my_tool"),
+but transformations are keyed by tool name (e.g., "my_tool").
+
+
+## Classes
+
+### `ArgTransform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L104" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Configuration for transforming a parent tool's argument.
+
+This class allows fine-grained control over how individual arguments are transformed
+when creating a new tool from an existing one. You can rename arguments, change their
+descriptions, add default values, or hide them from clients while passing constants.
+
+**Attributes:**
+- `name`: New name for the argument. Use None to keep original name, or ... for no change.
+- `description`: New description for the argument. Use None to remove description, or ... for no change.
+- `default`: New default value for the argument. Use ... for no change.
+- `default_factory`: Callable that returns a default value. Cannot be used with default.
+- `type`: New type for the argument. Use ... for no change.
+- `hide`: If True, hide this argument from clients but pass a constant value to parent.
+- `required`: If True, make argument required (remove default). Use ... for no change.
+- `examples`: Examples for the argument. Use ... for no change.
+
+**Examples:**
+
+Rename argument 'old_name' to 'new_name'
+```python
+ArgTransform(name="new_name")
+```
+
+Change description only
+```python
+ArgTransform(description="Updated description")
+```
+
+Add a default value (makes argument optional)
+```python
+ArgTransform(default=42)
+```
+
+Add a default factory (makes argument optional)
+```python
+ArgTransform(default_factory=lambda: time.time())
+```
+
+Change the type
+```python
+ArgTransform(type=str)
+```
+
+Hide the argument entirely from clients
+```python
+ArgTransform(hide=True)
+```
+
+Hide argument but pass a constant value to parent
+```python
+ArgTransform(hide=True, default="constant_value")
+```
+
+Hide argument but pass a factory-generated value to parent
+```python
+ArgTransform(hide=True, default_factory=lambda: uuid.uuid4().hex)
+```
+
+Make an optional parameter required (removes any default)
+```python
+ArgTransform(required=True)
+```
+
+Combine multiple transformations
+```python
+ArgTransform(name="new_name", description="New desc", default=None, type=int)
+```
+
+
+### `ArgTransformConfig` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L218" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A model for requesting a single argument transform.
+
+
+**Methods:**
+
+#### `to_arg_transform` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L236" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+to_arg_transform(self) -> ArgTransform
+```
+
+Convert the argument transform to a FastMCP argument transform.
+
+
+### `TransformedTool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L286" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+A tool that is transformed from another tool.
+
+This class represents a tool that has been created by transforming another tool.
+It supports argument renaming, schema modification, custom function injection,
+structured output control, and provides context for the forward() and forward_raw() functions.
+
+The transformation can be purely schema-based (argument renaming, dropping, etc.)
+or can include a custom function that uses forward() to call the parent tool
+with transformed arguments. Output schemas and structured outputs are automatically
+inherited from the parent tool but can be overridden or disabled.
+
+**Attributes:**
+- `parent_tool`: The original tool that this tool was transformed from.
+- `fn`: The function to execute when this tool is called (either the forwarding
+function for pure transformations or a custom user function).
+- `forwarding_fn`: Internal function that handles argument transformation and
+validation when forward() is called from custom functions.
+
+
+**Methods:**
+
+#### `run` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L315" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+run(self, arguments: dict[str, Any]) -> ToolResult
+```
+
+Run the tool with context set for forward() functions.
+
+This method executes the tool's function while setting up the context
+that allows forward() and forward_raw() to work correctly within custom
+functions.
+
+**Args:**
+- `arguments`: Dictionary of arguments to pass to the tool's function.
+
+**Returns:**
+- ToolResult object containing content and optional structured output.
+
+
+#### `from_tool` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L399" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+from_tool(cls, tool: Tool | Callable[..., Any], name: str | None = None, version: str | NotSetT | None = NotSet, title: str | NotSetT | None = NotSet, description: str | NotSetT | None = NotSet, tags: set[str] | None = None, transform_fn: Callable[..., Any] | None = None, transform_args: dict[str, ArgTransform] | None = None, annotations: ToolAnnotations | NotSetT | None = NotSet, output_schema: dict[str, Any] | NotSetT | None = NotSet, meta: dict[str, Any] | NotSetT | None = NotSet) -> TransformedTool
+```
+
+Create a transformed tool from a parent tool.
+
+**Args:**
+- `tool`: The parent tool to transform.
+- `transform_fn`: Optional custom function. Can use forward() and forward_raw()
+to call the parent tool. Functions with **kwargs receive transformed
+argument names.
+- `name`: New name for the tool. Defaults to parent tool's name.
+- `version`: New version for the tool. Defaults to parent tool's version.
+- `title`: New title for the tool. Defaults to parent tool's title.
+- `transform_args`: Optional transformations for parent tool arguments.
+Only specified arguments are transformed, others pass through unchanged.
+Use ArgTransform for rename, description, default, or hide operations.
+- `description`: New description. Defaults to parent's description.
+- `tags`: New tags. Defaults to parent's tags.
+- `annotations`: New annotations. Defaults to parent's annotations.
+- `output_schema`: Control output schema for structured outputs\:
+- None (default)\: Inherit from transform_fn if available, then parent tool
+- dict\: Use custom output schema
+- `meta`: Control meta information\:
+- NotSet (default)\: Inherit from parent tool
+- dict\: Use custom meta information
+- None\: Remove meta information
+
+**Returns:**
+- TransformedTool with the specified transformations.
+
+**Examples:**
+
+# Transform specific arguments only
+```python
+Tool.from_tool(parent, transform_args={"old": "new"})  # Others unchanged
+```
+
+# Custom function with partial transforms
+```python
+async def custom(x: int, y: int) -> str:
+    result = await forward(x=x, y=y)
+    return f"Custom: {result}"
+
+Tool.from_tool(parent, transform_fn=custom, transform_args={"a": "x", "b": "y"})
+```
+
+# Using **kwargs (gets all args, transformed and untransformed)
+```python
+async def flexible(**kwargs) -> str:
+    result = await forward(**kwargs)
+    return f"Got: {kwargs}"
+
+Tool.from_tool(parent, transform_fn=flexible, transform_args={"a": "x"})
+```
+
+# Control structured outputs and schemas
+```python
+# Custom output schema
+Tool.from_tool(parent, output_schema={
+    "type": "object",
+    "properties": {"status": {"type": "string"}}
+})
+
+# Disable structured outputs
+Tool.from_tool(parent, output_schema=None)
+
+# Return ToolResult for full control
+async def custom_output(**kwargs) -> ToolResult:
+    result = await forward(**kwargs)
+    return ToolResult(
+        content=[TextContent(text="Summary")],
+        structured_content={"processed": True}
+    )
+```
+
+
+### `ToolTransformConfig` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L968" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Provides a way to transform a tool.
+
+
+**Methods:**
+
+#### `apply` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/tools/tool_transform.py#L1001" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+apply(self, tool: Tool) -> TransformedTool
+```
+
+Create a TransformedTool from a provided tool and this transformation configuration.
+

--- a/docs/python-sdk/fastmcp-utilities-openapi-__init__.mdx
+++ b/docs/python-sdk/fastmcp-utilities-openapi-__init__.mdx
@@ -1,6 +1,6 @@
 ---
-title: openapi
-sidebarTitle: openapi
+title: __init__
+sidebarTitle: __init__
 ---
 
 # `fastmcp.utilities.openapi`

--- a/docs/python-sdk/fastmcp-utilities-openapi-director.mdx
+++ b/docs/python-sdk/fastmcp-utilities-openapi-director.mdx
@@ -1,0 +1,36 @@
+---
+title: director
+sidebarTitle: director
+---
+
+# `fastmcp.utilities.openapi.director`
+
+
+Request director using openapi-core for stateless HTTP request building.
+
+## Classes
+
+### `RequestDirector` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/director.py#L29" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Builds httpx2.Request objects from HTTPRoute and arguments using openapi-core.
+
+
+**Methods:**
+
+#### `build` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/director.py#L36" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+build(self, route: HTTPRoute, flat_args: dict[str, Any], base_url: str = 'http://localhost') -> httpx2.Request
+```
+
+Constructs a final httpx2.Request object, handling all OpenAPI serialization.
+
+**Args:**
+- `route`: HTTPRoute containing OpenAPI operation details
+- `flat_args`: Flattened arguments from LLM (may include suffixed parameters)
+- `base_url`: Base URL for the request
+
+**Returns:**
+- httpx2.Request: Properly formatted HTTP request
+

--- a/docs/python-sdk/fastmcp-utilities-openapi-formatters.mdx
+++ b/docs/python-sdk/fastmcp-utilities-openapi-formatters.mdx
@@ -1,0 +1,96 @@
+---
+title: formatters
+sidebarTitle: formatters
+---
+
+# `fastmcp.utilities.openapi.formatters`
+
+
+Parameter formatting functions for OpenAPI operations.
+
+## Functions
+
+### `format_array_parameter` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/formatters.py#L12" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+format_array_parameter(values: list, parameter_name: str, is_query_parameter: bool = False) -> str | list
+```
+
+
+Format an array parameter according to OpenAPI specifications.
+
+**Args:**
+- `values`: List of values to format
+- `parameter_name`: Name of the parameter (for error messages)
+- `is_query_parameter`: If True, can return list for explode=True behavior
+
+**Returns:**
+- String (comma-separated) or list (for query params with explode=True)
+
+
+### `format_deep_object_parameter` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/formatters.py#L66" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+format_deep_object_parameter(param_value: dict, parameter_name: str) -> dict[str, str]
+```
+
+
+Format a dictionary parameter for deep-object style serialization.
+
+According to OpenAPI 3.0 spec, deepObject style with explode=true serializes
+object properties as separate query parameters with bracket notation.
+
+For example, `{"id": "123", "type": "user"}` becomes
+`param[id]=123&param[type]=user`.
+
+**Args:**
+- `param_value`: Dictionary value to format
+- `parameter_name`: Name of the parameter
+
+**Returns:**
+- Dictionary with bracketed parameter names as keys
+
+
+### `generate_example_from_schema` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/formatters.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+generate_example_from_schema(schema: JsonSchema | None) -> Any
+```
+
+
+Generate a simple example value from a JSON schema dictionary.
+Very basic implementation focusing on types.
+
+
+### `format_json_for_description` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/formatters.py#L183" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+format_json_for_description(data: Any, indent: int = 2) -> str
+```
+
+
+Formats Python data as a JSON string block for Markdown.
+
+
+### `format_description_with_responses` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/formatters.py#L192" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+format_description_with_responses(base_description: str, responses: dict[str, Any], parameters: list[ParameterInfo] | None = None, request_body: RequestBodyInfo | None = None) -> str
+```
+
+
+Formats the base description string with response, parameter, and request body information.
+
+**Args:**
+- `base_description`: The initial description to be formatted.
+- `responses`: A dictionary of response information, keyed by status code.
+- `parameters`: A list of parameter information,
+including path and query parameters. Each parameter includes details such as name,
+location, whether it is required, and a description.
+- `request_body`: Information about the request body,
+including its description, whether it is required, and its content schema.
+
+**Returns:**
+- The formatted description string with additional details about responses, parameters,
+- and the request body.
+

--- a/docs/python-sdk/fastmcp-utilities-openapi-json_schema_converter.mdx
+++ b/docs/python-sdk/fastmcp-utilities-openapi-json_schema_converter.mdx
@@ -1,0 +1,62 @@
+---
+title: json_schema_converter
+sidebarTitle: json_schema_converter
+---
+
+# `fastmcp.utilities.openapi.json_schema_converter`
+
+
+
+Clean OpenAPI 3.0 to JSON Schema converter for the experimental parser.
+
+This module provides a systematic approach to converting OpenAPI 3.0 schemas
+to JSON Schema, inspired by py-openapi-schema-to-json-schema but optimized
+for our specific use case.
+
+
+## Functions
+
+### `convert_openapi_schema_to_json_schema` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/json_schema_converter.py#L41" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+convert_openapi_schema_to_json_schema(schema: dict[str, Any], openapi_version: str | None = None, remove_read_only: bool = False, remove_write_only: bool = False, convert_one_of_to_any_of: bool = True) -> dict[str, Any]
+```
+
+
+Convert an OpenAPI schema to JSON Schema format.
+
+This is a clean, systematic approach that:
+1. Removes OpenAPI-specific fields
+2. Converts nullable fields to type arrays (for OpenAPI 3.0 only)
+3. Converts oneOf to anyOf for overlapping union handling
+4. Recursively processes nested schemas
+5. Optionally removes readOnly/writeOnly properties
+
+**Args:**
+- `schema`: OpenAPI schema dictionary
+- `openapi_version`: OpenAPI version for optimization
+- `remove_read_only`: Whether to remove readOnly properties
+- `remove_write_only`: Whether to remove writeOnly properties
+- `convert_one_of_to_any_of`: Whether to convert oneOf to anyOf
+
+**Returns:**
+- JSON Schema-compatible dictionary
+
+
+### `convert_schema_definitions` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/json_schema_converter.py#L328" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+convert_schema_definitions(schema_definitions: dict[str, Any] | None, openapi_version: str | None = None, **kwargs) -> dict[str, Any]
+```
+
+
+Convert a dictionary of OpenAPI schema definitions to JSON Schema.
+
+**Args:**
+- `schema_definitions`: Dictionary of schema definitions
+- `openapi_version`: OpenAPI version for optimization
+- `**kwargs`: Additional arguments passed to convert_openapi_schema_to_json_schema
+
+**Returns:**
+- Dictionary of converted schema definitions
+

--- a/docs/python-sdk/fastmcp-utilities-openapi-models.mdx
+++ b/docs/python-sdk/fastmcp-utilities-openapi-models.mdx
@@ -1,0 +1,35 @@
+---
+title: models
+sidebarTitle: models
+---
+
+# `fastmcp.utilities.openapi.models`
+
+
+Intermediate Representation (IR) models for OpenAPI operations.
+
+## Classes
+
+### `ParameterInfo` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/models.py#L17" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Represents a single parameter for an HTTP operation in our IR.
+
+
+### `RequestBodyInfo` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/models.py#L29" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Represents the request body for an HTTP operation in our IR.
+
+
+### `ResponseInfo` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/models.py#L39" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Represents response information in our IR.
+
+
+### `HTTPRoute` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/models.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Intermediate Representation for a single OpenAPI operation.
+

--- a/docs/python-sdk/fastmcp-utilities-openapi-parser.mdx
+++ b/docs/python-sdk/fastmcp-utilities-openapi-parser.mdx
@@ -1,0 +1,43 @@
+---
+title: parser
+sidebarTitle: parser
+---
+
+# `fastmcp.utilities.openapi.parser`
+
+
+OpenAPI parsing logic for converting OpenAPI specs to HTTPRoute objects.
+
+## Functions
+
+### `parse_openapi_to_http_routes` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/parser.py#L56" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+parse_openapi_to_http_routes(openapi_dict: dict[str, Any]) -> list[HTTPRoute]
+```
+
+
+Parses an OpenAPI schema dictionary into a list of HTTPRoute objects
+using the openapi-pydantic library.
+
+Supports both OpenAPI 3.0.x and 3.1.x versions.
+
+
+## Classes
+
+### `OpenAPIParser` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/parser.py#L110" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+Unified parser for OpenAPI schemas with generic type parameters to handle both 3.0 and 3.1.
+
+
+**Methods:**
+
+#### `parse` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/parser.py#L697" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+parse(self) -> list[HTTPRoute]
+```
+
+Parse the OpenAPI schema into HTTP routes.
+

--- a/docs/python-sdk/fastmcp-utilities-openapi-schemas.mdx
+++ b/docs/python-sdk/fastmcp-utilities-openapi-schemas.mdx
@@ -1,0 +1,43 @@
+---
+title: schemas
+sidebarTitle: schemas
+---
+
+# `fastmcp.utilities.openapi.schemas`
+
+
+Schema manipulation utilities for OpenAPI operations.
+
+## Functions
+
+### `clean_schema_for_display` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/schemas.py#L14" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+clean_schema_for_display(schema: JsonSchema | None) -> JsonSchema | None
+```
+
+
+Clean up a schema dictionary for display by removing internal/complex fields.
+
+
+### `extract_output_schema_from_responses` <sup><a href="https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/utilities/openapi/schemas.py#L643" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+extract_output_schema_from_responses(responses: dict[str, ResponseInfo], schema_definitions: dict[str, Any] | None = None, openapi_version: str | None = None) -> dict[str, Any] | None
+```
+
+
+Extract output schema from OpenAPI responses for use as MCP tool output schema.
+
+This function finds the first successful response (200, 201, 202, 204) with a
+JSON-compatible content type and extracts its schema. If the schema is not an
+object type, it wraps it to comply with MCP requirements.
+
+**Args:**
+- `responses`: Dictionary of ResponseInfo objects keyed by status code
+- `schema_definitions`: Optional schema definitions to include in the output schema
+- `openapi_version`: OpenAPI version string, used to optimize nullable field handling
+
+**Returns:**
+- MCP-compliant output schema with potential wrapping, or None if no suitable schema found
+


### PR DESCRIPTION
Updates `published-docs` to the current `main` tree so the regenerated SDK reference (#4938), which restores `fastmcp.client` and its submodules, reaches gofastmcp.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
