### PR TITLE
client: deliver `ClientGroup` callback payloads with provenance context

### DIFF
--- a/docs/clients/client-groups.mdx
+++ b/docs/clients/client-groups.mdx
@@ -97,24 +97,32 @@ group = ClientGroup.from_config(config)
 
 Entries without a `mode` use `"auto"` by default.
 
-To control how each member client is constructed — most commonly to give shared handlers provenance — pass a `client_factory`. It receives the server name, the transport built from that entry, and the resolved mode, and returns the `Client` to use. A handler closed over the name can tell servers apart:
+## Shared handlers with provenance
+
+A shared handler attached at the group level receives every payload together with a `GroupCallbackContext` naming the member that produced it, so one handler can serve the whole group and still tell servers apart:
 
 ```python
-from fastmcp import Client
-from fastmcp.client.group import ClientGroup
+from fastmcp.client.group import ClientGroup, GroupCallbackContext
 
 
-def make_client(name, transport, mode):
-    async def log_handler(message):
-        print(f"[{name}] {message.data.get('msg')}")
-
-    return Client(transport, mode=mode, log_handler=log_handler)
+async def log_handler(message, context: GroupCallbackContext):
+    print(f"[{context.server_name}] {message.data.get('msg')}")
 
 
-group = ClientGroup.from_config(config, client_factory=make_client)
+async def progress_handler(progress, total, message, context: GroupCallbackContext):
+    print(f"[{context.server_name}/{context.tool_name}] {progress}/{total}")
+
+
+group = ClientGroup.from_config(
+    config,
+    log_handler=log_handler,
+    progress_handler=progress_handler,
+)
 ```
 
-The factory owns construction: handlers, auth, timeouts, and anything else `Client` accepts. Pass `transport` and `mode` through unless you specifically mean to override them.
+`progress_handler` is call-scoped: the group binds the route's server and upstream tool name when it dispatches each call, so it works on any group — including one built from explicit clients via `ClientGroup(clients, progress_handler=...)`. A per-call `progress_handler` passed to `call_tool()` takes precedence.
+
+`log_handler` and `message_handler` are connection-scoped: they must be bound when the member client is constructed, so the group accepts them only in `from_config`, where it builds the clients. A group assembled from explicit clients binds those handlers at `Client(...)` construction — closing over the server name gives the same provenance.
 
 ## Manage connections explicitly
 

--- a/docs/clients/client-groups.mdx
+++ b/docs/clients/client-groups.mdx
@@ -97,6 +97,25 @@ group = ClientGroup.from_config(config)
 
 Entries without a `mode` use `"auto"` by default.
 
+To control how each member client is constructed — most commonly to give shared handlers provenance — pass a `client_factory`. It receives the server name, the transport built from that entry, and the resolved mode, and returns the `Client` to use. A handler closed over the name can tell servers apart:
+
+```python
+from fastmcp import Client
+from fastmcp.client.group import ClientGroup
+
+
+def make_client(name, transport, mode):
+    async def log_handler(message):
+        print(f"[{name}] {message.data.get('msg')}")
+
+    return Client(transport, mode=mode, log_handler=log_handler)
+
+
+group = ClientGroup.from_config(config, client_factory=make_client)
+```
+
+The factory owns construction: handlers, auth, timeouts, and anything else `Client` accepts. Pass `transport` and `mode` through unless you specifically mean to override them.
+
 ## Manage connections explicitly
 
 Using the group as a context manager is optional. Applications can own each client connection and use the group only for discovery and routing:

--- a/fastmcp_slim/fastmcp/client/group.py
+++ b/fastmcp_slim/fastmcp/client/group.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType, TracebackType
 from typing import Any
@@ -14,13 +14,58 @@ import mcp_types
 from mcp.client.caching import CacheMode
 
 from fastmcp.client.client import CallToolResult, Client, ConnectMode
+from fastmcp.client.logging import LogMessage
 from fastmcp.client.progress import ProgressHandler
-from fastmcp.client.transports.base import ClientTransport
 from fastmcp.mcp_config import MCPConfig
 from fastmcp.utilities.async_utils import gather
 
