### PR TITLE
fix(auth): keep non-rejection refresh failures out of invalid_grant

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -109,7 +109,7 @@ from fastmcp.server.auth.oauth_proxy.models import (
     _hash_token,
 )
 from fastmcp.server.auth.oauth_proxy.ui import create_error_html
-from fastmcp.server.auth.oauth_proxy.upstream import AsyncOAuth2Client
+from fastmcp.server.auth.oauth_proxy.upstream import AsyncOAuth2Client, OAuthError
 from fastmcp.server.auth.redirect_validation import (
     build_client_redirect,
     is_redirect_uri_allowed_for_application_type,
@@ -1816,9 +1816,24 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                     **self._extra_token_params,
                 )
             logger.debug("Successfully refreshed upstream token")
-        except Exception as e:
-            logger.error("Upstream token refresh failed: %s", e)
-            raise TokenError("invalid_grant", f"Upstream refresh failed: {e}") from e
+        except OAuthError as e:
+            # Only a definitive upstream rejection invalidates the stored
+            # credential. Anything else must not surface as invalid_grant:
+            # clients discard credentials on invalid_grant, and a transient
+            # upstream failure is not a credential failure.
+            if e.error == "invalid_grant":
+                logger.warning("Upstream refresh token was rejected")
+                raise TokenError(
+                    "invalid_grant", "Upstream refresh token was rejected"
+                ) from e
+            logger.warning("Upstream token refresh failed with %s", e.error)
+            raise
+        except Exception:
+            # Transport and local failures are internal errors, never
+            # credential failures, and must not echo details to the client.
+            # The endpoint renders these as a generic 500.
+            logger.exception("Upstream token refresh failed")
+            raise
 
         # Update stored upstream token
         # In refresh flow, we know there's a refresh token, so default to 1 hour

--- a/tests/server/auth/oauth_proxy/test_tokens.py
+++ b/tests/server/auth/oauth_proxy/test_tokens.py
@@ -9,7 +9,7 @@ import pytest
 from key_value.aio.stores.memory import MemoryStore
 from mcp.server.auth.handlers.token import TokenErrorResponse
 from mcp.server.auth.handlers.token import TokenHandler as SDKTokenHandler
-from mcp.server.auth.provider import AuthorizationCode
+from mcp.server.auth.provider import AuthorizationCode, TokenError
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
 
@@ -31,6 +31,7 @@ from fastmcp.server.auth.oauth_proxy.models import (
     UpstreamTokenSet,
     _hash_token,
 )
+from fastmcp.server.auth.oauth_proxy.upstream import OAuthError
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 
 
@@ -2011,3 +2012,105 @@ class TestRefreshTokenMissLogging:
             and "test-client" in record.getMessage()
             for record in caplog.records
         )
