### PR TITLE
Fix upgrade checks for the M2M storage warning test

### DIFF
--- a/tests/client/auth/test_client_credentials.py
+++ b/tests/client/auth/test_client_credentials.py
@@ -188,7 +188,9 @@ class TestClientCredentialsConstruction:
     def test_in_memory_storage_does_not_warn(self):
         """M2M re-acquires tokens cheaply, so no in-memory storage warning."""
         with warnings.catch_warnings():
-            warnings.simplefilter("error")
+            warnings.filterwarnings(
+                "error", message="Using in-memory token storage", category=UserWarning
+            )
             ClientCredentialsOAuthProvider(
                 SERVER_URL, client_id="cid", client_secret="secret"
             )


### PR DESCRIPTION
The upgrade checks fail with MCP 2.2.0 because the M2M storage test promotes every warning to an error, including the SDK's new missing-issuer deprecation. Scope the assertion to the in-memory storage warning the test promises to prevent, leaving unrelated warnings visible.

Fixes #5034.

![bufo-shh](https://all-the.bufo.zone/bufo-shh.png)

generated with Codex (GPT-6)
