### PR TITLE
fix(openapi): encode JSON scalar request bodies

### DIFF
--- a/docs/integrations/openapi.mdx
+++ b/docs/integrations/openapi.mdx
@@ -454,6 +454,12 @@ FastMCP handles array parameters according to OpenAPI specifications:
 
 Header parameters are automatically converted to strings and included in the HTTP request.
 
+### JSON Request Bodies
+
+For request bodies declared as `application/json` or a `+json` media type, pass strings, numbers, and booleans as their actual values. FastMCP JSON-encodes them and preserves the declared Content-Type, including media-type parameters. Do not JSON-encode a string yourself: passing `"true"` sends the JSON string `"true"`, while passing `True` sends the JSON boolean `true`.
+
+Earlier versions sent string bodies as raw text even when the schema declared JSON. If you worked around that behavior by pre-encoding a string, remove the extra encoding. Bodies declared as `text/plain` continue to be sent as raw text.
+
 ### Composed Request Bodies
 
 A request body becomes a flat set of tool arguments, which is the shape LLM tool-calling APIs fill in most reliably. Schemas composed with `allOf` are resolved first, following `$ref` members, so fields inherited from a parent schema appear alongside the ones a schema declares itself.

--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -73,7 +73,7 @@ class RequestDirector:
         method: str = route.method.upper()
         params = query_params if query_params else None
         headers = header_params if header_params else None
-        json_body: dict[str, Any] | list[Any] | None = None
+        json_body: dict[str, Any] | list[Any] | str | int | float | bool | None = None
         content: str | bytes | None = None
 
         # Step 5: Determine the declared content type from the OpenAPI spec.
@@ -122,7 +122,14 @@ class RequestDirector:
                 and isinstance(body, dict)
             ):
                 data = body
-            elif isinstance(body, dict | list):
+            elif (
+                isinstance(body, dict | list)
+                or declared_content_type == "application/json"
+                or (
+                    declared_content_type is not None
+                    and declared_content_type.endswith("+json")
+                )
+            ):
                 if (
                     declared_content_type is not None
                     and declared_content_type != "application/json"

--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -132,13 +132,12 @@ class RequestDirector:
             ):
                 if (
                     declared_content_type is not None
-                    and declared_content_type != "application/json"
+                    and raw_content_type != "application/json"
                     and "json" in declared_content_type
                 ):
-                    # JSON-compatible types like application/json-patch+json
-                    # or application/merge-patch+json need an explicit
-                    # Content-Type header since httpx's json= always
-                    # sets application/json.
+                    # JSON media types with parameters or custom subtypes need
+                    # an explicit Content-Type header since httpx's json=
+                    # always sets bare application/json.
                     content = _json.dumps(body, allow_nan=False).encode("utf-8")
                     headers = dict(headers) if headers else {}
                     headers["Content-Type"] = raw_content_type

--- a/tests/server/providers/openapi/test_json_request_bodies.py
+++ b/tests/server/providers/openapi/test_json_request_bodies.py
@@ -1,0 +1,69 @@
+"""JSON scalar request bodies retain their type through OpenAPI tool calls."""
+
+import json
+
+import httpx2
+import pytest
+
+from fastmcp import Client, FastMCP
+
+
+@pytest.mark.parametrize(
+    "media_type",
+    [
+        "application/json",
+        "application/vnd.example+json",
+        "application/merge-patch+json; charset=utf-8",
+    ],
+)
+@pytest.mark.parametrize(
+    "schema_type,value",
+    [
+        ("string", "hello"),
+        ("string", "true"),
+        ("string", ""),
+        ("string", 'café "quoted"\ntext'),
+        ("integer", 42),
+        ("integer", 0),
+        ("number", 1.25),
+        ("boolean", True),
+        ("boolean", False),
+    ],
+)
+async def test_scalar_json_body_reaches_http_endpoint(
+    media_type: str, schema_type: str, value: str | int | float | bool
+) -> None:
+    spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "Scalar API", "version": "1.0"},
+        "paths": {
+            "/value": {
+                "post": {
+                    "operationId": "set_value",
+                    "requestBody": {
+                        "required": True,
+                        "content": {media_type: {"schema": {"type": schema_type}}},
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+    }
+    requests: list[httpx2.Request] = []
+
+    def capture(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, json={"ok": True})
+
+    async with httpx2.AsyncClient(
+        base_url="https://example.com", transport=httpx2.MockTransport(capture)
+    ) as http_client:
+        server = FastMCP.from_openapi(openapi_spec=spec, client=http_client)
+        async with Client(server) as client:
+            await client.call_tool("set_value", {"body": value})
+
+    assert len(requests) == 1
+    assert requests[0].headers["content-type"] == media_type
+    decoded = json.loads(requests[0].content)
+    assert decoded == value
+    assert type(decoded) is type(value)

--- a/tests/server/providers/openapi/test_json_request_bodies.py
+++ b/tests/server/providers/openapi/test_json_request_bodies.py
@@ -12,6 +12,8 @@ from fastmcp import Client, FastMCP
     "media_type",
     [
         "application/json",
+        "application/json; charset=utf-8",
+        'application/json; profile="https://example.com/schema"',
         "application/vnd.example+json",
         "application/merge-patch+json; charset=utf-8",
     ],

--- a/tests/utilities/openapi/test_director.py
+++ b/tests/utilities/openapi/test_director.py
@@ -476,7 +476,15 @@ class TestContentTypeHandling:
         assert request.headers["content-type"] == "application/merge-patch+json"
         assert json.loads(request.content) == {"name": "test"}
 
-    def test_content_type_preserves_media_type_parameters(self, director):
+    @pytest.mark.parametrize(
+        "media_type",
+        [
+            "application/json-patch+json; charset=utf-8",
+            "application/json; charset=utf-8",
+            'application/json; profile="https://example.com/schema"',
+        ],
+    )
+    def test_content_type_preserves_media_type_parameters(self, director, media_type):
         """Media-type parameters like charset are preserved on the wire."""
         route = HTTPRoute(
             path="/items",
@@ -485,7 +493,7 @@ class TestContentTypeHandling:
             request_body=RequestBodyInfo(
                 required=True,
                 content_schema={
-                    "application/json-patch+json; charset=utf-8": {
+                    media_type: {
                         "type": "object",
                         "properties": {"name": {"type": "string"}},
                     }
@@ -497,10 +505,7 @@ class TestContentTypeHandling:
         )
 
         request = director.build(route, {"name": "test"}, "https://example.com")
-        assert (
-            request.headers["content-type"]
-            == "application/json-patch+json; charset=utf-8"
-        )
+        assert request.headers["content-type"] == media_type
         assert json.loads(request.content) == {"name": "test"}
 
     def test_custom_content_type_preserves_other_headers(self, director):


### PR DESCRIPTION
OpenAPI tools declaring JSON scalar request bodies sent strings as raw content and raised `TypeError` for numeric and boolean values. For example, a tool argument `{"body": "true"}` was sent as the JSON boolean `true`, changing the caller's data type. The request director now applies JSON encoding to scalar bodies declared as `application/json` or a `+json` media type, preserving declared media-type parameters such as `charset` and `profile` in the outgoing header.

The 358 focused OpenAPI tests pass, including 45 scalar request cases and coverage for parameterized object requests. The 20 parameter-preservation cases added after review fail before the follow-up fix. Full-suite testing on Windows stopped with six failures, all reproduced against the unmodified upstream commit; the native Windows type check also reports existing test-platform diagnostics. Type checking passes for the changed files and for the full repository targeting Linux.

Fixes #5028.

Generated with OpenAI Codex.
