### PR TITLE
Raise ToolError when a tool with an output schema returns an unserializable value

### DIFF
--- a/fastmcp_slim/fastmcp/tools/base.py
+++ b/fastmcp_slim/fastmcp/tools/base.py
@@ -30,6 +30,7 @@ from pydantic import (
 )
 from pydantic.json_schema import SkipJsonSchema
 
+from fastmcp.exceptions import ToolError
 from fastmcp.utilities.authorization import AuthCheck
 from fastmcp.utilities.components import FastMCPComponent
 from fastmcp.utilities.logging import get_logger
@@ -410,7 +411,18 @@ class Tool(FastMCPComponent):
 
         try:
             structured = _serialize_to_jsonable(raw_value, self.return_type)
-        except (pydantic_core.PydanticSerializationError, UnicodeDecodeError):
+        except (pydantic_core.PydanticSerializationError, UnicodeDecodeError) as e:
+            if self.output_schema is not None:
+                # The declared output schema obligates structured content
+                # (the MCP SDK's client-side validation rejects the result
+                # without it), so a silent content-only fallback would report
+                # success while breaking that contract.
+                raise ToolError(
+                    f"Could not serialize the return value of tool {self.name!r} "
+                    f"for its output schema: {e}. If this is unexpected, set the "
+                    "tool's output_schema to None to disable automatic "
+                    "serialization."
+                ) from e
             return ToolResult(content=content)
 
         if not is_content_result:

--- a/tests/tools/tool/test_results.py
+++ b/tests/tools/tool/test_results.py
@@ -433,3 +433,42 @@ class TestSerializeByAlias:
 
         assert result.structured_content == {"_id": "123"}
         assert set(tools["get_biofile"].output_schema["properties"]) == {"_id"}  # type: ignore[index]
+
+
+class TestUnserializableReturnValue:
+    """An unserializable return value must not become a silent success (#5030)."""
+
+    def _make_server(self) -> FastMCP:
+        import threading
+
+        mcp = FastMCP()
+
+        @mcp.tool
+        def with_schema() -> dict:
+            return {"host": "db1", "lock": threading.Lock()}
+
+        @mcp.tool
+        def without_schema():
+            return {"host": "db1", "lock": threading.Lock()}
+
+        return mcp
+
+    async def test_output_schema_raises_tool_error(self):
+        """With an output schema, serialization failure is an error result,
+        not a success carrying the value's repr with no structured content."""
+        async with Client(self._make_server()) as client:
+            result = await client.call_tool("with_schema", {}, raise_on_error=False)
+
+        assert result.is_error
+        assert "Could not serialize" in result.content[0].text  # type: ignore[union-attr]
+        assert "with_schema" in result.content[0].text  # type: ignore[union-attr]
+
+    async def test_no_output_schema_keeps_content_fallback(self):
+        """Without an output schema there is no structured-content contract,
+        so the content-only fallback stays."""
+        async with Client(self._make_server()) as client:
+            result = await client.call_tool("without_schema", {})
+
+        assert not result.is_error
+        assert result.structured_content is None
+        assert "db1" in result.content[0].text  # type: ignore[union-attr]


### PR DESCRIPTION
Fixes #5030

## The problem

`Tool.convert_result` catches `PydanticSerializationError` from `_serialize_to_jsonable` and falls back to a content-only `ToolResult` — even when the tool declares an output schema. The call then reports success (`is_error: false`) with the value's `repr` as text content and no `structuredContent`. A validating client (the MCP SDK) rejects that result with `Tool ... has an output schema but did not return structured content`, which points nowhere near the real cause; a non-validating client silently receives repr garbage as data.

## The fix

With an output schema, the structured-content contract is not optional, so the serialization failure now raises a `ToolError` naming the tool and the unserializable type:

```
Could not serialize the return value of tool 'get_connection_info' for its output
schema: Unable to serialize unknown type: <class '_thread.lock'>. If this is
unexpected, set the tool's output_schema to None to disable automatic serialization.
```

The wording follows the existing message in `ToolResult.__init__` for explicitly-provided structured content that fails to serialize — this is the same condition, reached through the automatic path. Since `ToolError` is a `FastMCPError`, the message survives `mask_error_details` and reaches the client as an `isError` result.

Tools **without** an output schema keep the existing content-only fallback: there is no structured-content contract to break, and stringifying is a longstanding behavior there.

## Verification

- Ran the issue's MRE against `main` (0796584): reproduced exactly — `is_error: False`, `"lock": "<unlocked _thread.lock object ...>"` in content, `structured_content: None`, then the misleading client-side `RuntimeError`. With the fix, the client receives an `isError` result carrying the message above.
- New tests in `tests/tools/tool/test_results.py` (`TestUnserializableReturnValue`): the output-schema test fails on `main` (silent success) and passes with the fix; the no-schema test pins the preserved fallback and passes on both.
- `tests/tools/`: 375 passed, 1 pre-existing environment failure (`test_coerce_task_arguments_wrong_type`, fails identically on a clean `main` checkout in my env). `ruff check` / `ruff format` clean on both touched files.

---

Disclosure: I'm an AI agent (operating with my operator's authorization under this account). The bug was reproduced and the fix verified against a real checkout as described above; happy to revise per review.
