### PR TITLE
Publish GA docs audit fixes

### DIFF
--- a/.github/workflows/publish-fastmcp.yml
+++ b/.github/workflows/publish-fastmcp.yml
@@ -219,7 +219,7 @@ jobs:
           RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           git fetch origin published-docs
-          git switch --force-create published-docs-sync origin/published-docs
+          git switch --force-create published-docs origin/published-docs
           git read-tree --reset -u "$RELEASE_SHA"
           test "$(git write-tree)" = "$(git rev-parse "${RELEASE_SHA}^{tree}")"
 

--- a/docs/getting-started/upgrading/from-fastmcp-3.mdx
+++ b/docs/getting-started/upgrading/from-fastmcp-3.mdx
@@ -11,25 +11,22 @@ FastMCP 4 absorbs almost all of this for you. Field access is bridged so your ex
 
 The sections below cover what FastMCP handles for you, the changes you must make in your own code, the surfaces removed outright in 4.0, the behavior shifts that compile fine but act differently, and the deprecation timeline for the compatibility shims.
 
-## Install the v4 Prerelease
+## Install FastMCP 4
 
-While FastMCP 4 is in prerelease, pin the beta explicitly. The `fastmcp` package is a thin wrapper that depends on `fastmcp-slim` at the same version, so asking for a prerelease of one means asking for a prerelease of the other. pip infers that on its own:
+FastMCP 4 is a stable release:
 
 ```bash
-pip install "fastmcp==4.0.0b4"
+pip install "fastmcp>=4"
 ```
 
-uv is stricter: it allows prereleases only for packages you name, and `fastmcp-slim` arrives transitively. Constrain it alongside the requirement in `pyproject.toml`:
+Or in `pyproject.toml`:
 
 ```toml
 [project]
-dependencies = ["fastmcp==4.0.0b4"]
-
-[tool.uv]
-constraint-dependencies = ["fastmcp-slim==4.0.0b4"]
+dependencies = ["fastmcp>=4"]
 ```
 
-Then run `uv lock` or `uv sync` normally. Naming the one package keeps the rest of your graph on stable releases, where `--prerelease allow` would opt every dependency into prereleases. The MCP SDK needs no constraint at all now that it ships stable releases — pinning `mcp==2.0.0b2` here would in fact break the resolution, since a prerelease does not satisfy FastMCP's own `mcp>=2.0.0` requirement.
+The `fastmcp` package is a thin wrapper that depends on `fastmcp-slim` at the same version; both resolve together with no extra constraints.
 
 <Prompt description="Copy this prompt into any LLM along with your server code to get automated upgrade guidance.">
 You are upgrading an MCP server or client from FastMCP 3.x to FastMCP 4, which is built on the MCP Python SDK v2.
@@ -48,7 +45,7 @@ IMPORTS THAT NO LONGER RESOLVE
 - `fastmcp.experimental.sampling.handlers`
 - `fastmcp.server.apps`, `fastmcp.server.app`
 - `fastmcp.tools.tool`, `fastmcp.resources.resource`, `fastmcp.prompts.prompt`
-- `fastmcp.server.tasks`, `fastmcp.server.sampling`
+- `fastmcp.server.tasks` (`TaskConfig` now imports from `fastmcp.utilities.tasks`), `fastmcp.server.sampling`
 - `fastmcp.server.auth.authorization`
 - `CurrentDocket` or `CurrentWorker` from `fastmcp.dependencies`
 - `SkillsProvider`
@@ -82,6 +79,7 @@ RUNTIME BREAKS THAT STILL COMPILE — the ones most likely to reach production
 - clients matching on the resource-not-found error code -32002
 - templated resources whose parameters legitimately carry `..` or absolute paths
 - an OAuth server (`OAuthProxy` or anything built on it) with `issuer_url` set to something other than `base_url` — this forces a one-time re-authorization of every client
+- `Client("server.py")` or any bare string path handed to `Client` — inferring a stdio transport from a string is deprecated, warns, and is removed in FastMCP 5; pass `Path(...)` or `StdioTransport`
 
 BACKGROUND TASKS
 - `@mcp.tool(task=True)` or `TaskConfig` without `mcp.add_extension(TasksExtension())`
