### PR TITLE
Honor OpenAPI explode defaults for pipe and space delimited query arrays

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -290,8 +290,10 @@ class RequestDirector:
         Serialize query parameter values according to their OpenAPI style/explode settings.
 
         By default (style=form, explode=true), list values are passed through as-is
-        so httpx repeats the key (e.g. values=a&values=b). When explode=false,
-        list values are joined with the style-appropriate delimiter:
+        so httpx repeats the key (e.g. values=a&values=b). When explode is omitted,
+        OpenAPI 3.1 defaults explode to true only for ``form``; other styles
+        (pipeDelimited, spaceDelimited, deepObject, ...) default to false.
+        When explode=false, list values are joined with the style-appropriate delimiter:
           - form (default): comma  (values=a,b)
           - pipeDelimited:  pipe   (values=a|b)
           - spaceDelimited: space  (values=a%20b)
@@ -308,7 +310,12 @@ class RequestDirector:
         for key, value in query_params.items():
             param_info = param_lookup.get(key)
             if param_info is not None:
-                explode = param_info.explode if param_info.explode is not None else True
+                style = param_info.style or "form"
+                if param_info.explode is not None:
+                    explode = param_info.explode
+                else:
+                    # OpenAPI Parameter Object: explode defaults to true only for form.
+                    explode = style == "form"
                 if isinstance(value, dict):
                     if not value:
                         continue

--- a/tests/utilities/openapi/test_director.py
+++ b/tests/utilities/openapi/test_director.py
@@ -770,6 +770,58 @@ class TestQueryParameterSerialization:
         assert "ids=1+2+3" in url or "ids=1%202%203" in url
         assert url.count("ids=") == 1
 
+    def test_pipe_delimited_explode_omitted(self, director):
+        """Omitted explode with pipeDelimited defaults to false, not form-style repeats."""
+        route = HTTPRoute(
+            path="/items",
+            method="GET",
+            operation_id="list_items",
+            parameters=[
+                ParameterInfo(
+                    name="ids",
+                    location="query",
+                    required=True,
+                    schema={"type": "array", "items": {"type": "string"}},
+                    explode=None,
+                    style="pipeDelimited",
+                )
+            ],
+            parameter_map={
+                "ids": {"location": "query", "openapi_name": "ids"},
+            },
+        )
+
+        request = director.build(route, {"ids": ["a", "b"]}, "https://example.com")
+        url = str(request.url)
+        assert "ids=a%7Cb" in url or "ids=a|b" in url
+        assert url.count("ids=") == 1
+
+    def test_space_delimited_explode_omitted(self, director):
+        """Omitted explode with spaceDelimited defaults to false, not form-style repeats."""
+        route = HTTPRoute(
+            path="/items",
+            method="GET",
+            operation_id="list_items",
+            parameters=[
+                ParameterInfo(
+                    name="ids",
+                    location="query",
+                    required=True,
+                    schema={"type": "array", "items": {"type": "string"}},
+                    explode=None,
+                    style="spaceDelimited",
+                )
+            ],
+            parameter_map={
+                "ids": {"location": "query", "openapi_name": "ids"},
+            },
+        )
+
+        request = director.build(route, {"ids": ["a", "b"]}, "https://example.com")
+        url = str(request.url)
+        assert "ids=a+b" in url or "ids=a%20b" in url
+        assert url.count("ids=") == 1
+
     def test_explode_false_booleans_lowercased(self, director):
         """Booleans serialize as true/false, not True/False."""
         route = HTTPRoute(


### PR DESCRIPTION
Fixes #5060.

When a query array used `style: pipeDelimited` or `style: spaceDelimited` and omitted `explode`, the generated tool sent repeated keys (`ids=a&ids=b`). Setting `explode: false` already produced `ids=a|b` / `ids=a b`.

OpenAPI 3.1 defaults explode to true only for `form`. Other styles default to false. The director now follows that, so omitted explode on pipe/space delimited arrays joins with the declared delimiter. Form arrays are unchanged.

Tested with `TestQueryParameterSerialization.test_pipe_delimited_explode_omitted` and `test_space_delimited_explode_omitted`.
