### PR TITLE
fix(docstrings): don't leak Returns/Raises into description for parameterless functions

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/docstring_parsing.py
+++ b/fastmcp_slim/fastmcp/utilities/docstring_parsing.py
@@ -45,13 +45,18 @@ def parse_docstring(fn: Callable[..., Any]) -> ParsedDocstring:
     # keeps its parser and model graph out of ordinary server startup.
     from griffe import Docstring, DocstringSectionKind
 
-    # Try each parser and use the first one that finds parameters.
+    # Try each parser and use the first one that recognizes some structure
+    # (parameters, returns, raises, etc.) — not just a parameter section.
+    # A parameterless function can still have a Returns/Raises section that
+    # should be split out of the description, same as Args is for functions
+    # that take arguments.
     for parser in _PARSERS:
         docstring = Docstring(doc, lineno=1, parser=parser)
         sections = docstring.parse()
 
         description: str | None = None
         parameters: dict[str, str] = {}
+        found_structured_section = False
 
         for section in sections:
             if section.kind == DocstringSectionKind.text and description is None:
@@ -59,9 +64,12 @@ def parse_docstring(fn: Callable[..., Any]) -> ParsedDocstring:
             elif section.kind == DocstringSectionKind.parameters:
                 for param in section.value:
                     parameters[param.name] = param.description
+                found_structured_section = True
+            elif section.kind != DocstringSectionKind.text:
+                found_structured_section = True
 
-        if parameters:
+        if parameters or found_structured_section:
             return ParsedDocstring(description=description, parameters=parameters)
 
-    # No parser found parameters — return the full docstring unchanged.
+    # No parser recognized any structure — return the full docstring unchanged.
     return ParsedDocstring(description=doc)

--- a/tests/utilities/test_docstring_parsing.py
+++ b/tests/utilities/test_docstring_parsing.py
@@ -284,6 +284,34 @@ class TestEdgeCases:
         # filtering happens at the schema injection level
         assert parsed.parameters == {"nonexistent": "Wrong param name."}
 
+    def test_returns_section_excluded_no_params(self):
+        """A parameterless function's Returns section must not bleed into
+        the description, same as it doesn't for functions with Args."""
+
+        def fn() -> dict[str, bool]:
+            """Return current status.
+
+            Returns:
+                A dict containing the current status.
+            """
+            return {"ok": True}
+
+        parsed = parse_docstring(fn)
+        assert parsed.description == "Return current status."
+        assert parsed.parameters == {}
+
+    def test_raises_section_excluded_no_params(self):
+        def fn() -> None:
+            """Do a thing.
+
+            Raises:
+                ValueError: If something goes wrong.
+            """
+
+        parsed = parse_docstring(fn)
+        assert parsed.description == "Do a thing."
+        assert parsed.parameters == {}
+
     def test_async_function(self):
         async def fn(a: float) -> float:
             """Async summary.
@@ -544,6 +572,18 @@ class TestParsedFunctionIntegration:
         assert p.description == "Describes what the tool does."
         # x's description does NOT come from the class's constructor-focused Args
         assert "description" not in p.input_schema["properties"]["x"]
+
+    def test_parameterless_tool_returns_section_excluded(self):
+        def status() -> dict[str, bool]:
+            """Return current status.
+
+            Returns:
+                A dict containing the current status.
+            """
+            return {"ok": True}
+
+        p = ParsedFunction.from_function(status)
+        assert p.description == "Return current status."
 
     def test_callable_class_falls_back_to_call_description(self):
         """If the class has no docstring, fall back to __call__'s description."""


### PR DESCRIPTION
Fixes #4952.

A parameterless tool's `Returns:`/`Raises:` sections leaked into its client-visible description. `parse_docstring` only trusted a parser's cleanly-split `description` when it had also found a `parameters` section — so for a function with no arguments, none of the three parsers ever satisfied `if parameters:`, and the code fell through to returning the raw, unparsed docstring, `Returns:` block and all. The same Google/NumPy/Sphinx parser that correctly splits `Args:` out of the description for functions that take arguments already splits `Returns:` out too — the bug was in not trusting that result when there was nothing to put in `parameters`.

```python
@mcp.tool
async def status() -> dict[str, bool]:
    """Return current status.

    Returns:
        A dict containing the current status.
    """
    return {"ok": True}

# before: "Return current status.\n\nReturns:\n    A dict containing the current status."
# after:  "Return current status."
```

The fix widens the "did this parser understand the docstring's structure" check from just `parameters` to any recognized section (`parameters`, `returns`, `raises`, etc.), so a parameterless function's description is trimmed the same way an argument-taking function's already is.