### PR TITLE
server: warn when modern-era change notifications are silently dropped

### DIFF
--- a/fastmcp_slim/fastmcp/server/context.py
+++ b/fastmcp_slim/fastmcp/server/context.py
@@ -7,11 +7,12 @@ from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from logging import Logger
-from typing import Any, Literal, cast, overload
+from typing import Any, ClassVar, Literal, cast, overload
 
 import mcp_types
 from mcp import LoggingLevel, ServerSession
 from mcp.server.context import ServerRequestContext
+from mcp.shared.subscriptions import LISTEN_STREAM_METHODS
 from mcp_types import (
     GetPromptResult,
 )
@@ -128,6 +129,76 @@ _mcp_level_to_python_level = {
     "alert": logging.CRITICAL,
     "emergency": logging.CRITICAL,
 }
+
+
+class _EraCheckedServerSession:
+    """Proxy over `ServerSession` that warns where the SDK silently drops.
+
+    On modern (2026-07-28) connections the SDK discards connection-scoped
+    change notifications with only a debug log: the spec forbids sending a
+    change notification a client did not subscribe to, and the sanctioned
+    delivery path is a `subscriptions/listen` stream, which FastMCP does not
+    publish to yet. Until it does, sending one of these from application code
+    (e.g. a captured `ctx.session` in a background task) emits a warning
+    instead of reporting success for a message that can never arrive. A
+    warning rather than an error: the same send may also serve legacy
+    connections, where it still delivers.
+
+    See https://github.com/PrefectHQ/fastmcp/issues/4920.
+    """
+
+    __slots__ = ("_wrapped",)
+
+    _warned_methods: ClassVar[set[str]] = set()
+
+    def __init__(self, wrapped: ServerSession) -> None:
+        self._wrapped = wrapped
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+    def _check_deliverable(self, method: str) -> None:
+        protocol_version = self._wrapped.protocol_version
+        if (
+            protocol_version in MODERN_PROTOCOL_VERSIONS
+            and method not in self._warned_methods
+        ):
+            self._warned_methods.add(method)
+            logger.warning(
+                "%s cannot be delivered on a %s connection: the modern protocol "
+                "only delivers change notifications through a subscriptions/listen "
+                "stream opened by the client, which FastMCP does not publish to "
+                "yet, so the SDK silently discards this send. Track support at "
+                "https://github.com/PrefectHQ/fastmcp/issues/4920. "
+                "(warned once per notification method)",
+                method,
+                protocol_version,
+            )
+
+    async def send_notification(
+        self,
+        notification: mcp_types.ServerNotification,
+        related_request_id: mcp_types.RequestId | None = None,
+    ) -> None:
+        if related_request_id is None and notification.method in LISTEN_STREAM_METHODS:
+            self._check_deliverable(notification.method)
+        await self._wrapped.send_notification(notification, related_request_id)
+
+    async def send_tool_list_changed(self) -> None:
+        self._check_deliverable("notifications/tools/list_changed")
+        await self._wrapped.send_tool_list_changed()
+
+    async def send_resource_list_changed(self) -> None:
+        self._check_deliverable("notifications/resources/list_changed")
+        await self._wrapped.send_resource_list_changed()
+
+    async def send_prompt_list_changed(self) -> None:
+        self._check_deliverable("notifications/prompts/list_changed")
+        await self._wrapped.send_prompt_list_changed()
+
+    async def send_resource_updated(self, uri: str | AnyUrl) -> None:
+        self._check_deliverable("notifications/resources/updated")
+        await self._wrapped.send_resource_updated(uri)
 
 
 @contextmanager
