### PR TITLE
fix(auth): add grace window for concurrent client refresh token rotation

### DIFF
--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/models.py
@@ -32,6 +32,14 @@ DEFAULT_ACCESS_TOKEN_EXPIRY_NO_REFRESH_SECONDS: Final[int] = (
 DEFAULT_REFRESH_TOKEN_EXPIRY_SECONDS: Final[int] = 60 * 60 * 24 * 365  # 1 year
 DEFAULT_AUTH_CODE_EXPIRY_SECONDS: Final[int] = 5 * 60  # 5 minutes
 
+# Grace period after a client-facing refresh token is rotated during which the
+# just-replaced (previous) token is still accepted. A replay inside the window
+# returns the already-issued token pair instead of minting a new rotation, so
+# concurrent /token requests racing on the same refresh token (client retries,
+# multiple tabs, background + foreground refresh) don't fail with invalid_grant
+# and permanently lose the session.
+DEFAULT_ROTATION_GRACE_PERIOD_SECONDS: Final[float] = 45.0
+
 # HTTP client timeout
 HTTP_TIMEOUT_SECONDS: Final[int] = 30
 
@@ -147,6 +155,28 @@ class RefreshTokenMetadata(BaseModel):
     scopes: list[str]
     expires_at: int | None = None
     created_at: float
+
+
+class RefreshGraceRecord(BaseModel):
+    """Replay record for a just-rotated client-facing refresh token.
+
+    Stored keyed by the hash of the *previous* (rotated-out) refresh token for
+    ``rotation_grace_period_seconds`` after rotation. A second request arriving
+    with the previous token inside the window replays the already-issued token
+    pair instead of minting a fresh rotation, tolerating concurrent /token
+    races without allowing indefinite reuse of the old token. Raw tokens never
+    touch storage — both the key and the replayed pair are only usable by a
+    client that already holds them.
+    """
+
+    client_id: str
+    scopes: list[str]
+    rotated_at: float
+    access_token: str
+    refresh_token: str
+    expires_in: int
+    scope: str
+    expires_at: int | None = None
 
 
 def _hash_token(token: str) -> str:

--- a/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
+++ b/fastmcp_slim/fastmcp/server/auth/oauth_proxy/proxy.py
@@ -24,7 +24,7 @@ import time
 from base64 import urlsafe_b64encode
 from collections import OrderedDict
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from contextvars import ContextVar
 from typing import Any, Literal
 from urllib.parse import urlencode
@@ -98,12 +98,14 @@ from fastmcp.server.auth.oauth_proxy.models import (
     DEFAULT_ACCESS_TOKEN_EXPIRY_SECONDS,
     DEFAULT_AUTH_CODE_EXPIRY_SECONDS,
     DEFAULT_REFRESH_TOKEN_EXPIRY_SECONDS,
+    DEFAULT_ROTATION_GRACE_PERIOD_SECONDS,
     HTTP_TIMEOUT_SECONDS,
     ClientCode,
     ConsentCSRFToken,
     JTIMapping,
     OAuthTransaction,
     ProxyDCRClient,
+    RefreshGraceRecord,
     RefreshTokenMetadata,
     UpstreamTokenSet,
     _hash_token,
@@ -270,6 +272,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
     - _client_codes: Authorization codes with PKCE challenges and upstream tokens
     - _jti_mapping_store: Maps FastMCP token JTIs to upstream token IDs
     - _refresh_token_store: Refresh token metadata (keyed by token hash)
+    - _refresh_grace_store: Replay records for just-rotated refresh tokens
 
     All state is stored in the configured client_storage backend (Redis, disk, etc.)
     enabling horizontal scaling across multiple instances.
@@ -341,6 +344,8 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         fastmcp_access_token_expiry_seconds: int | None = None,
         # Token refresh threshold
         token_expiry_threshold_seconds: int = 0,
+        # Grace period for just-rotated client refresh tokens
+        rotation_grace_period_seconds: float = DEFAULT_ROTATION_GRACE_PERIOD_SECONDS,
         # CIMD (Client ID Metadata Document) support
         enable_cimd: bool = True,
         # Identity assertion (SEP-990 ID-JAG) support
@@ -440,6 +445,17 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 a token as expired (default 0). This prevents race conditions where a token
                 passes the expiry check but expires before the next operation completes.
                 For example, set to 30 to refresh tokens that will expire within 30 seconds.
+            rotation_grace_period_seconds: Seconds after a client-facing refresh token
+                is rotated during which the just-replaced token is still accepted
+                (default 45). A replay inside the window returns the already-issued
+                token pair instead of minting a new rotation, so concurrent /token
+                requests racing on the same refresh token (client retries, multiple
+                tabs, background + foreground refresh) don't fail with invalid_grant
+                and permanently lose the session. This mirrors the grace philosophy
+                already applied to the upstream refresh token (see load_access_token).
+                The window should be much shorter than the access token lifetime.
+                Set to 0 or a negative value to disable (a rotated token is rejected
+                immediately).
             enable_cimd: Enable CIMD (Client ID Metadata Document) support for URL-based
                 client IDs. When True, clients can authenticate using HTTPS URLs as client
                 IDs, with metadata fetched from the URL. Supports private_key_jwt auth.
@@ -553,6 +569,7 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             fastmcp_access_token_expiry_seconds
         )
         self._token_expiry_threshold_seconds: int = token_expiry_threshold_seconds
+        self._rotation_grace_period_seconds: float = rotation_grace_period_seconds
 
         if jwt_signing_key is None:
             if upstream_client_secret is None:
@@ -688,6 +705,19 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 key_value=self._client_storage,
                 pydantic_model=RefreshTokenMetadata,
                 default_collection="mcp-refresh-tokens",
+                raise_on_validation_error=True,
+            )
+        )
+
+        # Grace records for just-rotated client refresh tokens, keyed by the
+        # hash of the previous token. Same hashing discipline as
+        # _refresh_token_store: the raw token never touches storage. Records
+        # are TTL-bounded by the grace window so stale entries self-clean.
+        self._refresh_grace_store: PydanticAdapter[RefreshGraceRecord] = (
+            PydanticAdapter[RefreshGraceRecord](
+                key_value=self._client_storage,
+                pydantic_model=RefreshGraceRecord,
+                default_collection="mcp-refresh-grace",
                 raise_on_validation_error=True,
             )
         )