-ClientFactory = Callable[[str, ClientTransport, ConnectMode], Client[Any]]
-"""Builds one group member: ``(server_name, transport, mode) -> Client``."""
+
+@dataclass(frozen=True)
+class GroupCallbackContext:
+    """Provenance for a payload delivered through a group-level handler.
+
+    ``server_name`` is the group's name for the member client that produced
+    the payload. ``tool_name`` is the upstream tool name when the payload is
+    call-scoped (progress); connection-scoped payloads (logs, protocol
+    messages) carry ``None``.
+    """
+
+    server_name: str
+    tool_name: str | None = None
+
+
+GroupLogHandler = Callable[[LogMessage, GroupCallbackContext], Awaitable[None]]
+"""Group-level log handler: ``(message, context) -> None``."""
+
+GroupMessageHandler = Callable[
+    ["mcp_types.ServerNotification | Exception", GroupCallbackContext],
+    Awaitable[None],
+]
+"""Group-level protocol-message handler: ``(message, context) -> None``."""
+
+GroupProgressHandler = Callable[
+    [float, "float | None", "str | None", GroupCallbackContext],
+    Awaitable[None],
+]
+"""Group-level progress handler: ``(progress, total, message, context) -> None``."""
+
+
+def _bind_log_handler(
+    handler: GroupLogHandler, context: GroupCallbackContext
+) -> Callable[[LogMessage], Awaitable[None]]:
+    async def bound(message: LogMessage) -> None:
+        await handler(message, context)
+
+    return bound
+
+
+def _bind_message_handler(
+    handler: GroupMessageHandler, context: GroupCallbackContext
+) -> Callable[[Any], Awaitable[None]]:
+    async def bound(message: Any) -> None:
+        await handler(message, context)
+
+    return bound
 
 
 @dataclass(frozen=True)
@@ -43,11 +88,17 @@ class ClientGroup:
     is safe because client contexts are reference counted.
     """
 
-    def __init__(self, clients: Mapping[str, Client[Any]]) -> None:
+    def __init__(
+        self,
+        clients: Mapping[str, Client[Any]],
+        *,
+        progress_handler: GroupProgressHandler | None = None,
+    ) -> None:
         if not clients:
             raise ValueError("ClientGroup requires at least one client")
 
         self._clients = dict(clients)
+        self._progress_handler = progress_handler
         self._exit_stack: contextlib.AsyncExitStack | None = None
         self._tool_routes: dict[str, ToolRoute] = {}
         self._catalog_loaded = False
@@ -69,30 +120,31 @@ class ClientGroup:
         config: MCPConfig | dict[str, Any],
         *,
         default_mode: ConnectMode = "auto",
-        client_factory: ClientFactory | None = None,
+        log_handler: GroupLogHandler | None = None,
+        message_handler: GroupMessageHandler | None = None,
+        progress_handler: GroupProgressHandler | None = None,
     ) -> ClientGroup:
         """Create one independent client for each configured server.
 
         A server entry may include a FastMCP-specific ``mode`` field. It applies
         only to that server; entries without one use ``default_mode``.
 
-        ``client_factory`` constructs each member client from its server name,
-        transport, and resolved mode. Because the factory sees the server name,
-        handlers it binds carry provenance — a shared handler closed over the
-        name can tell servers apart:
+        Group-level handlers receive each payload together with a
+        `GroupCallbackContext` naming the member that produced it, so one
+        shared handler can tell servers apart:
 
         ```python
-        def make_client(name: str, transport: ClientTransport, mode: ConnectMode):
-            async def log_handler(message: LogMessage) -> None:
-                record(name, message)
+        async def log_handler(message: LogMessage, context: GroupCallbackContext):
+            print(f"[{context.server_name}] {message.data.get('msg')}")
 
-            return Client(transport, mode=mode, log_handler=log_handler)
-
-        group = ClientGroup.from_config(config, client_factory=make_client)
+        group = ClientGroup.from_config(config, log_handler=log_handler)
         ```
 
