### PR TITLE
Advertise the MCP Apps extension only when the server serves an app

### DIFF
--- a/docs/apps/low-level.mdx
+++ b/docs/apps/low-level.mdx
@@ -291,7 +291,7 @@ The tool generates a QR code as a base64 PNG. The resource loads the MCP Apps JS
 
 ## Checking client support
 
-Not all hosts support the Apps extension. You can check at runtime using the tool's [context](/servers/context):
+Not all hosts support the Apps extension, and a server declares `io.modelcontextprotocol/ui` in `capabilities.extensions` only while it has an app to serve — a tool carrying `_meta.ui`, or a `ui://` resource. A host that supports the extension declares it back, which is what you check at runtime using the tool's [context](/servers/context):
 
 ```python
 from fastmcp import Context

--- a/fastmcp_slim/fastmcp/apps/config.py
+++ b/fastmcp_slim/fastmcp/apps/config.py
@@ -185,6 +185,22 @@ def app_config_to_meta_dict(app: AppConfig | dict[str, Any]) -> dict[str, Any]:
     return app
 
 
+def component_serves_app(component: FastMCPComponent) -> bool:
+    """Whether a component participates in the MCP Apps extension.
+
+    A component does so by declaring ``meta["ui"]`` (``app=AppConfig(...)`` on a
+    tool or resource) or by being the UI document itself: a ``ui://`` resource,
+    or any resource the host would render as ``UI_MIME_TYPE``.
+    """
+    if component.meta and "ui" in component.meta:
+        return True
+    # `Resource.uri` is an AnyUrl, so compare on the string form.
+    uri = getattr(component, "uri", None) or getattr(component, "uri_template", None)
+    if uri is not None and str(uri).lower().startswith("ui://"):
+        return True
+    return getattr(component, "mime_type", None) == UI_MIME_TYPE
+
+
 def is_model_visible(component: FastMCPComponent) -> bool:
     """Whether a component may be shown to, or invoked by, the model.
 

--- a/fastmcp_slim/fastmcp/server/low_level.py
+++ b/fastmcp_slim/fastmcp/server/low_level.py
@@ -536,6 +536,9 @@ class LowLevelServer(_Server[LifespanResultT]):
     ) -> mcp_types.ServerCapabilities:
         """Override to advertise registered extensions and the MCP Apps UI extension.
 
+        The UI extension is advertised only while the server can serve an app
+        (see ``FastMCP.may_serve_apps``).
+
         ``ServerCapabilities.extensions`` is a real declared field in v2, so we
         update it directly. The
         `FastMCP(experimental_capabilities=...)` merge also lives here rather
@@ -559,19 +562,22 @@ class LowLevelServer(_Server[LifespanResultT]):
         # Advertise every registered extension's settings under
         # capabilities.extensions[identifier]. The hand-rolled UI splice stays
         # for now (MCP Apps migrates onto the extension API in a later phase);
-        # the two coexist. Advertisement is unconditional — the SDK's pre-2026
-        # version sieve strips capabilities.extensions on legacy eras, a known
+        # the two coexist. It is advertised only when the server has an app to
+        # serve: a host reads the declaration as a promise it can route UI to,
+        # and every server used to make that promise. The SDK's pre-2026 version
+        # sieve strips capabilities.extensions on legacy eras, a known
         # limitation (sdk-feedback #2).
         existing_extensions = capabilities.extensions or {}
         registered_extensions = {
             extension.identifier: extension.settings()
             for extension in self.fastmcp._extensions.values()
         }
+        app_extensions = {UI_EXTENSION_ID: {}} if self.fastmcp.may_serve_apps else {}
         return capabilities.model_copy(
             update={
                 "extensions": {
                     **existing_extensions,
-                    UI_EXTENSION_ID: {},
+                    **app_extensions,
                     **registered_extensions,
                 },
             }

--- a/fastmcp_slim/fastmcp/server/providers/aggregate.py
+++ b/fastmcp_slim/fastmcp/server/providers/aggregate.py
@@ -183,6 +183,11 @@ class AggregateProvider(Provider):
     def __repr__(self) -> str:
         return f"AggregateProvider(providers={self.providers!r})"
 
+    @property
+    def may_serve_apps(self) -> bool:
+        """Whether any child provider may serve MCP App UI."""
+        return any(provider.may_serve_apps for provider in self.providers)
+
     # -------------------------------------------------------------------------
     # Tools
     # -------------------------------------------------------------------------

--- a/fastmcp_slim/fastmcp/server/providers/base.py
+++ b/fastmcp_slim/fastmcp/server/providers/base.py
@@ -79,6 +79,21 @@ class Provider:
         return f"{self.__class__.__name__}()"
 
     @property
+    def may_serve_apps(self) -> bool:
+        """Whether this provider may serve MCP App UI (``meta["ui"]`` or ``ui://``).
+
+        Advertised capabilities are a promise the server has to keep, so a
+        provider that cannot be enumerated synchronously answers ``True``: a
+        proxy to a remote server, or a third-party provider, may well be holding
+        an app, and hiding the extension from it would leave the host unable to
+        render a UI that does exist. A spurious declaration is the lesser error.
+
+        ``LocalProvider`` answers precisely from its registry, and
+        ``AggregateProvider`` combines its children.
+        """
+        return True
+
+    @property
     def transforms(self) -> list[Transform]:
         """All transforms applied to components from this provider."""
         return list(self._transforms)

--- a/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py
+++ b/fastmcp_slim/fastmcp/server/providers/fastmcp_provider.py
@@ -400,6 +400,11 @@ class FastMCPProvider(Provider):
         super().__init__()
         self.server = server
 
+    @property
+    def may_serve_apps(self) -> bool:
+        """Whether the wrapped server may serve MCP App UI."""
+        return self.server.may_serve_apps
+
     # -------------------------------------------------------------------------
     # Tool methods
     # -------------------------------------------------------------------------

--- a/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py
+++ b/fastmcp_slim/fastmcp/server/providers/local_provider/local_provider.py
@@ -341,6 +341,23 @@ class LocalProvider(
             self._remove_component(key)
 
     # =========================================================================
+    # Capability queries
+    # =========================================================================
+
+    @property
+    def may_serve_apps(self) -> bool:
+        """Whether any registered component carries MCP App UI.
+
+        Local registrations are the one part of the provider graph the server
+        can enumerate without I/O, so this is the surface that answers the
+        question precisely and lets a plain server stop advertising the MCP Apps
+        extension (see ``Provider.may_serve_apps`` for the fail-open default).
+        """
+        from fastmcp.apps.config import component_serves_app
+
+        return any(component_serves_app(c) for c in self._components.values())
+
+    # =========================================================================
     # Provider interface implementation
     # =========================================================================
 

--- a/fastmcp_slim/fastmcp/server/providers/wrapped_provider.py
+++ b/fastmcp_slim/fastmcp/server/providers/wrapped_provider.py
@@ -49,6 +49,11 @@ class _WrappedProvider(Provider):
     def __repr__(self) -> str:
         return f"_WrappedProvider({self._inner!r}, transforms={self._transforms!r})"
 
+    @property
+    def may_serve_apps(self) -> bool:
+        """Whether the wrapped provider may serve MCP App UI."""
+        return self._inner.may_serve_apps
+
     # -------------------------------------------------------------------------
     # Delegate to inner provider's public methods (which apply inner's transforms)
     # -------------------------------------------------------------------------

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -26,7 +26,9 @@ from fastmcp.apps import (
     app_config_to_meta_dict,
 )
 from fastmcp.server.context import Context
+from fastmcp.server.extensions import ServerExtension
 from fastmcp.server.low_level import client_supports_extension
+from fastmcp.server.providers import Provider
 
 # ---------------------------------------------------------------------------
 # Model serialization
@@ -401,7 +403,7 @@ class TestExtensionAdvertisement:
     async def test_capabilities_include_ui_extension(self):
         server = FastMCP("test")
 
-        @server.tool
+        @server.tool(app=AppConfig(resource_uri="ui://dashboard"))
         def my_tool() -> str:
             return "hello"
 
@@ -432,6 +434,142 @@ class TestExtensionAdvertisement:
 # ---------------------------------------------------------------------------
 # Context.client_supports_extension
 # ---------------------------------------------------------------------------
+
+
+class TestAppCapabilityGating:
+    """The UI extension is advertised only while the server can serve an app.
+
+    Every FastMCP server used to declare it, so a host that reads the
+    declaration could offer a UI affordance with no app behind it.
+    """
+
+    @staticmethod
+    def _computed_extensions(server: FastMCP) -> dict[str, Any]:
+        """Extensions the server computes, before the SDK's version sieve."""
+        capabilities = server._mcp_server.get_capabilities()
+        return dict(capabilities.extensions or {})
+
+    def test_plain_server_does_not_advertise(self):
+        server = FastMCP("test")
+
+        @server.tool
+        def my_tool() -> str:
+            return "hello"
+
+        assert UI_EXTENSION_ID not in self._computed_extensions(server)
+
+    def test_app_tool_advertises(self):
+        server = FastMCP("test")
+
+        @server.tool(app=AppConfig(resource_uri="ui://dashboard"))
+        def dashboard() -> str:
+            return "data"
+
+        assert UI_EXTENSION_ID in self._computed_extensions(server)
+
+    def test_ui_resource_advertises(self):
+        server = FastMCP("test")
+
+        @server.resource("ui://my-app/view.html")
+        def view() -> str:
+            return "<html></html>"
+
+        assert UI_EXTENSION_ID in self._computed_extensions(server)
+
+    def test_ui_resource_template_advertises(self):
+        server = FastMCP("test")
+
+        @server.resource("ui://my-app/{name}.html")
+        def view(name: str) -> str:
+            return f"<html>{name}</html>"
+
+        assert UI_EXTENSION_ID in self._computed_extensions(server)
+
+    def test_ui_resource_with_other_mime_type_advertises(self):
+        """The scheme marks the app, not the MIME type.
+
+        An app ships more than its HTML entry point — a stylesheet served from
+        ``ui://`` is explicitly ``text/css``, and the server still has an app.
+        """
+        server = FastMCP("test")
+
+        @server.resource("ui://my-app/view.css", mime_type="text/css")
+        def stylesheet() -> str:
+            return "body {}"
+
+        assert UI_EXTENSION_ID in self._computed_extensions(server)
+
+    def test_mounted_app_advertises(self):
+        parent = FastMCP("parent")
+
+        @parent.tool
+        def plain() -> str:
+            return "x"
+
+        child = FastMCP("child")
+
+        @child.tool(app=AppConfig(resource_uri="ui://child/app"))
+        def child_app() -> str:
+            return "y"
+
+        parent.mount(child)
+
+        assert UI_EXTENSION_ID in self._computed_extensions(parent)
+
+    def test_mounted_plain_child_does_not_advertise(self):
+        parent = FastMCP("parent")
+        child = FastMCP("child")
+
+        @child.tool
+        def plain() -> str:
+            return "x"
+
+        parent.mount(child)
+
+        assert UI_EXTENSION_ID not in self._computed_extensions(parent)
+
+    def test_unenumerable_provider_stays_conservative(self):
+        """A provider whose components we can't enumerate keeps the promise.
+
+        Suppressing the declaration for a proxy, or for a third-party provider,
+        could hide an app that does exist — worse than a spurious promise.
+        """
+
+        class OpaqueProvider(Provider):
+            pass
+
+        server = FastMCP("test")
+        server.add_provider(OpaqueProvider())
+
+        assert UI_EXTENSION_ID in self._computed_extensions(server)
+
+    def test_registered_extension_does_not_imply_apps(self):
+        """An unrelated extension advertises itself without dragging UI along."""
+
+        class Other(ServerExtension):
+            identifier = "com.example/other"
+
+            def settings(self) -> dict[str, Any]:
+                return {"version": "1"}
+
+        server = FastMCP("test")
+        server.add_extension(Other())
+
+        extensions = self._computed_extensions(server)
+        assert extensions["com.example/other"] == {"version": "1"}
+        assert UI_EXTENSION_ID not in extensions
+
+    async def test_modern_client_sees_no_ui_extension_without_apps(self):
+        """The reporter's observation, on the era that carries extensions."""
+        server = FastMCP("test")
+
+        @server.tool
+        def my_tool() -> str:
+            return "hello"
+
+        async with Client(server, mode="auto") as client:
+            extensions = client.server_capabilities.extensions or {}
+            assert UI_EXTENSION_ID not in extensions
 
 
 class TestContextClientSupportsExtension:


### PR DESCRIPTION
Every FastMCP server declared `io.modelcontextprotocol/ui` in `capabilities.extensions`, whether or not it had anything to render. A host reads that declaration as a promise it can route UI to, and every server used to make it.

The extension is now advertised only while there is an app behind it — a tool or resource carrying `_meta.ui`, or a `ui://` resource:

```python
plain = FastMCP("plain")                    # no _meta.ui, no ui:// resource
@plain.tool
def ping() -> str: ...
# capabilities.extensions: {}

dashboard = FastMCP("dashboard")
@dashboard.tool(app=AppConfig(resource_uri="ui://dashboard"))
def dashboard() -> str: ...
# capabilities.extensions: {'io.modelcontextprotocol/ui': {}}
```

Providers answer a synchronous `may_serve_apps` so answering needs no I/O: the local registry answers precisely, mounted servers and namespaced wrappers delegate, and a provider that can't be enumerated — a proxy, a third-party provider — keeps the declaration, because hiding a real app from the host is worse than a spurious promise. The hand-rolled splice is otherwise unchanged; the Apps-to-extension-API migration still owns deleting it.

Fixes #4919
