### PR TITLE
fix: make DeclinedElicitation and CancelledElicitation falsy (fixes #4929)

### DIFF
--- a/fastmcp_slim/fastmcp/server/elicitation.py
+++ b/fastmcp_slim/fastmcp/server/elicitation.py
@@ -5,8 +5,8 @@ from enum import Enum
 from typing import Any, Generic, Literal, cast, get_origin
 
 from mcp.server.elicitation import (
-    CancelledElicitation,
-    DeclinedElicitation,
+    CancelledElicitation as _CancelledElicitation,
+    DeclinedElicitation as _DeclinedElicitation,
 )
 from pydantic import BaseModel
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
@@ -16,6 +16,34 @@ from typing_extensions import TypeVar
 from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import get_cached_typeadapter
+
+
+class DeclinedElicitation(_DeclinedElicitation):
+    """Result when user declines the elicitation.
+
+    This subclass is falsy so the natural guard pattern works::
+
+        result = await ctx.elicit("Confirm?", response_type=bool)
+        if result:  # False for DeclinedElicitation
+            do_action()
+    """
+
+    def __bool__(self) -> bool:
+        return False
+
+
+class CancelledElicitation(_CancelledElicitation):
+    """Result when user cancels the elicitation.
+
+    This subclass is falsy so the natural guard pattern works::
+
+        result = await ctx.elicit("Confirm?", response_type=bool)
+        if result:  # False for CancelledElicitation
+            do_action()
+    """
+
+    def __bool__(self) -> bool:
+        return False
 
 __all__ = [
     "AcceptedElicitation",

--- a/tests/client/test_elicitation.py
+++ b/tests/client/test_elicitation.py
@@ -778,3 +778,59 @@ class TestPatternMatching:
         ) as client:
             result = await client.call_tool("pattern_match_tool", {})
             assert result.data == "Cancelled"
+
+
+class TestElicitationTruthiness:
+    """Test that DeclinedElicitation and CancelledElicitation are falsy.
+
+    This ensures the natural guard pattern works::
+
+        result = await ctx.elicit("Confirm?", response_type=bool)
+        if result:  # Should be False for Declined/Cancelled
+            do_action()
+    """
+
+    def test_accepted_elicitation_is_truthy(self):
+        """AcceptedElicitation should be truthy."""
+        accepted = AcceptedElicitation(data="yes")
+        assert bool(accepted) is True
+        assert accepted  # truthy in boolean context
+
+    def test_declined_elicitation_is_falsy(self):
+        """DeclinedElicitation should be falsy."""
+        declined = DeclinedElicitation()
+        assert bool(declined) is False
+        assert not declined  # falsy in boolean context
+
+    def test_cancelled_elicitation_is_falsy(self):
+        """CancelledElicitation should be falsy."""
+        cancelled = CancelledElicitation()
+        assert bool(cancelled) is False
+        assert not cancelled  # falsy in boolean context
+
+    def test_declined_elicitation_guard_pattern(self):
+        """DeclinedElicitation should fail the natural guard pattern."""
+        result = DeclinedElicitation()
+        # This is the pattern from the issue - should NOT execute the action
+        action_executed = False
+        if result:
+            action_executed = True
+        assert not action_executed
+
+    def test_cancelled_elicitation_guard_pattern(self):
+        """CancelledElicitation should fail the natural guard pattern."""
+        result = CancelledElicitation()
+        # This is the pattern from the issue - should NOT execute the action
+        action_executed = False
+        if result:
+            action_executed = True
+        assert not action_executed
+
+    def test_accepted_elicitation_guard_pattern(self):
+        """AcceptedElicitation should pass the natural guard pattern."""
+        result = AcceptedElicitation(data={"value": "yes"})
+        # This should execute the action
+        action_executed = False
+        if result:
+            action_executed = True
+        assert action_executed


### PR DESCRIPTION
Fixes #4929

## Changes

- `DeclinedElicitation` and `CancelledElicitation` now return `False` from `__bool__`, making them falsy in boolean contexts
- `AcceptedElicitation` remains truthy (unchanged)

## Root Cause

All three elicitation result types (`AcceptedElicitation`, `DeclinedElicitation`, `CancelledElicitation`) were inherited from Pydantic `BaseModel`, which defaults to truthy. This caused the natural guard pattern to permit refused actions:

```python
result = await ctx.elicit("Create candidate?", response_type=str)
if result:  # True for ALL three types, including Declined!
    create()
```

## Testing

- Added 6 tests verifying truthiness for all three result types
- Tests cover both direct `bool()` checks and the natural guard pattern