@@ -801,15 +872,17 @@ class Context:
         """
         # Background task mode: use the stored session
         if self.is_background_task and self._session is not None:
-            return self._session
+            return cast(ServerSession, _EraCheckedServerSession(self._session))
 
         # Request mode: use request context
         if self.request_context is not None:
-            return self.request_context.session
+            return cast(
+                ServerSession, _EraCheckedServerSession(self.request_context.session)
+            )
 
         # Fallback to stored session (e.g., during on_initialize)
         if self._session is not None:
-            return self._session
+            return cast(ServerSession, _EraCheckedServerSession(self._session))
 
         raise RuntimeError(
             "session is not available because the MCP session has not been established yet. "

--- a/tests/server/test_context.py
+++ b/tests/server/test_context.py
@@ -489,3 +489,93 @@ class TestTransportIntegration:
             result = await client.call_tool("get_transport", {})
             assert observed_transport == "streamable-http"
             assert result.data == "streamable-http"
+
+
+class TestUndeliverableChangeNotifications:
+    """Out-of-band change notifications warn on modern-era connections.
+
+    Regression tests for https://github.com/PrefectHQ/fastmcp/issues/4920: the
+    SDK silently drops connection-scoped change notifications on 2026-07-28
+    connections, so ctx.session warns (once per method) instead of reporting
+    a successful no-op. Legacy connections still deliver.
+    """
+
+    def _server_with_captured_sessions(self) -> tuple[FastMCP, list]:
+        from fastmcp.server.middleware import Middleware
+
+        captured: list = []
+
+        class Capture(Middleware):
+            async def on_message(self, context, call_next):
+                fctx = getattr(context, "fastmcp_context", None)
+                if fctx is not None:
+                    captured.append(fctx.session)
+                return await call_next(context)
+
+        server = FastMCP("notify-repro")
+        server.add_middleware(Capture())
+
+        @server.tool
+        def hello() -> str:
+            return "hi"
+
+        return server, captured
+
+    @pytest.fixture(autouse=True)
+    def _reset_warned_methods(self):
+        from fastmcp.server.context import _EraCheckedServerSession
+
+        _EraCheckedServerSession._warned_methods.clear()
+        yield
+        _EraCheckedServerSession._warned_methods.clear()
+
+    async def test_modern_out_of_band_send_warns(self, caplog):
+        from fastmcp import Client
+
+        server, captured = self._server_with_captured_sessions()
+        async with Client(server, mode="auto") as client:
+            await client.list_tools()
+            assert client.protocol_version == "2026-07-28"
+            with caplog.at_level("WARNING", logger="FastMCP"):
+                await captured[-1].send_tool_list_changed()
+                await captured[-1].send_tool_list_changed()
+
+        warnings = [r for r in caplog.records if "4920" in r.getMessage()]
+        assert len(warnings) == 1  # once per method, not per call
+        assert "notifications/tools/list_changed" in warnings[0].getMessage()
+
+    async def test_modern_out_of_band_send_notification_warns(self, caplog):
+        import mcp_types
+
+        from fastmcp import Client
+
+        server, captured = self._server_with_captured_sessions()
+        async with Client(server, mode="auto") as client:
+            await client.list_tools()
+            with caplog.at_level("WARNING", logger="FastMCP"):
+                await captured[-1].send_notification(
+                    mcp_types.ToolListChangedNotification()
+                )
+
+        assert any("subscriptions/listen" in r.getMessage() for r in caplog.records)
+
+    async def test_legacy_out_of_band_send_delivers(self):
+        import asyncio
+
+        from fastmcp import Client
+        from fastmcp.client.messages import MessageHandler
+
+        class Recorder(MessageHandler):
+            def __init__(self):
+                super().__init__()
+                self.changed = asyncio.Event()
+
+            async def on_tool_list_changed(self, message):
+                self.changed.set()
+
+        server, captured = self._server_with_captured_sessions()
+        recorder = Recorder()
+        async with Client(server, message_handler=recorder, mode="legacy") as client:
+            await client.list_tools()
+            await captured[-1].send_tool_list_changed()
+            await asyncio.wait_for(recorder.changed.wait(), timeout=3)

--- a/tests/tasks/server/test_context_background_task.py
+++ b/tests/tasks/server/test_context_background_task.py
@@ -165,7 +165,8 @@ class TestContextSessionProperty:
             mcp, session=cast(ServerSession, mock_session), task_id="test-task-123"
         )
 
-        assert ctx.session is mock_session
+        session = cast(Any, ctx.session)
+        assert session._wrapped is mock_session
 
     def test_session_uses_stored_session_during_on_initialize(self):
         """session should use the stored session during on_initialize."""
@@ -177,7 +178,8 @@ class TestContextSessionProperty:
         mock_session = MockSession()
         ctx = Context(mcp, session=cast(ServerSession, mock_session))
 
-        assert ctx.session is mock_session
+        session = cast(Any, ctx.session)
+        assert session._wrapped is mock_session
 
 
 class TestContextBackgroundTaskLogging:


### PR DESCRIPTION
on `2026-07-28` connections the SDK silently discards connection-scoped change notifications — the spec only delivers them through a `subscriptions/listen` stream, which fastmcp doesn't publish to yet (#4920). the send reports success for a message that can never arrive, which cost the reporter a debugging session. `ctx.session` now returns a thin proxy that logs a warning (once per notification method) when one of these sends is discarded, pointing at the tracking issue.

a warning rather than an error: the same send may also serve legacy connections, where it still delivers — code that notifies best-effort across both eras keeps working.

```
notifications/tools/list_changed cannot be delivered on a 2026-07-28 connection: ...
Track support at https://github.com/PrefectHQ/fastmcp/issues/4920.
```

subscription support (`SubscriptionBus` publication + client listen streams) is the real fix and stays tracked in #4920.

![bufo-heralds-an-incident](https://all-the.bufo.zone/bufo-heralds-an-incident.png)