+
+
+class TestRefreshUpstreamErrorSemantics:
+    """Upstream refresh failures must keep their semantics (#5002).
+
+    Only a definitive upstream rejection invalidates the stored credential.
+    Anything else must not surface as ``invalid_grant`` (clients discard
+    credentials on it) and must not echo upstream/internal details.
+    """
+
+    async def _make_exchange(self, jwt_verifier, failure):
+        class FailingClient:
+            async def refresh_token(self, *args, **kwargs):
+                raise failure
+
+            async def aclose(self):
+                pass
+
+        class ReproProxy(OAuthProxy):
+            def _create_upstream_oauth_client(self):
+                return FailingClient()
+
+        proxy = ReproProxy(
+            upstream_authorization_endpoint="https://idp.example.com/authorize",
+            upstream_token_endpoint="https://idp.example.com/token",
+            upstream_client_id="upstream-client",
+            token_verifier=jwt_verifier,
+            base_url="https://proxy.example.com",
+            jwt_signing_key="test-secret-key",
+            client_storage=MemoryStore(),
+        )
+        proxy.set_mcp_path("/mcp")
+        now = time.time()
+        refresh_value = proxy.jwt_issuer.issue_refresh_token(
+            client_id="test-client",
+            scopes=["read"],
+            jti="refresh-jti",
+            expires_in=3600,
+        )
+        await proxy._jti_mapping_store.put(
+            key="refresh-jti",
+            value=JTIMapping(
+                jti="refresh-jti",
+                upstream_token_id="upstream-token-id",
+                created_at=now,
+            ),
+            ttl=3600,
+        )
+        await proxy._upstream_token_store.put(
+            key="upstream-token-id",
+            value=UpstreamTokenSet(
+                upstream_token_id="upstream-token-id",
+                access_token="old-access-token",
+                refresh_token="old-refresh-token",
+                refresh_token_expires_at=now + 3600,
+                expires_at=now - 1,
+                token_type="Bearer",
+                scope="read",
+                client_id="test-client",
+                created_at=now,
+            ),
+            ttl=3600,
+        )
+        client = OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://localhost:12345/callback")],
+        )
+        refresh_token = RefreshToken(
+            token=refresh_value,
+            client_id="test-client",
+            scopes=["read"],
+            expires_at=int(now) + 3600,
+        )
+        return proxy, client, refresh_token
+
+    async def test_invalid_grant_is_sanitized(self, jwt_verifier):
+        proxy, client, refresh_token = await self._make_exchange(
+            jwt_verifier,
+            OAuthError(error="invalid_grant", description="private-idp-detail"),
+        )
+        with pytest.raises(TokenError) as exc_info:
+            await proxy.exchange_refresh_token(client, refresh_token, ["read"])
+        assert exc_info.value.error == "invalid_grant"
+        assert "private-idp-detail" not in (exc_info.value.error_description or "")
+
+    async def test_transient_failure_is_not_invalid_grant(self, jwt_verifier):
+        proxy, client, refresh_token = await self._make_exchange(
+            jwt_verifier,
+            OAuthError(
+                error="temporarily_unavailable",
+                description="private-upstream-detail",
+            ),
+        )
+        with pytest.raises(OAuthError):
+            await proxy.exchange_refresh_token(client, refresh_token, ["read"])
+
+    async def test_local_failure_is_not_invalid_grant(self, jwt_verifier):
+        proxy, client, refresh_token = await self._make_exchange(
+            jwt_verifier, RuntimeError("pg connection exploded")
+        )
+        with pytest.raises(RuntimeError):
+            await proxy.exchange_refresh_token(client, refresh_token, ["read"])


### PR DESCRIPTION
## Description

Fixes #5002.

`OAuthProxy.exchange_refresh_token` mapped every upstream refresh failure to `TokenError("invalid_grant", f"Upstream refresh failed: {e}")`. That mislabels transient and local failures as credential failures (clients discard still-valid credentials on `invalid_grant`) and echoes upstream/internal text to the client.

Only a definitive upstream `invalid_grant` now yields `invalid_grant`, with a static description. Other `OAuthError`s and unexpected exceptions propagate so the endpoint renders a generic 500 without details; the full errors stay in server logs.

Note: the MCP SDK's `TokenErrorCode` literal has no `temporarily_unavailable`/`server_error` member, so a 400-vs-500 distinction is the conformant mapping available here. This supersedes #5011 (auto-closed by the assignment bot before review): transport and local failures are handled explicitly rather than falling through implicitly, and the tests pin all four behaviors from #5002 including no-leak assertions.

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)

## Checklist

- [x] This PR addresses an existing issue via `Fixes #5002`
- [x] I have read CONTRIBUTING.md (including the assignment gate and the AI section; posting no claim comments)
- [x] I have added tests that cover my changes (3 tests; verified they fail pre-fix and pass post-fix)
- [ ] I have run `uv run prek run --all-files` — sparse checkout here, so I ran `ruff format --check`, `ruff check` (zero new findings vs main), and the refresh-related tests in `test_tokens.py` locally; leaving the full suite to CI
- [x] I have self-reviewed my changes
- [x] AI-assisted work followed the repo's contributing conventions (one focused change, cause fix, lean diff)