@@ -1719,6 +1749,74 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         _ = idp_tokens
         return None
 
+    def _grace_enabled(self) -> bool:
+        """Whether rotated-refresh-token grace replay is enabled."""
+        return self._rotation_grace_period_seconds > 0
+
+    async def _get_grace_record(
+        self, presented_token: str
+    ) -> RefreshGraceRecord | None:
+        """Return the grace record for a just-rotated refresh token, if live.
+
+        A record that has aged past the grace window is deleted best-effort
+        and treated as absent, so reuse outside the window fails closed with
+        invalid_grant. Records also self-expire via storage TTL; the timestamp
+        check is the source of truth.
+        """
+        if not self._grace_enabled():
+            return None
+        token_hash = _hash_token(presented_token)
+        record = await self._refresh_grace_store.get(key=token_hash)
+        if record is None:
+            return None
+        if time.time() - record.rotated_at > self._rotation_grace_period_seconds:
+            with suppress(Exception):
+                await self._refresh_grace_store.delete(key=token_hash)
+            return None
+        return record
+
+    async def _replay_rotated_refresh(
+        self,
+        client: OAuthClientInformationFull,
+        record: RefreshGraceRecord,
+    ) -> OAuthToken:
+        """Replay the pair already issued for a just-rotated refresh token.
+
+        Returns the exact access/refresh pair minted by the winning rotation
+        without contacting upstream again, so concurrent /token requests
+        converge on one pair. The replacement refresh token must still be live;
+        if it was revoked after rotation the replay is rejected instead of
+        resurrecting it.
+        """
+        if record.client_id != client.client_id:
+            logger.warning(
+                "Rotated refresh token client_id mismatch: expected %s",
+                client.client_id,
+            )
+            raise TokenError("invalid_grant", "Invalid refresh token")
+        replacement = await self._refresh_token_store.get(
+            key=_hash_token(record.refresh_token)
+        )
+        if replacement is None:
+            logger.warning(
+                "Grace replay refused for client=%s: replacement refresh token "
+                "no longer exists (revoked or expired).",
+                client.client_id,
+            )
+            raise TokenError("invalid_grant", "Refresh token has been revoked")
+        logger.info(
+            "Concurrent refresh detected for client=%s within grace window; "
+            "replaying issued pair without a new rotation.",
+            client.client_id,
+        )
+        return OAuthToken(
+            access_token=record.access_token,
+            token_type="Bearer",
+            expires_in=record.expires_in,
+            refresh_token=record.refresh_token,
+            scope=record.scope,
+        )
+
     async def load_refresh_token(
         self,
         client: OAuthClientInformationFull,
@@ -1728,10 +1826,27 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
 
         Looks up by token hash and reconstructs the RefreshToken object.
         Validates that the token belongs to the requesting client.
+
+        A token that was just rotated by a concurrent /token request is still
+        accepted inside the rotation grace window (replaying the rotation);
+        reuse past the window fails closed with invalid_grant.
         """
         token_hash = _hash_token(refresh_token)
         metadata = await self._refresh_token_store.get(key=token_hash)
         if not metadata:
+            grace = await self._get_grace_record(refresh_token)
+            if grace is not None and grace.client_id == client.client_id:
+                logger.info(
+                    "Refresh token recently rotated for client=%s; accepting "
+                    "within grace window instead of invalid_grant.",
+                    client.client_id,
+                )
+                return RefreshToken(
+                    token=refresh_token,
+                    client_id=grace.client_id,
+                    scopes=grace.scopes,
+                    expires_at=grace.expires_at,
+                )
             logger.warning(
                 "Refresh token not found for client=%s (token_hash=%s); it was "
                 "already rotated, expired, or revoked. Rejecting with invalid_grant, "
@@ -1765,11 +1880,13 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
 
         Implements two-tier refresh:
         1. Verify FastMCP refresh token
-        2. Look up upstream token via JTI mapping
-        3. Refresh upstream token with upstream provider
-        4. Update stored upstream token
-        5. Issue new FastMCP access token
-        6. Keep same FastMCP refresh token (unless upstream rotates)
+        2. Replay the already-issued pair if this token was just rotated
+           (grace window for concurrent /token requests)
+        3. Look up upstream token via JTI mapping
+        4. Refresh upstream token with upstream provider
+        5. Update stored upstream token
+        6. Issue new FastMCP access token
+        7. Rotate the FastMCP refresh token (one-time use, with grace replay)
         """
         # Verify FastMCP refresh token
         try:
@@ -1781,9 +1898,42 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             logger.debug("FastMCP refresh token validation failed: %s", e)
             raise TokenError("invalid_grant", "Invalid refresh token") from e
 
+        # Serialize concurrent exchanges of the same refresh token within this
+        # process; cross-process races converge on one pair via the grace
+        # record. Mirrors the advisory-lock + re-read pattern used for the
+        # upstream token in load_access_token.
+        lock = self._get_refresh_lock(f"client-refresh:{refresh_jti}")
+        async with lock:
+            return await self._exchange_refresh_token_locked(
+                client, refresh_token, refresh_jti, scopes
+            )
+
+    async def _exchange_refresh_token_locked(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        refresh_jti: str,
+        scopes: list[str],
+    ) -> OAuthToken:
+        """Refresh body for one FastMCP refresh token.
+
+        The caller must hold the per-refresh-token lock for ``refresh_jti`` so
+        concurrent exchanges of the same token serialize and the loser replays
+        the winner's pair via the grace record instead of rotating again.
+        """
+        # A concurrent request may already have rotated this token: replay the
+        # issued pair inside the grace window instead of rotating again, so all
+        # racers converge on the same pair and nobody gets invalid_grant.
+        if grace := await self._get_grace_record(refresh_token.token):
+            return await self._replay_rotated_refresh(client, grace)
+
         # Look up upstream token via JTI mapping
         jti_mapping = await self._jti_mapping_store.get(key=refresh_jti)
         if not jti_mapping:
+            # A concurrent rotation may have deleted the mapping after our
+            # grace check above; replay if the winner published its record.
+            if grace := await self._get_grace_record(refresh_token.token):
+                return await self._replay_rotated_refresh(client, grace)
             logger.error("JTI mapping not found for refresh token: %s", refresh_jti[:8])
             raise TokenError("invalid_grant", "Refresh token mapping not found")
 
@@ -1817,6 +1967,19 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 )
             logger.debug("Successfully refreshed upstream token")
         except Exception as e:
+            # Another worker may have already rotated this session (consuming
+            # the upstream refresh token), making our upstream refresh fail.
+            # Give the winner a moment to publish its grace record, then replay
+            # it instead of failing with invalid_grant. Mirrors the
+            # reload-and-revalidate fallback in load_access_token.
+            if self._grace_enabled():
+                for _ in range(5):
+                    if grace := await self._get_grace_record(refresh_token.token):
+                        try:
+                            return await self._replay_rotated_refresh(client, grace)
+                        except TokenError:
+                            break
+                    await anyio.sleep(0.1)
             logger.error("Upstream token refresh failed: %s", e)
             raise TokenError("invalid_grant", f"Upstream refresh failed: {e}") from e
 
@@ -1970,12 +2133,6 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
             ttl=refresh_ttl,  # Align with upstream refresh token expiry
         )
 
-        # Invalidate old refresh token (refresh token rotation - enforces one-time use)
-        await self._jti_mapping_store.delete(key=refresh_jti)
-        logger.debug(
-            "Rotated refresh token (old JTI invalidated - one-time use enforced)"
-        )
-
         # Store new refresh token metadata (keyed by hash)
         await self._refresh_token_store.put(
             key=_hash_token(new_fastmcp_refresh),
@@ -1986,6 +2143,36 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
                 created_at=time.time(),
             ),
             ttl=refresh_ttl,
