### PR TITLE
ci: fix the published-docs PR step's working base

### DIFF
--- a/.github/workflows/publish-fastmcp.yml
+++ b/.github/workflows/publish-fastmcp.yml
@@ -219,7 +219,7 @@ jobs:
           RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           git fetch origin published-docs
-          git switch --force-create published-docs-sync origin/published-docs
+          git switch --force-create published-docs origin/published-docs
           git read-tree --reset -u "$RELEASE_SHA"
           test "$(git write-tree)" = "$(git rev-parse "${RELEASE_SHA}^{tree}")"
 


### PR DESCRIPTION
the v4.0.0 release run failed at 'Open published docs PR' (run 33424445204): the prep step force-creates a local-only `published-docs-sync` branch, and create-pull-request resets the working base with `git reset --hard origin/published-docs-sync` — a ref that has never existed on origin. this was the step's first real execution: every run since it landed in #4713 was a prerelease or maintenance release, which skip it.

checking out `published-docs` itself gives the action a working base that exists on origin. the release tree staging and the PR branch (`marvin/publish-docs-v<version>`) are unchanged.

```
fatal: ambiguous argument 'origin/published-docs-sync': unknown revision
```