### PR TITLE
chore: add current maintainer alongside jlowin in hardcoded references

### DIFF
--- a/.github/workflows/marvin-triage-issue.yml
+++ b/.github/workflows/marvin-triage-issue.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     if: |
       github.event.issue.user.login == 'strawgate' ||
-      (github.event.issue.user.login == 'jlowin' && contains(toJSON(github.event.issue.labels.*.name), 'bug'))
+      ((github.event.issue.user.login == 'jlowin' || github.event.issue.user.login == 'zzstoatzz') && contains(toJSON(github.event.issue.labels.*.name), 'bug'))
     concurrency:
       group: triage-issue-${{ github.event.issue.number }}
       cancel-in-progress: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Because the docs land *before* the tag exists, derive the entry from the maintai
 
 ### Commit Messages and Agent Attribution
 
-- **Agents NOT acting on behalf of @jlowin MUST identify themselves** (e.g., "🤖 Generated with Claude Code" in commits/PRs)
+- **Agents NOT acting on behalf of a PrefectHQ maintainer MUST identify themselves** (e.g., "🤖 Generated with Claude Code" in commits/PRs)
 - Keep commit messages brief - ideally just headlines, not detailed messages
 - Focus on what changed, not how or why
 - Always read issue comments for follow-up information (treat maintainers as authoritative)

--- a/fastmcp_slim/pyproject.toml
+++ b/fastmcp_slim/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fastmcp-slim"
 dynamic = ["version", "optional-dependencies"]
 description = "The dependency-slim FastMCP package."
-authors = [{ name = "Jeremiah Lowin" }]
+authors = [{ name = "Jeremiah Lowin" }, { name = "Nate Nowack" }]
 dependencies = [
     "mcp-types>=2.0.0,<3.0.0",
     "platformdirs>=4.0.0",

--- a/fastmcp_tasks/pyproject.toml
+++ b/fastmcp_tasks/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fastmcp-tasks"
 dynamic = ["version", "dependencies"]
 description = "Background task execution for FastMCP servers via the io.modelcontextprotocol/tasks extension (SEP-2663)."
-authors = [{ name = "Jeremiah Lowin" }]
+authors = [{ name = "Jeremiah Lowin" }, { name = "Nate Nowack" }]
 
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fastmcp"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 description = "The fast, Pythonic way to build MCP servers and clients."
-authors = [{ name = "Jeremiah Lowin" }]
+authors = [{ name = "Jeremiah Lowin" }, { name = "Nate Nowack" }]
 requires-python = ">=3.10"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
maintainer references were hardcoded to @jlowin in a few functional places. this adds @zzstoatzz alongside — nothing is replaced.

- `marvin-triage-issue.yml`: maintainer-filed bugs now auto-triage for either login
- all three package `pyproject.toml`s (`fastmcp`, `fastmcp-slim`, `fastmcp-tasks`): both names in `authors`
- the agent-attribution rule in `CLAUDE.md` (which `AGENTS.md` and `.github/copilot-instructions.md` symlink) now says "a PrefectHQ maintainer" instead of naming one person

historical jlowin.dev links in docs are deliberately untouched.

![heavy-is-the-bufo-that-wears-the-crown](https://all-the.bufo.zone/heavy-is-the-bufo-that-wears-the-crown.png)
