### PR TITLE
fix: treat empty-string pagination cursors as valid continuation tokens (fixes #5025)

### DIFF
--- a/fastmcp_slim/fastmcp/client/mixins/prompts.py
+++ b/fastmcp_slim/fastmcp/client/mixins/prompts.py
@@ -96,7 +96,7 @@ class ClientPromptsMixin:
         for _ in range(max_pages):
             result = await self.list_prompts_mcp(cursor=cursor)
             all_prompts.extend(result.prompts)
-            if not result.next_cursor:
+            if result.next_cursor is None:
                 break
             if result.next_cursor in seen_cursors:
                 logger.warning(

--- a/fastmcp_slim/fastmcp/client/mixins/resources.py
+++ b/fastmcp_slim/fastmcp/client/mixins/resources.py
@@ -96,7 +96,7 @@ class ClientResourcesMixin:
         for _ in range(max_pages):
             result = await self.list_resources_mcp(cursor=cursor)
             all_resources.extend(result.resources)
-            if not result.next_cursor:
+            if result.next_cursor is None:
                 break
             if result.next_cursor in seen_cursors:
                 logger.warning(
@@ -191,7 +191,7 @@ class ClientResourcesMixin:
         for _ in range(max_pages):
             result = await self.list_resource_templates_mcp(cursor=cursor)
             all_templates.extend(result.resource_templates)
-            if not result.next_cursor:
+            if result.next_cursor is None:
                 break
             if result.next_cursor in seen_cursors:
                 logger.warning(

--- a/fastmcp_slim/fastmcp/client/mixins/tools.py
+++ b/fastmcp_slim/fastmcp/client/mixins/tools.py
@@ -121,7 +121,7 @@ class ClientToolsMixin:
         for _ in range(max_pages):
             result = await self.list_tools_mcp(cursor=cursor, cache_mode=cache_mode)
             all_tools.extend(result.tools)
-            if not result.next_cursor:
+            if result.next_cursor is None:
                 break
             if result.next_cursor in seen_cursors:
                 logger.warning(

--- a/tests/client/test_empty_cursor_pagination.py
+++ b/tests/client/test_empty_cursor_pagination.py
@@ -1,0 +1,106 @@
+"""Tests for auto-pagination when servers return opaque cursor strings.
+
+Verifies that ``Client.list_tools()``, ``Client.list_resources()``, and
+``Client.list_prompts()`` correctly paginate when the server returns a non-null
+continuation cursor (including empty strings), per the MCP pagination contract
+which treats cursors as opaque tokens and ends pagination only when the cursor
+is absent or ``None``.
+"""
+
+import pytest
+import mcp_types
+from mcp_types import ListToolsResult, Tool, ListResourcesResult, Resource, ListPromptsResult, Prompt
+
+from fastmcp import Client, FastMCP
+
+
+class _EmptyCursorToolsServer(FastMCP):
+    """Server that returns an empty string ``next_cursor`` on page 1."""
+
+    async def _on_list_tools(self, ctx, params):
+        first_page = params is None or params.cursor is None
+        if not first_page:
+            assert params.cursor == ""
+        return ListToolsResult(
+            tools=[Tool(name="first" if first_page else "second", input_schema={"type": "object"})],
+            next_cursor="" if first_page else None,
+        )
+
+
+class _EmptyCursorResourcesServer(FastMCP):
+    """Server that returns an empty string ``next_cursor`` on page 1."""
+
+    async def _on_list_resources(self, ctx, params):
+        first_page = params is None or params.cursor is None
+        if not first_page:
+            assert params.cursor == ""
+        return ListResourcesResult(
+            resources=[Resource(uri="first" if first_page else "second", name="r")],
+            next_cursor="" if first_page else None,
+        )
+
+
+class _EmptyCursorPromptsServer(FastMCP):
+    """Server that returns an empty string ``next_cursor`` on page 1."""
+
+    async def _on_list_prompts(self, ctx, params):
+        first_page = params is None or params.cursor is None
+        if not first_page:
+            assert params.cursor == ""
+        return ListPromptsResult(
+            prompts=[Prompt(name="first" if first_page else "second")],
+            next_cursor="" if first_page else None,
+        )
+
+
+class TestEmptyCursorPagination:
+    """Auto-pagination must not stop when next_cursor is an empty string."""
+
+    async def test_list_tools_empty_cursor(self):
+        """list_tools must continue past an empty-string cursor."""
+        async with Client(_EmptyCursorToolsServer("tools")) as client:
+            tools = await client.list_tools(max_pages=5)
+            names = [t.name for t in tools]
+            assert names == ["first", "second"]
+
+    async def test_list_resources_empty_cursor(self):
+        """list_resources must continue past an empty-string cursor."""
+        async with Client(_EmptyCursorResourcesServer("resources")) as client:
+            resources = await client.list_resources(max_pages=5)
+            uris = [r.uri for r in resources]
+            assert uris == ["first", "second"]
+
+    async def test_list_prompts_empty_cursor(self):
+        """list_prompts must continue past an empty-string cursor."""
+        async with Client(_EmptyCursorPromptsServer("prompts")) as client:
+            prompts = await client.list_prompts(max_pages=5)
+            names = [p.name for p in prompts]
+            assert names == ["first", "second"]
+
+
+class _NonEmptyCursorServer(FastMCP):
+    """Server that uses a non-empty opaque cursor."""
+
+    async def _on_list_tools(self, ctx, params):
+        cursor = params.cursor if params and params.cursor else None
+        if cursor is None:
+            return ListToolsResult(
+                tools=[Tool(name="page1", input_schema={"type": "object"})],
+                next_cursor="opaque-token-abc",
+            )
+        elif cursor == "opaque-token-abc":
+            return ListToolsResult(
+                tools=[Tool(name="page2", input_schema={"type": "object"})],
+                next_cursor=None,
+            )
+        return ListToolsResult(tools=[], next_cursor=None)
+
+
+class TestNonEmptyCursorPagination:
+    """Standard non-empty cursor pagination still works."""
+
+    async def test_list_tools_non_empty_cursor(self):
+        async with Client(_NonEmptyCursorServer("opaque")) as client:
+            tools = await client.list_tools(max_pages=5)
+            names = [t.name for t in tools]
+            assert names == ["page1", "page2"]


### PR DESCRIPTION
## Summary
Fixes auto-pagination in `Client.list_tools()`, `list_resources()`, and `list_prompts()` to treat empty-string cursors as valid continuation tokens.

## Problem
The auto-pagination loops used `if not result.next_cursor:` to detect end-of-pagination. This treated empty-string cursors (`""`) as falsy, silently stopping pagination after the first page when a server returned `next_cursor=""`.

Per the MCP pagination contract, cursors are opaque tokens and pagination ends only when the cursor is absent or `None`. An empty string is a valid cursor.

## Fix
Changed the check from `not result.next_cursor` to `result.next_cursor is None` in all four client-side pagination loops (tools, prompts, resources, resource_templates).

## Changes
- `fastmcp/client/mixins/tools.py` - Fixed pagination check in `list_tools()`
- `fastmcp/client/mixins/prompts.py` - Fixed pagination check in `list_prompts()`
- `fastmcp/client/mixins/resources.py` - Fixed pagination check in `list_resources()` and `list_resource_templates()`
- `tests/client/test_empty_cursor_pagination.py` - Added 4 tests covering empty-string and non-empty cursor pagination

Fixes #5025
