### PR TITLE
fix: don't infer an output schema for unconstrained sequences

### DIFF
--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -546,7 +546,7 @@ def get_user_data(user_id: str) -> dict:
 
 #### Primitives and Collections
 
-When your tool returns a primitive type (int, str, bool) or a collection (list, set), FastMCP needs a return type annotation to generate structured content. The annotation tells FastMCP how to validate and serialize the result.
+When your tool returns a primitive type (int, str, bool) or a collection (list, set), FastMCP needs a return type annotation to generate structured content. The annotation tells FastMCP how to validate and serialize the result. The annotation has to say something about the items: a bare `list`, `tuple`, or `Sequence` (or `list[Any]`) describes nothing, so FastMCP infers no output schema for it, the same as for `Any`. Use `list[int]`, `list[dict]`, and so on when you want structured output for a collection.
 
 Without a type annotation, the tool only produces `content`:
 

--- a/fastmcp_slim/fastmcp/tools/function_parsing.py
+++ b/fastmcp_slim/fastmcp/tools/function_parsing.py
@@ -51,6 +51,23 @@ def _contains_prefab_type(tp: Any) -> bool:
     return False
 
 
+def _is_unconstrained_sequence(tp: Any) -> bool:
+    """A `list`/`tuple` that says nothing about its items.
+
+    Bare `list`, bare `tuple`, `list[Any]`, `tuple[Any, ...]`. The schema these
+    produce -- ``{"result": {"items": {}, "type": "array"}}`` -- constrains
+    nothing, which is why `Any` itself is already excluded from inference. These
+    are its sequence-shaped equivalent.
+    """
+    tp = _unwrap_type_alias(tp)
+    if tp in (list, tuple):
+        return True
+    if get_origin(tp) not in (list, tuple):
+        return False
+    args = [a for a in get_args(tp) if a is not Ellipsis]
+    return bool(args) and all(a is Any for a in args)
+
+
 def _unwrap_type_alias(tp: Any) -> Any:
     """Resolve a PEP 695 ``type X = ...`` alias to its underlying value.
 
@@ -401,6 +418,19 @@ class ParsedFunction:
             # `run()`'s subclass-aware control handling and covering every alias
             # shape that exact-match replace_type below would miss.
             if _contains_input_required(output_type):
+                output_type = _UnserializableType
+
+            # A bare `list`/`tuple` carries no item type, so `replace_type`
+            # below has nothing to match and the content types it exists to
+            # suppress slip through. The schema that results constrains
+            # nothing, and inferring it is not free: an output schema forces
+            # structured content, so a tool returning `[ImageContent, {...}]`
+            # under a `-> list` annotation sends the base64 image BOTH as an
+            # image block and again inside `structuredContent`. Clients
+            # mishandle that in both directions -- some render the JSON blob
+            # instead of the picture, others inject the base64 into model
+            # context and blow their tool-output token cap.
+            if _is_unconstrained_sequence(output_type):
                 output_type = _UnserializableType
 
             # there are a variety of types that we don't want to attempt to

--- a/fastmcp_slim/fastmcp/tools/function_parsing.py
+++ b/fastmcp_slim/fastmcp/tools/function_parsing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import inspect
 import types
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Annotated, Any, Generic, Union, get_args, get_origin, get_type_hints
 
@@ -41,6 +41,9 @@ def _contains_bytes_type(tp: Any) -> bool:
     return False
 
 
+_UNCONSTRAINED_SEQUENCE_ORIGINS = (list, tuple, Sequence)
+
+
 def _contains_prefab_type(tp: Any) -> bool:
     """Check if *tp* is or contains a prefab type, recursing through unions and Annotated."""
     if is_prefab_type(tp):
@@ -52,20 +55,28 @@ def _contains_prefab_type(tp: Any) -> bool:
 
 
 def _is_unconstrained_sequence(tp: Any) -> bool:
-    """A `list`/`tuple` that says nothing about its items.
+    """A sequence annotation that says nothing about its items.
 
-    Bare `list`, bare `tuple`, `list[Any]`, `tuple[Any, ...]`. The schema these
-    produce -- ``{"result": {"items": {}, "type": "array"}}`` -- constrains
-    nothing, which is why `Any` itself is already excluded from inference. These
-    are its sequence-shaped equivalent.
+    Bare `list`, `tuple`, `Sequence` (and their `typing` spellings), plus
+    `list[Any]`, `Sequence[Any]` and the variadic `tuple[Any, ...]`. The schema
+    these produce -- ``{"result": {"items": {}, "type": "array"}}`` -- constrains
+    nothing, which is why `Any` itself is already excluded from inference. A
+    fixed-length `tuple[Any, Any]` still pins its length, so it keeps its schema.
     """
     tp = _unwrap_type_alias(tp)
