### PR TITLE
fix(openapi): flatten nested discriminated schemas in request bodies

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/schemas.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/schemas.py
@@ -370,6 +370,46 @@ def _flatten_discriminator_subtypes(
     return properties
 
 
+def _flatten_nested_discriminator(
+    prop_schema: Any,
+    schema_defs: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Inline one nested property's discriminated schema like the top-level body.
+
+    ``_combine_schemas_and_map_params`` flattens the discriminator carried by
+    the request body itself, but a discriminated schema nested one level down
+    (e.g. an envelope object holding a ``pet``) keeps a bare ``$ref`` while
+    its sibling subtypes are pruned from ``$defs``. The subtype fields then
+    disappear from the tool schema even though the parent still validates
+    them upstream.
+
+    Returns a replacement object schema for the property, or None when the
+    property does not reference a usable discriminated schema (left untouched).
+    Only one level is expanded; deeper nesting keeps the previous behavior.
+    """
+    if not isinstance(prop_schema, dict):
+        return None
+    target = prop_schema
+    ref = prop_schema.get("$ref")
+    if isinstance(ref, str):
+        name = _discriminator_target_name(ref)
+        target = schema_defs.get(name) if name else None
+        if not isinstance(target, dict):
+            return None
+    flattened = _flatten_discriminator_subtypes(target, schema_defs)
+    if flattened is None:
+        return None
+    nested = {
+        key: value
+        for key, value in target.items()
+        if key not in ("$ref", "discriminator", "properties")
+    }
+    nested["properties"] = flattened
+    if "type" not in nested:
+        nested["type"] = "object"
+    return nested
+
+
 def _combine_schemas_and_map_params(
     route: HTTPRoute,
     convert_refs: bool = True,
@@ -451,6 +491,17 @@ def _combine_schemas_and_map_params(
         if flattened_props is not None:
             body_schema["properties"] = flattened_props
             body_schema.pop("discriminator", None)
+
+        # Merge discriminated subtype fields one level down as well, so a
+        # nested discriminated schema is advertised the same way the
+        # top-level body is instead of keeping a bare $ref.
+        if isinstance(body_schema.get("properties"), dict):
+            for prop_name, prop_schema in list(body_schema["properties"].items()):
+                nested = _flatten_nested_discriminator(
+                    prop_schema, route.request_schemas
+                )
+                if nested is not None:
+                    body_schema["properties"][prop_name] = nested
 
         body_props = body_schema.get("properties", {})
 

--- a/tests/server/providers/openapi/test_openapi_discriminator.py
+++ b/tests/server/providers/openapi/test_openapi_discriminator.py
@@ -173,6 +173,128 @@ async def tool_schema(spec: dict[str, Any]) -> dict[str, Any]:
             return next(t for t in tools if t.name == "create_pet").input_schema
 
 
+def nested_envelope_spec() -> dict[str, Any]:
+    """A discriminated schema nested one level down (issue #5029 shape).
+
+    ``PetEnvelope`` holds a ``pet`` property referencing the discriminated
+    ``Pet`` parent; ``Cat``/``Dog`` add their own fields through ``allOf``.
+    """
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Pet API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/pets": {
+                "post": {
+                    "operationId": "createPet",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/PetEnvelope"}
+                            }
+                        },
+                    },
+                    "responses": {"200": {"description": "Created"}},
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "PetEnvelope": {
+                    "type": "object",
+                    "required": ["pet"],
+                    "properties": {"pet": {"$ref": "#/components/schemas/Pet"}},
+                },
+                "Pet": {
+                    "type": "object",
+                    "required": ["petType"],
+                    "properties": {"petType": {"type": "string"}},
+                    "discriminator": {
+                        "propertyName": "petType",
+                        "mapping": {
+                            "cat": "#/components/schemas/Cat",
+                            "dog": "#/components/schemas/Dog",
+                        },
+                    },
+                },
+                "Cat": {
+                    "allOf": [
+                        {"$ref": "#/components/schemas/Pet"},
+                        {
+                            "type": "object",
+                            "required": ["meowVolume"],
+                            "properties": {"meowVolume": {"type": "integer"}},
+                        },
+                    ]
+                },
+                "Dog": {
+                    "allOf": [
+                        {"$ref": "#/components/schemas/Pet"},
+                        {
+                            "type": "object",
+                            "required": ["barkVolume"],
+                            "properties": {"barkVolume": {"type": "number"}},
+                        },
+                    ]
+                },
+            }
+        },
+    }
+
+
+async def nested_pet_schema() -> dict[str, Any]:
+    """Return the generated ``pet`` property schema for the envelope spec."""
+    schema = await tool_schema(nested_envelope_spec())
+    assert set(schema["properties"]) == {"pet"}
+    return schema["properties"]["pet"]
+
+
+class TestNestedDiscriminator:
+    """A discriminated schema one level down is advertised like the top level."""
+
+    async def test_nested_subtype_fields_are_advertised(self):
+        """Variant-only fields must not disappear behind a bare $ref (#5029)."""
+        pet = await nested_pet_schema()
+
+        assert "$ref" not in pet
+        assert pet["properties"].keys() >= {"petType", "meowVolume", "barkVolume"}
+
+    async def test_nested_subtype_fields_are_optional(self):
+        """Only the parent's own required fields stay required."""
+        pet = await nested_pet_schema()
+
+        assert pet["required"] == ["petType"]
+
+    async def test_nested_discriminator_keyword_is_dropped(self):
+        """The mapping points at pruned $defs, so it cannot survive."""
+        pet = await nested_pet_schema()
+
+        assert "discriminator" not in pet
+        assert "discriminator" not in pet["properties"]["petType"]
+
+    async def test_nested_variant_field_reaches_the_request_body(self):
+        """The reported failure: meowVolume must reach the upstream API."""
+        received: dict[str, object] = {}
+
+        def handler(request):
+            received["body"] = json.loads(request.content)
+            return httpx2.Response(200, json={"ok": True})
+
+        async with httpx2.AsyncClient(
+            transport=httpx2.MockTransport(handler),
+            base_url="https://api.example.com",
+        ) as client:
+            server = create_openapi_server(nested_envelope_spec(), client)
+            async with Client(server) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "createPet", {"pet": {"petType": "cat", "meowVolume": 11}}
+                )
+
+        assert result.structured_content == {"ok": True}
+        assert received["body"] == {"pet": {"petType": "cat", "meowVolume": 11}}
+
+
 class TestDiscriminatorRequestBodies:
     """Subtypes named by a discriminator mapping are flattened in as optional."""
 


### PR DESCRIPTION
## Root Cause
_combine_schemas_and_map_params flattens the discriminator carried by the request body itself, but a discriminated schema nested one level down (e.g. an envelope object holding a pet property that refs a discriminated parent) keeps a bare ref while its sibling subtypes are pruned from defs. The subtype fields then disappear from the tool schema even though the upstream API still validates them. Fixes #5029.

## Fix
After the top-level flatten, walk the body properties: any property whose (ref-resolved) schema carries a usable discriminator mapping is replaced with an inline object schema carrying the same flattened properties the top-level case produces (subtype fields optional, parent required kept, discriminator keyword dropped). Only one level is expanded; deeper nesting keeps the previous behavior. Unresolvable refs and non-discriminated properties are untouched.

## Test
- New TestNestedDiscriminator in tests/server/providers/openapi/test_openapi_discriminator.py (4 cases: fields advertised, fields optional, keyword dropped, variant field reaches upstream body).
- Verified the issue repro locally: nested pet previously emitted a bare ref, now emits flattened properties with the variant note (full CI run left to GitHub Actions).
- ruff check + ruff format clean on both files.

## Diff scope
2 files, +173 (schemas.py +51, discriminator tests +122).