### PR TITLE
fix: fall back to highest authorized component version

### DIFF
--- a/fastmcp_slim/fastmcp/server/server.py
+++ b/fastmcp_slim/fastmcp/server/server.py
@@ -219,6 +219,21 @@ def _get_auth_context() -> tuple[bool, Any]:
     return (False, get_access_token())
 
 
+async def _is_component_authorized(
+    component: Tool | Resource | ResourceTemplate | Prompt,
+) -> bool:
+    """Return whether the current request may access a component."""
+    skip_auth, token = _get_auth_context()
+    if skip_auth or component.auth is None:
+        return True
+
+    ctx = AuthContext(token=token, component=component)
+    try:
+        return await run_auth_checks(component.auth, ctx)
+    except AuthorizationError:
+        return False
+
+
 def _tool_identity(tool: Tool) -> str | None:
     """Read a tool's stable identity hash, if it carries one."""
     from fastmcp.server.providers.addressing import TOOL_HASH_META_KEY
@@ -902,17 +917,18 @@ class FastMCP(
         if tool is None:
             return None
 
-        # Component auth - return None if unauthorized (consistent with list filtering)
-        skip_auth, token = _get_auth_context()
-        if not skip_auth and tool.auth is not None:
-            ctx = AuthContext(token=token, component=tool)
-            try:
-                if not await run_auth_checks(tool.auth, ctx):
-                    return None
-            except AuthorizationError:
-                return None
+        # Component auth - select the highest authorized default version.
+        if await _is_component_authorized(tool):
+            return tool
+        if version is not None:
+            return None
 
-        return tool
+        all_tools = [t for t in await super().list_tools() if t.name == name]
+        all_tools = list(await apply_session_transforms(all_tools))
+        authorized = [t for t in all_tools if await _is_component_authorized(t)]
+        if not authorized:
+            return None
+        return max(authorized, key=version_sort_key)
 
     async def get_tool(
         self, name: str, version: VersionSpec | None = None
@@ -923,8 +939,8 @@ class FastMCP(
         transforms (including session-level) have been applied. This ensures
         session transforms can override provider-level disables.
 
-        When the highest version is disabled and no explicit version was
-        requested, falls back to the next-highest enabled version.
+        When the highest version is disabled or unauthorized and no explicit
+        version was requested, falls back to the next-highest usable version.
 
         Args:
             name: The tool name.
@@ -1041,17 +1057,18 @@ class FastMCP(
         if resource is None:
             return None
 
-        # Component auth - return None if unauthorized (consistent with list filtering)
-        skip_auth, token = _get_auth_context()
-        if not skip_auth and resource.auth is not None:
-            ctx = AuthContext(token=token, component=resource)
-            try:
-                if not await run_auth_checks(resource.auth, ctx):
-                    return None
-            except AuthorizationError:
-                return None
+        # Component auth - select the highest authorized default version.
+        if await _is_component_authorized(resource):
+            return resource
+        if version is not None:
+            return None
 
-        return resource
+        all_resources = [r for r in await super().list_resources() if str(r.uri) == uri]
+        all_resources = list(await apply_session_transforms(all_resources))
+        authorized = [r for r in all_resources if await _is_component_authorized(r)]
+        if not authorized:
+            return None
+        return max(authorized, key=version_sort_key)
 
     async def get_resource(
         self, uri: str, version: VersionSpec | None = None
@@ -1061,8 +1078,8 @@ class FastMCP(
         Overrides Provider.get_resource() to add visibility filtering after all
         transforms (including session-level) have been applied.
 
-        When the highest version is disabled and no explicit version was
-        requested, falls back to the next-highest enabled version.
+        When the highest version is disabled or unauthorized and no explicit
+        version was requested, falls back to the next-highest usable version.
 
         Args:
             uri: The resource URI.
@@ -1173,17 +1190,22 @@ class FastMCP(
         if template is None:
             return None
 
-        # Component auth - return None if unauthorized (consistent with list filtering)
-        skip_auth, token = _get_auth_context()
-        if not skip_auth and template.auth is not None:
-            ctx = AuthContext(token=token, component=template)
-            try:
-                if not await run_auth_checks(template.auth, ctx):
-                    return None
-            except AuthorizationError:
-                return None
+        # Component auth - select the highest authorized default version.
+        if await _is_component_authorized(template):
+            return template
+        if version is not None:
+            return None
 
-        return template
+        all_templates = [
+            t
+            for t in await super().list_resource_templates()
+            if t.matches(uri) is not None
+        ]
+        all_templates = list(await apply_session_transforms(all_templates))
+        authorized = [t for t in all_templates if await _is_component_authorized(t)]
+        if not authorized:
+            return None
+        return max(authorized, key=version_sort_key)
 
     async def get_resource_template(
         self, uri: str, version: VersionSpec | None = None
@@ -1193,8 +1215,8 @@ class FastMCP(
         Overrides Provider.get_resource_template() to add visibility filtering after
         all transforms (including session-level) have been applied.
 
-        When the highest version is disabled and no explicit version was
-        requested, falls back to the next-highest enabled version.
+        When the highest version is disabled or unauthorized and no explicit
+        version was requested, falls back to the next-highest usable version.
 
         Args:
             uri: The template URI.
@@ -1299,17 +1321,18 @@ class FastMCP(
         if prompt is None:
             return None
 
-        # Component auth - return None if unauthorized (consistent with list filtering)
-        skip_auth, token = _get_auth_context()
-        if not skip_auth and prompt.auth is not None:
-            ctx = AuthContext(token=token, component=prompt)
-            try:
-                if not await run_auth_checks(prompt.auth, ctx):
-                    return None
-            except AuthorizationError:
-                return None
+        # Component auth - select the highest authorized default version.
+        if await _is_component_authorized(prompt):
+            return prompt
+        if version is not None:
+            return None
 
-        return prompt
+        all_prompts = [p for p in await super().list_prompts() if p.name == name]
+        all_prompts = list(await apply_session_transforms(all_prompts))
+        authorized = [p for p in all_prompts if await _is_component_authorized(p)]
+        if not authorized:
+            return None
+        return max(authorized, key=version_sort_key)
 
     async def get_prompt(
         self, name: str, version: VersionSpec | None = None
@@ -1319,8 +1342,8 @@ class FastMCP(
         Overrides Provider.get_prompt() to add visibility filtering after all
         transforms (including session-level) have been applied.
 
-        When the highest version is disabled and no explicit version was
-        requested, falls back to the next-highest enabled version.
+        When the highest version is disabled or unauthorized and no explicit
+        version was requested, falls back to the next-highest usable version.
 
         Args:
             name: The prompt name.

--- a/tests/server/versioning/test_visibility_version_fallback.py
+++ b/tests/server/versioning/test_visibility_version_fallback.py
@@ -1,4 +1,4 @@
-"""Tests for version fallback when the highest version is disabled via visibility.
+"""Tests for version fallback when the highest version is unusable.
 
 Regression tests for https://github.com/jlowin/fastmcp/issues/3421:
 When the latest version of a component is disabled, get_* methods should
@@ -258,6 +258,10 @@ class TestFallbackRespectsAuth:
     versions, those candidates must go through auth filtering. Otherwise
     a protected v1 could be exposed to unauthenticated users when a
     public v2 is disabled.
+
+    When the highest version is unauthorized, default lookups must also
+    continue to the highest version the caller can access. Otherwise a
+    component visible in a list response cannot be called or retrieved.
     """
 
     async def test_tool_fallback_respects_auth(self):
@@ -277,6 +281,76 @@ class TestFallbackRespectsAuth:
         # Without an admin token, v1 should NOT be returned
         tool = await mcp.get_tool("calc")
         assert tool is None
+
+    async def test_client_call_falls_back_from_unauthorized_highest_version(self):
+        """A client should call the highest version it is authorized to use."""
+        from fastmcp import Client
+
+        mcp = FastMCP()
+
+        @mcp.tool(version="1.0")
+        def calc() -> int:
+            return 1
+
+        @mcp.tool(version="2.0", auth=require_scopes("admin"))
+        def calc() -> int:
+            return 2
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            assert len(tools) == 1
+            assert tools[0].name == "calc"
+
+            result = await client.call_tool("calc", {})
+            assert result.data == 1
+
+    async def test_resource_lookup_falls_back_from_unauthorized_highest_version(self):
+        """A resource lookup should select the highest authorized version."""
+        mcp = FastMCP()
+
+        @mcp.resource("data://info", version="1.0")
+        def info() -> str:
+            return "v1"
+
+        @mcp.resource("data://info", version="2.0", auth=require_scopes("admin"))
+        def info() -> str:
+            return "v2"
+
+        resource = await mcp.get_resource("data://info")
+        assert resource is not None
+        assert resource.version == "1.0"
+
+    async def test_template_lookup_falls_back_from_unauthorized_highest_version(self):
+        """A template lookup should select the highest authorized version."""
+        mcp = FastMCP()
+
+        @mcp.resource("data://items/{id}", version="1.0")
+        def item(id: str) -> str:
+            return f"v1-{id}"
+
+        @mcp.resource("data://items/{id}", version="2.0", auth=require_scopes("admin"))
+        def item(id: str) -> str:
+            return f"v2-{id}"
+
+        template = await mcp.get_resource_template("data://items/{id}")
+        assert template is not None
+        assert template.version == "1.0"
+
+    async def test_prompt_lookup_falls_back_from_unauthorized_highest_version(self):
+        """A prompt lookup should select the highest authorized version."""
+        mcp = FastMCP()
+
+        @mcp.prompt(version="1.0")
+        def greet() -> str:
+            return "v1"
+
+        @mcp.prompt(version="2.0", auth=require_scopes("admin"))
+        def greet() -> str:
+            return "v2"
+
+        prompt = await mcp.get_prompt("greet")
+        assert prompt is not None
+        assert prompt.version == "1.0"
 
     async def test_tool_fallback_allows_authorized_user(self):
         """Fallback should return auth-protected v1 to authorized users."""


### PR DESCRIPTION
Fixes #4950

## Summary

When a versioned component's highest version fails its component-level authorization check, default lookups now continue to the highest version authorized for the current request.

This keeps direct lookup and invocation consistent with list operations for:

- tools
- resources
- resource templates
- prompts

The fallback now uses the same internal provider lookup space as the initial lookup, so server-level renaming transforms such as `Namespace` and `ToolTransform` remain addressable. Transform-injected version constraints are also kept separate from explicit caller requests: default lookups fall back within `VersionFilter`, while explicit version requests remain strict.

## Verification

- `uv run pytest -q tests/server/versioning/test_visibility_version_fallback.py tests/server/versioning/test_filtering.py tests/server/versioning/test_calls.py tests/server/auth/test_authorization.py::TestAuthMiddlewareVersionedRequests` — 82 passed
- Real local Uvicorn + Streamable HTTP check with `Namespace` and `VersionFilter` — `list_tools() == ["api_calc"]`, `call_tool("api_calc") == 1`
- Mounted-server check — default lookup returned `1.0`; explicit version range remained unavailable
- Full suite with proxy variables removed — 7296 passed, 6 skipped, 16 xfailed; 4 unrelated environment-dependent failures remain in MCP conformance, GitHub OpenAPI download/performance, and two parallel OAuth consent tests (the OAuth tests pass individually)
- `ruff`, `ruff-format`, and `ty` pre-commit hooks pass. The Prettier hook cannot run in this environment because Node.js is v12 while the hook requires Node.js >=14. Existing loq file-size violations are not enforced.

Follow-up commits on the existing branch:

- `f1f4b94c` — preserve transformed lookup space and default version-filter fallback
- `6f4c7907` — cover renamed component fallback with a regression test