### PR TITLE
Keep selected tools direct in CodeMode

### DIFF
--- a/docs/servers/transforms/code-mode.mdx
+++ b/docs/servers/transforms/code-mode.mdx
@@ -46,6 +46,36 @@ def multiply(x: int, y: int) -> int:
 
 Clients connecting to this server no longer see `add` and `multiply` directly. Instead, they see the meta-tools that CodeMode provides — tools for discovering what's available and executing code against it. The original tools are still there, but they're accessed through the CodeMode layer.
 
+## Keeping Tools Direct
+
+Some tools are better called once with their native schema, such as a skill loader whose parameter lists the available skills. Use `direct_tool_names` to keep those tools alongside the discovery and execute tools:
+
+```python
+from typing import Literal
+
+from fastmcp import FastMCP
+from fastmcp.experimental.transforms.code_mode import CodeMode
+
+mcp = FastMCP(
+    "Server",
+    transforms=[CodeMode(direct_tool_names={"load_skill"})],
+)
+
+@mcp.tool
+def load_skill(skill: Literal["research", "review"]) -> str:
+    """Load instructions for a skill."""
+    return f"Instructions for {skill}"
+
+@mcp.tool
+def add(x: int, y: int) -> int:
+    """Add two numbers."""
+    return x + y
+```
+
+Clients see `load_skill` with its original enum schema, plus `search`, `get_schema`, and `execute`. The discovery tools expose `add`; they exclude `load_skill`, which must be called directly and cannot be invoked through the sandbox's `call_tool`. Custom discovery factories receive the same filtered catalog.
+
+Names match at CodeMode's position in the transform pipeline. If a `Namespace("api")` transform runs before CodeMode, select `"api_load_skill"`; if it runs after, select `"load_skill"`. Direct tools retain their original metadata, authorization checks, and version selection, including fallback when the newest version is disabled. Unknown names have no effect. A name that collides with a discovery or execute tool raises `ValueError`; rename the synthetic tool or change the direct selection to resolve it.
+
 ## Discovery
 
 Before the LLM can write code that calls your tools, it needs to know what tools exist and how to call them. This is the **discovery** process — the LLM uses meta-tools to learn about your tool catalog, then writes code against what it finds.

--- a/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
+++ b/fastmcp_slim/fastmcp/experimental/transforms/code_mode.py
@@ -536,6 +536,11 @@ class CodeMode(CatalogTransform):
 
     The ``execute`` tool is always present and provides a sandboxed Python
     environment with ``call_tool(name, params)`` in scope.