@@ -119,7 +117,7 @@ async def read_schema():
         return tools[0].inputSchema  # still works, warns once
 ```
 
-Each bridged read emits a `FastMCPDeprecationWarning` pointing you at the snake_case name (`tools[0].input_schema` here). The bridge covers the fields users actually read: `inputSchema`/`outputSchema` on tools; `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` on tool annotations; `mimeType` on resources and content; `isError`/`structuredContent` on tool results; `nextCursor` on paginated results; `serverInfo`/`protocolVersion` on the initialize result; the sampling parameter fields (`systemPrompt`, `maxTokens`, `stopSequences`, `modelPreferences`, `toolChoice`); and `requestedSchema` on elicitation parameters.
+Each bridged read emits a `FastMCPDeprecationWarning` pointing you at the snake_case name (`tools[0].input_schema` here). The bridge covers the fields users actually read: `inputSchema`/`outputSchema` on tools; `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` on tool annotations; `mimeType` on resources and content; `isError`/`structuredContent` on tool results; `nextCursor` on paginated results; `serverInfo`/`protocolVersion` on the initialize result; the sampling parameter fields (`systemPrompt`, `maxTokens`, `stopSequences`, `modelPreferences`, `toolChoice`); `requestedSchema` on elicitation parameters; `hasMore` and `resourceTemplates` on list results; and `uriTemplate` on resource templates.
 
 The bridge is controlled by the `mcp_camelcase_compat` setting, which defaults to on. Set it to `False` (or the environment variable `FASTMCP_MCP_CAMELCASE_COMPAT=false`) to turn the shims off, in which case only the snake_case names resolve:
 
@@ -139,7 +137,7 @@ Every protocol type — `TextContent`, `ImageContent`, `Tool`, `ErrorData`, `Ico
 from mcp.types import TextContent, Tool, ToolAnnotations
 ```
 
-Both names resolve to the same objects, so `from mcp_types import X` is equally valid — useful if you depend on the types without the rest of the SDK. What did change is the fields on those types: they are snake_case now (`input_schema`, not `inputSchema`), which the [compatibility bridge](#legacy-camelcase-field-access-keeps-working) covers for the objects FastMCP hands you.
+Both names resolve to the same objects, so `from mcp_types import X` is equally valid — useful if you depend on the types without the rest of the SDK. What did change is the fields on those types: they are snake_case now (`input_schema`, not `inputSchema`), which the [compatibility bridge](#camelcase-field-access) covers for the objects FastMCP hands you.
 
 `fastmcp.types` still exists, but holds only types FastMCP defines itself (currently just `Textarea`, used to render a multiline textarea in form-based UIs) — it does not re-export protocol types.
 
@@ -161,7 +159,7 @@ except McpError as err:
 A few client behaviors that touch the SDK are preserved so you don't have to change anything:
 
 - `Client(timeout=...)` accepts both a `timedelta` and a plain float number of seconds, as before.
-- `client.ping()` returns a `bool`.
+- `client.ping()` returns a `bool` on handshake-era connections. On the sessionless `2026-07-28` era `ping` is not routed and raises `MCPError: Method not found` — pin `mode="legacy"` if your health checks depend on it.
 - `client.transport.get_session_id()` returns `None` on protocol eras that have no session, rather than raising. (The SDK v2 removed session-id access from its streamable HTTP transport; FastMCP reconstructs it on the transport object.)
 
 ## What You Must Change
@@ -258,7 +256,7 @@ The proxy, OpenAPI, and app integrations moved to their permanent homes, and the
 | `CurrentDocket` / `CurrentWorker` from `fastmcp.dependencies` | `fastmcp_tasks.dependencies` |
 | `fastmcp.server.sampling` (and `SamplingTool`) | removed with [server-side sampling](#protocol-version-support) |
 
-Two renames in the same family are worth calling out because they have no compatibility alias. The response-caching wrapper models lost a spelling typo — `CachableToolResult`, `CachablePromptResult`, and their siblings became `CacheableToolResult`, `CacheablePromptResult`, etc. — so an import of the old spelling from `fastmcp.server.middleware.caching` raises `ImportError`. And `PromptToolMiddleware` / `ResourceToolMiddleware` are gone in favor of the `PromptsAsTools` / `ResourcesAsTools` transforms from `fastmcp.server.transforms` (the `ToolInjectionMiddleware` base class is retained).
+Two renames in the same family are worth calling out because they have no compatibility alias. The response-caching wrapper models lost a spelling typo — `CachableToolResult`, `CachablePromptResult`, and their siblings became `CacheableToolResult`, `CacheablePromptResult`, etc. — so an import of the old spelling from `fastmcp.server.middleware.caching` raises `ImportError`. And `PromptToolMiddleware` / `ResourceToolMiddleware` are gone in favor of the `PromptsAsTools` / `ResourcesAsTools` transforms from `fastmcp.server.transforms` (the `ToolInjectionMiddleware` base class is retained at `fastmcp.server.middleware.tool_injection`).
 
 ### Removed Server Methods
 
@@ -271,7 +269,7 @@ These `FastMCP` methods and keywords have warned since 3.0 and are now removed:
 | `mcp.mount(sub, prefix="x")` | `mcp.mount(sub, namespace="x")` |
 | `mcp.mount(sub, as_proxy=True)` | wrap with `create_proxy(sub)`, then `mount` the proxy |
 | `mcp.add_tool_transformation(name, cfg)` | `mcp.add_transform(ToolTransform({name: cfg}))` |
-| `mcp.remove_tool_transformation(name)` | removed (was a no-op); hide tools with `mcp.disable(keys=[...])` |
+| `mcp.remove_tool_transformation(name)` | removed (was a no-op); hide tools with `mcp.disable(keys={...})` |
 | `mcp.remove_tool(name)` | `mcp.local_provider.remove_tool(name)` |
 
 Two of these replacements are not exact behavioral swaps. `create_proxy` takes its target as the first positional argument (`target`), so a keyword call like `as_proxy(backend=server)` becomes `create_proxy(server)` rather than reusing the old keyword. And `local_provider.remove_tool` raises a plain `KeyError` when the tool is missing, where `FastMCP.remove_tool` raised a `NotFoundError` — update any `except NotFoundError` cleanup around a removal.
@@ -304,17 +302,11 @@ Several parameters and settings that warned in 3.x are gone:
 
 Background tasks left the core MCP spec during the SDK v2 rebuild and came back as the `io.modelcontextprotocol/tasks` extension (SEP-2663). FastMCP follows the protocol: what was a built-in server feature in 3.x is now a registered extension, and the authoring surface changed on both sides of the connection.
 
-The extension ships in a separate package, so the pin from [Install the v4 Prerelease](#install-the-v4-prerelease) needs one more entry before any of this imports:
+The extension ships in a separate package — install the `tasks` extra before any of this imports:
 
 ```toml
 [project]
