### PR TITLE
docs: repoint two more dead context.mdx anchors in middleware.mdx

### DIFF
--- a/docs/v3/servers/middleware.mdx
+++ b/docs/v3/servers/middleware.mdx
@@ -326,7 +326,7 @@ async def on_request(self, context: MiddlewareContext, call_next):
     return await call_next(context)
 ```
 
-For HTTP-specific data (headers, client IP) when using HTTP transports, see [HTTP Requests](/servers/context#http-requests).
+For HTTP-specific data (headers, client IP) when using HTTP transports, see [HTTP Requests](/servers/dependency-injection).
 
 ## Built-in Middleware
 
@@ -795,7 +795,7 @@ def get_user_data(ctx: Context) -> str:
     return f"Data for user: {user_id}"
 ```
 
-See [Context State Management](/servers/context#state-management) for details.
+See [Context State Management](/servers/context#session-state) for details.
 
 ### Constructor Parameters
 


### PR DESCRIPTION
Follow-up to #5045: two more links from `servers/middleware.mdx` into `servers/context.mdx` targeted anchors that don't exist (`#http-requests` at :329, `#state-management` at :798). Repointed: HTTP-request access is documented under the Dependency Injection page (per context.mdx's own pointer), and Context State Management maps to the `Session State` section. Docs-only.