### PR TITLE
fix(server): VersionFilter get_tool/get_resource/get_prompt respect include_unversioned=False

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/version_filter.py
+++ b/fastmcp_slim/fastmcp/server/transforms/version_filter.py
@@ -87,7 +87,12 @@ class VersionFilter(Transform):
     async def get_tool(
         self, name: str, call_next: GetToolNext, *, version: VersionSpec | None = None
     ) -> Tool | None:
-        return await call_next(name, version=self._spec.intersect(version))
+        tool = await call_next(name, version=self._spec.intersect(version))
+        if tool is None or self._spec.matches(
+            tool.version, match_none=self.include_unversioned
+        ):
+            return tool
+        return None
 
     # -------------------------------------------------------------------------
     # Resources
@@ -107,7 +112,12 @@ class VersionFilter(Transform):
         *,
         version: VersionSpec | None = None,
     ) -> Resource | None:
-        return await call_next(uri, version=self._spec.intersect(version))
+        resource = await call_next(uri, version=self._spec.intersect(version))
+        if resource is None or self._spec.matches(
+            resource.version, match_none=self.include_unversioned
+        ):
+            return resource
+        return None
 
     # -------------------------------------------------------------------------
     # Resource Templates
@@ -129,7 +139,12 @@ class VersionFilter(Transform):
         *,
         version: VersionSpec | None = None,
     ) -> ResourceTemplate | None:
-        return await call_next(uri, version=self._spec.intersect(version))
+        template = await call_next(uri, version=self._spec.intersect(version))
+        if template is None or self._spec.matches(
+            template.version, match_none=self.include_unversioned
+        ):
+            return template
+        return None
 
     # -------------------------------------------------------------------------
     # Prompts
@@ -145,4 +160,9 @@ class VersionFilter(Transform):
     async def get_prompt(
         self, name: str, call_next: GetPromptNext, *, version: VersionSpec | None = None
     ) -> Prompt | None:
-        return await call_next(name, version=self._spec.intersect(version))
+        prompt = await call_next(name, version=self._spec.intersect(version))
+        if prompt is None or self._spec.matches(
+            prompt.version, match_none=self.include_unversioned
+        ):
+            return prompt
+        return None

--- a/tests/server/versioning/test_filtering.py
+++ b/tests/server/versioning/test_filtering.py
@@ -172,6 +172,21 @@ class TestVersionFilter:
         tools = await mcp.list_tools()
         assert [tool.name for tool in tools] == ["included_versioned_tool"]
 
+    async def test_include_unversioned_false_excludes_unversioned_tools_via_get_tool(
+        self,
+    ):
+        """get_tool() direct lookup respects include_unversioned=False too."""
+
+        mcp = FastMCP()
+
+        @mcp.tool
+        def unversioned_tool() -> str:
+            return "unversioned"
+
+        mcp.add_transform(VersionFilter(version_lt="3.0", include_unversioned=False))
+
+        assert await mcp.get_tool("unversioned_tool") is None
+
     async def test_date_versions(self):
         """Works with date-based versions like '2025-01-15'."""
         from fastmcp.server.transforms import VersionFilter
@@ -266,6 +281,21 @@ class TestVersionFilter:
             "file:///included_versioned"
         ]
 
+    async def test_include_unversioned_false_excludes_unversioned_resources_via_get_resource(
+        self,
+    ):
+        """get_resource() direct lookup respects include_unversioned=False too."""
+
+        mcp = FastMCP()
+
+        @mcp.resource("file:///unversioned")
+        def unversioned_resource() -> str:
+            return "unversioned"
+
+        mcp.add_transform(VersionFilter(version_lt="2.0", include_unversioned=False))
+
+        assert await mcp.get_resource("file:///unversioned") is None
+
     async def test_include_unversioned_false_excludes_unversioned_resource_templates(
         self,
     ):
@@ -290,6 +320,20 @@ class TestVersionFilter:
         assert [template.uri_template for template in templates] == [
             "resource://included_versioned/{name}"
         ]
+
+    async def test_include_unversioned_false_excludes_unversioned_resource_templates_via_get_resource_template(
+        self,
+    ):
+        """get_resource_template() direct lookup respects include_unversioned=False too."""
+        mcp = FastMCP()
+
+        @mcp.resource("resource://unversioned/{name}")
+        def unversioned_template(name: str) -> str:
+            return f"unversioned:{name}"
+
+        mcp.add_transform(VersionFilter(version_lt="2.0", include_unversioned=False))
+
+        assert await mcp.get_resource_template("resource://unversioned/{name}") is None
 
     async def test_prompts_filtered(self):
         """Prompts are filtered by version."""
@@ -331,6 +375,20 @@ class TestVersionFilter:
 
         prompts = await mcp.list_prompts()
         assert [prompt.name for prompt in prompts] == ["included_versioned_prompt"]
+
+    async def test_include_unversioned_false_excludes_unversioned_prompts_via_get_prompt(
+        self,
+    ):
+        """get_prompt() direct lookup respects include_unversioned=False too."""
+        mcp = FastMCP()
+
+        @mcp.prompt
+        def unversioned_prompt(name: str) -> str:
+            return f"Unversioned: {name}"
+
+        mcp.add_transform(VersionFilter(version_lt="2.0", include_unversioned=False))
+
+        assert await mcp.get_prompt("unversioned_prompt") is None
 
     async def test_repr(self):
         """Test VersionFilter string representation."""


### PR DESCRIPTION
Fixes #4946.

`VersionFilter(include_unversioned=False)` is meant to hide unversioned components entirely, and `list_tools()` honors that by filtering with `match_none=self.include_unversioned`. But `get_tool()` only combines the caller's version constraint with the filter's range (`self._spec.intersect(version)`) and forwards it to `call_next` — `VersionSpec` has no way to carry "and also reject unversioned," so the direct lookup never applies `include_unversioned` at all. The same gap exists for `get_resource`, `get_resource_template`, and `get_prompt`. A component invisible in `list_tools()` was still directly reachable by name:

```python
mcp.add_transform(VersionFilter(version_gte="1.0", include_unversioned=False))

await mcp.list_tools()          # []
await mcp.get_tool("hidden_tool")  # returns the tool anyway
```

Each `get_*` method now re-checks its result against the same spec used for listing before returning it, so a direct lookup can no longer see something the corresponding list already excludes.