### PR TITLE
docs: note the 4.0.1 floor for ClientGroup reentrancy

### DIFF
--- a/docs/clients/client-groups.mdx
+++ b/docs/clients/client-groups.mdx
@@ -108,7 +108,7 @@ async with legacy_client, modern_client:
 
 It is also safe to enter the group inside a client context. FastMCP client contexts are reference counted, so leaving the group does not close a connection still owned by an outer context.
 
-The group's own context is reentrant in the same way. Entering a group that is already connected, whether from a nested block or a concurrent task, reuses the existing connections. The first entry connects every client and the last exit disconnects them, so code that already relies on `Client` being safe to enter more than once can hold a `ClientGroup` the same way:
+The group's own context is reentrant in the same way (FastMCP 4.0.1 and later). Entering a group that is already connected, whether from a nested block or a concurrent task, reuses the existing connections. The first entry connects every client and the last exit disconnects them, so code that already relies on `Client` being safe to enter more than once can hold a `ClientGroup` the same way:
 
 ```python
 async with group:

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -11,7 +11,7 @@ title="FastMCP v4.0.1: Come Back Any Time"
 href="https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.1"
 cta="Read the release notes"
 >
-`ClientGroup` is now reentrant like `Client`: nested or concurrent entries reuse the group's connections, and the last exit closes them.
+`ClientGroup` is now reentrant like `Client`: nested or concurrent entries reuse the group's connections, and only the last exit closes them.
 </Card>
 </Update>
 


### PR DESCRIPTION
small wording edits to the two pages Mintlify never built. its failed deploy on the previous published-docs tip recorded file hashes before the parse error, so the following successful deploy only re-applied `changelog.mdx`; `updates.mdx` and `clients/client-groups.mdx` are still serving the pre-4.0.1 build. changing their content makes the next deploy pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnQWsYm2JjJbW24WCk25ku