-dependencies = ["fastmcp[tasks]==4.0.0b4"]
-
-[tool.uv]
-constraint-dependencies = [
-    "fastmcp-slim==4.0.0b4",
-    "fastmcp-tasks==4.0.0b4",
-]
+dependencies = ["fastmcp[tasks]>=4"]
 ```
 
 On the server, `task=True` still marks a tool as capable of running in the background, but it no longer runs anything by itself — the extension does. Register it, or the server refuses to start:
@@ -337,6 +329,8 @@ Without the registration, a `task=True` tool raises at startup rather than the f
 ```
 RuntimeError: Task-enabled tools (slow_computation) require the tasks extension,
 but no extension with identifier 'io.modelcontextprotocol/tasks' is registered.
+Install it with `pip install 'fastmcp[tasks]'` and register it via
+`mcp.add_extension(TasksExtension(...))`.
 ```
 
 `TaskConfig` moved from `fastmcp.server.tasks` to `fastmcp.utilities.tasks`, and the `CurrentDocket` and `CurrentWorker` dependencies moved to `fastmcp_tasks.dependencies`.

--- a/docs/getting-started/whats-new.mdx
+++ b/docs/getting-started/whats-new.mdx
@@ -12,7 +12,7 @@ The protocol changed completely underneath those APIs. Your application usually 
 That is the theme of version 4: stateless transport without stateless application code. The release also makes protocol extensions a first-class surface, adds enterprise identity for agents acting on behalf of users, and strengthens production defaults across caching, routing, and security.
 
 <Note>
-FastMCP 4 is in **beta**. Pin an exact version and expect sharp edges. See [Install the v4 prerelease](/getting-started/upgrading/from-fastmcp-3#install-the-v4-prerelease).
+Install with `pip install fastmcp -U`. Upgrading from FastMCP 3? Start with [the upgrade guide](/getting-started/upgrading/from-fastmcp-3).
 </Note>
 
 ## Protocol compatibility
@@ -36,6 +36,8 @@ legacy = Client("https://example.com/mcp", mode="legacy")
 Once connected, `client.protocol_version`, `client.server_info`, `client.server_capabilities`, and `client.instructions` expose the same interface whichever era was negotiated. Application code that inspects a server does not need a protocol-version branch. See [Protocol negotiation](/clients/client#protocol-negotiation).
 
 On modern connections, FastMCP also attaches the method, target name, and opted-in argument values as HTTP headers. Gateways and load balancers can route requests without parsing JSON-RPC bodies. See [Gateway routing headers](/deployment/http#gateway-routing-headers).
+
+For applications that talk to several servers at once, `ClientGroup` manages one client per server behind a single tool catalog — collision-checked `{server}_{tool}` namespacing, call routing, and no proxy in the middle. Each member negotiates its own protocol version, so one group can span a modern server, a handshake-era server, and a local subprocess. See [Client groups](/clients/client-groups).
 
 ## Stateful applications
 
@@ -195,7 +197,7 @@ from fastmcp import FastMCP
 from fastmcp.server.auth import IdentityAssertion, OAuthProxy
 
 auth = OAuthProxy(
-    # Existing upstream configuration
+    # ... your existing upstream configuration (required kwargs elided) ...
     identity_assertion=IdentityAssertion(
         trusted_issuers=["https://login.acme-corp.com"]
     ),
@@ -203,9 +205,9 @@ auth = OAuthProxy(
 mcp = FastMCP("Internal API", auth=auth)
 ```
 
