### PR TITLE
Drive HTTP server lifespan through ASGI lifecycle to support SIGTERM teardown

### DIFF
--- a/fastmcp_slim/fastmcp/server/mixins/transport.py
+++ b/fastmcp_slim/fastmcp/server/mixins/transport.py
@@ -354,20 +354,23 @@ class TransportMixin:
             config_kwargs["log_level"] = default_log_level_to_use
 
         with temporary_log_level(log_level):
-            async with self._lifespan_manager():
-                config = uvicorn.Config(app, host=host, port=port, **config_kwargs)
-                server = uvicorn.Server(config)
-                path = getattr(app.state, "path", "").lstrip("/")
-                mode = " (stateless)" if stateless_http else ""
-                display_host = _format_host_for_url(host)
-                logger.info(
-                    f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{display_host}:{port}/{path}"
-                )
+            config = uvicorn.Config(app, host=host, port=port, **config_kwargs)
+            server = uvicorn.Server(config)
+            path = getattr(app.state, "path", "").lstrip("/")
+            mode = " (stateless)" if stateless_http else ""
+            display_host = _format_host_for_url(host)
+            logger.info(
+                f"Starting MCP server {self.name!r} with transport {transport!r}{mode} on http://{display_host}:{port}/{path}"
+            )
 
+            try:
                 if sockets is not None:
                     await server.serve(sockets=sockets)
                 else:
                     await server.serve()
+            finally:
+                if server.started and not server.should_exit:
+                    await server.shutdown(sockets=sockets)
 
     def http_app(
         self: FastMCP,

--- a/tests/server/http/test_http_sigterm.py
+++ b/tests/server/http/test_http_sigterm.py
@@ -1,0 +1,93 @@
+"""Tests for HTTP server lifespan teardown on process signals (SIGTERM / SIGINT).
+
+Regression test for Issue #4927: Docker, Kubernetes, and Cloud Run terminate
+containers with SIGTERM. The lifespan teardown must execute before the process
+exits so that connections, buffers, and background tasks are cleanly finalized.
+"""
+
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from fastmcp.utilities.tests import find_available_port
+
+SERVER_SCRIPT = """
+import sys
+from pathlib import Path
+from fastmcp import FastMCP
+from fastmcp.server.lifespan import lifespan
+
+events_file = Path(sys.argv[1])
+port = int(sys.argv[2])
+
+def log_event(name: str):
+    with events_file.open("a") as f:
+        f.write(name + "\\n")
+
+@lifespan
+async def server_lifespan(server):
+    log_event("startup")
+    yield {"db": "connected"}
+    log_event("shutdown")
+
+mcp = FastMCP("SignalTestServer", lifespan=server_lifespan)
+
+@mcp.tool
+def ping() -> str:
+    return "pong"
+
+if __name__ == "__main__":
+    mcp.run(transport="http", host="127.0.0.1", port=port, show_banner=False)
+"""
+
+
+@pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT])
+def test_http_server_lifespan_teardown_on_signal(tmp_path: Path, sig: signal.Signals):
+    """Lifespan teardown must run when the server process receives SIGTERM or SIGINT."""
+    events_file = tmp_path / "events.txt"
+    server_script = tmp_path / "server.py"
+    server_script.write_text(SERVER_SCRIPT)
+
+    port = find_available_port()
+    proc = subprocess.Popen(
+        [sys.executable, str(server_script), str(events_file), str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    # Wait for the startup event to be recorded
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if events_file.exists() and "startup" in events_file.read_text():
+            break
+        if proc.poll() is not None:
+            stdout, stderr = proc.communicate()
+            raise RuntimeError(
+                f"Server exited prematurely with code {proc.returncode}:\nSTDOUT: {stdout}\nSTDERR: {stderr}"
+            )
+        time.sleep(0.05)
+    else:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+        raise TimeoutError(f"Server did not log startup within timeout.\nSTDOUT: {stdout}\nSTDERR: {stderr}")
+
+    # Send the signal
+    proc.send_signal(sig)
+
+    # Wait for process termination
+    try:
+        proc.wait(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+        raise TimeoutError(f"Server did not exit within timeout after {sig.name}.\nSTDOUT: {stdout}\nSTDERR: {stderr}")
+
+    # Assert that teardown ran
+    events = events_file.read_text().splitlines()
+    assert "startup" in events
+    assert "shutdown" in events


### PR DESCRIPTION
Fixes #4927

### Problem
When FastMCP HTTP servers are terminated with `SIGTERM` (the default signal used by Docker, Kubernetes, and Cloud Run), user lifespan teardown hooks do not run. This causes resource leaks (unclosed DB connections, unflushed buffers, orphaned tasks).

### Root Cause
In `run_http_async()`, `_lifespan_manager()` was entered in an outer wrapper around `server.serve()`. Simultaneously, Starlette's ASGI lifespan mechanism inside Uvicorn entered it a second time. Because `_lifespan_manager()` is reference-counted, Uvicorn's ASGI shutdown only decremented the count from 2 to 1 without executing teardown. Uvicorn then re-raised `SIGTERM` via default OS signal handling, killing the process before the outer block could unwind.

### Changes
1. Removed the outer `_lifespan_manager()` block around `server.serve()` in `TransportMixin.run_http_async()`, letting Starlette's ASGI lifespan inside Uvicorn drive the lifecycle.
2. Added a `finally` block in `run_http_async()` to ensure `server.shutdown()` is awaited if the serving task is directly cancelled.
3. Added regression tests in `tests/server/http/test_http_sigterm.py` testing subprocess termination under both `SIGTERM` and `SIGINT`.

### Verification
- `uv run pytest tests/server/http/test_http_sigterm.py`: Passed (both SIGTERM and SIGINT)
- `uv run pytest tests/server/http`: 68 passed
- `uv run prek run --all-files`: Passed cleanly
