### PR TITLE
perf: start each backend once when a mixed fleet resolves to legacy

### DIFF
--- a/fastmcp_slim/fastmcp/client/transports/config.py
+++ b/fastmcp_slim/fastmcp/client/transports/config.py
@@ -32,6 +32,19 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _transport_for(config: MCPServerTypes) -> ClientTransport:
+    """Build the underlying transport for one configured backend.
+
+    Transforming configs delegate to their base class: their transforms apply
+    to the proxy wrapped around the transport, not to the transport itself.
+    """
+    if isinstance(config, TransformingStdioMCPServer):
+        return StdioMCPServer.to_transport(config)
+    if isinstance(config, TransformingRemoteMCPServer):
+        return RemoteMCPServer.to_transport(config)
+    return config.to_transport()
+
+
 class MCPConfigTransport(ClientTransport):
     """Transport for connecting to one or more MCP servers defined in an MCPConfig.
 
@@ -219,11 +232,33 @@ class MCPConfigTransport(ClientTransport):
         )
         self._transports = []
         backend_versions: list[str] = []
+        proxies: dict[str, FastMCP[Any]] = {}
 
-        for name, server_config in self.config.mcpServers.items():
+        # Build every transport before connecting any of them, so a transport
+        # that already declares the handshake era can be connected first. One
+        # legacy backend settles the aggregate's era, and every backend that
+        # connects after it can start in that era directly instead of
+        # negotiating modern and being torn down by the caller's retry.
+        #
+        # The era is taken from connections that actually succeeded, never from
+        # the static flag alone: a declared-legacy backend that is unreachable
+        # must not drag its healthy modern siblings down with it.
+        transports = self._build_transports()
+        connect_order = sorted(
+            self.config.mcpServers.items(),
+            key=lambda item: not getattr(transports.get(item[0]), "legacy_only", False),
+        )
+        connect_mode = backend_mode
+
+        for name, server_config in connect_order:
             try:
                 transport, client, proxy = await self._create_proxy(
-                    name, server_config, timeout, stack, backend_mode
+                    name,
+                    server_config,
+                    timeout,
+                    stack,
+                    connect_mode,
+                    transport=transports.get(name),
                 )
             except Exception:  # Broad catch is intentional: failure modes
                 # are diverse (OSError, TimeoutError, RuntimeError, etc.) and
@@ -237,12 +272,45 @@ class MCPConfigTransport(ClientTransport):
             self._transports.append(transport)
             assert client.protocol_version is not None
             backend_versions.append(client.protocol_version)
-            composite.mount(proxy, namespace=name if self.name_as_prefix else None)
+            proxies[name] = proxy
+            if (
+                backend_mode == "auto"
+                and client.protocol_version not in MODERN_PROTOCOL_VERSIONS
+            ):
+                connect_mode = "legacy"
 
         if not self._transports:
             raise ConnectionError("All MCP servers failed to connect")
 
+        # Connection order follows the era heuristic above; mount order stays
+        # the order the user declared, since that is what decides precedence
+        # between backends exposing the same component name.
+        for name in self.config.mcpServers:
+            if (proxy := proxies.get(name)) is not None:
+                composite.mount(proxy, namespace=name if self.name_as_prefix else None)
+
         return composite, backend_versions
+
+    def _build_transports(self) -> dict[str, ClientTransport]:
+        """Build each backend's transport so its era capability can be read.
+
+        A config whose transport cannot be built is simply absent from the
+        result. The connection loop builds it again, fails where it always
+        failed, and reports it through the handler there — keeping one place
+        that decides what an unreachable backend means.
+        """
+        transports: dict[str, ClientTransport] = {}
+        for name, server_config in self.config.mcpServers.items():
+            try:
+                transports[name] = _transport_for(server_config)
+            except Exception:
+                logger.debug(
+                    "Could not build a transport for MCP server %r ahead of "
+                    "connecting; deferring to the connection attempt",
+                    name,
+                    exc_info=True,
+                )
+        return transports
 
     async def _create_proxy(
         self,
@@ -251,6 +319,7 @@ class MCPConfigTransport(ClientTransport):
         timeout: float | None,
         stack: contextlib.AsyncExitStack,
         backend_mode: str | None = None,
+        transport: ClientTransport | None = None,
     ) -> tuple[ClientTransport, Any, "FastMCP[Any]"]:
         """Create underlying transport, proxy client, and proxy server for a single backend.
 
