### PR TITLE
docs: fix dead anchor links in cli and storage-backends docs

### DIFF
--- a/docs/v3/cli/running.mdx
+++ b/docs/v3/cli/running.mdx
@@ -69,7 +69,7 @@ fastmcp run mcp.json
 ```
 
 <Warning>
-`fastmcp run` completely ignores the `if __name__ == "__main__"` block. Any setup code in that block won't execute. If you need initialization logic to run, use a [factory function](/cli/overview#factory-functions).
+`fastmcp run` completely ignores the `if __name__ == "__main__"` block. Any setup code in that block won't execute. If you need initialization logic to run, see [Entrypoints](#entrypoints) for factory-function details.
 </Warning>
 
 ### Options

--- a/docs/v3/servers/storage-backends.mdx
+++ b/docs/v3/servers/storage-backends.mdx
@@ -201,7 +201,7 @@ Both parameters are required for production. **Wrap your storage in `FernetEncry
 
 ### Response Caching Middleware
 
-The [Response Caching Middleware](/servers/middleware#caching-middleware) caches tool calls, resource reads, and prompt requests. Storage configuration is passed via the `cache_storage` parameter:
+The [Response Caching Middleware](/servers/middleware#caching) caches tool calls, resource reads, and prompt requests. Storage configuration is passed via the `cache_storage` parameter:
 
 ```python
 from pathlib import Path
@@ -291,6 +291,6 @@ This allows clients to reconnect without re-authenticating after restarts.
 ## More Resources
 
 - [py-key-value-aio GitHub](https://github.com/strawgate/py-key-value) - Full library documentation
-- [Response Caching Middleware](/servers/middleware#caching-middleware) - Using storage for caching
+- [Response Caching Middleware](/servers/middleware#caching) - Using storage for caching
 - [OAuth Token Security](/deployment/http#oauth-token-security) - Production OAuth configuration
 - [HTTP Deployment](/deployment/http) - Complete deployment guide


### PR DESCRIPTION
Three dead anchors in the v3 docs:

- `cli/running.mdx`: linked `/cli/overview#factory-functions` — `overview.mdx` has no such heading; factory functions are documented under this very page's `### Entrypoints` section, so the link now targets it locally
- `servers/storage-backends.mdx` (×2): linked `/servers/middleware#caching-middleware` — the heading is `### Caching` (slug `#caching`)

Docs-only typo/link fixes.