### PR TITLE
fix(version_filter): honor include_unversioned in direct get_* lookups

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/version_filter.py
+++ b/fastmcp_slim/fastmcp/server/transforms/version_filter.py
@@ -73,6 +73,22 @@ class VersionFilter(Transform):
             parts.append("include_unversioned=False")
         return f"VersionFilter({', '.join(parts)})"
 
+    def _guard_unversioned(self, component):
+        """Drop a component if it is unversioned and this filter excludes them.
+
+        ``list_*`` operations filter components through
+        ``self._spec.matches(version, match_none=self.include_unversioned)``, so
+        unversioned components are removed from list results. Direct lookups,
+        however, resolve via the intersected version spec at the provider
+        layer, where ``VersionSpec.matches`` uses the default
+        ``match_none=True`` -- so an excluded unversioned component can still be
+        returned by a direct ``get_*``. Re-apply the ``include_unversioned``
+        intent here so direct lookups agree with list operations.
+        """
+        if component is not None and not self.include_unversioned and component.version is None:
+            return None
+        return component
+
     # -------------------------------------------------------------------------
     # Tools
     # -------------------------------------------------------------------------
@@ -87,7 +103,9 @@ class VersionFilter(Transform):
     async def get_tool(
         self, name: str, call_next: GetToolNext, *, version: VersionSpec | None = None
     ) -> Tool | None:
-        return await call_next(name, version=self._spec.intersect(version))
+        return self._guard_unversioned(
+            await call_next(name, version=self._spec.intersect(version))
+        )
 
     # -------------------------------------------------------------------------
     # Resources
@@ -107,7 +125,9 @@ class VersionFilter(Transform):
         *,
         version: VersionSpec | None = None,
     ) -> Resource | None:
-        return await call_next(uri, version=self._spec.intersect(version))
+        return self._guard_unversioned(
+            await call_next(uri, version=self._spec.intersect(version))
+        )
 
     # -------------------------------------------------------------------------
     # Resource Templates
@@ -129,7 +149,9 @@ class VersionFilter(Transform):
         *,
         version: VersionSpec | None = None,
     ) -> ResourceTemplate | None:
-        return await call_next(uri, version=self._spec.intersect(version))
+        return self._guard_unversioned(
+            await call_next(uri, version=self._spec.intersect(version))
+        )
 
     # -------------------------------------------------------------------------
     # Prompts
@@ -145,4 +167,6 @@ class VersionFilter(Transform):
     async def get_prompt(
         self, name: str, call_next: GetPromptNext, *, version: VersionSpec | None = None
     ) -> Prompt | None:
-        return await call_next(name, version=self._spec.intersect(version))
+        return self._guard_unversioned(
+            await call_next(name, version=self._spec.intersect(version))
+        )

--- a/tests/server/versioning/test_filtering.py
+++ b/tests/server/versioning/test_filtering.py
@@ -172,6 +172,45 @@ class TestVersionFilter:
         tools = await mcp.list_tools()
         assert [tool.name for tool in tools] == ["included_versioned_tool"]
 
+    async def test_get_tool_excludes_unversioned_when_disabled(self):
+        """Regression (#4946): with include_unversioned=False, a direct
+        ``get_tool()`` lookup must exclude unversioned components, agreeing
+        with ``list_tools()``. Previously only the list operations honored the
+        exclusion; the direct lookup resolved through the provider layer where
+        ``VersionSpec.matches`` defaults to ``match_none=True``, so an excluded
+        unversioned component was still returned."""
+
+        mcp = FastMCP()
+
+        @mcp.tool
+        def hidden_tool() -> str:
+            return "hidden"
+
+        mcp.add_transform(VersionFilter(version_gte="1.0", include_unversioned=False))
+
+        # List operation excludes the unversioned tool.
+        assert [t.name for t in await mcp.list_tools()] == []
+        # Direct lookup must agree.
+        assert await mcp.get_tool("hidden_tool") is None
+
+    async def test_get_tool_keeps_in_range_versioned_when_disabled(self):
+        """Regression (#4946): with include_unversioned=False, a versioned
+        component that is within the filter range is still returned by a direct
+        lookup -- the guard only drops unversioned (version=None) components, so
+        legitimate versioned tools are never over-suppressed."""
+
+        mcp = FastMCP()
+
+        @mcp.tool(version="1.5")
+        def calc() -> int:
+            return 15
+
+        mcp.add_transform(VersionFilter(version_gte="1.0", include_unversioned=False))
+
+        got = await mcp.get_tool("calc")
+        assert got is not None
+        assert got.version == "1.5"
+
     async def test_date_versions(self):
         """Works with date-based versions like '2025-01-15'."""
         from fastmcp.server.transforms import VersionFilter


### PR DESCRIPTION
Fixes #4946

## Problem

`VersionFilter(include_unversioned=False)` removes unversioned components from
`list_*` results, but a direct `get_*` lookup still returns them. With the issue
repro, `list_tools()` reports `[]` while `get_tool("hidden_tool")` hands back the
excluded unversioned tool, so the two paths disagree.

## Root cause

List operations filter through `self._spec.matches(version, match_none=self.include_unversioned)`.
Direct lookups, however, resolve at the provider layer via the intersected
`VersionSpec`, whose `matches()` defaults to `match_none=True`. The
`include_unversioned` intent is never propagated down that path, so an excluded
unversioned component survives a direct lookup.

## Fix

`VersionFilter` now re-applies its `include_unversioned` intent to the result of
each direct `get_*` call: when it is `False`, an unversioned (`version is None`)
result is dropped to `None`, so direct lookups agree with list operations. A
versioned component within range is unaffected (only `version is None` is
dropped).

Two regression tests added in `tests/server/versioning/test_filtering.py`:
- a direct `get_tool()` for an unversioned tool returns `None` when
  `include_unversioned=False` (fails without the fix),
- an in-range versioned tool is still returned, so the guard does not
  over-suppress legitimate versioned components.

Verified: full `tests/server/versioning/` (115) and `tests/server/transforms/`
(124) pass.