-    if tp in (list, tuple):
+    if get_origin(tp) is Annotated:
+        tp = get_args(tp)[0]
+    if tp in _UNCONSTRAINED_SEQUENCE_ORIGINS:
         return True
-    if get_origin(tp) not in (list, tuple):
+    origin = get_origin(tp)
+    if origin not in _UNCONSTRAINED_SEQUENCE_ORIGINS:
         return False
-    args = [a for a in get_args(tp) if a is not Ellipsis]
-    return bool(args) and all(a is Any for a in args)
+    args = get_args(tp)
+    if not args:
+        return True
+    if origin is tuple:
+        return len(args) == 2 and args[0] is Any and args[1] is Ellipsis
+    return all(a is Any for a in args)
 
 
 def _unwrap_type_alias(tp: Any) -> Any:

--- a/tests/server/providers/local_provider_tools/test_output_schema.py
+++ b/tests/server/providers/local_provider_tools/test_output_schema.py
@@ -45,7 +45,7 @@ class PersonDataclass:
 
 
 class TestToolOutputSchema:
-    @pytest.mark.parametrize("annotation", [str, int, float, bool, list, AnyUrl])
+    @pytest.mark.parametrize("annotation", [str, int, float, bool, AnyUrl])
     async def test_simple_output_schema(self, annotation):
         mcp = FastMCP()
 

--- a/tests/tools/tool/test_output_schema.py
+++ b/tests/tools/tool/test_output_schema.py
@@ -1,6 +1,8 @@
+import json
 from dataclasses import dataclass
 from typing import Annotated, Any
 
