### PR TITLE
feat: report partial multi-server connections

### DIFF
--- a/docs/clients/client.mdx
+++ b/docs/clients/client.mdx
@@ -220,6 +220,28 @@ async with Client("https://example.com/mcp", mode="auto") as client:
 `mode="auto"` is the default as of FastMCP 4.0. Earlier versions defaulted to `"legacy"`. If a server behaves unexpectedly under discovery, or you depend on the legacy `initialize` result, pin the old behavior with `Client(..., mode="legacy")`.
 
 The SSE transport is legacy-only — it cannot carry the sessionless modern era — so a client connecting over SSE always negotiates the legacy handshake, even under `mode="auto"`. A multi-server config (`MCPConfigTransport` with more than one server) negotiates the best era shared by every connected backend: it stays modern when every backend is modern-capable and reconnects every leg under the handshake era when any backend requires legacy. Pinning `mode="legacy"` or a modern version applies that mode to every backend. All-modern configurations follow normal modern semantics; applications that rely on handshake-era server-initiated sampling or elicitation should pin `mode="legacy"`. To keep each server on its own natively negotiated era instead, use one client per server — [Client Groups](/clients/client-groups) coordinate several independent clients under one tool catalog.
+
+Multi-server configs keep best-effort connection behavior: an unavailable backend is skipped while healthy siblings remain available. To inspect which configured backends were included in the most recent connection attempt, read the transport's `last_connection_report`:
+
+```python
+from fastmcp import Client
+from fastmcp.client.transports import MCPConfigTransport
+
+config = {
+    "mcpServers": {
+        "weather": {"url": "https://example.com/mcp"},
+        "calendar": {"url": "https://example.org/mcp"},
+    }
+}
+transport = MCPConfigTransport(config)
+async with Client(transport):
+    ...
+report = transport.last_connection_report
+if report is not None and report.is_partial:
+    print("Skipped backends:", report.skipped)
+```
+
+The report describes the final connection pass, including any retry after automatic protocol-era fallback. It records connection-attempt membership, not ongoing backend health.
 </Note>
 
 ## Response caching

--- a/fastmcp_slim/fastmcp/client/transports/__init__.py
+++ b/fastmcp_slim/fastmcp/client/transports/__init__.py
@@ -5,7 +5,10 @@ from fastmcp.client.transports.base import (
     ClientTransportT,
     SessionKwargs,
 )
-from fastmcp.client.transports.config import MCPConfigTransport
+from fastmcp.client.transports.config import (
+    MCPConfigConnectionReport,
+    MCPConfigTransport,
+)
 from fastmcp.client.transports.http import StreamableHttpTransport
 from fastmcp.client.transports.inference import infer_transport
 from fastmcp.client.transports.sse import SSETransport
@@ -24,6 +27,7 @@ __all__ = [
     "ClientTransport",
     "FastMCPStdioTransport",
     "FastMCPTransport",
+    "MCPConfigConnectionReport",
     "NodeStdioTransport",
     "NpxStdioTransport",
     "PythonStdioTransport",

--- a/fastmcp_slim/fastmcp/client/transports/config.py
+++ b/fastmcp_slim/fastmcp/client/transports/config.py
@@ -1,5 +1,6 @@
 import contextlib
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mcp import ClientSession
@@ -30,6 +31,19 @@ if TYPE_CHECKING:
     from fastmcp.server.server import FastMCP
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class MCPConfigConnectionReport:
+    """Backends included or skipped by the most recent aggregate attempt."""
+
+    included: tuple[str, ...]
+    skipped: tuple[str, ...]
+
+    @property
+    def is_partial(self) -> bool:
+        """Whether at least one configured backend was skipped."""
+        return bool(self.skipped)
 
 
 class MCPConfigTransport(ClientTransport):
@@ -87,6 +101,7 @@ class MCPConfigTransport(ClientTransport):
         self._transports: list[ClientTransport] = []
         self._request_state_security: RequestStateSecurity | None = None
         self._resolved_legacy_only = False
+        self._last_connection_report: MCPConfigConnectionReport | None = None
 
         if not self.config.mcpServers:
             raise ValueError("No MCP servers defined in the config")
@@ -125,6 +140,15 @@ class MCPConfigTransport(ClientTransport):
         if len(self.config.mcpServers) == 1:
             return self.transport.legacy_only
         return self._resolved_legacy_only
+
+    @property
+    def last_connection_report(self) -> MCPConfigConnectionReport | None:
+        """Report from the most recent multi-server connection attempt.
+
+        This records membership in the last attempt; it does not represent
+        current backend health after the connection context has closed.
+        """
+        return self._last_connection_report
 
     @contextlib.asynccontextmanager
     async def connect_session(
@@ -226,6 +250,7 @@ class MCPConfigTransport(ClientTransport):
         self._transports = []
         backend_versions: list[str] = []
         proxies: dict[str, FastMCP[Any]] = {}
+        skipped_names: list[str] = []
 
         if prepared_transports is None:
             prepared_transports = self._prepare_transports()
@@ -265,6 +290,7 @@ class MCPConfigTransport(ClientTransport):
                     name,
                     exc_info=True,
                 )
+                skipped_names.append(name)
                 continue
             self._transports.append(connected_transport)
             assert client.protocol_version is not None
@@ -276,14 +302,21 @@ class MCPConfigTransport(ClientTransport):
             ):
                 current_mode = "legacy"
 
