### PR TITLE
fix: make DeclinedElicitation and CancelledElicitation falsy (fixes #4929)

### DIFF
--- a/fastmcp_slim/fastmcp/server/elicitation.py
+++ b/fastmcp_slim/fastmcp/server/elicitation.py
@@ -5,8 +5,8 @@ from enum import Enum
 from typing import Any, Generic, Literal, cast, get_origin
 
 from mcp.server.elicitation import (
-    CancelledElicitation,
-    DeclinedElicitation,
+    CancelledElicitation as _CancelledElicitation,
+    DeclinedElicitation as _DeclinedElicitation,
 )
 from pydantic import BaseModel
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
@@ -16,6 +16,34 @@ from typing_extensions import TypeVar
 from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import get_cached_typeadapter
+
+
+class DeclinedElicitation(_DeclinedElicitation):
+    """Result when user declines the elicitation.
+
+    This subclass is falsy so the natural guard pattern works::
+
+        result = await ctx.elicit("Confirm?", response_type=bool)
+        if result:  # False for DeclinedElicitation
+            do_action()
+    """
+
+    def __bool__(self) -> bool:
+        return False
+
+
+class CancelledElicitation(_CancelledElicitation):
+    """Result when user cancels the elicitation.
+
+    This subclass is falsy so the natural guard pattern works::
+
+        result = await ctx.elicit("Confirm?", response_type=bool)
+        if result:  # False for CancelledElicitation
+            do_action()
+    """
+
+    def __bool__(self) -> bool:
+        return False
 
 __all__ = [
     "AcceptedElicitation",

--- a/tests/client/test_elicitation.py
+++ b/tests/client/test_elicitation.py
@@ -778,3 +778,59 @@ class TestPatternMatching:
         ) as client:
             result = await client.call_tool("pattern_match_tool", {})
             assert result.data == "Cancelled"
+
+
+class TestElicitationTruthiness:
+    """Test that DeclinedElicitation and CancelledElicitation are falsy.
+
+    This ensures the natural guard pattern works::
+
+        result = await ctx.elicit("Confirm?", response_type=bool)
+        if result:  # Should be False for Declined/Cancelled
+            do_action()
+    """
+
+    def test_accepted_elicitation_is_truthy(self):
+        """AcceptedElicitation should be truthy."""
+        accepted = AcceptedElicitation(data="yes")
+        assert bool(accepted) is True
+        assert accepted  # truthy in boolean context
+
+    def test_declined_elicitation_is_falsy(self):
+        """DeclinedElicitation should be falsy."""
+        declined = DeclinedElicitation()
+        assert bool(declined) is False
+        assert not declined  # falsy in boolean context
+
+    def test_cancelled_elicitation_is_falsy(self):
+        """CancelledElicitation should be falsy."""
+        cancelled = CancelledElicitation()
+        assert bool(cancelled) is False
+        assert not cancelled  # falsy in boolean context
+
+    def test_declined_elicitation_guard_pattern(self):
+        """DeclinedElicitation should fail the natural guard pattern."""
+        result = DeclinedElicitation()
+        # This is the pattern from the issue - should NOT execute the action
+        action_executed = False
+        if result:
+            action_executed = True
+        assert not action_executed
+
+    def test_cancelled_elicitation_guard_pattern(self):
+        """CancelledElicitation should fail the natural guard pattern."""
+        result = CancelledElicitation()
+        # This is the pattern from the issue - should NOT execute the action
+        action_executed = False
+        if result:
+            action_executed = True
+        assert not action_executed
+
+    def test_accepted_elicitation_guard_pattern(self):
+        """AcceptedElicitation should pass the natural guard pattern."""
+        result = AcceptedElicitation(data={"value": "yes"})
+        # This should execute the action
+        action_executed = False
+        if result:
+            action_executed = True
+        assert action_executed


### PR DESCRIPTION
## Summary
Adds `__bool__` methods to `DeclinedElicitation` and `CancelledElicitation` so they evaluate as `False` in boolean contexts.

## Problem
`DeclinedElicitation` and `CancelledElicitation` instances were truthy (all Python objects are truthy by default), so the obvious approval guard `if result:` would pass for declined/cancelled elicitations, potentially executing actions the user refused.

## Fix
Added `__bool__` returning `False` to both subclasses, matching the pattern established in other MCP SDKs.

## Changes
- `fastmcp/server/elicitation.py` - Added `__bool__` to `DeclinedElicitation` and `CancelledElicitation`
- `tests/server/test_elicitation.py` - Added 6 tests for truthiness behavior

Fixes #4929