### PR TITLE
docs: repoint three dead context.mdx anchors in middleware.mdx

### DIFF
--- a/docs/v3/servers/middleware.mdx
+++ b/docs/v3/servers/middleware.mdx
@@ -84,7 +84,7 @@ parent.mount(child, namespace="child")
 
 Requests to `child_tool` flow through the parent's `AuthMiddleware` first, then through the child's `LoggingMiddleware`.
 
-Middleware-stored state does not automatically cross mount boundaries. If `AuthMiddleware` on the parent calls `ctx.set_state("user_id", ...)`, a tool on the child server calling `ctx.get_state("user_id")` will get `None` — each `FastMCP` instance owns its own session state store. To share state across the mount, either pass the same `session_state_store` to both servers or use `serializable=False` for request-scoped values. See [State and Mounted Servers](/servers/context#state-and-mounted-servers) for details.
+Middleware-stored state does not automatically cross mount boundaries. If `AuthMiddleware` on the parent calls `ctx.set_state("user_id", ...)`, a tool on the child server calling `ctx.get_state("user_id")` will get `None` — each `FastMCP` instance owns its own session state store. To share state across the mount, either pass the same `session_state_store` to both servers or use `serializable=False` for request-scoped values. See [Session State](/servers/context#session-state) for details.
 
 ## Hooks
 
@@ -326,7 +326,7 @@ async def on_request(self, context: MiddlewareContext, call_next):
     return await call_next(context)
 ```
 
-For HTTP-specific data (headers, client IP) when using HTTP transports, see [HTTP Requests](/servers/context#http-requests).
+For HTTP-specific data (headers, client IP) when using HTTP transports, see [Dependency Injection](/servers/dependency-injection).
 
 ## Built-in Middleware
 
@@ -795,7 +795,7 @@ def get_user_data(ctx: Context) -> str:
     return f"Data for user: {user_id}"
 ```
 
-See [Context State Management](/servers/context#state-management) for details.
+See [Session State](/servers/context#session-state) for details.
 
 ### Constructor Parameters
 


### PR DESCRIPTION
Three links from `servers/middleware.mdx` into `servers/context.mdx` targeted anchors that don't exist (`#state-and-mounted-servers`, `#http-requests`, `#state-management`). Repointed to the real targets: the `Session State` section (×2) and the Dependency Injection page (where HTTP-request access is documented, per context.mdx's own pointer). Docs-only link fixes.