### PR TITLE
Raise ToolError when structured serialization fails on a schema-bearing tool

### DIFF
--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -30,6 +30,7 @@ from pydantic import (
 )
 from pydantic.json_schema import SkipJsonSchema
 
+from fastmcp.exceptions import ToolError
 from fastmcp.utilities.authorization import AuthCheck
 from fastmcp.utilities.components import FastMCPComponent
 from fastmcp.utilities.logging import get_logger
@@ -410,7 +411,17 @@ class Tool(FastMCPComponent):
 
         try:
             structured = _serialize_to_jsonable(raw_value, self.return_type)
-        except (pydantic_core.PydanticSerializationError, UnicodeDecodeError):
+        except (pydantic_core.PydanticSerializationError, UnicodeDecodeError) as e:
+            if self.output_schema is not None:
+                # Falling back to text-only content would violate the declared
+                # output schema and surface as a confusing validation error on
+                # the client, so fail the call with the real cause instead.
+                raise ToolError(
+                    f"Tool {self.name!r} declares an output schema but its "
+                    f"return value could not be serialized to structured "
+                    f"content: {e}. Set output_schema=None to disable "
+                    f"structured output."
+                ) from e
             return ToolResult(content=content)
 
         if not is_content_result:

--- a/tests/tools/tool/test_output_schema.py
+++ b/tests/tools/tool/test_output_schema.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import typing
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ from pydantic import AnyUrl, BaseModel, Field, TypeAdapter
 from typing_extensions import TypedDict
 
 from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
 from fastmcp.tools.base import Tool, ToolResult
 from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.types import Audio, File, Image
@@ -715,3 +717,45 @@ class TestUnconstrainedSequenceReturns:
 
         assert [b.type for b in result.content] == ["image", "text"]
         assert png not in json.dumps(result.structured_content or {})
+
+
+class TestUnserializableReturnValues:
+    """A value that fails structured serialization must not become a silent success."""
+
+    async def test_output_schema_tool_raises_tool_error(self):
+        def get_connection_info() -> dict:
+            return {"host": "db1", "lock": threading.Lock()}
+
+        tool = Tool.from_function(get_connection_info)
+        assert tool.output_schema is not None
+
+        with pytest.raises(
+            ToolError, match="could not be serialized to structured content"
+        ):
+            await tool.run({})
+
+    async def test_no_output_schema_tool_keeps_text_fallback(self):
+        def get_connection_info():
+            return {"host": "db1", "lock": threading.Lock()}
+
+        tool = Tool.from_function(get_connection_info)
+        assert tool.output_schema is None
+
+        result = await tool.run({})
+
+        assert result.structured_content is None
+        assert isinstance(result.content[0], TextContent)
+        assert "db1" in result.content[0].text
+
+    async def test_client_receives_error_result_not_silent_success(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        def bad() -> dict:
+            return {"lock": threading.Lock()}
+
+        async with Client(mcp) as client:
+            with pytest.raises(
+                ToolError, match="could not be serialized to structured content"
+            ):
+                await client.call_tool("bad")


### PR DESCRIPTION
When a tool declares an output schema but its return value contains something pydantic can't serialize (a lock, a client handle, a forgotten-`await` coroutine), `convert_result` caught the serialization error and fell back to a text-only result — producing `is_error: false` with the object's `repr` as content and no `structuredContent` at all. That result violates the tool's own declared schema: a non-validating client silently consumes the repr string as data, and a validating client (including FastMCP's own, via the SDK) fails with `RuntimeError: Tool ... has an output schema but did not return structured content`, which points nowhere near the real cause.

The fallback now only applies when the tool has no output schema (where best-effort text content remains the right behavior, unchanged). With a schema declared, the call fails as a `ToolError` naming the value that couldn't be serialized:

```python
@mcp.tool
def get_connection_info() -> dict:
    return {"host": "db1", "lock": threading.Lock()}

# before: is_error=False, content='{"host":"db1","lock":"<unlocked _thread.lock object at 0x...>"}'
# after:  ToolError: Tool 'get_connection_info' declares an output schema but its return
#         value could not be serialized to structured content: Unable to serialize
#         unknown type: <class '_thread.lock'>. Set output_schema=None to disable
#         structured output.
```

Fixes #5030

🤖 Generated with Claude Code
