### PR TITLE
docs: refresh sidebar tags and fix audit findings

### DIFF
--- a/docs/apps/fastmcp-app.mdx
+++ b/docs/apps/fastmcp-app.mdx
@@ -3,7 +3,6 @@ title: FastMCPApp
 sidebarTitle: FastMCPApp
 description: Wire an interactive UI to backend tools with managed visibility and composition safety.
 icon: puzzle-piece
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/apps/generative.mdx
+++ b/docs/apps/generative.mdx
@@ -3,7 +3,6 @@ title: Generative UI
 sidebarTitle: Generative UI
 description: Let the LLM build custom Prefab UIs on the fly.
 icon: wand-magic-sparkles
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/apps/prefab.mdx
+++ b/docs/apps/prefab.mdx
@@ -3,7 +3,6 @@ title: Interactive Tools
 sidebarTitle: Interactive Tools
 description: Turn your tools into interactive UIs with charts, tables, and dashboards.
 icon: palette
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/apps/providers/approval.mdx
+++ b/docs/apps/providers/approval.mdx
@@ -3,7 +3,6 @@ title: Approval
 sidebarTitle: Approval
 description: Human-in-the-loop approval gates for agent actions
 icon: shield-check
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/apps/providers/choice.mdx
+++ b/docs/apps/providers/choice.mdx
@@ -3,7 +3,6 @@ title: Choice
 sidebarTitle: Choice
 description: Present clickable options instead of free-text responses
 icon: list-check
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/apps/providers/file-upload.mdx
+++ b/docs/apps/providers/file-upload.mdx
@@ -3,7 +3,6 @@ title: File Upload
 sidebarTitle: File Upload
 description: Drag-and-drop file upload for any MCP server
 icon: upload
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/apps/providers/form.mdx
+++ b/docs/apps/providers/form.mdx
@@ -3,7 +3,6 @@ title: Form Input
 sidebarTitle: Form Input
 description: Collect structured data from users via Pydantic models
 icon: rectangle-list
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/apps/quickstart.mdx
+++ b/docs/apps/quickstart.mdx
@@ -3,7 +3,6 @@ title: Quickstart
 sidebarTitle: Quickstart
 description: Build your first FastMCP app in under a minute.
 icon: rocket
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/clients/auth/cimd.mdx
+++ b/docs/clients/auth/cimd.mdx
@@ -3,7 +3,6 @@ title: CIMD Authentication
 sidebarTitle: CIMD
 description: Use Client ID Metadata Documents for verifiable, domain-based client identity.
 icon: id-badge
-tag: NEW
 ---
 
 import { VersionBadge } from "/snippets/version-badge.mdx"

--- a/docs/clients/client-groups.mdx
+++ b/docs/clients/client-groups.mdx
@@ -2,6 +2,7 @@
 title: Client Groups
 sidebarTitle: Client Groups
 icon: layer-group
+tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/clients/client.mdx
+++ b/docs/clients/client.mdx
@@ -347,6 +347,8 @@ The client supports callback handlers for advanced server interactions. These le
 Sampling, elicitation, and roots are the requests a server makes of the client. A server reaches your handler by whichever route its [era](#protocol-negotiation) allows — pushed down the open session on the handshake, returned as an input-required result on the modern protocol — and both routes dispatch to the same handler, so one registration covers both. Logging and progress arrive as notifications on the response stream and work in either era.
 
 ```python
+from pathlib import Path
+
 from fastmcp import Client
 from fastmcp.client.logging import LogMessage
 
@@ -361,7 +363,7 @@ async def sampling_handler(messages, params, context):
     return "Generated response"
 
 client = Client(
-    "my_mcp_server.py",
+    Path("my_mcp_server.py"),
     log_handler=log_handler,
     progress_handler=progress_handler,
     sampling_handler=sampling_handler,

--- a/docs/clients/notifications.mdx
+++ b/docs/clients/notifications.mdx
@@ -18,6 +18,8 @@ MCP servers can send notifications to inform clients about state changes. The me
 The simplest approach is a function that receives all messages and filters for the notifications you care about:
 
 ```python
+from pathlib import Path
+
 from fastmcp import Client
 
 async def message_handler(message):
@@ -35,7 +37,7 @@ async def message_handler(message):
             print("A resource was updated")
 
 client = Client(
-    "my_mcp_server.py",
+    Path("my_mcp_server.py"),
     message_handler=message_handler,
 )
 ```
@@ -45,6 +47,8 @@ client = Client(
 For fine-grained targeting, subclass `MessageHandler` to use specific hooks:
 
 ```python
+from pathlib import Path
+
 from fastmcp import Client
 from fastmcp.client.messages import MessageHandler
 import mcp.types
@@ -69,7 +73,7 @@ class MyMessageHandler(MessageHandler):
         print("Prompt list changed")
 
 client = Client(
-    "my_mcp_server.py",
+    Path("my_mcp_server.py"),
     message_handler=MyMessageHandler(),
 )
 ```

--- a/docs/clients/transports.mdx
+++ b/docs/clients/transports.mdx
@@ -34,7 +34,7 @@ transport = StdioTransport(
 client = Client(transport)
 ```
 
-For convenience, the client can infer STDIO transport from file paths, though this limits configuration options:
+For convenience, the client can infer STDIO transport from file paths, though this limits configuration options. Pass a `Path`: inferring a subprocess from a bare *string* like `Client("my_server.py")` is deprecated as of 4.0 — it warns, and in FastMCP 5 a string will only ever mean a URL:
 
 ```python
 from pathlib import Path

--- a/docs/deployment/http.mdx
+++ b/docs/deployment/http.mdx
@@ -792,7 +792,7 @@ This automatic approach is convenient for development but not suitable for produ
 Production requires explicit key management to ensure tokens survive restarts and can be shared across multiple server instances. This requires the following two things working together:
 
 1. **Explicit JWT signing key** for signing tokens issued to clients
-3. **Persistent network-accessible storage** for upstream tokens (wrapped in `FernetEncryptionWrapper` to encrypt sensitive data at rest)
+2. **Persistent network-accessible storage** for upstream tokens (wrapped in `FernetEncryptionWrapper` to encrypt sensitive data at rest)
 
 **Configuration:**
 

--- a/docs/deployment/running-server.mdx
+++ b/docs/deployment/running-server.mdx
@@ -180,7 +180,7 @@ fastmcp run server.py --reload --transport http --port 8080
 ```
 
 <Note>
-Auto-reload uses stateless mode to enable seamless restarts. For stdio transport, this is fully featured. For HTTP transport, some bidirectional features like elicitation are not available during reload mode.
+Auto-reload uses stateless mode to enable seamless restarts. For stdio transport, this is fully featured. For HTTP transport, handshake-era `ctx.elicit()` is not available during reload mode; the modern guard pattern (returning `InputRequiredResult`) needs no session back-channel and is unaffected.
 </Note>
 
 SSE transport does not support auto-reload due to session limitations. Use HTTP transport instead if you need both network access and auto-reload.

--- a/docs/integrations/keycloak.mdx
+++ b/docs/integrations/keycloak.mdx
@@ -3,7 +3,6 @@ title: Keycloak OAuth 🤝 FastMCP
 sidebarTitle: Keycloak
 description: Secure your FastMCP server with Keycloak OAuth
 icon: shield-check
-tag: NEW
 ---
 
 import { VersionBadge } from "/snippets/version-badge.mdx"

--- a/docs/servers/authorization.mdx
+++ b/docs/servers/authorization.mdx
@@ -3,7 +3,6 @@ title: Authorization
 sidebarTitle: Authorization
 description: Control access to components using callable-based authorization checks that filter visibility and enforce permissions.
 icon: shield-halved
-tag: NEW
 ---
 
 import { VersionBadge } from "/snippets/version-badge.mdx"

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -3,7 +3,6 @@ title: MCP Context
 sidebarTitle: Context
 description: Access MCP capabilities like logging, progress, and resources within your MCP objects.
 icon: rectangle-code
-tag: NEW
 ---
 import { VersionBadge } from '/snippets/version-badge.mdx'
 

--- a/docs/servers/dependency-injection.mdx
+++ b/docs/servers/dependency-injection.mdx
@@ -3,7 +3,6 @@ title: Dependency Injection
 sidebarTitle: Dependencies
 description: Inject runtime values like HTTP requests, access tokens, and custom dependencies into your MCP components.
 icon: syringe
-tag: NEW
 ---
 
 import { VersionBadge } from "/snippets/version-badge.mdx";

--- a/docs/servers/lifespan.mdx
+++ b/docs/servers/lifespan.mdx
@@ -3,7 +3,6 @@ title: Lifespans
 sidebarTitle: Lifespan
 description: Server-level setup and teardown with composable lifespans
 icon: heart-pulse
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/middleware.mdx
+++ b/docs/servers/middleware.mdx
@@ -484,7 +484,7 @@ mcp.add_middleware(ResponseCachingMiddleware(
 See [Storage Backends](/servers/storage-backends) for complete options.
 
 <Note>
-Cache keys are based on the operation name and arguments only — they do not include user or session identity. If your tools return user-specific data derived from auth context (e.g., headers or session state) rather than from the request arguments, you should either disable caching for those tools or ensure user identity is part of the tool arguments.
+Cache keys include the method name, arguments, the requested component version, and the caller's access token — entries are partitioned per token, so responses cannot leak across users with different permissions. Unauthenticated callers (including STDIO) share a single anonymous partition. Data derived from request context *other than* the auth token — custom HTTP headers, session state — is not part of the key, so disable caching for tools whose results depend on it.
 </Note>
 
 ### Rate Limiting

--- a/docs/servers/pagination.mdx
+++ b/docs/servers/pagination.mdx
@@ -3,7 +3,6 @@ title: Pagination
 sidebarTitle: Pagination
 description: Control how servers return large lists of components to clients.
 icon: page
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/providers/custom.mdx
+++ b/docs/servers/providers/custom.mdx
@@ -3,7 +3,6 @@ title: Custom Providers
 sidebarTitle: Custom
 description: Build providers that source components from any data source
 icon: code
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/providers/filesystem.mdx
+++ b/docs/servers/providers/filesystem.mdx
@@ -3,7 +3,6 @@ title: Filesystem Provider
 sidebarTitle: Filesystem
 description: Automatic component discovery from Python files
 icon: folder-tree
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/providers/local.mdx
+++ b/docs/servers/providers/local.mdx
@@ -3,7 +3,6 @@ title: Local Provider
 sidebarTitle: Local
 description: The default provider for decorator-registered components
 icon: house
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/providers/overview.mdx
+++ b/docs/servers/providers/overview.mdx
@@ -3,7 +3,6 @@ title: Providers
 sidebarTitle: Overview
 description: How FastMCP sources tools, resources, and prompts
 icon: layer-group
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/providers/proxy.mdx
+++ b/docs/servers/providers/proxy.mdx
@@ -163,10 +163,12 @@ proxy = create_proxy(Path("advanced_backend.py"))
 Selectively disable forwarding:
 
 ```python
+from pathlib import Path
+
 from fastmcp.server.providers.proxy import ProxyClient
 
 backend = ProxyClient(
-    "backend_server.py",
+    Path("backend_server.py"),
     sampling_handler=None,  # Disable LLM sampling
     log_handler=None        # Disable log forwarding
 )

--- a/docs/servers/providers/skills.mdx
+++ b/docs/servers/providers/skills.mdx
@@ -3,7 +3,6 @@ title: Skills Provider
 sidebarTitle: Skills
 description: Expose agent skills as MCP resources
 icon: wand-magic-sparkles
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/storage-backends.mdx
+++ b/docs/servers/storage-backends.mdx
@@ -3,7 +3,6 @@ title: Storage Backends
 sidebarTitle: Storage Backends
 description: Configure persistent and distributed storage for caching and OAuth state management
 icon: database
-tag: NEW
 ---
 
 import { VersionBadge } from "/snippets/version-badge.mdx"

--- a/docs/servers/tasks.mdx
+++ b/docs/servers/tasks.mdx
@@ -293,8 +293,10 @@ The `Progress` dependency lets you report progress back to clients. Inject it as
 ```python
 from fastmcp import FastMCP
 from fastmcp.dependencies import Progress
+from fastmcp_tasks import TasksExtension
 
 mcp = FastMCP("MyServer")
+mcp.add_extension(TasksExtension())
 
 @mcp.tool(task=True)
 async def process_files(files: list[str], progress: Progress = Progress()) -> str:
@@ -323,9 +325,11 @@ FastMCP exposes Docket's full dependency injection system within your task-enabl
 from docket import Docket, Worker
 from fastmcp import FastMCP
 from fastmcp.dependencies import Progress
+from fastmcp_tasks import TasksExtension
 from fastmcp_tasks.dependencies import CurrentDocket, CurrentWorker
 
 mcp = FastMCP("MyServer")
+mcp.add_extension(TasksExtension())
 
 @mcp.tool(task=True)
 async def my_task(

--- a/docs/servers/transforms/code-mode.mdx
+++ b/docs/servers/transforms/code-mode.mdx
@@ -3,7 +3,6 @@ title: Code Mode
 sidebarTitle: Code Mode
 description: Let LLMs write Python to orchestrate tools in a sandbox
 icon: flask
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/transforms/prompts-as-tools.mdx
+++ b/docs/servers/transforms/prompts-as-tools.mdx
@@ -3,7 +3,6 @@ title: Prompts as Tools
 sidebarTitle: Prompts as Tools
 description: Expose prompts to tool-only clients
 icon: message-lines
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/transforms/resources-as-tools.mdx
+++ b/docs/servers/transforms/resources-as-tools.mdx
@@ -3,7 +3,6 @@ title: Resources as Tools
 sidebarTitle: Resources as Tools
 description: Expose resources to tool-only clients
 icon: toolbox
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/transforms/tool-search.mdx
+++ b/docs/servers/transforms/tool-search.mdx
@@ -3,7 +3,6 @@ title: Tool Search
 sidebarTitle: Tool Search
 description: Replace large tool catalogs with on-demand search
 icon: magnifying-glass
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'

--- a/docs/servers/versioning.mdx
+++ b/docs/servers/versioning.mdx
@@ -3,7 +3,6 @@ title: Versioning
 sidebarTitle: Versioning
 description: Serve multiple API versions from a single codebase
 icon: code-branch
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'
@@ -289,13 +288,14 @@ def add(x: int, y: int) -> int:
 def add(x: int, y: int) -> int:
     return x + y + 100  # Different behavior
 
-# Get highest version (default)
-tool = await mcp.get_tool("add")
-print(tool.version)  # "2.0"
+async def main():
+    # Get highest version (default)
+    tool = await mcp.get_tool("add")
+    print(tool.version)  # "2.0"
 
-# Get specific version
-tool_v1 = await mcp.get_tool("add", version="1.0")
-print(tool_v1.version)  # "1.0"
+    # Get specific version
+    tool_v1 = await mcp.get_tool("add", version="1.0")
+    print(tool_v1.version)  # "1.0"
 ```
 
 If the requested version doesn't exist, a `NotFoundError` is raised.

--- a/docs/servers/visibility.mdx
+++ b/docs/servers/visibility.mdx
@@ -3,7 +3,6 @@ title: Component Visibility
 sidebarTitle: Visibility
 description: Control which components are available to clients
 icon: toggle-on
-tag: NEW
 ---
 
 import { VersionBadge } from '/snippets/version-badge.mdx'
@@ -241,6 +240,7 @@ Server-level visibility state applies to all components from all providers. When
 from fastmcp import FastMCP
 
 main = FastMCP("Main")
+sub_server = FastMCP("Sub")
 main.mount(sub_server, namespace="api")
 
 @main.tool(tags={"internal"})


### PR DESCRIPTION
second pass of the post-GA docs audit, covering servers/, clients/, and deployment/ plus the sidebar tags.

the headline fix: the response-caching note in middleware.mdx claimed cache keys ignore user identity and suggested putting identity in tool arguments — the middleware actually partitions entries by access token and requested component version, so the note now describes the real key and scopes the caveat to non-token request context.

<details><summary>everything else</summary>

- sidebar tags: NEW stripped from 27 pre-4.0 pages (the apps section was 3.1-3.2 era, context/DI were 2.14, storage-backends 2.13); client-groups — an actual 4.0 feature — gains the NEW it was missing; tasks pages keep theirs
- four missed bare-string Client(...) examples (notifications x2, client.mdx, proxy.mdx) now pass Path, with imports
- transports.mdx notes the string-inference deprecation on the page readers actually consult for transports
- two tasks.mdx examples used task=True with no TasksExtension registered and would refuse to start
- running-server.mdx reload caveat scoped to handshake-era ctx.elicit(); the modern guard pattern is unaffected
- http.mdx production list renumbered (1,3 -> 1,2); versioning.mdx module-level awaits wrapped; visibility.mdx undefined sub_server defined
</details>