### PR TITLE
Apply include_unversioned in VersionFilter direct lookups

### DIFF
--- a/fastmcp_slim/fastmcp/server/transforms/version_filter.py
+++ b/fastmcp_slim/fastmcp/server/transforms/version_filter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from fastmcp.server.transforms import (
     GetPromptNext,
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     from fastmcp.resources.base import Resource
     from fastmcp.resources.template import ResourceTemplate
     from fastmcp.tools.base import Tool
+    from fastmcp.utilities.components import FastMCPComponent
+
+_ComponentT = TypeVar("_ComponentT", bound="FastMCPComponent")
 
 
 class VersionFilter(Transform):
@@ -73,6 +76,25 @@ class VersionFilter(Transform):
             parts.append("include_unversioned=False")
         return f"VersionFilter({', '.join(parts)})"
 
+    def _apply_unversioned_exclusion(
+        self, component: _ComponentT | None
+    ) -> _ComponentT | None:
+        """Re-apply the ``include_unversioned`` check that ``list_*`` enforces.
+
+        The version *range* reaches ``call_next`` as a ``VersionSpec``, but a
+        spec carries no ``include_unversioned`` flag, so an unversioned
+        component (``version is None``) passes it unconditionally. Without this,
+        a direct lookup (``get_tool`` etc.) returns a component that
+        ``list_tools`` hides. See jlowin/fastmcp#4946.
+        """
+        if (
+            component is not None
+            and not self.include_unversioned
+            and component.version is None
+        ):
+            return None
+        return component
+
     # -------------------------------------------------------------------------
     # Tools
     # -------------------------------------------------------------------------
@@ -87,7 +109,9 @@ class VersionFilter(Transform):
     async def get_tool(
         self, name: str, call_next: GetToolNext, *, version: VersionSpec | None = None
     ) -> Tool | None:
-        return await call_next(name, version=self._spec.intersect(version))
+        return self._apply_unversioned_exclusion(
+            await call_next(name, version=self._spec.intersect(version))
+        )
 
     # -------------------------------------------------------------------------
     # Resources
@@ -107,7 +131,9 @@ class VersionFilter(Transform):
         *,
         version: VersionSpec | None = None,
     ) -> Resource | None:
-        return await call_next(uri, version=self._spec.intersect(version))
+        return self._apply_unversioned_exclusion(
+            await call_next(uri, version=self._spec.intersect(version))
+        )
 
     # -------------------------------------------------------------------------
     # Resource Templates
@@ -129,7 +155,9 @@ class VersionFilter(Transform):
         *,
         version: VersionSpec | None = None,
     ) -> ResourceTemplate | None:
-        return await call_next(uri, version=self._spec.intersect(version))
+        return self._apply_unversioned_exclusion(
+            await call_next(uri, version=self._spec.intersect(version))
+        )
 
     # -------------------------------------------------------------------------
     # Prompts
@@ -145,4 +173,6 @@ class VersionFilter(Transform):
     async def get_prompt(
         self, name: str, call_next: GetPromptNext, *, version: VersionSpec | None = None
     ) -> Prompt | None:
-        return await call_next(name, version=self._spec.intersect(version))
+        return self._apply_unversioned_exclusion(
+            await call_next(name, version=self._spec.intersect(version))
+        )

--- a/tests/server/versioning/test_filtering.py
+++ b/tests/server/versioning/test_filtering.py
@@ -172,6 +172,11 @@ class TestVersionFilter:
         tools = await mcp.list_tools()
         assert [tool.name for tool in tools] == ["included_versioned_tool"]
 
+        # Direct lookup must match list_tools (jlowin/fastmcp#4946)
+        assert await mcp.get_tool("unversioned_tool") is None
+        assert await mcp.get_tool("excluded_versioned_tool") is None
+        assert (await mcp.get_tool("included_versioned_tool")) is not None
+
     async def test_date_versions(self):
         """Works with date-based versions like '2025-01-15'."""
         from fastmcp.server.transforms import VersionFilter
@@ -266,6 +271,11 @@ class TestVersionFilter:
             "file:///included_versioned"
         ]
 
+        # Direct lookup must match list_resources (jlowin/fastmcp#4946)
+        assert await mcp.get_resource("file:///unversioned") is None
+        assert await mcp.get_resource("file:///excluded_versioned") is None
+        assert (await mcp.get_resource("file:///included_versioned")) is not None
+
     async def test_include_unversioned_false_excludes_unversioned_resource_templates(
         self,
     ):
@@ -290,6 +300,16 @@ class TestVersionFilter:
         assert [template.uri_template for template in templates] == [
             "resource://included_versioned/{name}"
         ]
+
+        # Direct lookup must match list_resource_templates (jlowin/fastmcp#4946)
+        assert await mcp.get_resource_template("resource://unversioned/{name}") is None
+        assert (
+            await mcp.get_resource_template("resource://excluded_versioned/{name}")
+            is None
+        )
+        assert (
+            await mcp.get_resource_template("resource://included_versioned/{name}")
+        ) is not None
 
     async def test_prompts_filtered(self):
         """Prompts are filtered by version."""
@@ -331,6 +351,11 @@ class TestVersionFilter:
 
         prompts = await mcp.list_prompts()
         assert [prompt.name for prompt in prompts] == ["included_versioned_prompt"]
+
+        # Direct lookup must match list_prompts (jlowin/fastmcp#4946)
+        assert await mcp.get_prompt("unversioned_prompt") is None
+        assert await mcp.get_prompt("excluded_versioned_prompt") is None
+        assert (await mcp.get_prompt("included_versioned_prompt")) is not None
 
     async def test_repr(self):
         """Test VersionFilter string representation."""


### PR DESCRIPTION
Fixes #4946

`VersionFilter(include_unversioned=False)` drops unversioned components from
`list_tools()` and friends, but `get_tool()` still returns them. The filter's
version *range* reaches the underlying lookup as a `VersionSpec`, and a spec has
no `include_unversioned` flag — so `VersionSpec.matches(None)` passes an
unversioned component through unconditionally on the retrieval path. The
`list_*` methods sidestep this by passing `match_none=self.include_unversioned`
directly; the `get_*` methods had nothing equivalent.

This re-applies that one check at the point where the information still exists —
after `call_next` returns, in the four `get_*` methods — via a small
`_apply_unversioned_exclusion` helper. Direct lookups now agree with list
operations.

```python
mcp.add_transform(VersionFilter(version_gte="1.0", include_unversioned=False))

await mcp.list_tools()            # []           (unversioned hidden)
await mcp.get_tool("hidden")      # None  (was: the unversioned Tool)
```

The existing `test_include_unversioned_false_excludes_unversioned_*` tests are
extended to assert the `get_*` path alongside the `list_*` path they already
covered; each fails without this change.

_Assisted by an AI coding tool; reviewed, run, and owned by me._
