### PR TITLE
Expose ClientGroup from package root

### DIFF
--- a/docs/clients/client-groups.mdx
+++ b/docs/clients/client-groups.mdx
@@ -21,8 +21,7 @@ Construct the clients explicitly when each server needs its own handlers, authen
 from pathlib import Path
 import asyncio
 
-from fastmcp import Client
-from fastmcp.client.group import ClientGroup
+from fastmcp import Client, ClientGroup
 
 legacy_client = Client(Path("legacy_server.py"), mode="legacy")
 modern_client = Client("https://modern.example.com/mcp", mode="auto")
@@ -76,7 +75,7 @@ The group aggregates names and detects collisions; it never stands between the a
 `ClientGroup.from_config` creates one client per server rather than passing the entire configuration through a proxy. A FastMCP-specific `mode` field can select the protocol behavior for each server:
 
 ```python
-from fastmcp.client.group import ClientGroup
+from fastmcp import ClientGroup
 
 config = {
     "mcpServers": {

--- a/fastmcp_slim/fastmcp/__init__.py
+++ b/fastmcp_slim/fastmcp/__init__.py
@@ -12,6 +12,7 @@ from fastmcp.utilities.logging import configure_logging as _configure_logging
 
 if TYPE_CHECKING:
     from fastmcp.client import Client as Client
+    from fastmcp.client.group import ClientGroup as ClientGroup
     from fastmcp.apps.app import FastMCPApp as FastMCPApp
     from fastmcp.server.context import Context as Context
     from fastmcp.server.server import FastMCP as FastMCP
@@ -41,8 +42,8 @@ if settings.deprecation_warnings:
 
 
 # --- Lazy imports for performance (see #3292) ---
-# Client and the client submodule are deferred so that server-only users
-# don't pay for the client import chain. Do not convert back to top-level.
+# Client exports and the client submodule are deferred so that server-only users
+# don't pay for the client import chain. Do not make these eager module imports.
 
 
 def __getattr__(name: str) -> object:
@@ -53,6 +54,13 @@ def __getattr__(name: str) -> object:
             raise ImportError(_install_hints.CLIENT_SUPPORT) from exc
 
         return Client
+    if name == "ClientGroup":
+        try:
+            from fastmcp.client.group import ClientGroup
+        except ImportError as exc:
+            raise ImportError(_install_hints.CLIENT_SUPPORT) from exc
+
+        return ClientGroup
     if name == "Context":
         try:
             from fastmcp.server.context import Context
@@ -89,6 +97,7 @@ def __getattr__(name: str) -> object:
 
 __all__ = [
     "Client",
+    "ClientGroup",
     "Context",
     "FastMCP",
     "FastMCPApp",

--- a/tests/client/group/test_client_group.py
+++ b/tests/client/group/test_client_group.py
@@ -7,8 +7,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import ConfigDict
 
-from fastmcp import Client, Context, FastMCP
-from fastmcp.client.group import ClientGroup
+from fastmcp import Client, ClientGroup, Context, FastMCP
 from fastmcp.client.transports import FastMCPTransport
 from fastmcp.mcp_config import MCPConfig, StdioMCPServer
 

--- a/tests/client/test_slim_package_boundaries.py
+++ b/tests/client/test_slim_package_boundaries.py
@@ -72,8 +72,9 @@ def test_bare_slim_import_needs_only_mcp_types() -> None:
     while the full `mcp` package lives in the `[mcp]` extra pulled by
     `[client]`/`[server]`. With `mcp` absent but `mcp-types` present, `import
     fastmcp`, `import fastmcp.settings`, and `import fastmcp.types` must all
-    succeed, while `fastmcp.FastMCP` and `fastmcp.Client` raise the friendly
-    install-hint ImportError (they need `mcp.*` from the server/client extras).
+    succeed, while `fastmcp.FastMCP`, `fastmcp.Client`, and
+    `fastmcp.ClientGroup` raise the friendly install-hint ImportError (they need
+    `mcp.*` from the server/client extras).
     """
     script = textwrap.dedent(
         """
@@ -97,7 +98,7 @@ def test_bare_slim_import_needs_only_mcp_types() -> None:
         assert "mcp_types" in sys.modules, "mcp_types should load on a bare install"
         assert "mcp" not in sys.modules, "full mcp must not load on a bare install"
 
-        for attr in ("FastMCP", "Client"):
+        for attr in ("FastMCP", "Client", "ClientGroup"):
             try:
                 getattr(fastmcp, attr)
             except ImportError:


### PR DESCRIPTION
`ClientGroup` is a first-class client primitive, but unlike `Client` it could
only be imported through its implementation module. That forced downstream
integrations to couple to FastMCP's internal package layout.

This gives `ClientGroup` the same lazy package-root export as `Client`, while
preserving the bare-Slim import boundary. Client-only and full installations
now share the public import:

```python
from fastmcp import Client, ClientGroup
```

Fixes #4986