+        )
+
+        # Record the rotation so a concurrent request presenting the just-
+        # replaced refresh token replays this pair inside the grace window
+        # instead of failing with invalid_grant (which would orphan the
+        # session). Written after the replacement entries exist (so replays
+        # always resolve) but before the old entries are deleted (so a crash
+        # between the two favors availability over a lost session). The record
+        # self-expires via TTL; reuse past the window fails closed in the
+        # load/exchange paths.
+        if self._grace_enabled():
+            await self._refresh_grace_store.put(
+                key=_hash_token(refresh_token.token),
+                value=RefreshGraceRecord(
+                    client_id=client.client_id,
+                    scopes=refreshed_scopes,
+                    rotated_at=time.time(),
+                    access_token=new_fastmcp_access,
+                    refresh_token=new_fastmcp_refresh,
+                    expires_in=fastmcp_access_expires_in,
+                    scope=" ".join(refreshed_scopes),
+                    expires_at=int(time.time()) + refresh_ttl,
+                ),
+                ttl=max(int(self._rotation_grace_period_seconds), 1),
+            )
+
+        # Invalidate old refresh token (refresh token rotation - enforces one-time use)
+        await self._jti_mapping_store.delete(key=refresh_jti)
+        logger.debug(
+            "Rotated refresh token (old JTI invalidated - one-time use enforced)"
         )
 
         # Delete old refresh token (by hash)
