### PR TITLE
server: make declined and cancelled elicitation results falsy

### DIFF
--- a/docs/servers/elicitation.mdx
+++ b/docs/servers/elicitation.mdx
@@ -69,6 +69,17 @@ The elicitation result contains an `action` field indicating how the user respon
 | `decline` | User chose not to provide the requested information |
 | `cancel` | User cancelled the entire operation |
 
+A declined or cancelled result is falsy, so the obvious guard around a destructive action refuses when the user does:
+
+```python
+result = await ctx.elicit("Delete the project?", response_type=bool)
+if not result or not result.data:
+    return "Cancelled"
+delete_project()
+```
+
+An accepted result is always truthy, including when the user accepted the form and answered `False`, so a confirmation still checks `result.data`.
+
 FastMCP also provides typed result classes for pattern matching:
 
 ```python

--- a/fastmcp_slim/fastmcp/server/elicitation.py
+++ b/fastmcp_slim/fastmcp/server/elicitation.py
@@ -4,10 +4,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generic, Literal, cast, get_origin
 
-from mcp.server.elicitation import (
-    CancelledElicitation,
-    DeclinedElicitation,
-)
+from mcp.server.elicitation import CancelledElicitation as _CancelledElicitation
+from mcp.server.elicitation import DeclinedElicitation as _DeclinedElicitation
 from pydantic import BaseModel
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 from pydantic_core import core_schema
@@ -107,6 +105,24 @@ class AcceptedElicitation(BaseModel, Generic[T]):
 
     action: Literal["accept"] = "accept"
     data: T
+
+
+class DeclinedElicitation(_DeclinedElicitation):
+    """Result when the user declines the elicitation.
+
+    Falsy, so `if not result:` refuses the action. The accepted result stays
+    truthy even when its data is a negative answer; check `result.data` for that.
+    """
+
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+class CancelledElicitation(_CancelledElicitation):
+    """Result when the user cancels the elicitation. Falsy, like a decline."""
+
+    def __bool__(self) -> Literal[False]:
+        return False
 
 
 @dataclass

--- a/tests/server/test_elicitation_results.py
+++ b/tests/server/test_elicitation_results.py
@@ -1,0 +1,65 @@
+"""Refused elicitations must not pass a truthiness guard (#4929)."""
+
+from mcp.server.elicitation import CancelledElicitation as SDKCancelledElicitation
+from mcp.server.elicitation import DeclinedElicitation as SDKDeclinedElicitation
+
+from fastmcp import Client, Context, FastMCP
+from fastmcp.client.elicitation import ElicitResult
+from fastmcp.server.elicitation import (
+    AcceptedElicitation,
+    CancelledElicitation,
+    DeclinedElicitation,
+)
+
+
+def test_refused_results_are_falsy():
+    assert not DeclinedElicitation()
+    assert not CancelledElicitation()
+
+
+def test_accepted_result_is_truthy_even_for_a_negative_answer():
+    assert AcceptedElicitation[bool](data=False)
+    assert AcceptedElicitation[str](data="")
+
+
+def test_refused_results_remain_sdk_instances():
+    assert isinstance(DeclinedElicitation(), SDKDeclinedElicitation)
+    assert isinstance(CancelledElicitation(), SDKCancelledElicitation)
+    assert DeclinedElicitation().action == "decline"
+    assert CancelledElicitation().action == "cancel"
+
+
+async def test_truthiness_guard_refuses_declined_and_cancelled():
+    mcp = FastMCP("guard")
+    writes: list[str] = []
+
+    @mcp.tool
+    async def create(ctx: Context) -> str:
+        result = await ctx.elicit("Create it?", response_type=bool)
+        if not result or not result.data:
+            return "refused"
+        writes.append("created")
+        return "created"
+
+    for action in ("decline", "cancel"):
+
+        async def handler(message, response_type, params, ctx, action=action):
+            return ElicitResult(action=action)
+
+        async with Client(mcp, mode="legacy", elicitation_handler=handler) as client:
+            result = await client.call_tool("create")
+            assert result.data == "refused"
+
+    async def accept_no(message, response_type, params, ctx):
+        return ElicitResult(action="accept", content={"value": False})
+
+    async with Client(mcp, mode="legacy", elicitation_handler=accept_no) as client:
+        assert (await client.call_tool("create")).data == "refused"
+
+    async def accept_yes(message, response_type, params, ctx):
+        return ElicitResult(action="accept", content={"value": True})
+
+    async with Client(mcp, mode="legacy", elicitation_handler=accept_yes) as client:
+        assert (await client.call_tool("create")).data == "created"
+
+    assert writes == ["created"]


### PR DESCRIPTION
`DeclinedElicitation` and `CancelledElicitation` are now falsy, so the obvious guard around a destructive action refuses when the user does. before this, all three `ctx.elicit()` results were truthy and `if result: delete()` ran on a decline or cancel with `is_error=False`, which is the exact case elicitation exists for.

```python
result = await ctx.elicit("Delete the project?", response_type=bool)
if not result or not result.data:
    return "Cancelled"
delete_project()
```

the two classes become FastMCP subclasses of the SDK types with `__bool__` returning `Literal[False]`, so `isinstance` against the SDK classes and `match` arms keep working and type checkers narrow `if not result` correctly. an accepted result stays truthy even when its data is `False`; the docs say to check `result.data` for that.

this changes behavior for code that relied on a refusal being truthy. that code was treating a refusal as an approval.

Fixes #4929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112aezpq7PVaiQf9sibnmwZ
