### PR TITLE
refactor: let transports propagate client-owned options

### DIFF
--- a/fastmcp_slim/fastmcp/client/client.py
+++ b/fastmcp_slim/fastmcp/client/client.py
@@ -9,7 +9,7 @@ import ssl
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine, Mapping, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
 
@@ -800,17 +800,13 @@ class Client(
 
     @asynccontextmanager
     async def _context_manager(self):
-        transport_options = self._transport_options
-        if (
-            isinstance(self.transport, MCPConfigTransport)
-            and len(self.transport.config.mcpServers) > 1
-        ):
-            # Resolve mutable connection policy here rather than at construction:
-            # both `Client.mode` and an MCPConfig's server set may change before
-            # the client connects. Preserve options contributed by other layers.
-            transport_options = replace(
-                transport_options or TransportOptions(), backend_mode=self.mode
-            )
+        # Resolve mutable connection policy here rather than at construction:
+        # both `Client.mode` and a wrapping transport's backend set may change
+        # before the client connects. The transport owns which client options
+        # it needs; preserve options contributed by other client layers.
+        transport_options = self.transport.get_client_transport_options(
+            mode=self.mode, transport_options=self._transport_options
+        )
 
         # Only passed when this client actually wants non-default settings, so an
         # ordinary client never sends an argument a transport might not accept.

--- a/fastmcp_slim/fastmcp/client/transports/base.py
+++ b/fastmcp_slim/fastmcp/client/transports/base.py
@@ -93,6 +93,20 @@ class ClientTransport(abc.ABC):
     #: `server/discover` (which some servers answer over SSE but then cannot serve).
     legacy_only: bool = False
 
+    def get_client_transport_options(
+        self,
+        *,
+        mode: str,
+        transport_options: TransportOptions | None,
+    ) -> TransportOptions | None:
+        """Add transport-specific options derived from the owning client.
+
+        Wrapping transports can override this hook when they create backend
+        clients that need client-owned connection settings. Returning the
+        existing options unchanged is the default for direct transports.
+        """
+        return transport_options
+
     @abc.abstractmethod
     @contextlib.asynccontextmanager
     async def connect_session(

--- a/fastmcp_slim/fastmcp/client/transports/config.py
+++ b/fastmcp_slim/fastmcp/client/transports/config.py
@@ -1,5 +1,6 @@
 import contextlib
 from collections.abc import AsyncIterator
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from mcp import ClientSession
@@ -125,6 +126,20 @@ class MCPConfigTransport(ClientTransport):
         if len(self.config.mcpServers) == 1:
             return self.transport.legacy_only
         return self._resolved_legacy_only
+
+    def get_client_transport_options(
+        self,
+        *,
+        mode: str,
+        transport_options: TransportOptions | None,
+    ) -> TransportOptions | None:
+        """Pass the owning client's mode into multi-server backend clients."""
+        if len(self.config.mcpServers) == 1:
+            return transport_options
+        return replace(
+            transport_options or TransportOptions(),
+            backend_mode=mode,
+        )
 
     @contextlib.asynccontextmanager
     async def connect_session(

--- a/fastmcp_slim/fastmcp/server/providers/proxy.py
+++ b/fastmcp_slim/fastmcp/server/providers/proxy.py
@@ -1359,13 +1359,8 @@ def _create_client_factory(
             credentials get forwarded upstream.
             """
             fresh = c.new()
-            # The caller chose this client's era, so a multi-server MCPConfig
-            # target's mounted backend legs should negotiate it too rather than
-            # stopping at the composite router (see
-            # `TransportOptions.backend_mode`).
-            fresh._transport_options = replace(
-                _with_proxy_transport_options(fresh._transport_options),
-                backend_mode=fresh.mode,
+            fresh._transport_options = _with_proxy_transport_options(
+                fresh._transport_options
             )
             return fresh
 
@@ -1427,16 +1422,10 @@ def _create_client_factory(
                 if backend_mode is not None:
                     fresh.mode = backend_mode
             if backend_mode is not None:
-                # A multi-server MCPConfig target reaches its real backends
-                # through proxies mounted on a composite router, so setting the
-                # era on this client alone would stop at the router. Carry the
-                # era down to those backend legs too (see
-                # `TransportOptions.backend_mode`), resolved here — at the
-                # moment a client is built for this request — so it tracks the
-                # front era rather than whatever was true at construction.
-                fresh._transport_options = replace(
-                    _with_proxy_transport_options(fresh._transport_options),
-                    backend_mode=backend_mode,
+                # The transport derives any backend-specific options from the
+                # fresh client's mode when it connects.
+                fresh._transport_options = _with_proxy_transport_options(
+                    fresh._transport_options
                 )
             return fresh
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -31,6 +31,7 @@ from fastmcp.client.transports import (
     StdioTransport,
     StreamableHttpTransport,
 )
+from fastmcp.client.transports.base import TransportOptions
 from fastmcp.mcp_config import (
     CanonicalMCPConfig,
     CanonicalMCPServerTypes,
@@ -154,6 +155,36 @@ class TestConfigTransportEraNegotiation:
         }
         transport = MCPConfigTransport(config)
         assert transport.legacy_only is False
+
+    def test_multi_server_transport_adds_client_mode_without_dropping_options(self):
+        config = {
+            "mcpServers": {
+                "a": {"url": "https://a.example.com/mcp"},
+                "b": {"url": "https://b.example.com/mcp"},
+            },
+        }
+        transport = MCPConfigTransport(config)
+        options = TransportOptions(forward_incoming_headers=True)
+
+        resolved = transport.get_client_transport_options(
+            mode="auto", transport_options=options
+        )
+
+        assert resolved is not None
+        assert resolved.backend_mode == "auto"
+        assert resolved.forward_incoming_headers is True
+
+    def test_single_server_transport_leaves_client_options_unchanged(self):
+        config = {"mcpServers": {"only": {"url": "https://example.com/mcp"}}}
+        transport = MCPConfigTransport(config)
+        options = TransportOptions(forward_incoming_headers=True)
+
+        assert (
+            transport.get_client_transport_options(
+                mode="auto", transport_options=options
+            )
+            is options
+        )
 
     def test_transforming_single_server_wrapper_is_legacy_only(self):
         """A single-server config that uses tool transforms or tag filters wraps


### PR DESCRIPTION
Fixes #4894

## Summary

- Move wrapped-backend option propagation behind ClientTransport.get_client_transport_options.
- Let MCPConfigTransport provide backend_mode for multi-server configs.
- Keep ProxyClient focused on proxy-owned session/header options without a concrete transport check.

## Verification

- uv run pytest tests/test_mcp_config.py tests/server/providers/proxy/test_proxy_client.py: 61 passed, 11 skipped.
- uv run ruff check: passed.
- uv run ty check: passed.
- git diff --check: passed.