@@ -2325,6 +2512,8 @@ class OAuthProxy(OAuthProvider, ConsentMixin):
         # For refresh tokens, delete from local storage by hash
         if isinstance(token, RefreshToken):
             await self._refresh_token_store.delete(key=_hash_token(token.token))
+            # A revoked pre-rotation token must not replay its successor.
+            await self._refresh_grace_store.delete(key=_hash_token(token.token))
 
         # ID-JAG access tokens are self-contained and never known upstream, so
         # upstream revocation cannot invalidate them. Track the jti locally so

--- a/tests/server/auth/oauth_proxy/test_refresh_rotation_grace.py
+++ b/tests/server/auth/oauth_proxy/test_refresh_rotation_grace.py
@@ -1,0 +1,340 @@
+"""Tests for client refresh-token rotation grace (issue #4901).
+
+Rotating the client-facing refresh token must not orphan the session when two
+/token requests race on the same refresh token (client retries, multiple
+tabs, background + foreground refresh). The second request arriving inside the
+rotation grace window replays the already-issued pair instead of failing with
+invalid_grant.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+from mcp.server.auth.provider import TokenError
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+from fastmcp.server.auth.auth import RefreshToken, TokenVerifier
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.oauth_proxy.models import (
+    DEFAULT_ROTATION_GRACE_PERIOD_SECONDS,
+    JTIMapping,
+    RefreshTokenMetadata,
+    UpstreamTokenSet,
+    _hash_token,
+)
+
+SCOPES = ["read", "write"]
+
+
+@pytest.fixture
+def jwt_verifier():
+    verifier = Mock(spec=TokenVerifier)
+    verifier.required_scopes = SCOPES
+    verifier.verify_token = AsyncMock(return_value=None)
+    return verifier
+
+
+def _make_proxy(jwt_verifier, **kwargs):
+    return OAuthProxy(
+        upstream_authorization_endpoint="https://idp.example.com/authorize",
+        upstream_token_endpoint="https://idp.example.com/token",
+        upstream_client_id="test-client",
+        upstream_client_secret="test-secret",
+        token_verifier=jwt_verifier,
+        base_url="https://proxy.example.com",
+        jwt_signing_key="test-secret-key",
+        client_storage=MemoryStore(),
+        **kwargs,
+    )
+
+
+async def _register_client(proxy, client_id="test-client"):
+    client = OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret="test-secret",
+        redirect_uris=[AnyUrl("http://localhost:12345/callback")],
+    )
+    await proxy.register_client(client)
+    return client
+
+
+async def _seed_session(proxy, client_id="test-client"):
+    """Seed an upstream session + FastMCP refresh JWT; return the JWT string."""
+    now = time.time()
+    upstream_token_id = f"upstream-{client_id}"
+    await proxy._upstream_token_store.put(
+        key=upstream_token_id,
+        value=UpstreamTokenSet(
+            upstream_token_id=upstream_token_id,
+            access_token="upstream-access-old",
+            refresh_token="upstream-refresh",
+            refresh_token_expires_at=now + 86400,
+            expires_at=now + 3600,
+            token_type="Bearer",
+            scope=" ".join(SCOPES),
+            client_id=client_id,
+            created_at=now,
+            raw_token_data={},
+        ),
+        ttl=86400,
+    )
+    old_jti = f"old-refresh-jti-{client_id}"
+    old_jwt = proxy.jwt_issuer.issue_refresh_token(
+        client_id=client_id,
+        scopes=SCOPES,
+        jti=old_jti,
+        expires_in=86400,
+    )
+    await proxy._jti_mapping_store.put(
+        key=old_jti,
+        value=JTIMapping(
+            jti=old_jti,
+            upstream_token_id=upstream_token_id,
+            created_at=now,
+        ),
+        ttl=86400,
+    )
+    await proxy._refresh_token_store.put(
+        key=_hash_token(old_jwt),
+        value=RefreshTokenMetadata(
+            client_id=client_id,
+            scopes=SCOPES,
+            expires_at=int(now) + 86400,
+            created_at=now,
+        ),
+        ttl=86400,
+    )
+    return old_jwt
+
+
+def _mock_upstream_refresh():
+    """Patch helper: upstream refresh succeeds without rotating its token."""
+    mock_client = Mock()
+    mock_client.refresh_token = AsyncMock(
+        return_value={
+            "access_token": "upstream-access-new",
+            "refresh_token": "upstream-refresh",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+    )
+    mock_client.aclose = AsyncMock()
+    return patch.object(
+        OAuthProxy, "_create_upstream_oauth_client", return_value=mock_client
+    ), mock_client
+
+
+def _as_refresh_token(token_str, client_id="test-client"):
+    return RefreshToken(
+        token=token_str,
+        client_id=client_id,
+        scopes=SCOPES,
+        expires_at=int(time.time()) + 86400,
+    )
+
+
+class TestRotationGracePeriod:
+    def test_default_grace_period(self, jwt_verifier):
+        proxy = _make_proxy(jwt_verifier)
+        assert (
+            proxy._rotation_grace_period_seconds
+            == DEFAULT_ROTATION_GRACE_PERIOD_SECONDS
+            == 45.0
+        )
+
+    async def test_sequential_replay_within_grace_returns_same_pair(self, jwt_verifier):
+        """Second exchange with the rotated-out token replays the issued pair."""
+        proxy = _make_proxy(jwt_verifier)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        old_jwt = await _seed_session(proxy)
+        old = _as_refresh_token(old_jwt)
+
+        patcher, mock_client = _mock_upstream_refresh()
+        with patcher:
+            first = await proxy.exchange_refresh_token(client, old, SCOPES)
+            assert first.refresh_token is not None
+            assert first.refresh_token != old_jwt
+
+            # The load path (run first by the /token handler) also accepts it.
+            loaded = await proxy.load_refresh_token(client, old_jwt)
+            assert loaded is not None
+            assert loaded.token == old_jwt
+            assert loaded.client_id == "test-client"
+
+            second = await proxy.exchange_refresh_token(client, old, SCOPES)
+
+        assert second.access_token == first.access_token
+        assert second.refresh_token == first.refresh_token
+        # No second upstream round-trip: the replay is served from storage.
+        mock_client.refresh_token.assert_awaited_once()
+
+    async def test_concurrent_refresh_converges_on_single_pair(self, jwt_verifier):
+        """Two in-flight exchanges of the same token both succeed identically."""
+        proxy = _make_proxy(jwt_verifier)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        old_jwt = await _seed_session(proxy)
+
+        patcher, mock_client = _mock_upstream_refresh()
+        with patcher:
+            first, second = await asyncio.gather(
+                proxy.exchange_refresh_token(
+                    client, _as_refresh_token(old_jwt), SCOPES
+                ),
+                proxy.exchange_refresh_token(
+                    client, _as_refresh_token(old_jwt), SCOPES
+                ),
+            )
+
+        assert first.refresh_token is not None
+        assert second.access_token == first.access_token
+        assert second.refresh_token == first.refresh_token
+        mock_client.refresh_token.assert_awaited_once()
+
+    async def test_new_token_refreshes_normally_after_rotation(self, jwt_verifier):
+        """Rotation still advances: the replayed pair's refresh token rotates."""
+        proxy = _make_proxy(jwt_verifier)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        old_jwt = await _seed_session(proxy)
+
+        patcher, mock_client = _mock_upstream_refresh()
+        with patcher:
+            first = await proxy.exchange_refresh_token(
+                client, _as_refresh_token(old_jwt), SCOPES
+            )
+            assert first.refresh_token is not None
+            third = await proxy.exchange_refresh_token(
+                client, _as_refresh_token(first.refresh_token), SCOPES
+            )
+
+        assert third.refresh_token != first.refresh_token
+        assert third.access_token != first.access_token
+        assert mock_client.refresh_token.await_count == 2
+
+    async def test_grace_expiry_rejects_old_token(self, jwt_verifier):
+        """Reuse past the window fails closed with invalid_grant."""
+        proxy = _make_proxy(jwt_verifier)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        old_jwt = await _seed_session(proxy)
+
+        patcher, _ = _mock_upstream_refresh()
+        with patcher:
+            first = await proxy.exchange_refresh_token(
+                client, _as_refresh_token(old_jwt), SCOPES
+            )
+            assert first.refresh_token is not None
+
+        # Age the grace record past the window.
+        record = await proxy._refresh_grace_store.get(key=_hash_token(old_jwt))
+        assert record is not None
+        record.rotated_at -= proxy._rotation_grace_period_seconds + 10
+        await proxy._refresh_grace_store.put(
+            key=_hash_token(old_jwt), value=record, ttl=60
+        )
+
+        assert await proxy.load_refresh_token(client, old_jwt) is None
+        patcher, _ = _mock_upstream_refresh()
+        with pytest.raises(TokenError) as exc_info:
+            with patcher:
+                await proxy.exchange_refresh_token(
+                    client, _as_refresh_token(old_jwt), SCOPES
+                )
+        assert exc_info.value.error == "invalid_grant"
+
+    async def test_grace_disabled_rejects_rotated_token_immediately(self, jwt_verifier):
+        """rotation_grace_period_seconds=0 preserves the old fail-fast behavior."""
+        proxy = _make_proxy(jwt_verifier, rotation_grace_period_seconds=0)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        old_jwt = await _seed_session(proxy)
+
+        patcher, _ = _mock_upstream_refresh()
+        with patcher:
+            first = await proxy.exchange_refresh_token(
+                client, _as_refresh_token(old_jwt), SCOPES
+            )
+            assert first.refresh_token is not None
+
+        assert await proxy._refresh_grace_store.get(key=_hash_token(old_jwt)) is None
+        assert await proxy.load_refresh_token(client, old_jwt) is None
+        patcher, _ = _mock_upstream_refresh()
+        with pytest.raises(TokenError) as exc_info:
+            with patcher:
+                await proxy.exchange_refresh_token(
+                    client, _as_refresh_token(old_jwt), SCOPES
+                )
+        assert exc_info.value.error == "invalid_grant"
+
+    async def test_grace_replay_rejects_foreign_client(self, jwt_verifier):
+        """A grace record never crosses client boundaries."""
+        proxy = _make_proxy(jwt_verifier)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        other = await _register_client(proxy, client_id="other-client")
+        old_jwt = await _seed_session(proxy)
+
+        patcher, _ = _mock_upstream_refresh()
+        with patcher:
+            first = await proxy.exchange_refresh_token(
+                client, _as_refresh_token(old_jwt), SCOPES
+            )
+            assert first.refresh_token is not None
+
+        assert await proxy.load_refresh_token(other, old_jwt) is None
+        patcher, _ = _mock_upstream_refresh()
+        with pytest.raises(TokenError) as exc_info:
+            with patcher:
+                await proxy.exchange_refresh_token(
+                    other, _as_refresh_token(old_jwt, client_id="other-client"), SCOPES
+                )
+        assert exc_info.value.error == "invalid_grant"
+
+    async def test_grace_replay_refused_after_replacement_revoked(self, jwt_verifier):
+        """Revoking the replacement pair also closes the replay path."""
+        proxy = _make_proxy(jwt_verifier)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        old_jwt = await _seed_session(proxy)
+
+        patcher, _ = _mock_upstream_refresh()
+        with patcher:
+            first = await proxy.exchange_refresh_token(
+                client, _as_refresh_token(old_jwt), SCOPES
+            )
+            assert first.refresh_token is not None
+
+        await proxy.revoke_token(_as_refresh_token(first.refresh_token))
+
+        patcher, _ = _mock_upstream_refresh()
+        with pytest.raises(TokenError) as exc_info:
+            with patcher:
+                await proxy.exchange_refresh_token(
+                    client, _as_refresh_token(old_jwt), SCOPES
+                )
+        assert exc_info.value.error == "invalid_grant"
+
+    async def test_revoking_old_token_closes_replay(self, jwt_verifier):
+        """Revoking the pre-rotation token deletes its grace record too."""
+        proxy = _make_proxy(jwt_verifier)
+        proxy.set_mcp_path("/mcp")
+        client = await _register_client(proxy)
+        old_jwt = await _seed_session(proxy)
+
+        patcher, _ = _mock_upstream_refresh()
+        with patcher:
+            first = await proxy.exchange_refresh_token(
+                client, _as_refresh_token(old_jwt), SCOPES
+            )
+            assert first.refresh_token is not None
+
+        await proxy.revoke_token(_as_refresh_token(old_jwt))
+
+        assert await proxy._refresh_grace_store.get(key=_hash_token(old_jwt)) is None
+        assert await proxy.load_refresh_token(client, old_jwt) is None


