### PR TITLE
Publish GA banner to production docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -16,7 +16,7 @@
       "dark": "#475569",
       "light": "#1e3a5f"
     },
-    "content": "FastMCP 4 beta is here — get the latest MCP protocol. [See what's new](/getting-started/whats-new)."
+    "content": "FastMCP 4 is here — built for the new MCP protocol. [See what's new](/getting-started/whats-new)."
   },
   "colors": {
     "dark": "#f72585",


### PR DESCRIPTION
syncs published-docs to main (banner no longer says beta).