@@ -271,19 +340,14 @@ class MCPConfigTransport(ClientTransport):
         include_tags = None
         exclude_tags = None
 
-        # Handle transforming servers - call base class to_transport() for underlying transport
-        if isinstance(config, TransformingStdioMCPServer):
-            transport = StdioMCPServer.to_transport(config)
+        if transport is None:
+            transport = _transport_for(config)
+        # Transforming servers carry their transforms on the proxy, not the
+        # transport, so they are read here rather than when building it.
+        if isinstance(config, TransformingStdioMCPServer | TransformingRemoteMCPServer):
             tool_transforms = config.tools
             include_tags = config.include_tags
             exclude_tags = config.exclude_tags
-        elif isinstance(config, TransformingRemoteMCPServer):
-            transport = RemoteMCPServer.to_transport(config)
-            tool_transforms = config.tools
-            include_tags = config.include_tags
-            exclude_tags = config.exclude_tags
-        else:
-            transport = config.to_transport()
 
         client_kwargs: dict[str, Any] = {}
         if backend_mode is not None:

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -7,7 +7,8 @@ import os
 import sys
 import tempfile
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -172,8 +173,22 @@ class TestConfigTransportEraNegotiation:
         assert transport.legacy_only is True
 
 
-def _make_protocol_era_server(name: str) -> FastMCP:
-    server = FastMCP(name)
+def _make_protocol_era_server(name: str, starts: list[str] | None = None) -> FastMCP:
+    """Build a backend server, optionally recording each lifespan start.
+
+    ``starts`` is how the tests below observe how many times a backend was
+    actually brought up, which is the cost the era heuristic exists to avoid.
+    """
+    if starts is None:
+        server = FastMCP(name)
+    else:
+
+        @asynccontextmanager
+        async def counting_lifespan(_server: FastMCP) -> AsyncIterator[dict[str, Any]]:
+            starts.append(name)
+            yield {}
+
+        server = FastMCP(name, lifespan=counting_lifespan)
 
     @server.tool
     async def protocol_era(ctx: Context) -> str:
@@ -1379,3 +1394,94 @@ async def test_script(tmp_path: Path) -> AsyncGenerator[Path, Any]:
         yield Path(f.name)
 
     pass
+
+
+async def test_mixed_era_config_starts_each_backend_once():
+    """A mixed fleet resolves to one era without restarting every backend.
+
+    The composite can only expose one era, so a legacy backend makes legacy the
+    aggregate's era. Connecting the declared-legacy backend first lets the rest
+    start in that era directly instead of negotiating modern and being torn
+    down and rebuilt.
+    """
+    starts: list[str] = []
+    config = MCPConfig(
+        mcpServers={
+            "modern": InMemoryStdioMCPServer(
+                mcp=_make_protocol_era_server("modern", starts)
+            ),
+            "legacy": LegacyInMemoryStdioMCPServer(
+                mcp=_make_protocol_era_server("legacy", starts)
+            ),
+        }
+    )
+
+    async with Client(config) as client:
+        assert client.protocol_version not in MODERN_PROTOCOL_VERSIONS
+
+    assert starts.count("modern") == 1
+    assert starts.count("legacy") == 1
+
+
+async def test_all_modern_config_starts_each_backend_once():
+    """The all-modern path is unaffected by the era heuristic."""
+    starts: list[str] = []
+    config = MCPConfig(
+        mcpServers={
+            "alpha": InMemoryStdioMCPServer(
+                mcp=_make_protocol_era_server("alpha", starts)
+            ),
+            "beta": InMemoryStdioMCPServer(
+                mcp=_make_protocol_era_server("beta", starts)
+            ),
+        }
+    )
+
+    async with Client(config) as client:
+        assert client.protocol_version in MODERN_PROTOCOL_VERSIONS
+
+    assert starts.count("alpha") == 1
+    assert starts.count("beta") == 1
+
+
+async def test_unreachable_legacy_backend_leaves_survivors_modern():
+    """A declared-legacy backend that never connects settles nothing.
+
+    The era follows connections that succeeded, so an unreachable legacy
+    backend must not drag a healthy modern sibling into the handshake era.
+    """
+
+    @asynccontextmanager
+    async def unavailable(_server: FastMCP) -> AsyncIterator[dict[str, Any]]:
+        raise RuntimeError("backend unavailable")
+        yield {}  # pragma: no cover
+
+    config = MCPConfig(
+        mcpServers={
+            "modern": InMemoryStdioMCPServer(mcp=_make_protocol_era_server("modern")),
+            "legacy": LegacyInMemoryStdioMCPServer(
+                mcp=FastMCP("legacy", lifespan=unavailable)
+            ),
+        }
+    )
+
+    async with Client(config) as client:
+        assert client.protocol_version in MODERN_PROTOCOL_VERSIONS
+        era = await client.call_tool("modern_protocol_era", {})
+
+    assert era.data in MODERN_PROTOCOL_VERSIONS
+
+
+async def test_mixed_era_config_mounts_in_declared_order():
+    """Connecting a legacy backend first does not reorder mounted components."""
+    config = MCPConfig(
+        mcpServers={
+            "alpha": InMemoryStdioMCPServer(mcp=_make_protocol_era_server("alpha")),
+            "zulu": LegacyInMemoryStdioMCPServer(mcp=_make_protocol_era_server("zulu")),
+        }
+    )
+
+    async with Client(config) as client:
+        names = [tool.name for tool in await client.list_tools()]
+
+    assert names.index("alpha_add") < names.index("zulu_add")