### PR DESCRIPTION
## Race analysis

`OAuthProxy.exchange_refresh_token` rotates the client-facing refresh token and deletes the old JTI mapping + refresh metadata immediately, with no grace period. When two `/token` requests race on the same refresh token (client retries, multiple tabs/sessions, background refresh vs foreground refresh), the loser finds no mapping/metadata and fails with `invalid_grant`, permanently losing the session with no recovery path:

```
POST /token (refresh_token=X) -> 200 OK   (rotates to Y, invalidates X)
POST /token (refresh_token=X) -> 401 invalid_grant
```

Notably, the **upstream** refresh token already gets grace-style treatment in `load_access_token` (advisory lock + re-read, plus a reload-and-revalidate fallback with the "another worker may have already rotated the token" comment). The client-facing token issued by `OAuthProxy` itself had no equivalent. This PR applies that same grace philosophy to the client-facing token.

## Fix

- New `rotation_grace_period_seconds` option on `OAuthProxy` (default **45s**; `<= 0` disables and preserves the old fail-fast behavior) + `DEFAULT_ROTATION_GRACE_PERIOD_SECONDS` constant.
- New `RefreshGraceRecord` model + `mcp-refresh-grace` store in the shared `client_storage` backend (TTL-bounded, keyed by token hash, so it works across workers and self-cleans; raw tokens never touch storage).
- After each rotation, a grace record is written (after the replacement entries exist, before the old ones are deleted). A second request presenting the just-replaced token inside the window **replays the exact already-issued pair** instead of minting a new rotation; reuse past the window fails closed with `invalid_grant`.
- `load_refresh_token` accepts the rotated-out token inside the window (the `/token` handler calls it first); `exchange_refresh_token` replays under a per-token advisory lock (same lock helper as the upstream path), with a grace re-check on JTI-mapping miss and a short poll-and-replay fallback if the upstream refresh fails because another worker already consumed the upstream token.
- Replay is refused (rather than resurrecting) if the replacement pair was revoked; revoking the pre-rotation token also deletes its grace record; cross-client replay is rejected.

## Tests

- New `tests/server/auth/oauth_proxy/test_refresh_rotation_grace.py` (9 tests): default window, sequential replay returns the identical pair with a single upstream call, true-concurrent `asyncio.gather` convergence with one upstream call, rotation still advances via the new token, post-window rejection, disabled-grace fail-fast, foreign-client rejection, revoked-replacement refusal, old-token revocation cleanup.
- `tests/server/auth/oauth_proxy/`: 240 passed + 9 new passed. One `test_e2e` failure and a handful of provider-integration failures (descope/propelauth/scalekit/supabase/workos/jwt-bearer) also fail on the unmodified base in this environment (external-network dependent) — no regressions.
- `ruff check`, `ruff format --check`, and `ty check` pass on the touched files.

Fixes #4901