+
+    `direct_tool_names` keeps selected tools in the native tool listing,
+    excluding them from discovery and sandbox calls. Names are matched at
+    this transform's position in the pipeline. All versions are preserved
+    for the server's normal visibility and version selection.
     """
 
     def __init__(
@@ -543,12 +548,14 @@ class CodeMode(CatalogTransform):
         *,
         sandbox_provider: SandboxProvider | None = None,
         discovery_tools: list[DiscoveryToolFactory] | None = None,
+        direct_tool_names: set[str] | None = None,
         execute_tool_name: str = "execute",
         execute_description: str | None = None,
         max_tool_calls: int | None = 50,
     ) -> None:
         super().__init__()
         self.execute_tool_name = execute_tool_name
+        self._direct_tool_names = set(direct_tool_names or ())
         self.execute_description = execute_description
         self.max_tool_calls = max_tool_calls
         self.sandbox_provider = sandbox_provider or MontySandboxProvider()
@@ -574,11 +581,22 @@ class CodeMode(CatalogTransform):
                 )
             if len(names) != len(tools):
                 raise ValueError("Discovery tools must have unique names.")
+            collisions = self._direct_tool_names & (names | {self.execute_tool_name})
+            if collisions:
+                raise ValueError(
+                    "Direct tool names collide with CodeMode tools: "
+                    + ", ".join(sorted(collisions))
+                )
             self._built_discovery_tools = tools
         return self._built_discovery_tools
 
     async def transform_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
-        return [*self._build_discovery_tools(), self._get_execute_tool()]
+        direct = [tool for tool in tools if tool.name in self._direct_tool_names]
+        return [*self._build_discovery_tools(), self._get_execute_tool(), *direct]
+
+    async def filter_tool_catalog(self, tools: Sequence[Tool]) -> Sequence[Tool]:
+        """Exclude direct tools before later transforms can rename them."""
+        return [tool for tool in tools if tool.name not in self._direct_tool_names]
 
     async def get_tool(
         self,

--- a/fastmcp_slim/fastmcp/server/transforms/catalog.py
+++ b/fastmcp_slim/fastmcp/server/transforms/catalog.py
@@ -20,6 +20,8 @@ short-circuit a method after ``super()`` returns.
 Solution: ``CatalogTransform`` owns ``list_tools()`` and uses a
 per-instance ``ContextVar`` to detect re-entrant calls.  During bypass,
 it passes through to the base ``Transform.list_tools()`` (a no-op).
+For tools, the bypass also applies ``filter_tool_catalog()`` so a subclass
+can exclude tools at its own position in the transform pipeline.
 Otherwise, it delegates to ``transform_tools()`` — the subclass hook
 where replacement logic lives.  Same pattern for resources, prompts,
 and resource templates.
@@ -89,7 +91,7 @@ class CatalogTransform(Transform):
 
     async def list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
         if self._bypass.get():
-            return await super().list_tools(tools)
+            return await self.filter_tool_catalog(await super().list_tools(tools))
         return await self.transform_tools(tools)
 
     async def list_resources(self, resources: Sequence[Resource]) -> Sequence[Resource]:
@@ -112,6 +114,15 @@ class CatalogTransform(Transform):
     # ------------------------------------------------------------------
     # Subclass hooks (override these, not list_*)
     # ------------------------------------------------------------------
+
+    async def filter_tool_catalog(self, tools: Sequence[Tool]) -> Sequence[Tool]:
+        """Filter real tools while `get_tool_catalog` bypasses replacement.
+
+        Runs at this transform's position in the pipeline, before later
+        transforms can rename tools. The default keeps all tools. Server
+        visibility and authorization checks still apply after this hook.
+        """
+        return tools
 
     async def transform_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
         """Transform the tool catalog.