+import mcp_types
 import pytest
 from inline_snapshot import snapshot
 from mcp_types import (
@@ -13,6 +15,7 @@ from mcp_types import (
 from pydantic import AnyUrl, BaseModel, Field, TypeAdapter
 from typing_extensions import TypedDict
 
+from fastmcp import Client, FastMCP
 from fastmcp.tools.base import Tool, ToolResult
 from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.types import Audio, File, Image
@@ -34,7 +37,6 @@ class TestToolFromFunctionOutputSchema:
             bool,
             str,
             int | float,
-            list,
             list[int],
             list[int | float],
             dict,
@@ -623,3 +625,65 @@ class TestWrapResultMeta:
         result = await tool.run({})
         assert result.structured_content == {"key": "val"}
         assert result.meta is None
+
+
+class TestUnconstrainedSequenceReturns:
+    """A `list`/`tuple` with no item type infers no output schema.
+
+    `Any` is already excluded from inference because the schema it yields
+    constrains nothing. A bare `list` is the sequence-shaped equivalent: its
+    schema is ``{"result": {"items": {}, "type": "array"}}``, which permits
+    every value that no schema at all permits.
+
+    Inferring it is not free. An output schema forces structured content, and
+    `replace_type` cannot suppress the MCP content types inside a `list` that
+    has no item type to match. So a tool annotated `-> list` that returns
+    `[ImageContent(...), {...}]` -- the shape the docs recommend for pairing a
+    picture with its metadata -- put the base64 image on the wire twice: once
+    as an image block, once serialised into `structuredContent`. Clients break
+    on that in both directions, some rendering the JSON blob instead of the
+    picture and others injecting the base64 into model context.
+    """
+
+    @pytest.mark.parametrize("annotation", [list, tuple, list[Any], "bare"])
+    def test_no_schema_is_inferred(self, annotation):
+        if annotation == "bare":
+
+            def func():
+                return []
+        else:
+
+            def func() -> annotation:  # type: ignore[valid-type]
+                return []
+
+        assert Tool.from_function(func).output_schema is None
+
+    @pytest.mark.parametrize("annotation", [list[int], dict, str, tuple[int, str]])
+    def test_a_constrained_sequence_still_infers(self, annotation):
+        """The guard must not swallow annotations that do say something."""
+
+        def func() -> annotation:  # type: ignore[valid-type]
+            return []
+
+        assert Tool.from_function(func).output_schema is not None
+
+    async def test_an_image_is_not_duplicated_into_structured_content(self):
+        """The regression this exists to prevent."""
+        png = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8"
+            "z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        def render() -> list:
+            return [
+                mcp_types.ImageContent(type="image", data=png, mime_type="image/png"),
+                {"note": "metadata"},
+            ]
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("render")
+
+        assert [b.type for b in result.content] == ["image", "text"]
+        assert png not in json.dumps(result.structured_content or {})

--- a/tests/tools/tool/test_output_schema.py
+++ b/tests/tools/tool/test_output_schema.py
@@ -1,4 +1,6 @@
 import json
+import typing
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Annotated, Any
 
@@ -645,7 +647,22 @@ class TestUnconstrainedSequenceReturns:
     picture and others injecting the base64 into model context.
     """
 
-    @pytest.mark.parametrize("annotation", [list, tuple, list[Any], "bare"])
+    @pytest.mark.parametrize(
+        "annotation",
+        [
+            list,
+            tuple,
+            Sequence,
+            list,
+            tuple,
+            typing.Sequence,
+            list[Any],
+            Sequence[Any],
+            tuple[Any, ...],
+            Annotated[list, "meta"],
+            "bare",
+        ],
+    )
     def test_no_schema_is_inferred(self, annotation):
         if annotation == "bare":
 
@@ -658,7 +675,18 @@ class TestUnconstrainedSequenceReturns:
 
         assert Tool.from_function(func).output_schema is None
 
-    @pytest.mark.parametrize("annotation", [list[int], dict, str, tuple[int, str]])
+    @pytest.mark.parametrize(
+        "annotation",
+        [
+            list[int],
+            dict,
+            str,
+            tuple[int, str],
+            tuple[Any],
+            tuple[Any, Any],
+            Sequence[str],
+        ],
+    )
     def test_a_constrained_sequence_still_infers(self, annotation):
         """The guard must not swallow annotations that do say something."""
 


### PR DESCRIPTION
Fixes #4998

### What

`list`, `tuple`, `list[Any]` and `tuple[Any, ...]` now infer no output schema, matching `Any`.

### Why this layer

The suppression for MCP content types already exists — it's the `replace_type` swap that puts `_UnserializableType` in place of `ImageContent`, `AudioContent` and friends. It works by matching types *inside* the annotation, so it covers `list[ContentBlock]` but has nothing to match in a bare `list`, which is why `list` infers a schema and `list[ContentBlock]` doesn't.

Fixing it at the conversion site instead wouldn't work: the schema is advertised at `list_tools` time, before the runtime value is known, so suppressing `structured_content` there would leave the tool advertising a schema it doesn't satisfy. Inference is the layer where this is decidable.

The rule is the same one already applied to `Any`: don't infer a schema that constrains nothing. `{"result": {"items": {}, "type": "array"}}` permits every value that no schema permits, and its only effect is to force structured content — which for a content-block result means duplicating the payload.

Parameterised annotations are untouched: `list[int]`, `tuple[int, str]`, `dict`, `str` all infer exactly as before.

### Tests

Two existing parametrized sweeps included `list` among many annotations as a wrapped-schema case; `list` is dropped from both. New tests cover the annotations that now infer nothing, the parameterised ones that still do, and a regression test that a returned image doesn't appear in `structuredContent`.

`uv run pytest -n auto` — 7304 passed. `uv run prek run --all-files` — clean.

### Confirmed against a real client

We hit this on a remote MCP server whose `get_result` returns `[ImageContent, record]` under a `-> list` annotation. claude.ai showed no inline image while the base64 was duplicated into `structuredContent` (3533 B, mostly base64); with the duplication removed (415 B, no base64) the image renders inline. Same server, same tool, same client — the duplication was the difference.