### PR DESCRIPTION
`Client(MCPConfig)` builds one composite behind a proxy chain, so the aggregate can only ever expose a single protocol era. Today it discovers that era the expensive way: every backend connects under `auto`, and if any of them turns out to be legacy, the whole stack is torn down and every backend is started a second time in the handshake era. Process-backed backends pay that startup twice.

A transport that declares `legacy_only` already knows the answer. Connecting those first lets the era settle before the rest are started, so each backend comes up once:

```
mixed fleet (one modern + one legacy backend), lifespan starts per backend

  before   {'modern': 2, 'legacy': 2}
  after    {'modern': 1, 'legacy': 1}
```

The era is taken from connections that *succeeded*, never from the static flag alone — an unreachable legacy backend must not drag its healthy modern siblings into the handshake era, and a backend that turns out to be legacy without declaring it still downgrades the ones connected after it. Connection order now follows that heuristic, so mounting is done afterwards in the order the user declared, which is what decides precedence between backends exposing the same component name.

Only SSE declares `legacy_only` today, so in practice this is the mixed fleet containing an SSE backend. Everything else keeps the existing behavior: an all-modern fleet is untouched, and a legacy backend discovered only at connect time still falls back to the rebuild.

<details><summary>tests</summary>

- `test_mixed_era_config_starts_each_backend_once` — the regression guard; fails on `main` with two starts per backend
- `test_all_modern_config_starts_each_backend_once` — the untouched path stays untouched
- `test_unreachable_legacy_backend_leaves_survivors_modern` — the failure path keeps survivors modern
- `test_mixed_era_config_mounts_in_declared_order` — connection order does not leak into mount order
</details>

<details><summary>relationship to #4971</summary>

#4971 proposes the same optimization and arrives at the same core design; this was written after reviewing it, and its approach is what convinced me the design is forced. I first tried the simpler thing — resolve the era up front from the static flags and connect everything once in it — and it is wrong: when the declared-legacy backend is unreachable, it downgrades the healthy modern backends, which neither `main` nor #4971 does.

The differences here are small: a construction failure while pre-building transports is logged at debug and left for the connection loop to report (rather than reported as a connection failure that has not been attempted yet), transport construction is shared by one module-level helper instead of being duplicated, and the tests cover the all-modern and mount-order invariants as well as the failure path.

Worth deciding deliberately whether this supersedes #4971 or #4971 is reviewed on its own merits.
</details>

<details><summary>the wider picture</summary>

`ClientGroup` does not have this cost at all: it keeps one client per server, each negotiating its own era, so nothing needs reconciling and nothing is restarted. On the same fleet it also leaves the modern backend modern rather than downgrading it. This makes the aggregate path cheaper; it does not make it the better model.
</details>