--- a/tests/experimental/transforms/test_code_mode_direct_tools.py
+++ b/tests/experimental/transforms/test_code_mode_direct_tools.py
@@ -1,0 +1,299 @@
+"""Direct tools retain native MCP schemas alongside the CodeMode surface."""
+
+from typing import Any, Literal
+
+import pytest
+
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.experimental.transforms.code_mode import (
+    CodeMode,
+    GetSchemas,
+    GetTags,
+    GetToolCatalog,
+    ListTools,
+    Search,
+)
+from fastmcp.server.context import Context
+from fastmcp.server.transforms import Namespace
+from fastmcp.tools import Tool
+from fastmcp.utilities.versions import VersionSpec
+
+
+async def test_direct_tool_keeps_schema_metadata_and_native_call() -> None:
+    mcp = FastMCP("Direct tools")
+
+    @mcp.tool(tags={"instructions"}, meta={"purpose": "onboarding"})
+    def load_skill(skill: Literal["research", "review"]) -> str:
+        """Load instructions for a skill."""
+        return f"Instructions for {skill}"
+
+    @mcp.tool
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    original = await mcp.get_tool("load_skill")
+    assert original is not None
+    mcp.add_transform(CodeMode(direct_tool_names={"load_skill"}))
+
+    async with Client(mcp) as client:
+        listed = {tool.name: tool for tool in await client.list_tools()}
+        assert set(listed) == {"search", "get_schema", "execute", "load_skill"}
+        assert listed["load_skill"].input_schema == original.parameters
+        assert listed["load_skill"].meta == original.get_meta()
+        direct = await client.call_tool("load_skill", {"skill": "research"})
+        assert direct.data == "Instructions for research"
+        executed = await client.call_tool(
+            "execute", {"code": "return await call_tool('add', {'x': 2, 'y': 3})"}
+        )
+        assert executed.data == {"result": 5}
+        with pytest.raises(ToolError, match="Unknown tool: load_skill"):
+            await client.call_tool(
+                "execute",
+                {"code": "return await call_tool('load_skill', {'skill': 'review'})"},
+            )
+
+
+@pytest.mark.parametrize("discovery", [Search, GetSchemas, GetTags, ListTools])
+async def test_direct_tools_excluded_from_every_discovery(
+    discovery: type[Search | GetSchemas | GetTags | ListTools],
+) -> None:
+    mcp = FastMCP("Direct discovery")
+
+    @mcp.tool(tags={"direct_only"})
+    def load_skill() -> str:
+        """Load a skill."""
+        return "instructions"
+
+    @mcp.tool(tags={"backend"})
+    def calculate() -> int:
+        """Calculate something."""
+        return 42
+
+    mcp.add_transform(
+        CodeMode(
+            direct_tool_names={"load_skill"},
+            discovery_tools=[discovery(name="discover")],
+        )
+    )
+    arguments: dict[str, Any] = (
+        {"query": "skill calculate"} if discovery is Search else {}
+    )
+    if discovery is GetSchemas:
+        arguments = {"tools": ["load_skill", "calculate"]}
+    async with Client(mcp) as client:
+        result = await client.call_tool("discover", arguments)
+        text = str(result.data)
+        assert "direct_only" not in text
+        assert ("backend" if discovery is GetTags else "calculate") in text
+        # GetSchemas explicitly reports the requested missing name.
+        if discovery is GetSchemas:
+            assert "Tools not found: load_skill" in text
+            assert "Load a skill" not in text
+        else:
+            assert "load_skill" not in text
+
+
+async def test_custom_discovery_receives_filtered_catalog() -> None:
+    def catalog_names(get_catalog: GetToolCatalog) -> Tool:
+        async def names(ctx: Context) -> list[str]:
+            return [tool.name for tool in await get_catalog(ctx)]
+
+        return Tool.from_function(names)
+
+    mcp = FastMCP("Custom discovery")
+
+    @mcp.tool
+    def direct() -> None:
+        pass
+
+    @mcp.tool
+    def backend() -> None:
+        pass
+
+    mcp.add_transform(
+        CodeMode(direct_tool_names={"direct"}, discovery_tools=[catalog_names])
+    )
+    async with Client(mcp) as client:
+        assert (await client.call_tool("names")).data == ["backend"]
+
+
+@pytest.mark.parametrize("disable_latest", [False, True])
+async def test_direct_versions_use_native_selection_and_fallback(
+    disable_latest: bool,
+) -> None:
+    mcp = FastMCP("Direct versions")
+
+    @mcp.tool(name="load_skill", version="1", tags={"old"})
+    def old_skill(old: str) -> str:
+        return f"old {old}"
+
+    @mcp.tool(name="load_skill", version="2", tags={"new"})
+    def new_skill(new: int) -> str:
+        return f"new {new}"
+
+    if disable_latest:
+        mcp.disable(names={"load_skill"}, version=VersionSpec(eq="2"))
+    mcp.add_transform(CodeMode(direct_tool_names={"load_skill"}))
+
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+        parameters = tools["load_skill"].input_schema["properties"]
+        argument = {"old": "skill"} if disable_latest else {"new": 2}
+        assert set(parameters) == set(argument)
+        assert (await client.call_tool("load_skill", argument)).data == (
+            "old skill" if disable_latest else "new 2"
+        )
+        catalog = await client.call_tool("get_schema", {"tools": ["load_skill"]})
+        assert "Tools not found: load_skill" in str(catalog.data)
+
+
+@pytest.mark.parametrize("restricted_by", ["disabled", "auth"])
+async def test_direct_tools_respect_visibility_and_auth(restricted_by: str) -> None:
+    mcp = FastMCP("Restricted direct tools")
+
+    @mcp.tool(auth=(lambda _ctx: False) if restricted_by == "auth" else None)
+    def secret() -> str:
+        return "secret value"
+
+    if restricted_by == "disabled":
+        mcp.disable(names={"secret"})
+    mcp.add_transform(CodeMode(direct_tool_names={"secret"}))
+
+    async with Client(mcp) as client:
+        assert "secret" not in {tool.name for tool in await client.list_tools()}
+        with pytest.raises(ToolError):
+            await client.call_tool("secret")
+        with pytest.raises(ToolError, match="Unknown tool: secret"):
+            await client.call_tool(
+                "execute", {"code": "return await call_tool('secret', {})"}
+            )
+
+
+@pytest.mark.parametrize("namespace_first", [False, True])
+async def test_direct_names_follow_transform_position(namespace_first: bool) -> None:
+    mcp = FastMCP("Namespaced direct tools")
+
+    @mcp.tool
+    def load_skill() -> str:
+        return "instructions"
+
+    @mcp.tool
+    def calculate() -> int:
+        return 42
+
+    code_mode = CodeMode(
+        direct_tool_names={"api_load_skill" if namespace_first else "load_skill"},
+        discovery_tools=[ListTools()],
+    )
+    transforms = [Namespace("api"), code_mode]
+    if not namespace_first:
+        transforms.reverse()
+    for transform in transforms:
+        mcp.add_transform(transform)
+
+    synthetic_prefix = "" if namespace_first else "api_"
+    async with Client(mcp) as client:
+        listed = {tool.name for tool in await client.list_tools()}
+        assert listed == {
+            "api_load_skill",
+            f"{synthetic_prefix}list_tools",
+            f"{synthetic_prefix}execute",
+        }
+        assert (await client.call_tool("api_load_skill")).data == "instructions"
+        catalog = await client.call_tool(f"{synthetic_prefix}list_tools")
+        assert "api_calculate" in str(catalog.data)
+        assert "load_skill" not in str(catalog.data)
+        with pytest.raises(ToolError, match="Unknown tool: api_load_skill"):
+            await client.call_tool(
+                f"{synthetic_prefix}execute",
+                {"code": "return await call_tool('api_load_skill', {})"},
+            )
+
+
+@pytest.mark.parametrize("name", ["search", "get_schema", "execute"])
+async def test_direct_names_cannot_shadow_default_synthetic_tools(name: str) -> None:
+    mode = CodeMode(direct_tool_names={name})
+    with pytest.raises(ValueError, match=f"Direct tool names collide.*{name}"):
+        await mode.transform_tools([])
+
+
+@pytest.mark.parametrize("name", ["find", "run"])
+async def test_direct_names_cannot_shadow_custom_synthetic_tools(name: str) -> None:
+    mcp = FastMCP(
+        "Collision",
+        transforms=[
+            CodeMode(
+                direct_tool_names={name},
+                discovery_tools=[Search(name="find")],
+                execute_tool_name="run",
+            )
+        ],
+    )
+    with pytest.raises(ValueError, match=f"Direct tool names collide.*{name}"):
+        await mcp.get_tool(name)
+
+
+@pytest.mark.parametrize("direct_names", [None, set(), {"absent"}])
+async def test_default_and_unknown_direct_names_keep_code_mode_behavior(
+    direct_names: set[str] | None,
+) -> None:
+    mcp = FastMCP("Default behavior")
+
+    @mcp.tool
+    def load_skill() -> str:
+        return "instructions"
+
+    mcp.add_transform(CodeMode(direct_tool_names=direct_names))
+    async with Client(mcp) as client:
+        assert {tool.name for tool in await client.list_tools()} == {
+            "search",
+            "get_schema",
+            "execute",
+        }
+        result = await client.call_tool(
+            "execute", {"code": "return await call_tool('load_skill', {})"}
+        )
+        assert result.data == {"result": "instructions"}
+
+
+@pytest.mark.parametrize("transform_on_child", [False, True])
+async def test_direct_tools_on_mounted_server(transform_on_child: bool) -> None:
+    child = FastMCP("Child")
+
+    @child.tool
+    def load_skill() -> str:
+        return "instructions"
+
+    @child.tool
+    def calculate() -> int:
+        return 42
+
+    parent = FastMCP("Parent")
+    mode = CodeMode(
+        direct_tool_names={"load_skill" if transform_on_child else "api_load_skill"},
+        discovery_tools=[ListTools()],
+    )
+    if transform_on_child:
+        child.add_transform(mode)
+    parent.mount(child, namespace="api")
+    if not transform_on_child:
+        parent.add_transform(mode)
+
+    prefix = "api_" if transform_on_child else ""
+    backend_name = "calculate" if transform_on_child else "api_calculate"
+    async with Client(parent) as client:
+        assert {tool.name for tool in await client.list_tools()} == {
+            "api_load_skill",
+            f"{prefix}list_tools",
+            f"{prefix}execute",
+        }
+        assert (await client.call_tool("api_load_skill")).data == "instructions"
+        catalog = await client.call_tool(f"{prefix}list_tools")
+        assert backend_name in str(catalog.data)
+        assert "load_skill" not in str(catalog.data)
+        executed = await client.call_tool(
+            f"{prefix}execute",
+            {"code": f"return await call_tool('{backend_name}', {{}})"},
+        )
+        assert executed.data == {"result": 42}


