### PR TITLE
fix: handle forward slashes in OpenAPI operationId slugification (fixes #5017)

### DIFF
--- a/fastmcp_slim/fastmcp/server/providers/openapi/components.py
+++ b/fastmcp_slim/fastmcp/server/providers/openapi/components.py
@@ -147,8 +147,8 @@ def _slugify(text: str) -> str:
     if not text:
         return ""
 
-    # Replace spaces and common separators with underscores
-    slug = re.sub(r"[\s\-\.]+", "_", text)
+    # Replace spaces, common separators, and forward slashes with underscores
+    slug = re.sub(r"[\s\-\.\/]+", "_", text)
 
     # Remove non-alphanumeric characters except underscores
     slug = re.sub(r"[^a-zA-Z0-9_]", "", slug)

--- a/tests/server/providers/openapi/test_server.py
+++ b/tests/server/providers/openapi/test_server.py
@@ -361,3 +361,38 @@ class TestOpenAPIProviderBasicFunctionality:
                     "title": "User",
                 }
                 assert tool.output_schema == expected_output_schema
+
+
+class TestSlugify:
+    """Tests for the _slugify function used in OpenAPI tool name generation."""
+
+    def test_slash_replaced_with_underscore(self):
+        """Forward slashes in operationId should become underscores."""
+        from fastmcp.server.providers.openapi.components import _slugify
+
+        assert _slugify("actions/add-custom-labels") == "actions_add_custom_labels"
+
+    def test_tag_slash_operation_format(self):
+        """GitHub-style tag/operation IDs should produce correct tool names."""
+        from fastmcp.server.providers.openapi.components import _slugify
+
+        result = _slugify("actions/add-custom-labels-to-self-hosted-runner-for-org")
+        assert result == "actions_add_custom_labels_to_self_hosted_runner_for_org"
+
+    def test_multiple_slashes(self):
+        """Multiple slashes should all become underscores."""
+        from fastmcp.server.providers.openapi.components import _slugify
+
+        assert _slugify("a/b/c") == "a_b_c"
+
+    def test_slash_at_start(self):
+        """Leading slash should not produce leading underscore."""
+        from fastmcp.server.providers.openapi.components import _slugify
+
+        assert _slugify("/actions/list") == "actions_list"
+
+    def test_slash_at_end(self):
+        """Trailing slash should not produce trailing underscore."""
+        from fastmcp.server.providers.openapi.components import _slugify
+
+        assert _slugify("actions/list/") == "actions_list"


### PR DESCRIPTION
## Summary

Fixes `_slugify()` in `fastmcp/server/providers/openapi/components.py` to handle forward slashes in OpenAPI operationIds.

## Problem

The `_slugify()` function only treated `.`, `-`, `_`, and spaces as word separators. Forward slashes (`/`) were silently deleted, producing mangled tool names.

For example, GitHub's REST API spec uses slash-separated operationIds:
- operationId: `actions/add-custom-labels-to-self-hosted-runner-for-org`
- **Before fix:** `actionsadd_custom_labels_to_self_hosted_runner_for_org` (silently deleted slash)
- **After fix:** `actions_add_custom_labels_to_self_hosted_runner_for_org` (correctly converted)

## Fix

Added `/` to the separator regex in `_slugify()`. The pattern now treats `/` the same as `.`, `-`, `_`, and spaces: replacing them with `_`, collapsing consecutive separators, and trimming leading/trailing underscores.

## Changes

- `fastmcp/server/providers/openapi/components.py` - Added `/` to the separator regex
- `tests/server/providers/openapi/test_server.py` - Added 5 tests for slash handling (slash in middle, multiple slashes, leading/trailing slashes, realistic GitHub-style operationId)

Fixes #5017
