### PR TITLE
Wire subscriptions/listen on both the server and the client

### DIFF
--- a/fastmcp_slim/fastmcp/client/client.py
+++ b/fastmcp_slim/fastmcp/client/client.py
@@ -8,7 +8,12 @@ import secrets
 import ssl
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine, Mapping, Sequence
-from contextlib import AsyncExitStack, asynccontextmanager, suppress
+from contextlib import (
+    AbstractAsyncContextManager,
+    AsyncExitStack,
+    asynccontextmanager,
+    suppress,
+)
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
@@ -46,6 +51,7 @@ from mcp.client.session import (
     ElicitationFnT,
     MessageHandlerFnT,
 )
+from mcp.client.subscriptions import Subscription, listen
 from mcp_types.methods import validate_server_result
 from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
 from pydantic import AnyUrl, ValidationError
@@ -1370,6 +1376,35 @@ class Client(
         """Send a ping request."""
         result = await self._await_with_session_monitoring(self.session.send_ping())
         return isinstance(result, mcp_types.EmptyResult)
+
+    def listen(
+        self,
+        *,
+        tools_list_changed: bool = False,
+        prompts_list_changed: bool = False,
+        resources_list_changed: bool = False,
+        resource_subscriptions: Sequence[str] = (),
+    ) -> AbstractAsyncContextManager[Subscription]:
+        """Open a `subscriptions/listen` stream of change events.
+
+        MCP 2026-07-28 connections only: they have no standing server->client
+        channel, so change events arrive on a stream the client opens. Raises
+        `ListenNotSupportedError` on a handshake connection, where
+        `message_handler` receives the same notifications instead.
+
+        ```python
+        async with client.listen(tools_list_changed=True) as subscription:
+            async for event in subscription:
+                tools = await client.list_tools()
+        ```
+        """
+        return listen(
+            self.session,
+            tools_list_changed=tools_list_changed,
+            prompts_list_changed=prompts_list_changed,
+            resources_list_changed=resources_list_changed,
+            resource_subscriptions=resource_subscriptions,
+        )
 
     async def cancel(
         self,

--- a/fastmcp_slim/fastmcp/server/low_level.py
+++ b/fastmcp_slim/fastmcp/server/low_level.py
@@ -25,6 +25,11 @@ from mcp.server.models import InitializationOptions
 from mcp.server.request_state import RequestStateBoundary, RequestStateSecurity
 from mcp.server.session import ServerSession
 from mcp.server.stdio import stdio_server as stdio_server
+from mcp.server.subscriptions import (
+    InMemorySubscriptionBus,
+    ListenHandler,
+    SubscriptionBus,
+)
 from mcp.shared.exceptions import MCPError
 from pydantic import ValidationError
 
@@ -454,6 +459,12 @@ class FastMCPServerMiddleware:
 
 class LowLevelServer(_Server[LifespanResultT]):
     def __init__(self, fastmcp: FastMCP, *args: Any, **kwargs: Any):
+        # The 2026-07-28 era has no standing GET stream: server events reach a
+        # client only through a `subscriptions/listen` stream it opens. The SDK
+        # registers that method only when a handler is supplied, and answers
+        # METHOD_NOT_FOUND without one.
+        self._subscriptions: SubscriptionBus = InMemorySubscriptionBus()
+        kwargs.setdefault("on_subscriptions_listen", ListenHandler(self._subscriptions))
         super().__init__(*args, **kwargs)
         # Store a weak reference to FastMCP to avoid circular references
         self._fastmcp_ref: weakref.ref[FastMCP] = weakref.ref(fastmcp)
@@ -461,7 +472,8 @@ class LowLevelServer(_Server[LifespanResultT]):
         # FastMCP servers support notifications for all components. v2 derives
         # capabilities from registered handlers + protocol_version, but legacy
         # clients still read NotificationOptions at create_initialization_options
-        # time, so keep a default here and pass it through.
+        # time, so keep a default here and pass it through. On 2026-07-28 these
+        # are delivered by the listen stream registered above.
         self.notification_options = NotificationOptions(
             prompts_changed=True,
             resources_changed=True,

--- a/tests/server/test_protocol_eras.py
+++ b/tests/server/test_protocol_eras.py
@@ -21,11 +21,14 @@ migration feedback dossier (``<scratchpad>/specs/sdk-feedback.md``).
 
 from __future__ import annotations
 
+import anyio
 import mcp_types as types
 import pytest
 from mcp.client import Client as SDKClient
 from mcp.client.session import ClientRequestContext
+from mcp.client.subscriptions import ListenNotSupportedError, listen
 from mcp.server import Server as LowLevelServer
+from mcp.server.subscriptions import ToolsListChanged
 from mcp.shared.exceptions import MCPError
 from pydantic import FileUrl
 
@@ -326,6 +329,70 @@ async def test_logging_notification_still_flows_on_modern(push_server, mode):
         result = await client.call_tool("do_log", {})
     assert result.is_error is False
     assert _texts(result.content) == ["logged"]
+
+
+# ---------------------------------------------------------------------------
+# 4. subscriptions/listen carries server events on 2026-07-28
+# ---------------------------------------------------------------------------
+
+
+async def test_listen_stream_opens_on_modern(dual_era_server):
+    """2026-07-28 has no standing GET stream, so `subscriptions/listen` is how
+    a client receives server events. Unregistered it answers METHOD_NOT_FOUND,
+    closing the connection for a client that subscribes before it lists.
+    """
+    async with SDKClient(_server(dual_era_server), mode="auto") as client:
+        async with listen(client.session, tools_list_changed=True) as stream:
+            assert stream is not None
+
+
+async def test_listen_delivers_a_subscribed_event(dual_era_server):
+    """Events published on the server's bus reach an opted-in stream."""
+    bus = dual_era_server._mcp_server._subscriptions
+
+    async with SDKClient(_server(dual_era_server), mode="auto") as client:
+        async with listen(client.session, tools_list_changed=True) as stream:
+            await bus.publish(ToolsListChanged())
+            with anyio.fail_after(5):
+                event = await anext(aiter(stream))
+
+    assert isinstance(event, ToolsListChanged)
+
+
+async def test_listen_withholds_an_unsubscribed_event(dual_era_server):
+    """A stream never carries a kind the client did not opt in to."""
+    bus = dual_era_server._mcp_server._subscriptions
+
+    async with SDKClient(_server(dual_era_server), mode="auto") as client:
+        async with listen(client.session, prompts_list_changed=True) as stream:
+            await bus.publish(ToolsListChanged())
+            with pytest.raises(TimeoutError), anyio.fail_after(0.2):
+                await anext(aiter(stream))
+
+
+async def test_a_fastmcp_client_reaches_the_stream(dual_era_server):
+    """A FastMCP client reaches the stream through `Client.listen`, so both
+    ends of a change event work without dropping to the SDK client.
+    """
+    bus = dual_era_server._mcp_server._subscriptions
+
+    async with FastMCPClient(dual_era_server, mode="auto") as client:
+        async with client.listen(tools_list_changed=True) as subscription:
+            await bus.publish(ToolsListChanged())
+            with anyio.fail_after(5):
+                event = await anext(aiter(subscription))
+
+    assert isinstance(event, ToolsListChanged)
+
+
+async def test_listen_is_refused_on_legacy(dual_era_server):
+    """The stream is a 2026-07-28 construct, so asking for one on a handshake
+    connection is an error rather than a silently empty subscription.
+    """
+    async with FastMCPClient(dual_era_server, mode="legacy") as client:
+        with pytest.raises(ListenNotSupportedError):
+            async with client.listen(tools_list_changed=True):
+                pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`subscriptions/listen` was never registered: the lowlevel SDK `Server` registers it only when `on_subscriptions_listen=` is supplied, and `LowLevelServer` supplied none, so it answered METHOD_NOT_FOUND. On MCP 2026-07-28 that stream is the only route for server events, so change notifications had nowhere to go, and a client that opens a subscription while connecting drops the connection — Antigravity completes OAuth and then disconnects before listing a tool.

`LowLevelServer` now holds an `InMemorySubscriptionBus` and passes `ListenHandler(bus)` down, the same construction `MCPServer` uses, and `Client.listen()` opens a stream with the SDK client's signature.

Left out on purpose: the publish surface. `MCPServer` exposes it as `Context.notify_tools_changed()` rather than a bare bus, so FastMCP's equivalent — and whether `add_tool` should fire it — is a design call rather than wiring. The bus stays private (`_subscriptions`) for the same reason. Reopen #4920 for that half if you'd rather track it separately.

```python
async with Client(mcp, mode="auto") as client:
    async with client.listen(tools_list_changed=True) as subscription:
        async for event in subscription:
            tools = await client.list_tools()
```

Closes #4920

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