### PR DESCRIPTION
## Description

A skill loader should keep its native enum schema even when the rest of a server uses CodeMode. `direct_tool_names` preserves selected tools in the MCP listing and excludes them from every discovery factory and sandbox `call_tool`. All versions remain available to FastMCP's normal visibility, authorization, and version selection.

The catalog filter runs at CodeMode's position in the transform pipeline, so names still match when a later Namespace transform renames tools. Internal tool-catalog reads bypass only `ResponseCachingMiddleware`'s ordinary listing cache, preserving other middleware and authorization checks. A generic `ToolTransform` validation rejects later renames whose advertised schema would disagree with reverse call routing, including collisions with CodeMode tools; same-source versions and explicit name swaps remain valid.

```python
from fastmcp.experimental.transforms.code_mode import CodeMode

CodeMode(direct_tool_names={"load_skill"})
```

Closes #4925. [Design proposal](https://github.com/PrefectHQ/fastmcp/issues/4925#issuecomment-5548762176).

Validation for the initial revision: the full suite had 7,325 passes, 19 failures and one setup error on this host; all 20 cases passed on a serial rerun with localhost excluded from the host HTTP proxy.

Review follow-up reproductions confirmed ordinary-list/cache contamination in four cold/warm and namespaced cases, plus post-CodeMode renames to `execute`/`search`. The shared rename issue was also reproduced without CodeMode. Regression tests cover middleware/auth preservation, nested catalog reads, reset after failure, registration order, version selection, missing rename sources, and swaps. The follow-up full suite passed: 7,360 passed, 7 skipped, 16 xfailed. `uv run prek run --all-files` passed, including ty. The first follow-up full run exposed an old test that applied its registered transform twice; it now asserts the provider's public listing and a real Client call, without weakening collision validation.

Follow-up fixes are available in [commit 19618e3 on the same fork branch](https://github.com/lidongChen-ai/fastmcp/commit/19618e346a4ddaa4c7d6a2ecd4145c596c73c2f9). GitHub currently retains the original head snapshot while this PR is closed pending issue assignment; this existing PR has not been manually reopened or replaced.

Generated with Codex. Automated implementation and review were used; no human review or maintainer assignment is claimed.

## Contribution type

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
