### PR TITLE
fix: send multipart array values as separate form fields (fixes #5072)

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -106,17 +106,24 @@ class RequestDirector:
                 # treats them as form fields. Scalars must be stringified
                 # because httpx rejects non-string/bytes values in files=.
                 # Use _query_scalar_to_str for booleans (true/false, not True/False).
-                files = {}
+                # For arrays, we build a list of (name, (filename, value)) tuples
+                # so httpx sends each element as a separate form field.
+                files: list[tuple[str, tuple[str | None, str]]] = []
                 for k, v in body.items():
                     if isinstance(v, tuple):
-                        files[k] = v
+                        files.append((k, v))
                     elif isinstance(v, bytes | io.IOBase):
                         # bytes and file-like objects are passed directly so
                         # httpx can transmit them as binary parts without
                         # stringifying to their Python repr.
-                        files[k] = (None, v)
+                        files.append((k, (None, v)))
+                    elif isinstance(v, list):
+                        # Arrays should be sent as multiple form fields with
+                        # the same name per the OpenAPI multipart spec.
+                        for item in v:
+                            files.append((k, (None, _query_scalar_to_str(item))))
                     else:
-                        files[k] = (None, _query_scalar_to_str(v))
+                        files.append((k, (None, _query_scalar_to_str(v))))
             elif (
                 declared_content_type == "application/x-www-form-urlencoded"
                 and isinstance(body, dict)

--- a/tests/utilities/openapi/test_director.py
+++ b/tests/utilities/openapi/test_director.py
@@ -586,6 +586,44 @@ class TestContentTypeHandling:
         # multipart/form-data should be sent as multipart, not JSON
         assert "multipart/form-data" in request.headers["content-type"]
 
+    def test_multipart_array_fields_sent_separately(self, director):
+        """Array values in multipart should be sent as multiple fields, not a list string."""
+        route = HTTPRoute(
+            path="/submit",
+            method="POST",
+            operation_id="submit",
+            request_body=RequestBodyInfo(
+                required=True,
+                content_schema={
+                    "multipart/form-data": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            }
+                        },
+                        "required": ["tags"],
+                    }
+                },
+            ),
+            parameter_map={
+                "tags": {"location": "body", "openapi_name": "tags"},
+            },
+        )
+
+        request = director.build(route, {"tags": ["a", "b"]}, "https://example.com")
+        # Should be multipart
+        assert "multipart/form-data" in request.headers["content-type"]
+        # The stream should be a MultipartStream with array values as separate parts.
+        from httpx2._multipart import MultipartStream
+
+        assert isinstance(request.stream, MultipartStream)
+        # Collect all field names from the multipart parts
+        field_names = [field.name for field in request.stream.fields]
+        # tags should appear twice (once for "a", once for "b")
+        assert field_names.count("tags") == 2
+
 
 class TestQueryParameterSerialization:
     """Test that query parameters respect OpenAPI explode/style settings."""


### PR DESCRIPTION
## Summary
Fixes multipart form data handling so array values are sent as separate form fields instead of Python `repr()` strings.

## Problem
When building multipart form data from OpenAPI request bodies, array values were converted using `str()`, producing Python list repr strings like `"['a', 'b']"` instead of sending each array element as a separate form field.

## Fix
Changed the `files` parameter from a `dict` to a `list` of tuples (the `requests` library's format for multiple values per key), so array values become separate form fields.

## Changes
- `fastmcp/utilities/openapi/director.py` - Changed `files` from dict to list-of-tuples
- `tests/server/openapi/test_openapi_director.py` - Added 1 test for multipart string arrays

Fixes #5072