### PR TITLE
docs: escape <1 in changelog so MDX parses

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -104,7 +104,7 @@ FastMCP 4 is the FastMCP release for the new MCP: full support for the `2026-07-
 * Cover CallArgument resolution in background tasks by [@zzstoatzz](https://github.com/zzstoatzz) in [#4833](https://github.com/PrefectHQ/fastmcp/pull/4833)
 * Scalekit issuer updates backward compatibility by [@AkshayParihar33](https://github.com/AkshayParihar33) in [#4798](https://github.com/PrefectHQ/fastmcp/pull/4798)
 * Add Prefect Horizon account commands by [@parkedwards](https://github.com/parkedwards) in [#4786](https://github.com/PrefectHQ/fastmcp/pull/4786)
-* Cap anthropic dependency to <1 by [@craigie-ant](https://github.com/craigie-ant) in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
+* Cap anthropic dependency to `<1` by [@craigie-ant](https://github.com/craigie-ant) in [#4864](https://github.com/PrefectHQ/fastmcp/pull/4864)
 * Remove obsolete Docket memory-server reset fixtures by [@TyceHerrman](https://github.com/TyceHerrman) in [#4912](https://github.com/PrefectHQ/fastmcp/pull/4912)
 * add independent client groups by [@zzstoatzz](https://github.com/zzstoatzz) in [#4904](https://github.com/PrefectHQ/fastmcp/pull/4904)
 ### Security 🔒


### PR DESCRIPTION
the 4.0.0 changelog entry had a bare `<1` ("Cap anthropic dependency to <1"), which MDX reads as a JSX tag. Mintlify rejected every published-docs deploy since #4955, so neither the 4.0.0 nor the 4.0.1 changelog entry is live. wrapping it in backticks fixes the parse; `mint broken-links` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnQWsYm2JjJbW24WCk25ku
