### PR TITLE
fix: reject malformed pagination cursor offsets (fixes #5070)

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/pagination.py
+++ b/fastmcp_slim/fastmcp/utilities/pagination.py
@@ -32,11 +32,22 @@ class CursorState:
         """Decode cursor from an opaque string.
 
         Raises:
-            ValueError: If the cursor is invalid or malformed.
+            ValueError: If the cursor is invalid, malformed, or contains
+                a non-integer or negative offset.
         """
         try:
             data = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
-            return cls(offset=data["o"])
+            raw_offset = data["o"]
+            if not isinstance(raw_offset, int) or isinstance(raw_offset, bool):
+                raise ValueError(
+                    f"Cursor offset must be a non-negative integer, "
+                    f"got {type(raw_offset).__name__}"
+                )
+            if raw_offset < 0:
+                raise ValueError(
+                    f"Cursor offset must be non-negative, got {raw_offset}"
+                )
+            return cls(offset=raw_offset)
         except (
             json.JSONDecodeError,
             KeyError,
@@ -44,6 +55,10 @@ class CursorState:
             TypeError,
             binascii.Error,
         ) as e:
+            if isinstance(e, ValueError) and (
+                "Cursor offset" in str(e) or "non-negative" in str(e)
+            ):
+                raise
             raise ValueError(f"Invalid cursor: {cursor}") from e
 
 

--- a/tests/server/test_pagination.py
+++ b/tests/server/test_pagination.py
@@ -51,6 +51,61 @@ class TestCursorEncoding:
         with pytest.raises(ValueError, match="Invalid cursor"):
             CursorState.decode(invalid)
 
+    def test_decode_string_offset_raises(self) -> None:
+        """String offset should raise ValueError."""
+        import base64
+        import json
+
+        cursor = base64.urlsafe_b64encode(
+            json.dumps({"o": "1"}).encode()
+        ).decode()
+        with pytest.raises(ValueError, match="non-negative integer"):
+            CursorState.decode(cursor)
+
+    def test_decode_float_offset_raises(self) -> None:
+        """Float offset should raise ValueError."""
+        import base64
+        import json
+
+        cursor = base64.urlsafe_b64encode(
+            json.dumps({"o": 1.5}).encode()
+        ).decode()
+        with pytest.raises(ValueError, match="non-negative integer"):
+            CursorState.decode(cursor)
+
+    def test_decode_negative_offset_raises(self) -> None:
+        """Negative offset should raise ValueError."""
+        import base64
+        import json
+
+        cursor = base64.urlsafe_b64encode(
+            json.dumps({"o": -1}).encode()
+        ).decode()
+        with pytest.raises(ValueError, match="non-negative"):
+            CursorState.decode(cursor)
+
+    def test_decode_boolean_offset_raises(self) -> None:
+        """Boolean offset should raise ValueError."""
+        import base64
+        import json
+
+        cursor = base64.urlsafe_b64encode(
+            json.dumps({"o": True}).encode()
+        ).decode()
+        with pytest.raises(ValueError, match="non-negative integer"):
+            CursorState.decode(cursor)
+
+    def test_decode_null_offset_raises(self) -> None:
+        """Null offset should raise ValueError."""
+        import base64
+        import json
+
+        cursor = base64.urlsafe_b64encode(
+            json.dumps({"o": None}).encode()
+        ).decode()
+        with pytest.raises(ValueError, match="non-negative integer"):
+            CursorState.decode(cursor)
+
 
 class TestPaginateSequence:
     """Tests for the paginate_sequence helper."""


### PR DESCRIPTION
Fixes #5070

## Changes

- `CursorState.decode()` now validates that the offset field ("o") is a non-negative integer
- Previously, string, float, negative, and boolean offsets were silently accepted, causing internal server errors (for non-integer types) or incorrect pagination results (for negative offsets)
- Added type validation: offset must be an int (rejects bool, float, str, None)
- Added range validation: offset must be >= 0

## Testing

- Added 5 new test cases in TestCursorEncoding:
  - test_decode_string_offset_raises - string offsets rejected
  - test_decode_float_offset_raises - float offsets rejected
  - test_decode_negative_offset_raises - negative offsets rejected
  - test_decode_boolean_offset_raises - boolean offsets rejected
  - test_decode_null_offset_raises - null offsets rejected
- All existing pagination tests continue to pass
