### PR TITLE
docs: link the GA announcement and blog from What's New

### DIFF
--- a/docs/getting-started/whats-new.mdx
+++ b/docs/getting-started/whats-new.mdx
@@ -12,7 +12,7 @@ The protocol changed completely underneath those APIs. Your application usually 
 That is the theme of version 4: stateless transport without stateless application code. The release also makes protocol extensions a first-class surface, adds enterprise identity for agents acting on behalf of users, and strengthens production defaults across caching, routing, and security.
 
 <Note>
-Install with `pip install fastmcp -U`. Upgrading from FastMCP 3? Start with [the upgrade guide](/getting-started/upgrading/from-fastmcp-3).
+Install with `pip install fastmcp -U`. Upgrading from FastMCP 3? Start with [the upgrade guide](/getting-started/upgrading/from-fastmcp-3). The release announcement, [FastMCP 4 is GA](https://blog.gofastmcp.com/3mufbh2vcv22o), is on the [FastMCP blog](https://blog.gofastmcp.com).
 </Note>
 
 ## Protocol compatibility

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -21,7 +21,7 @@ title="FastMCP v4.0.0: Four Real"
 href="https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.0"
 cta="Read the release notes"
 >
-FastMCP 4 is stable: the FastMCP release for the new MCP protocol and the rewritten Python SDK v2, with old-protocol clients supported through per-connection negotiation.
+FastMCP 4 is stable: the FastMCP release for the new MCP protocol and the rewritten Python SDK v2, with old-protocol clients supported through per-connection negotiation. Read the announcement: [FastMCP 4 is GA](https://blog.gofastmcp.com/3mufbh2vcv22o).
 
 🌐 **Every protocol era** — one deployment serves `2026-07-28` and legacy clients; `Client(url)` negotiates from the other side.
 


### PR DESCRIPTION
links the GA announcement on blog.gofastmcp.com from the What's New note and the 4.0.0 card on Updates, the same spot earlier releases link their posts. partners are pointing readers at What's New, and nothing on the site said the blog exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112aezpq7PVaiQf9sibnmwZ
