### PR TITLE
skills(release): cover merges Mintlify skipped without a check-run

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -137,10 +137,12 @@ connections instead of raising.
 
 ## Gotchas
 
-- Mintlify keeps its per-file hashes even when a deploy fails on a parse error, so
-  the next successful deploy only rebuilds files changed since the failure. After
-  fixing a parse error, make a small wording edit to every path the failed run
-  listed under "Updating targeted paths", merge that to `main`, and publish by hand.
+- Mintlify only rebuilds files changed since the last merge it processed, and a
+  merge it skipped (a failed parse, or no check-run at all during an incident)
+  still counts as processed. Files changed only in a skipped merge stay stale until
+  their content changes again. Compare the files the skipped merge touched against
+  the successful run's "Updating targeted paths" list, make a small wording edit
+  to each missing one, merge that to `main`, and publish by hand.
 - `--generate-notes` copies PR titles verbatim; a title containing `<1`, `{`, or `}`
   breaks MDX. `scripts/changelog_entry.py` wraps those in backticks; the validator
   in step 4 catches anything it misses.


### PR DESCRIPTION
tonight's case: the blog-link merge landed during a Mintlify queue incident and never got a check-run; the next successful deploy diffed against it anyway and skipped `whats-new.mdx`. the gotcha only described the failed-parse variant. it now describes both and says how to find the missing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112aezpq7PVaiQf9sibnmwZ