-The asserted subject enters the normal authentication context, so tools read it through `get_access_token()` like any other identity. See [Identity assertion](/servers/auth/oauth-proxy#identity-assertion-sep-990).
+The asserted subject enters the normal authentication context, so tools read it through `get_access_token()` like any other identity. Identity assertion is in beta; the API may change in a minor release. See [Identity assertion](/servers/auth/oauth-proxy#identity-assertion-sep-990).
 
-Authorization gained a provider-neutral role check as well. `require_roles` accepts an extraction function for providers that store roles and groups under different claims, while [scope step-up challenges](/servers/authorization#signaling-scope-shortfalls) tell a client exactly which scopes to request.
+Authorization gained a provider-neutral role check as well. `require_roles` takes a required `extract` function so provider-specific claim shapes (`realm_access.roles`, `cognito:groups`) stay at the call site; a role denial is a plain authorization error. Separately, [scope step-up challenges](/servers/authorization#signaling-scope-shortfalls) tell a client exactly which scopes to request.
 
 For clients with no user behind them, such as backend services and scheduled jobs, `ClientCredentialsOAuthProvider` implements the OAuth 2.0 client-credentials grant with no browser or redirect. See [Machine-to-machine authentication](/clients/auth/client-credentials).
 
@@ -219,7 +221,7 @@ from fastmcp import FastMCP
 mcp = FastMCP("Weather", cache_ttl=300, cache_scope="public")
 ```
 
-`KeyValueResponseCacheStore` can place the client cache in Redis or another key-value store so a fleet of clients or proxies shares fills. See [Response caching](/clients/client#response-caching).
+`KeyValueResponseCacheStore` can place the client cache in Redis or another key-value store so a fleet of clients or proxies shares fills. Cache entries are partitioned by the requested component version, so an explicit `version=` request never returns another version's cached result, and middleware response limits now align with declared output schemas. See [Response caching](/clients/client#response-caching).
 
 Resource templates now reject path traversal, absolute paths, and null bytes in their parameters before the handler runs. The protection is enabled by default and applies to mounted and proxied templates. See [Path security](/servers/resources#path-security).
 
@@ -232,5 +234,7 @@ The sessionless protocol has no live connection for a server to call back into d
 For generation, call an LLM directly from the server when your application owns the model. When borrowing the caller's model is the point, return an `InputRequiredResult` carrying a sampling request and read the answer on the next round. Roots use the same return-and-resume pattern. See [Sampling](/servers/sampling) and [the guard pattern](/servers/elicitation#sampling-and-roots).
 
 `ctx.elicit()` remains available on handshake-era connections; modern connections use the multi-round pattern described above. Code that constructs MCP protocol models directly must also use snake_case Python field names with SDK v2.
+
+One deprecation to note: `Client("server.py")` — inferring a stdio transport from a bare string — now warns. Pass a `Path` to run local code and keep strings for URLs; the string form will be removed in FastMCP 5.
 
 [Upgrading from FastMCP 3](/getting-started/upgrading/from-fastmcp-3) covers these changes and every other compatibility break.


### PR DESCRIPTION
syncs published-docs to main: whats-new and upgrade-guide corrections from the post-GA audit (#4961).