### PR TITLE
Fix task timing field serialization

### DIFF
--- a/fastmcp_tasks/fastmcp_tasks/client_models.py
+++ b/fastmcp_tasks/fastmcp_tasks/client_models.py
@@ -51,9 +51,9 @@ class _ClientTaskFields(Result):
     status: TaskStatus
     created_at: str = Field(alias="createdAt")
     last_updated_at: str = Field(alias="lastUpdatedAt")
-    ttl_ms: float | None = Field(default=None, alias="ttlMs")
+    ttl_ms: int | None = Field(default=None, alias="ttlMs")
     status_message: str | None = Field(default=None, alias="statusMessage")
-    poll_interval_ms: float | None = Field(default=None, alias="pollIntervalMs")
+    poll_interval_ms: int | None = Field(default=None, alias="pollIntervalMs")
 
 
 class ClientCreateTaskResult(_ClientTaskFields):

--- a/fastmcp_tasks/fastmcp_tasks/models.py
+++ b/fastmcp_tasks/fastmcp_tasks/models.py
@@ -71,11 +71,11 @@ class _TaskFields(BaseModel):
     status: TaskStatus
     created_at: str = Field(serialization_alias="createdAt")
     last_updated_at: str = Field(serialization_alias="lastUpdatedAt")
-    ttl_ms: float | None = Field(serialization_alias="ttlMs")
+    ttl_ms: int | None = Field(serialization_alias="ttlMs")
     status_message: str | None = Field(
         default=None, serialization_alias="statusMessage"
     )
-    poll_interval_ms: float | None = Field(
+    poll_interval_ms: int | None = Field(
         default=None, serialization_alias="pollIntervalMs"
     )
 

--- a/tests/tasks/client/test_client_models.py
+++ b/tests/tasks/client/test_client_models.py
@@ -1,0 +1,19 @@
+from fastmcp_tasks.client_models import ClientCreateTaskResult
+
+
+def test_client_task_timing_fields_parse_as_integers():
+    result = ClientCreateTaskResult.model_validate(
+        {
+            "taskId": "t1",
+            "status": "working",
+            "createdAt": "2026-09-03T00:00:00Z",
+            "lastUpdatedAt": "2026-09-03T00:00:00Z",
+            "ttlMs": 900000,
+            "pollIntervalMs": 5000,
+            "resultType": "task",
+        },
+        by_name=False,
+    )
+
+    assert type(result.ttl_ms) is int
+    assert type(result.poll_interval_ms) is int

--- a/tests/tasks/server/test_wire_models.py
+++ b/tests/tasks/server/test_wire_models.py
@@ -95,6 +95,21 @@ def test_create_task_result_emits_result_type_discriminator():
     assert _dump(result)["resultType"] == "task"
 
 
+def test_server_task_timing_fields_serialize_as_integers():
+    result = CreateTaskResult(
+        task_id="t1",
+        status="working",
+        created_at=_ISO,
+        last_updated_at=_ISO,
+        ttl_ms=900000,
+        poll_interval_ms=5000,
+    )
+
+    dumped = _dump(result)
+    assert type(dumped["ttlMs"]) is int
+    assert type(dumped["pollIntervalMs"]) is int
+
+
 @pytest.mark.parametrize(
     ("status", "payload"),
     [


### PR DESCRIPTION
## Description

`fastmcp-tasks` currently annotates `ttlMs` and `pollIntervalMs` as floats, so Pydantic converts integer inputs into JSON values such as `60000.0`. Strict MCP clients that implement the published Tasks schema reject those values because both fields are defined as integers.

This changes the server and client task models to use integer timing fields. It also adds regression coverage confirming that server wire output contains JSON integers and that client models preserve integer values.

Fixes #5000

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement or feature

## Validation

- `uv run pytest tests/tasks/server/test_wire_models.py tests/tasks/client/test_client_models.py` (`13 passed`)
- `uv run pytest tests/tasks -n auto` (`348 passed`)
- `uv run pytest -n auto` (`7300 passed, 6 skipped, 16 xfailed`)
- `uv run prek run --all-files`

## Checklist

- [x] This PR addresses an existing issue.
- [x] `CONTRIBUTING.md` was read and followed for this contribution.
- [x] Tests cover the changed behavior.
- [x] The repository's full test suite and pre-commit checks pass.

Generated with OpenAI Codex (GPT-5).
