### PR TITLE
Preserve repeated fields for default multipart string arrays

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -96,7 +96,7 @@ class RequestDirector:
         # Step 6: Handle request body — dispatch on declared content type.
         # httpx body kwargs (json, content, data, files) are mutually exclusive
         # but all accept None, so we set exactly one and pass all to Request().
-        files: dict[str, Any] | None = None
+        files: list[tuple[str, Any]] | None = None
         data: dict[str, Any] | None = None
         if body is not None:
             if declared_content_type == "multipart/form-data" and isinstance(
@@ -106,17 +106,29 @@ class RequestDirector:
                 # treats them as form fields. Scalars must be stringified
                 # because httpx rejects non-string/bytes values in files=.
                 # Use _query_scalar_to_str for booleans (true/false, not True/False).
-                files = {}
+                files = []
+                encoding = (
+                    route.request_body.encoding.get(raw_content_type, {})
+                    if route.request_body and raw_content_type is not None
+                    else {}
+                )
                 for k, v in body.items():
-                    if isinstance(v, tuple):
-                        files[k] = v
+                    if (
+                        isinstance(v, list)
+                        and v
+                        and all(isinstance(item, str) for item in v)
+                        and not encoding.get(k)
+                    ):
+                        files.extend((k, (None, item)) for item in v)
+                    elif isinstance(v, tuple):
+                        files.append((k, v))
                     elif isinstance(v, bytes | io.IOBase):
                         # bytes and file-like objects are passed directly so
                         # httpx can transmit them as binary parts without
                         # stringifying to their Python repr.
-                        files[k] = (None, v)
+                        files.append((k, (None, v)))
                     else:
-                        files[k] = (None, _query_scalar_to_str(v))
+                        files.append((k, (None, _query_scalar_to_str(v))))
             elif (
                 declared_content_type == "application/x-www-form-urlencoded"
                 and isinstance(body, dict)

--- a/fastmcp_slim/fastmcp/utilities/openapi/models.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/models.py
@@ -34,6 +34,7 @@ class RequestBodyInfo(FastMCPBaseModel):
         default_factory=dict
     )  # Key: media type
     description: str | None = None
+    encoding: dict[str, dict[str, Any]] = Field(default_factory=dict)
 
 
 class ResponseInfo(FastMCPBaseModel):

--- a/fastmcp_slim/fastmcp/utilities/openapi/parser.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/parser.py
@@ -372,6 +372,11 @@ class OpenAPIParser(
             # Extract content schemas
             if hasattr(request_body, "content") and request_body.content:
                 for media_type_str, media_type_obj in request_body.content.items():
+                    if media_type_obj and media_type_obj.encoding:
+                        request_body_info.encoding[media_type_str] = {
+                            name: value.model_dump(by_alias=True, exclude_unset=True)
+                            for name, value in media_type_obj.encoding.items()
+                        }
                     if (
                         media_type_obj
                         and hasattr(media_type_obj, "media_type_schema")

--- a/tests/server/providers/openapi/test_multipart_array_defaults.py
+++ b/tests/server/providers/openapi/test_multipart_array_defaults.py
@@ -1,0 +1,137 @@
+"""Multipart string arrays arrive as repeated form fields."""
+
+import io
+from email.parser import BytesParser
+from email.policy import default
+from typing import Any
+
+import httpx2
+import pytest
+from fastapi import FastAPI, Request
+from jsonschema_path import SchemaPath
+
+from fastmcp import Client, FastMCP
+from fastmcp.utilities.openapi.director import RequestDirector
+from fastmcp.utilities.openapi.models import HTTPRoute, RequestBodyInfo
+
+
+@pytest.mark.parametrize("tags", [["a", "b"], ["a"], [], ["中文", "a&b"]])
+@pytest.mark.parametrize(
+    "encoding", [None, {"explode": False}, {"contentType": "application/json"}]
+)
+async def test_multipart_string_array_defaults(
+    tags: list[str], encoding: dict[str, Any] | None
+):
+    app = FastAPI()
+
+    @app.post("/items")
+    async def receive(request: Request):
+        form = await request.form()
+        return {"tags": form.getlist("tags"), "label": form["label"]}
+
+    media: dict[str, Any] = {
+        "schema": {
+            "type": "object",
+            "properties": {
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "label": {"type": "string"},
+            },
+            "required": ["tags", "label"],
+        }
+    }
+    if encoding is not None:
+        media["encoding"] = {"tags": encoding}
+    spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "Multipart", "version": "1"},
+        "paths": {
+            "/items": {
+                "post": {
+                    "operationId": "submit",
+                    "requestBody": {
+                        "required": True,
+                        "content": {"multipart/form-data": media},
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+    }
+    async with httpx2.AsyncClient(
+        base_url="http://test", transport=httpx2.ASGITransport(app=app)
+    ) as http:
+        server = FastMCP.from_openapi(openapi_spec=spec, client=http)
+        async with Client(server) as client:
+            result = await client.call_tool("submit", {"tags": tags, "label": "keep"})
+    # Explicit encodings are not implemented here; preserve their existing wire format.
+    assert result.structured_content == {
+        "tags": tags if tags and encoding is None else [str(tags)],
+        "label": "keep",
+    }
+
+
+def test_only_empty_array_preserves_multipart_content_type() -> None:
+    route = HTTPRoute(
+        path="/items",
+        method="POST",
+        request_body=RequestBodyInfo(
+            content_schema={"multipart/form-data": {"type": "object"}}
+        ),
+        parameter_map={"tags": {"location": "body", "openapi_name": "tags"}},
+    )
+    request = RequestDirector(SchemaPath.from_dict({})).build(
+        route, {"tags": []}, "http://test"
+    )
+    message = BytesParser(policy=default).parsebytes(
+        f"Content-Type: {request.headers['content-type']}\r\n\r\n".encode()
+        + request.read()
+    )
+    assert message.get_content_type() == "multipart/form-data"
+    parts = list(message.iter_parts())
+    assert len(parts) == 1
+    assert parts[0].get_payload(decode=True) == b"[]"
+
+
+@pytest.mark.parametrize("kind", ["tuple", "bytes", "stream", "object", "nested"])
+def test_multipart_arrays_preserve_other_parts(kind: str) -> None:
+    values = {
+        "tuple": ("sample.txt", b"payload", "text/plain"),
+        "bytes": b"payload",
+        "stream": io.BytesIO(b"payload"),
+        "object": {"name": "alice"},
+        "nested": [["a"]],
+    }
+    route = HTTPRoute(
+        path="/items",
+        method="POST",
+        request_body=RequestBodyInfo(
+            content_schema={"multipart/form-data": {"type": "object"}}
+        ),
+        parameter_map={
+            name: {"location": "body", "openapi_name": name}
+            for name in ["tags", "other"]
+        },
+    )
+    try:
+        request = RequestDirector(SchemaPath.from_dict({})).build(
+            route, {"tags": ["a", "b"], "other": values[kind]}, "http://test"
+        )
+        raw = request.read()
+        message = BytesParser(policy=default).parsebytes(
+            f"Content-Type: {request.headers['content-type']}\r\n\r\n".encode() + raw
+        )
+        parts = list(message.iter_parts())
+        assert [
+            part.get_param("name", header="content-disposition") for part in parts
+        ] == ["tags", "tags", "other"]
+        assert [part.get_payload(decode=True) for part in parts[:2]] == [b"a", b"b"]
+        expected = (
+            b"payload"
+            if kind in {"tuple", "bytes", "stream"}
+            else str(values[kind]).encode()
+        )
+        assert parts[2].get_payload(decode=True) == expected
+        if kind == "tuple":
+            assert parts[2].get_filename() == "sample.txt"
+    finally:
+        values["stream"].close()


### PR DESCRIPTION
Generated OpenAPI tools send non-empty string arrays in multipart bodies as a single Python list string, so a receiver sees `"['a', 'b']"` instead of two `tags` fields. Use ordered multipart entries to send each string as its own same-name part.

Retain explicit per-property encoding metadata so this change applies only to the default encoding path. Existing empty-array, non-string-array, object, and file-part behavior is preserved. This does not implement the previously unsupported explicit encoding rules.

Fixes #5072.

Prepared with OpenAI Codex assistance.
Validation is incomplete on this Windows environment: the full run before the final empty-array compatibility guard had 7,341 passes and 34 failures. The final OpenAPI subset had 390 passes with the network performance case run separately. The other 33 failing test IDs matched an unmodified checkout of the same commit and locked dependencies; the GitHub schema test also timed out on the baseline. Full prek passes except for four Windows fcntl attribute errors in an unchanged test file. The final empty-array guard was checked with the OpenAPI suite and full static checks, not another full-suite run. This PR is a draft pending maintainer review and CI validation.
