### PR TITLE
Support anthropic 1.x alongside 0.x

### DIFF
--- a/docs/clients/sampling.mdx
+++ b/docs/clients/sampling.mdx
@@ -143,7 +143,9 @@ client = Client(
 ```
 
 <Note>
-Install the Anthropic handler with `pip install 'fastmcp[anthropic]'`.
+Install the Anthropic handler with `pip install 'fastmcp[anthropic]'`. The handler supports Anthropic SDK 0.48.0 through 1.x.
+
+When upgrading to Anthropic SDK 1.x, custom HTTP clients passed to `AsyncAnthropic` must use `httpx2` instead of `httpx`. See Anthropic's [migration guide](https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md) for changes to SDK integrations. The handler continues to forward an explicitly requested temperature, including zero, for models that support it.
 </Note>
 
 ### Google Gemini Handler

--- a/fastmcp_slim/fastmcp/client/sampling/handlers/anthropic.py
+++ b/fastmcp_slim/fastmcp/client/sampling/handlers/anthropic.py
@@ -135,7 +135,7 @@ class AnthropicSamplingHandler:
         if params.system_prompt is not None:
             kwargs["system"] = params.system_prompt
         if params.temperature is not None:
-            kwargs["temperature"] = params.temperature
+            kwargs["extra_body"] = {"temperature": params.temperature}
         if params.stop_sequences is not None:
             kwargs["stop_sequences"] = params.stop_sequences
         if anthropic_tools is not None:

--- a/fastmcp_slim/pyproject.toml
+++ b/fastmcp_slim/pyproject.toml
@@ -65,7 +65,7 @@ bump = true
 fallback-version = "0.0.0"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
-anthropic = ["anthropic>=0.48.0,<1"]
+anthropic = ["anthropic>=0.48.0"]
 apps = ["prefab-ui>=0.18.0"]
 # PyJWT floor: transitive via msal; CVE-2026-32597 affects <= 2.11.0
 azure = ["azure-identity>=1.16.0", "PyJWT>=2.12.0"]

--- a/fastmcp_slim/pyproject.toml
+++ b/fastmcp_slim/pyproject.toml
@@ -65,7 +65,7 @@ bump = true
 fallback-version = "0.0.0"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
-anthropic = ["anthropic>=0.48.0"]
+anthropic = ["anthropic>=0.48.0,<2"]
 apps = ["prefab-ui>=0.18.0"]
 # PyJWT floor: transitive via msal; CVE-2026-32597 affects <= 2.11.0
 azure = ["azure-identity>=1.16.0", "PyJWT>=2.12.0"]

--- a/tests/client/sampling/handlers/test_anthropic_handler.py
+++ b/tests/client/sampling/handlers/test_anthropic_handler.py
@@ -1,8 +1,11 @@
+import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
+import httpx
+import httpx2
 import pytest
-from anthropic import AsyncAnthropic
+from anthropic import AsyncAnthropic, DefaultAsyncHttpxClient
 from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
 from mcp_types import (
     AudioContent,
@@ -402,33 +405,57 @@ def test_convert_messages_raises_on_unsupported_content_type():
         AnthropicSamplingHandler._convert_to_anthropic_messages([msg])
 
 
-async def test_handler_sends_temperature_through_extra_body():
-    """Verify temperature goes via extra_body (anthropic 1.x dropped the parameter)."""
-    mock_client = MagicMock(spec=AsyncAnthropic)
-    mock_client.messages = MagicMock()
-    mock_client.messages.create = AsyncMock(
-        return_value=Message(
-            id="msg_123",
-            type="message",
-            role="assistant",
-            content=[TextBlock(type="text", text="hi")],
-            model="claude-sonnet-4-5",
-            stop_reason="end_turn",
-            stop_sequence=None,
-            usage=Usage(input_tokens=1, output_tokens=1),
-        )
+@pytest.mark.parametrize("temperature", [None, 0.0, 0.5])
+async def test_handler_preserves_temperature_on_the_wire(temperature: float | None):
+    requests: list[dict[str, Any]] = []
+    # Anthropic 0.x uses httpx; 1.x uses httpx2. Exercise the installed SDK.
+    http: Any = (
+        httpx if issubclass(DefaultAsyncHttpxClient, httpx.AsyncClient) else httpx2
     )
-    handler = AnthropicSamplingHandler(
-        default_model="claude-sonnet-4-5", client=mock_client
-    )
-    messages = [
-        SamplingMessage(role="user", content=TextContent(type="text", text="hello"))
-    ]
-    params = CreateMessageRequestParams(
-        messages=messages, max_tokens=100, temperature=0.5
-    )
-    await handler(messages, params, context=None)
 
-    call_kwargs = mock_client.messages.create.call_args
-    assert call_kwargs.kwargs["extra_body"] == {"temperature": 0.5}
-    assert "temperature" not in call_kwargs.kwargs
+    def capture(request):
+        requests.append(json.loads(request.content))
+        return http.Response(
+            200,
+            json={
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hi"}],
+                "model": "claude-sonnet-4-5",
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    async with AsyncAnthropic(
+        api_key="test-key",
+        http_client=DefaultAsyncHttpxClient(transport=http.MockTransport(capture)),
+    ) as sdk:
+        handler = AnthropicSamplingHandler(
+            default_model="claude-sonnet-4-5", client=sdk
+        )
+        messages = [
+            SamplingMessage(role="user", content=TextContent(type="text", text="hello"))
+        ]
+        params = CreateMessageRequestParams(
+            messages=messages,
+            max_tokens=100,
+            temperature=temperature,
+            system_prompt="Be concise",
+            stop_sequences=["STOP"],
+        )
+        result = await handler(messages, params, context=None)
+
+    expected = {
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 100,
+        "system": "Be concise",
+        "stop_sequences": ["STOP"],
+    }
+    if temperature is not None:
+        expected["temperature"] = temperature
+    assert requests == [expected]
+    assert result.content == TextContent(type="text", text="hi")

--- a/tests/client/sampling/handlers/test_anthropic_handler.py
+++ b/tests/client/sampling/handlers/test_anthropic_handler.py
@@ -1,11 +1,12 @@
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from anthropic import AsyncAnthropic
 from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
 from mcp_types import (
     AudioContent,
+    CreateMessageRequestParams,
     CreateMessageResult,
     CreateMessageResultWithTools,
     EmbeddedResource,
@@ -399,3 +400,35 @@ def test_convert_messages_raises_on_unsupported_content_type():
 
     with pytest.raises(ValueError, match="Unsupported content type for Anthropic"):
         AnthropicSamplingHandler._convert_to_anthropic_messages([msg])
+
+
+async def test_handler_sends_temperature_through_extra_body():
+    """Verify temperature goes via extra_body (anthropic 1.x dropped the parameter)."""
+    mock_client = MagicMock(spec=AsyncAnthropic)
+    mock_client.messages = MagicMock()
+    mock_client.messages.create = AsyncMock(
+        return_value=Message(
+            id="msg_123",
+            type="message",
+            role="assistant",
+            content=[TextBlock(type="text", text="hi")],
+            model="claude-sonnet-4-5",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage=Usage(input_tokens=1, output_tokens=1),
+        )
+    )
+    handler = AnthropicSamplingHandler(
+        default_model="claude-sonnet-4-5", client=mock_client
+    )
+    messages = [
+        SamplingMessage(role="user", content=TextContent(type="text", text="hello"))
+    ]
+    params = CreateMessageRequestParams(
+        messages=messages, max_tokens=100, temperature=0.5
+    )
+    await handler(messages, params, context=None)
+
+    call_kwargs = mock_client.messages.create.call_args
+    assert call_kwargs.kwargs["extra_body"] == {"temperature": 0.5}
+    assert "temperature" not in call_kwargs.kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -1042,7 +1042,7 @@ server = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0,<2" },
     { name = "authlib", marker = "extra == 'client'", specifier = ">=1.6.11" },
     { name = "authlib", marker = "extra == 'server'", specifier = ">=1.6.11" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.16.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -90,21 +90,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.117.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0d/8f71d535edb0d438f023bd825fb65f67c14fa88a2bd6b75f292a58a63de4/anthropic-0.117.0.tar.gz", hash = "sha256:98107f2b76439641e0ae2a1754087534b8f178dbab99d6eb1bc4b7bc8c744496", size = 989933, upload-time = "2026-07-16T19:36:13.07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/50/463166f02179ab279edb61de1589a6f69cb3838d6a2fb6f2c92a3f8042f1/anthropic-1.3.0.tar.gz", hash = "sha256:6873492a77ede8849a161ab1bc78bc9a1e492a006d0b5bb4c57ac77845df838a", size = 1148177, upload-time = "2026-09-01T17:37:10.392Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/4c/917d21d6619a4475cdafc6d13a69fdb3b901ddac57e76caca5a25c117b6d/anthropic-0.117.0-py3-none-any.whl", hash = "sha256:451a0a6905f11dff7663d13e4ee5dbf909eb8942b1d049803c7b937a13ac47ec", size = 998327, upload-time = "2026-07-16T19:36:11.225Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5d/7863a9961d320c23787c7b594956afe4e878f9c0ae2376b11a20e416791d/anthropic-1.3.0-py3-none-any.whl", hash = "sha256:e7e7dbebf9f3c84a23954ab989378af6ae10a4d1804c81e9fea4b5ced695ce75", size = 1296959, upload-time = "2026-09-01T17:37:08.525Z" },
 ]
 
 [[package]]
@@ -1043,7 +1042,7 @@ server = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0,<1" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0" },
     { name = "authlib", marker = "extra == 'client'", specifier = ">=1.6.11" },
     { name = "authlib", marker = "extra == 'server'", specifier = ">=1.6.11" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.16.0" },


### PR DESCRIPTION
## Description

Adds support for [anthropic-sdk-python](https://github.com/anthropics/anthropic-sdk-python) v1.x alongside 0.x.

anthropic <1 was pinned in #4864. The breaking changes in v1 are minor and are described in Anthropic's [MIGRATION.md](https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md#removed-deprecated-request-parameters). The change one that tripped tests in fastmcp-slim is the removal of some deprecated request parameters from the messages.create() Python interface.

Tests pass against both old and new versions of `anthropic`.

Closes #5059.

## Contribution type

- [ ] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [x] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)
