### PR TITLE
docs: add v4.0.3 changelog entries

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,32 @@ rss: true
 tag: NEW
 ---
 
+<Update label="v4.0.3" description="2026-09-04">
+
+**[v4.0.3: Once Is Enough](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.3)**
+
+Multi-server clients with legacy-only backends now avoid unnecessary startup retries, and tools returning unconstrained sequences no longer send images twice. This patch also fixes task timing values rejected by strict clients and cleans up unfinished Monty callbacks when execution ends.
+
+### Enhancements ✨
+* ci: deploy docs through Mintlify's admin API and wait for a verdict by [@zzstoatzz](https://github.com/zzstoatzz) in [#4996](https://github.com/PrefectHQ/fastmcp/pull/4996)
+* perf: avoid duplicate startup for mixed-era backends by [@ningmao-hlyz](https://github.com/ningmao-hlyz) in [#4971](https://github.com/PrefectHQ/fastmcp/pull/4971)
+* docs: clarify release title history lookup by [@zzstoatzz](https://github.com/zzstoatzz) in [#5006](https://github.com/PrefectHQ/fastmcp/pull/5006)
+### Fixes 🐞
+* fix: don't infer an output schema for unconstrained sequences by [@fsecada01](https://github.com/fsecada01) in [#4999](https://github.com/PrefectHQ/fastmcp/pull/4999)
+* Clean up unfinished Monty callbacks by [@zzstoatzz](https://github.com/zzstoatzz) in [#5005](https://github.com/PrefectHQ/fastmcp/pull/5005)
+* Fix task timing field serialization by [@LarryHu0217](https://github.com/LarryHu0217) in [#5003](https://github.com/PrefectHQ/fastmcp/pull/5003)
+### Docs 📚
+* docs: point What's New at the changelog for later releases by [@zzstoatzz](https://github.com/zzstoatzz) in [#4992](https://github.com/PrefectHQ/fastmcp/pull/4992)
+* docs: attribute the back-channel removal to SEP-2322/2575, not SEP-2577 by [@zzstoatzz](https://github.com/zzstoatzz) in [#4988](https://github.com/PrefectHQ/fastmcp/pull/4988)
+
+## New Contributors
+* @fsecada01 made their first contribution in [#4999](https://github.com/PrefectHQ/fastmcp/pull/4999)
+* @ningmao-hlyz made their first contribution in [#4971](https://github.com/PrefectHQ/fastmcp/pull/4971)
+
+**Full Changelog**: [v4.0.2...v4.0.3](https://github.com/PrefectHQ/fastmcp/compare/v4.0.2...v4.0.3)
+
+</Update>
+
 <Update label="v4.0.2" description="2026-09-02">
 
 **[v4.0.2: Root Access](https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.2)**

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,16 @@ icon: "sparkles"
 tag: NEW
 ---
 
+<Update label="FastMCP 4.0.3" description="September 4, 2026" tags={["Releases"]}>
+<Card
+title="FastMCP v4.0.3: Once Is Enough"
+href="https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.3"
+cta="Read the release notes"
+>
+Multi-server clients with legacy-only backends now avoid unnecessary startup retries, and tools returning unconstrained sequences no longer send images twice. This patch also fixes task timing values rejected by strict clients and cleans up unfinished Monty callbacks when execution ends.
+</Card>
+</Update>
+
 <Update label="FastMCP 4.0.2" description="September 2, 2026" tags={["Releases"]}>
 <Card
 title="FastMCP v4.0.2: Root Access"


### PR DESCRIPTION
Add the v4.0.3 “Once Is Enough” changelog and updates-feed entries from the approved notes and GitHub release preview.