-        if not self._transports:
-            raise ConnectionError("All MCP servers failed to connect")
-
         # Connection order may prioritize known legacy-only transports, but
         # mounted component order remains the order declared by the user.
         for name in self.config.mcpServers:
             if proxy := proxies.get(name):
                 composite.mount(proxy, namespace=name if self.name_as_prefix else None)
+
+        self._last_connection_report = MCPConfigConnectionReport(
+            included=tuple(name for name in self.config.mcpServers if name in proxies),
+            skipped=tuple(
+                name for name in self.config.mcpServers if name in skipped_names
+            ),
+        )
+
+        if not self._transports:
+            raise ConnectionError("All MCP servers failed to connect")
 
         return composite, backend_versions
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -308,6 +308,41 @@ async def test_failed_known_legacy_backend_does_not_downgrade_healthy_backends()
     assert modern_era.data in MODERN_PROTOCOL_VERSIONS
 
 
+async def test_multi_server_connection_report_records_skipped_backends():
+    @asynccontextmanager
+    async def unavailable_lifespan(
+        server: FastMCP,
+    ) -> AsyncIterator[dict[str, Any]]:
+        if server.name == "unavailable":
+            raise RuntimeError("backend unavailable")
+        yield {}
+
+    healthy = FastMCP("healthy", lifespan=unavailable_lifespan)
+    unavailable = FastMCP("unavailable", lifespan=unavailable_lifespan)
+
+    @healthy.tool(name="health")
+    def health() -> str:
+        return "ok"
+
+    config = MCPConfig(
+        mcpServers={
+            "healthy": InMemoryStdioMCPServer(mcp=healthy),
+            "unavailable": InMemoryStdioMCPServer(mcp=unavailable),
+        }
+    )
+    transport = MCPConfigTransport(config)
+
+    async with Client(transport) as client:
+        result = await client.call_tool("healthy_health", {})
+        assert result.content[0].text == "ok"
+
+    report = transport.last_connection_report
+    assert report is not None
+    assert report.included == ("healthy",)
+    assert report.skipped == ("unavailable",)
+    assert report.is_partial is True
+
+
 @pytest.mark.parametrize(
     ("mode", "is_modern"),
     [("legacy", False), ("2026-07-28", True)],


### PR DESCRIPTION
Fixes #4895

## Summary

- Add an immutable MCPConfigConnectionReport with included/skipped backend names.
- Expose the report as MCPConfigTransport.last_connection_report.
- Record the final connection pass, including after automatic protocol-era fallback, while preserving best-effort startup.
- Document the report and add a regression test for a healthy backend plus a skipped backend.

## Verification

- uv run pytest tests/test_mcp_config.py: 36 passed, 11 skipped.
- uv run ruff check: passed.
- uv run ty check: passed.
- git diff --check: passed.
