### PR TITLE
fix(server): reject a malformed pagination cursor offset

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/pagination.py
+++ b/fastmcp_slim/fastmcp/utilities/pagination.py
@@ -36,7 +36,17 @@ class CursorState:
         """
         try:
             data = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
-            return cls(offset=data["o"])
+            offset = data["o"]
+            # The offset reaches a slice and an addition, so a string or a float
+            # surfaces as a TypeError the caller reports as an internal error, and
+            # a negative one slices from the end and returns a valid-looking page
+            # the client never asked for. A cursor is ours to produce, so anything
+            # but a whole non-negative count means it was tampered with.
+            if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+                raise ValueError(
+                    f"cursor offset must be a non-negative integer: {offset!r}"
+                )
+            return cls(offset=offset)
         except (
             json.JSONDecodeError,
             KeyError,

--- a/tests/server/test_pagination.py
+++ b/tests/server/test_pagination.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import mcp_types
 import pytest
 from mcp.shared.exceptions import MCPError
+from mcp.types import INVALID_PARAMS
 
 from fastmcp import Client, FastMCP
 from fastmcp.utilities.pagination import CursorState, paginate_sequence
@@ -39,6 +40,21 @@ class TestCursorEncoding:
         import base64
 
         invalid = base64.urlsafe_b64encode(b"not json").decode()
+        with pytest.raises(ValueError, match="Invalid cursor"):
+            CursorState.decode(invalid)
+
+    @pytest.mark.parametrize("offset", ["1", 1.5, -1, True, None, [0]])
+    def test_decode_rejects_a_malformed_offset(self, offset: object) -> None:
+        """An offset that is not a whole non-negative count is an invalid cursor.
+
+        A string or a float reached the slice and raised TypeError, which the
+        server reports as an internal error rather than invalid parameters, and a
+        negative one sliced from the end and returned a valid-looking page.
+        """
+        import base64
+        import json
+
+        invalid = base64.urlsafe_b64encode(json.dumps({"o": offset}).encode()).decode()
         with pytest.raises(ValueError, match="Invalid cursor"):
             CursorState.decode(invalid)
 
@@ -103,6 +119,40 @@ class TestPaginateSequence:
         """Invalid cursor should raise ValueError."""
         with pytest.raises(ValueError, match="Invalid cursor"):
             paginate_sequence([1, 2, 3], "invalid!", 10)
+
+
+class TestMalformedCursorParams:
+    """A tampered cursor is invalid parameters, not an internal error."""
+
+    @staticmethod
+    def _cursor(offset: object) -> str:
+        import base64
+        import json
+
+        return base64.urlsafe_b64encode(json.dumps({"o": offset}).encode()).decode()
+
+    @pytest.mark.parametrize("offset", ["1", 1.5, -1])
+    def test_paginate_sequence_rejects_a_malformed_offset(self, offset: object) -> None:
+        with pytest.raises(ValueError, match="Invalid cursor"):
+            paginate_sequence([0, 1, 2], self._cursor(offset), page_size=2)
+
+    async def test_list_tools_reports_invalid_params(self) -> None:
+        """The caller maps the ValueError to INVALID_PARAMS, so the client sees that."""
+        server = FastMCP(list_page_size=1)
+
+        @server.tool(name="one")
+        def one() -> int:
+            return 1
+
+        @server.tool(name="two")
+        def two() -> int:
+            return 2
+
+        async with Client(server) as client:
+            with pytest.raises(MCPError) as excinfo:
+                await client.list_tools_mcp(cursor=self._cursor(-1))
+
+        assert excinfo.value.error.code == INVALID_PARAMS
 
 
 class TestServerPagination:


### PR DESCRIPTION
## Description

Fixes #5070.

`CursorState.decode` took the decoded offset verbatim. The value then reaches `offset + page_size` and `items[offset:end]`, so what the client gets depends on the type that was smuggled in:

```
'1'    TypeError: can only concatenate str (not "int") to str
1.5    TypeError: slice indices must be integers or None or have an __index__ method
-1     accepted: page=[] next=eyJvIjogMX0=
```

`_apply_pagination` only maps `ValueError` to `INVALID_PARAMS`, so the first two escape as an internal error, and the third is worse than an error: an empty page plus a cursor that restarts in the middle of the list, with nothing to tell the client its cursor was wrong.

A cursor is opaque and server-produced, so an offset that is not a whole non-negative count means it was tampered with. `decode` now raises on that inside its own `try`, which the existing handler turns into the same `Invalid cursor: …` `ValueError` that malformed base64, malformed JSON and a missing key already produce, and `_apply_pagination` maps to `INVALID_PARAMS`. `bool` is excluded explicitly, since `isinstance(True, int)` is true and `{"o": true}` is not a cursor this server ever wrote.

After the change, all three inputs from the issue behave the same way, and valid offsets are untouched:

```
'1'    ValueError: Invalid cursor: eyJvIjogIjEifQ==
1.5    ValueError: Invalid cursor: eyJvIjogMS41fQ==
-1     ValueError: Invalid cursor: eyJvIjogLTF9
True   ValueError: Invalid cursor: eyJvIjogdHJ1ZX0=
0      accepted: page=[0, 1] next=eyJvIjogMn0=
2      accepted: page=[2] next=None
```

## Contribution type

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [ ] Documentation improvement
- [ ] Enhancement (maintainers typically implement enhancements — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Checklist

- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] I have run `uv run prek run --all-files` and all checks pass
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)

On the fourth box, to be precise rather than to claim more than I ran: I ran `prek run --files` on the two changed files, where `ruff check`, `ruff format`, `ty check`, `loq`, `codespell` and the main-branch guard all pass. Running it across the whole tree reports 26 pre-existing `loq` file-size violations in files this PR does not touch, and that hook prints "not enforced... yet!".

Tests, in `tests/server/test_pagination.py`:

- `TestCursorEncoding::test_decode_rejects_a_malformed_offset`, parametrized over `"1"`, `1.5`, `-1`, `True`, `None`, `[0]`
- `TestMalformedCursorParams`, which checks `paginate_sequence` for the three offsets from the issue and then drives a real client against a `list_page_size=1` server to assert the error the client actually receives is `INVALID_PARAMS`

```
uv run pytest tests/server/test_pagination.py -q
41 passed
```

Reverting the guard fails 10 of them, including the client-level one.

I understand the issue-link check stays red until a maintainer assigns the issue, and that the reporter has first claim on it. #4332 attempted the same gap and was closed for having no linked issue, so this is the same fix with the issue now in place and with the client-visible error code pinned; close it if you would rather own the change.