-        The factory must pass ``transport`` and ``mode`` through to the client
-        it builds; it owns everything else about construction.
+        ``log_handler`` and ``message_handler`` are connection-scoped, so they
+        can only be bound here, where the group constructs the member clients;
+        a group built from explicit clients binds those at `Client(...)`
+        construction instead. ``progress_handler`` is call-scoped and works on
+        every group — it is forwarded to the constructor.
         """
         parsed = (
             config if isinstance(config, MCPConfig) else MCPConfig.from_dict(config)
@@ -103,19 +155,20 @@ class ClientGroup:
             configured_mode = (server.model_extra or {}).get("mode", default_mode)
             if not isinstance(configured_mode, str):
                 raise TypeError(f"Protocol mode for server {name!r} must be a string")
-            transport = server.to_transport()
-            if client_factory is None:
-                clients[name] = Client(transport, mode=configured_mode)
-            else:
-                client = client_factory(name, transport, configured_mode)
-                if not isinstance(client, Client):
-                    raise TypeError(
-                        f"client_factory returned {type(client).__name__!r} for "
-                        f"server {name!r}; it must return a fastmcp Client."
-                    )
-                clients[name] = client
 
-        return cls(clients)
+            client_kwargs: dict[str, Any] = {}
+            context = GroupCallbackContext(server_name=name)
+            if log_handler is not None:
+                client_kwargs["log_handler"] = _bind_log_handler(log_handler, context)
+            if message_handler is not None:
+                client_kwargs["message_handler"] = _bind_message_handler(
+                    message_handler, context
+                )
+            clients[name] = Client(
+                server.to_transport(), mode=configured_mode, **client_kwargs
+            )
+
+        return cls(clients, progress_handler=progress_handler)
 
     @property
     def protocol_versions(self) -> dict[str, str | None]:
@@ -175,6 +228,30 @@ class ClientGroup:
         if disconnected:
             names = ", ".join(repr(name) for name in disconnected)
             raise RuntimeError(f"ClientGroup clients are not connected: {names}")
+
+    def _route_progress_handler(
+        self, route: ToolRoute, explicit: ProgressHandler | None
+    ) -> ProgressHandler | None:
+        """Contextualize the group progress handler for one routed call.
+
+        An explicit per-call handler wins; otherwise the group-level handler is
+        bound to this call's provenance. Returns None when neither is set.
+        """
+        if explicit is not None:
+            return explicit
+        group_handler = self._progress_handler
+        if group_handler is None:
+            return None
+        context = GroupCallbackContext(
+            server_name=route.server_name, tool_name=route.upstream_name
+        )
+
+        async def handler(
+            progress: float, total: float | None, message: str | None
+        ) -> None:
+            await group_handler(progress, total, message, context)
+
+        return handler
 
     def _require_route_connected(self, route: ToolRoute) -> None:
         if not route.client.is_connected():
@@ -269,7 +346,7 @@ class ClientGroup:
             route.upstream_name,
             arguments or {},
             timeout=timeout,
-            progress_handler=progress_handler,
+            progress_handler=self._route_progress_handler(route, progress_handler),
             meta=meta,
         )
 
@@ -291,7 +368,7 @@ class ClientGroup:
             arguments,
             version=version,
             timeout=timeout,
-            progress_handler=progress_handler,
+            progress_handler=self._route_progress_handler(route, progress_handler),
             raise_on_error=raise_on_error,
             meta=meta,
         )

--- a/fastmcp_slim/fastmcp/client/group.py
+++ b/fastmcp_slim/fastmcp/client/group.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType, TracebackType
 from typing import Any
@@ -15,8 +15,12 @@ from mcp.client.caching import CacheMode
 
 from fastmcp.client.client import CallToolResult, Client, ConnectMode
 from fastmcp.client.progress import ProgressHandler
+from fastmcp.client.transports.base import ClientTransport
 from fastmcp.mcp_config import MCPConfig
 from fastmcp.utilities.async_utils import gather
+
+ClientFactory = Callable[[str, ClientTransport, ConnectMode], Client[Any]]
+"""Builds one group member: ``(server_name, transport, mode) -> Client``."""
 
 
 @dataclass(frozen=True)
@@ -65,11 +69,30 @@ class ClientGroup:
         config: MCPConfig | dict[str, Any],
         *,
         default_mode: ConnectMode = "auto",
+        client_factory: ClientFactory | None = None,
     ) -> ClientGroup:
         """Create one independent client for each configured server.
 
         A server entry may include a FastMCP-specific ``mode`` field. It applies
         only to that server; entries without one use ``default_mode``.
