### PR TITLE
fix(openapi): flatten discriminator mappings nested in request bodies

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/schemas.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/schemas.py
@@ -370,6 +370,69 @@ def _flatten_discriminator_subtypes(
     return properties
 
 
+def _flatten_nested_discriminator_subtypes(
+    schema: dict[str, Any],
+    schema_defs: dict[str, Any],
+    _seen: set[str] | None = None,
+) -> None:
+    """Flatten discriminator mappings on schemas nested below the request body.
+
+    The body schema itself is flattened by the caller, but a discriminated
+    union can equally sit inside an envelope property, array items, or a
+    free-form map value. Left as a bare ``$ref``, such a schema advertises
+    nothing but the discriminator property once composition keywords are
+    cleaned for display. The ref is replaced with the flattened schema
+    inline, so the mapped subtypes are pruned from ``$defs`` exactly as they
+    are at the top level.
+    """
+    if _seen is None:
+        _seen = set()
+
+    nested: list[tuple[dict[str, Any], Any]] = []
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        nested.extend(
+            (props, key) for key, value in props.items() if isinstance(value, dict)
+        )
+    nested.extend(
+        (schema, key)
+        for key in ("items", "additionalProperties")
+        if isinstance(schema.get(key), dict)
+    )
+
+    for container, key in nested:
+        child = container[key]
+        target = child
+        ref = child.get("$ref")
+        if isinstance(ref, str):
+            name = ref.rsplit("/", 1)[-1]
+            if name in _seen:
+                continue
+            resolved = schema_defs.get(name)
+            if not isinstance(resolved, dict):
+                continue
+            target = resolved
+            _seen.add(name)
+
+        flattened = _flatten_discriminator_subtypes(target, schema_defs)
+        if flattened is not None:
+            if target is child:
+                # An inline schema is rewritten in place, as at the top level.
+                child["properties"] = flattened
+                child.pop("discriminator", None)
+            else:
+                replacement: dict[str, Any] = {
+                    "type": "object",
+                    "properties": flattened,
+                }
+                if isinstance(target.get("required"), list):
+                    replacement["required"] = target["required"]
+                if isinstance(target.get("description"), str):
+                    replacement["description"] = target["description"]
+                container[key] = replacement
+        _flatten_nested_discriminator_subtypes(container[key], schema_defs, _seen)
+
+
 def _combine_schemas_and_map_params(
     route: HTTPRoute,
     convert_refs: bool = True,
@@ -451,6 +514,11 @@ def _combine_schemas_and_map_params(
         if flattened_props is not None:
             body_schema["properties"] = flattened_props
             body_schema.pop("discriminator", None)
+
+        # The same flattening applies below the top level, where the
+        # discriminated schema is reached through a $ref (or inline) rather
+        # than being the body schema itself.
+        _flatten_nested_discriminator_subtypes(body_schema, route.request_schemas)
 
         body_props = body_schema.get("properties", {})
 

--- a/tests/server/providers/openapi/test_openapi_discriminator.py
+++ b/tests/server/providers/openapi/test_openapi_discriminator.py
@@ -284,3 +284,131 @@ class TestDiscriminatorRequestBodies:
 
         assert set(schema["properties"]) == {"petType", "meowVolume"}
         assert sorted(schema["required"]) == ["meowVolume", "petType"]
+
+
+def envelope_discriminator_spec(
+    mapping: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """The discriminated parent nested one level below the request body."""
+    spec = discriminator_spec(mapping=mapping)
+    spec["components"]["schemas"]["PetEnvelope"] = {
+        "type": "object",
+        "required": ["pet"],
+        "properties": {"pet": {"$ref": "#/components/schemas/Pet"}},
+    }
+    body = spec["paths"]["/pets"]["post"]["requestBody"]["content"]
+    body["application/json"]["schema"] = {"$ref": "#/components/schemas/PetEnvelope"}
+    return spec
+
+
+def array_envelope_discriminator_spec() -> dict[str, Any]:
+    """The discriminated parent nested inside an array of envelope items."""
+    spec = envelope_discriminator_spec()
+    envelope = spec["components"]["schemas"]["PetEnvelope"]
+    envelope["properties"] = {
+        "pets": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/Pet"},
+        }
+    }
+    envelope["required"] = ["pets"]
+    return spec
+
+
+class TestNestedDiscriminatorRequestBodies:
+    """A discriminated schema below the top level flattens like the body itself."""
+
+    async def test_subtype_fields_are_advertised(self):
+        """Fields reachable only through the nested mapping reach the schema."""
+        schema = await tool_schema(envelope_discriminator_spec())
+
+        pet = schema["properties"]["pet"]
+        assert pet["type"] == "object"
+        assert pet["properties"].keys() >= {"petType", "meowVolume", "packSize"}
+
+    async def test_subtype_fields_are_optional(self):
+        """Only the discriminator is required inside the nested schema."""
+        schema = await tool_schema(envelope_discriminator_spec())
+
+        assert schema["properties"]["pet"]["required"] == ["petType"]
+        assert schema["required"] == ["pet"]
+
+    async def test_discriminator_property_describes_the_variants(self):
+        """The nested discriminator names which fields belong to which variant."""
+        schema = await tool_schema(envelope_discriminator_spec())
+
+        description = schema["properties"]["pet"]["properties"]["petType"][
+            "description"
+        ]
+        assert "meowVolume" in description
+        assert "packSize" in description
+
+    async def test_discriminator_keyword_is_dropped(self):
+        """The nested mapping points at defs that no longer survive."""
+        schema = await tool_schema(envelope_discriminator_spec())
+
+        assert "discriminator" not in schema["properties"]["pet"]
+        assert (
+            "discriminator" not in schema["properties"]["pet"]["properties"]["petType"]
+        )
+
+    async def test_subtype_fields_reach_the_request_body(self):
+        """The reported failure: meowVolume must reach the upstream API."""
+        received: dict[str, object] = {}
+
+        def handler(request):
+            received["body"] = json.loads(request.content)
+            return httpx2.Response(200, json={"ok": True})
+
+        async with httpx2.AsyncClient(
+            transport=httpx2.MockTransport(handler),
+            base_url="https://api.example.com",
+        ) as client:
+            server = create_openapi_server(envelope_discriminator_spec(), client)
+            async with Client(server) as mcp_client:
+                await mcp_client.call_tool(
+                    "create_pet",
+                    {"pet": {"petType": "cat", "meowVolume": 11}},
+                )
+
+        assert received["body"] == {"pet": {"petType": "cat", "meowVolume": 11}}
+
+    async def test_array_items_are_flattened(self):
+        """A discriminated schema under array items flattens the same way."""
+        schema = await tool_schema(array_envelope_discriminator_spec())
+
+        pet = schema["properties"]["pets"]["items"]
+        assert pet["properties"].keys() >= {"petType", "meowVolume", "packSize"}
+        assert pet["required"] == ["petType"]
+
+    async def test_unresolvable_mapping_is_ignored(self):
+        """An unusable mapping leaves the nested schema as it was."""
+        schema = await tool_schema(
+            envelope_discriminator_spec(mapping={"cat": "#/components/schemas/Missing"})
+        )
+
+        pet = schema["properties"]["pet"]
+        assert set(pet.get("properties", {})) <= {"petType"}
+
+    async def test_subtype_envelope_body_is_unaffected(self):
+        """A nested child ref keeps its allOf shape; merging stays top-level."""
+        spec = envelope_discriminator_spec()
+        spec["components"]["schemas"]["PetEnvelope"]["properties"] = {
+            "cat": {"$ref": "#/components/schemas/Cat"}
+        }
+        spec["components"]["schemas"]["PetEnvelope"]["required"] = ["cat"]
+
+        schema = await tool_schema(spec)
+
+        cat = schema["properties"]["cat"]
+        members = cat.get("allOf", [])
+        if members:
+            declared = {
+                prop
+                for member in members
+                if isinstance(member, dict)
+                for prop in member.get("properties", {})
+            }
+            assert declared == {"petType", "meowVolume"}
+        else:
+            assert set(cat["properties"]) == {"petType", "meowVolume"}


### PR DESCRIPTION
## What

`OpenAPIProvider` now flattens discriminated unions that sit *below* the top level of a request body — inside an envelope property, array items, or a map value — the same way it already flattens a discriminated body schema itself.

## Why

Fixes #5029.

When the discriminated schema is one level down, the body schema itself carries no discriminator, so the existing flattening never ran: the emitted tool schema kept a bare `$ref` to the parent, which — once composition keywords are cleaned for display — advertises nothing but the discriminator property. A model calling the tool cannot see or send any variant field.

## How

`_combine_schemas_and_map_params` already flattens the top-level body schema via `_flatten_discriminator_subtypes`. The new `_flatten_nested_discriminator_subtypes` walks the body schema's `properties`, `items`, and `additionalProperties` (the same positions `clean_schema_for_display` recurses through) and applies the same flattening wherever a usable `discriminator.mapping` is reachable — through a `$ref` or inline. The flattened schema replaces the ref inline, so the mapped subtypes drop out of `$defs` exactly as at the top level. Ref-name tracking guards against definition cycles.

## Verification

- New `TestNestedDiscriminatorRequestBodies` in `tests/server/providers/openapi/test_openapi_discriminator.py`: envelope property, array items, request payload round-trip to the upstream API, unresolvable mapping ignored, and child-ref shape unchanged (8 tests).
- Full affected suites: `tests/server/providers/openapi/` + `tests/utilities/openapi/` — 320 passed. `ruff check`, `ruff format`, and `ty` clean.
- The MRE from the issue now advertises `petType`/`meowVolume`/`barkVolume` on the nested `pet` with the variant description, and a selected variant field reaches the upstream request body.