+
+        ``client_factory`` constructs each member client from its server name,
+        transport, and resolved mode. Because the factory sees the server name,
+        handlers it binds carry provenance — a shared handler closed over the
+        name can tell servers apart:
+
+        ```python
+        def make_client(name: str, transport: ClientTransport, mode: ConnectMode):
+            async def log_handler(message: LogMessage) -> None:
+                record(name, message)
+
+            return Client(transport, mode=mode, log_handler=log_handler)
+
+        group = ClientGroup.from_config(config, client_factory=make_client)
+        ```
+
+        The factory must pass ``transport`` and ``mode`` through to the client
+        it builds; it owns everything else about construction.
         """
         parsed = (
             config if isinstance(config, MCPConfig) else MCPConfig.from_dict(config)
@@ -80,7 +103,17 @@ class ClientGroup:
             configured_mode = (server.model_extra or {}).get("mode", default_mode)
             if not isinstance(configured_mode, str):
                 raise TypeError(f"Protocol mode for server {name!r} must be a string")
-            clients[name] = Client(server.to_transport(), mode=configured_mode)
+            transport = server.to_transport()
+            if client_factory is None:
+                clients[name] = Client(transport, mode=configured_mode)
+            else:
+                client = client_factory(name, transport, configured_mode)
+                if not isinstance(client, Client):
+                    raise TypeError(
+                        f"client_factory returned {type(client).__name__!r} for "
+                        f"server {name!r}; it must return a fastmcp Client."
+                    )
+                clients[name] = client
 
         return cls(clients)
 

--- a/tests/client/group/test_client_group.py
+++ b/tests/client/group/test_client_group.py
@@ -1,14 +1,14 @@
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, cast
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from pydantic import ConfigDict
 
 from fastmcp import Client, Context, FastMCP
-from fastmcp.client.group import ClientGroup
+from fastmcp.client.group import ClientGroup, GroupCallbackContext
 from fastmcp.client.transports import FastMCPTransport
 from fastmcp.mcp_config import MCPConfig, StdioMCPServer
 
@@ -349,33 +349,7 @@ async def test_explicit_list_tools_refreshes_past_client_response_cache():
         assert result.data == "added"
 
 
-async def test_from_config_client_factory_receives_name_transport_and_mode():
-    config = MCPConfig(
-        mcpServers={
-            "old": InMemoryServer(mcp=make_server("old"), mode="legacy"),
-            "new": InMemoryServer(mcp=make_server("new")),
-        }
-    )
-    seen: list[tuple[str, type, str]] = []
-
-    def factory(name: str, transport: Any, mode: Any) -> Client[Any]:
-        seen.append((name, type(transport), mode))
-        return Client(transport, mode=mode)
-
-    group = ClientGroup.from_config(config, client_factory=factory)
-
-    assert seen == [
-        ("old", FastMCPTransport, "legacy"),
-        ("new", FastMCPTransport, "auto"),
-    ]
-    async with group:
-        assert group.protocol_versions == {
-            "old": "2025-11-25",
-            "new": "2026-07-28",
-        }
-
-
-async def test_from_config_client_factory_gives_handlers_provenance():
+async def test_from_config_log_handler_receives_provenance():
     def make_logging_server(name: str) -> FastMCP:
         server = FastMCP(name)
 
@@ -392,27 +366,119 @@ async def test_from_config_client_factory_gives_handlers_provenance():
             "beta": InMemoryServer(mcp=make_logging_server("beta"), mode="legacy"),
         }
     )
-    records: list[tuple[str, str]] = []
+    records: list[tuple[str, str | None, Any]] = []
 
-    def factory(name: str, transport: Any, mode: Any) -> Client[Any]:
-        async def log_handler(message: Any) -> None:
-            records.append((name, message.data.get("msg")))
+    async def log_handler(message: Any, context: GroupCallbackContext) -> None:
+        records.append(
+            (context.server_name, context.tool_name, message.data.get("msg"))
+        )
 
-        return Client(transport, mode=mode, log_handler=log_handler)
-
-    group = ClientGroup.from_config(config, client_factory=factory)
+    group = ClientGroup.from_config(config, log_handler=log_handler)
 
     async with group:
         await group.call_tool("alpha_announce", {})
         await group.call_tool("beta_announce", {})
 
-    assert ("alpha", "hello from alpha") in records
-    assert ("beta", "hello from beta") in records
+    assert ("alpha", None, "hello from alpha") in records
+    assert ("beta", None, "hello from beta") in records
 
 
-async def test_from_config_client_factory_must_return_a_client():
-    config = MCPConfig(mcpServers={"only": InMemoryServer(mcp=make_server("only"))})
+async def test_group_progress_handler_receives_call_provenance():
+    def make_progress_server(name: str) -> FastMCP:
+        server = FastMCP(name)
 
-    with pytest.raises(TypeError, match="must return a fastmcp Client"):
-        bad_factory = cast(Any, lambda *args: object())
-        ClientGroup.from_config(config, client_factory=bad_factory)
+        @server.tool
+        async def work(ctx: Context) -> str:
+            await ctx.report_progress(progress=1, total=2)
+            return name
+
+        return server
+
+    records: list[tuple[str, str | None, float]] = []
+
+    async def progress_handler(
+        progress: float,
+        total: float | None,
+        message: str | None,
+        context: GroupCallbackContext,
+    ) -> None:
+        records.append((context.server_name, context.tool_name, progress))
+
+    group = ClientGroup(
+        {
+            "alpha": Client(make_progress_server("alpha")),
+            "beta": Client(make_progress_server("beta")),
+        },
+        progress_handler=progress_handler,
+    )
+
+    async with group:
+        await group.call_tool("alpha_work", {})
+        await group.call_tool("beta_work", {})
+
+    assert ("alpha", "work", 1.0) in records
+    assert ("beta", "work", 1.0) in records
+
+
+async def test_explicit_progress_handler_overrides_group_handler():
+    server = FastMCP("only")
+
+    @server.tool
+    async def work(ctx: Context) -> str:
+        await ctx.report_progress(progress=1, total=1)
+        return "done"
+
+    group_calls: list[float] = []
+    explicit_calls: list[float] = []
+
+    async def group_handler(
+        progress: float,
+        total: float | None,
+        message: str | None,
+        context: GroupCallbackContext,
+    ) -> None:
+        group_calls.append(progress)
+
+    async def explicit_handler(
+        progress: float, total: float | None, message: str | None
+    ) -> None:
+        explicit_calls.append(progress)
+
+    group = ClientGroup({"only": Client(server)}, progress_handler=group_handler)
+
+    async with group:
+        await group.call_tool("only_work", {}, progress_handler=explicit_handler)
+
+    assert explicit_calls == [1.0]
+    assert group_calls == []
+
+
+async def test_from_config_message_handler_receives_provenance():
+    from fastmcp.server.middleware import Middleware
+
+    captured: list[Any] = []
+
+    class Capture(Middleware):
+        async def on_message(self, context: Any, call_next: Any) -> Any:
+            fctx = getattr(context, "fastmcp_context", None)
+            if fctx is not None:
+                captured.append(fctx.session)
+            return await call_next(context)
+
+    server = make_server("alpha")
+    server.add_middleware(Capture())
+    config = MCPConfig(mcpServers={"alpha": InMemoryServer(mcp=server, mode="legacy")})
+    seen: list[str] = []
+
+    async def message_handler(message: Any, context: GroupCallbackContext) -> None:
+        seen.append(context.server_name)
+
+    group = ClientGroup.from_config(config, message_handler=message_handler)
+
+    async with group:
+        await group.call_tool("alpha_echo", {"value": "hi"})
+        # out-of-band server notification on the legacy session
+        await captured[-1].send_tool_list_changed()
+        await asyncio.sleep(0.1)
+
+    assert "alpha" in seen

--- a/tests/client/group/test_client_group.py
+++ b/tests/client/group/test_client_group.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -347,3 +347,72 @@ async def test_explicit_list_tools_refreshes_past_client_response_cache():
 
         result = await group.call_tool("hinted_added")
         assert result.data == "added"
+
+
+async def test_from_config_client_factory_receives_name_transport_and_mode():
+    config = MCPConfig(
+        mcpServers={
+            "old": InMemoryServer(mcp=make_server("old"), mode="legacy"),
+            "new": InMemoryServer(mcp=make_server("new")),
+        }
+    )
+    seen: list[tuple[str, type, str]] = []
+
+    def factory(name: str, transport: Any, mode: Any) -> Client[Any]:
+        seen.append((name, type(transport), mode))
+        return Client(transport, mode=mode)
+
+    group = ClientGroup.from_config(config, client_factory=factory)
+
+    assert seen == [
+        ("old", FastMCPTransport, "legacy"),
+        ("new", FastMCPTransport, "auto"),
+    ]
+    async with group:
+        assert group.protocol_versions == {
+            "old": "2025-11-25",
+            "new": "2026-07-28",
+        }
+
+
+async def test_from_config_client_factory_gives_handlers_provenance():
+    def make_logging_server(name: str) -> FastMCP:
+        server = FastMCP(name)
+
+        @server.tool
+        async def announce(ctx: Context) -> str:
+            await ctx.info(f"hello from {name}")
+            return name
+
+        return server
+
+    config = MCPConfig(
+        mcpServers={
+            "alpha": InMemoryServer(mcp=make_logging_server("alpha"), mode="legacy"),
+            "beta": InMemoryServer(mcp=make_logging_server("beta"), mode="legacy"),
+        }
+    )
+    records: list[tuple[str, str]] = []
+
+    def factory(name: str, transport: Any, mode: Any) -> Client[Any]:
+        async def log_handler(message: Any) -> None:
+            records.append((name, message.data.get("msg")))
+
+        return Client(transport, mode=mode, log_handler=log_handler)
+
+    group = ClientGroup.from_config(config, client_factory=factory)
+
+    async with group:
+        await group.call_tool("alpha_announce", {})
+        await group.call_tool("beta_announce", {})
+
+    assert ("alpha", "hello from alpha") in records
+    assert ("beta", "hello from beta") in records
+
+
+async def test_from_config_client_factory_must_return_a_client():
+    config = MCPConfig(mcpServers={"only": InMemoryServer(mcp=make_server("only"))})
+
+    with pytest.raises(TypeError, match="must return a fastmcp Client"):
+        bad_factory = cast(Any, lambda *args: object())
+        ClientGroup.from_config(config, client_factory=bad_factory)


### PR DESCRIPTION
aggregating layers are where callback provenance dies: a `ClientGroup` merges several servers behind one tool catalog, so a payload arriving at a shared handler no longer says which server produced it, and every downstream adapter ends up rebuilding the same shim — binding server names to handlers by closure, per server, per handler type. the layer that erases the information should be the one that preserves it.

group-level handlers now receive each payload with a `GroupCallbackContext`:

```python
async def log_handler(message, context: GroupCallbackContext):
    print(f"[{context.server_name}] {message.data.get('msg')}")

async def progress_handler(progress, total, message, context: GroupCallbackContext):
    print(f"[{context.server_name}/{context.tool_name}] {progress}/{total}")

group = ClientGroup.from_config(config, log_handler=log_handler, progress_handler=progress_handler)
```

the surface follows handler scope. `progress_handler` is call-scoped: the group binds the route's server and upstream tool name at dispatch, so it works on any group (explicit or config-built), and a per-call handler still wins. `log_handler` / `message_handler` are connection-scoped: only bindable where the member client is constructed, so the group accepts them in `from_config`; explicitly-constructed members keep closure binding, which is the same mechanism spelled by hand.

<details><summary>how this PR got here</summary>

the first draft added a `client_factory` to `from_config` — a construction hook that let handlers close over the server name. that answered a construction problem, not the provenance ask: it only served config-built groups, couldn't carry call-scoped tool names, and reading the requesting integration's code showed they already hand-roll exactly the context-injection pattern this PR now provides natively (`(payload, context)` with server and tool names). the factory is gone; the context-carrying handlers are its replacement.
</details>

<details><summary>what's in it</summary>

- `GroupCallbackContext` (frozen dataclass: `server_name`, `tool_name | None`) and `GroupLogHandler` / `GroupMessageHandler` / `GroupProgressHandler` aliases in `fastmcp.client.group`
- `ClientGroup(clients, progress_handler=...)` and `from_config(..., log_handler=..., message_handler=..., progress_handler=...)`
- tests: log provenance end-to-end across two servers; call-scoped progress provenance incl. upstream tool name; per-call handler precedence; message-handler provenance on an out-of-band legacy notification
- docs: "Shared handlers with provenance" section in `client-groups.mdx`
</details>

![bufo-offers-a-pull-request](https://all-the.bufo.zone/bufo-offers-a-pull-request.png)
