### PR TITLE
fix(openapi): serialize header and path parameters per the simple style

### DIFF
--- a/fastmcp_slim/fastmcp/utilities/openapi/director.py
+++ b/fastmcp_slim/fastmcp/utilities/openapi/director.py
@@ -67,12 +67,29 @@ class RequestDirector:
         query_params = self._serialize_query_params(route, query_params)
 
         # Step 3: Build base URL with path parameters
-        url = self._build_url(route.path, path_params, base_url)
+        url = self._build_url(route, path_params, base_url)
 
         # Step 4: Prepare request data
         method: str = route.method.upper()
         params = query_params if query_params else None
-        headers = header_params if header_params else None
+        # Header parameters always use the OpenAPI "simple" style; values must
+        # be strings or httpx rejects the request outright.
+        header_lookup: dict[str, ParameterInfo] = {
+            p.name: p for p in route.parameters if p.location == "header"
+        }
+        headers = (
+            {
+                k: self._simple_param_to_str(
+                    v,
+                    explode=bool(header_lookup[k].explode)
+                    if k in header_lookup
+                    else False,
+                )
+                for k, v in header_params.items()
+            }
+            if header_params
+            else None
+        )
         json_body: dict[str, Any] | list[Any] | str | int | float | bool | None = None
         content: str | bytes | None = None
 
@@ -131,7 +148,8 @@ class RequestDirector:
                 )
             ):
                 if (
-                    declared_content_type is not None
+                    raw_content_type is not None
+                    and declared_content_type is not None
                     and raw_content_type != "application/json"
                     and "json" in declared_content_type
                 ):
@@ -357,27 +375,56 @@ class RequestDirector:
             serialized[key] = value
         return serialized
 
+    @staticmethod
+    def _simple_param_to_str(value: Any, explode: bool = False) -> str:
+        """Serialize a value per the OpenAPI "simple" style (path and header parameters).
+
+        Arrays join with commas either way; explode only changes object
+        serialization from "k,v" pairs to "k=v" pairs.
+        """
+        if isinstance(value, dict):
+            parts: list[str] = []
+            for k, v in value.items():
+                if explode:
+                    parts.append(f"{_query_scalar_to_str(k)}={_query_scalar_to_str(v)}")
+                else:
+                    parts.append(_query_scalar_to_str(k))
+                    parts.append(_query_scalar_to_str(v))
+            return ",".join(parts)
+        if isinstance(value, list | tuple):
+            return ",".join(_query_scalar_to_str(v) for v in value)
+        return _query_scalar_to_str(value)
+
     def _build_url(
-        self, path_template: str, path_params: dict[str, Any], base_url: str
+        self, route: HTTPRoute, path_params: dict[str, Any], base_url: str
     ) -> str:
         """
         Build URL by substituting path parameters in the template.
 
         Args:
-            path_template: OpenAPI path template (e.g., "/users/{id}")
+            route: HTTPRoute containing the path template and parameter definitions
             path_params: Path parameter values
             base_url: Base URL to prepend
 
         Returns:
             Complete URL with path parameters substituted
         """
-        # Substitute path parameters with URL-encoding to prevent
-        # path traversal and SSRF via crafted parameter values
-        url_path = path_template
+        # Path parameters default to the OpenAPI "simple" style, so values are
+        # serialized before substitution (e.g. true/false for booleans, "a,b"
+        # for arrays) instead of leaking Python reprs into the URL.
+        path_lookup: dict[str, ParameterInfo] = {
+            p.name: p for p in route.parameters if p.location == "path"
+        }
+        url_path = route.path
         for param_name, param_value in path_params.items():
             placeholder = f"{{{param_name}}}"
             if placeholder in url_path:
-                safe_value = quote(str(param_value), safe="").replace(".", "%2E")
+                param_info = path_lookup.get(param_name)
+                explode = bool(param_info.explode) if param_info else False
+                serialized = self._simple_param_to_str(param_value, explode=explode)
+                # Substitute path parameters with URL-encoding to prevent
+                # path traversal and SSRF via crafted parameter values
+                safe_value = quote(serialized, safe="").replace(".", "%2E")
                 url_path = url_path.replace(placeholder, safe_value)
 
         # Combine with base URL

--- a/tests/server/providers/openapi/test_header_path_serialization.py
+++ b/tests/server/providers/openapi/test_header_path_serialization.py
@@ -1,0 +1,167 @@
+"""Header and path parameter values follow the OpenAPI "simple" style."""
+
+from typing import Any
+
+import httpx2
+import pytest
+
+from fastmcp import Client, FastMCP
+
+
+def make_spec(parameters: list[dict[str, Any]], path: str = "/items") -> dict[str, Any]:
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Header/path scalars", "version": "1"},
+        "paths": {
+            path: {
+                "get": {
+                    "operationId": "get_items",
+                    "parameters": parameters,
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+    }
+
+
+async def call_and_capture(
+    spec: dict[str, Any], args: dict[str, Any]
+) -> list[httpx2.Request]:
+    requests: list[httpx2.Request] = []
+
+    def capture(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, json={"ok": True})
+
+    async with httpx2.AsyncClient(
+        base_url="https://example.test", transport=httpx2.MockTransport(capture)
+    ) as http_client:
+        server = FastMCP.from_openapi(openapi_spec=spec, client=http_client)
+        async with Client(server) as client:
+            await client.call_tool("get_items", args)
+
+    assert len(requests) == 1
+    return requests
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "true"),
+        (False, "false"),
+        (5, "5"),
+        (1.5, "1.5"),
+        ("plain", "plain"),
+    ],
+)
+async def test_header_scalar_serialization(value: Any, expected: str) -> None:
+    spec = make_spec(
+        [
+            {
+                "name": "X-Flag",
+                "in": "header",
+                "required": True,
+                "schema": {"type": "string"},
+            }
+        ]
+    )
+    requests = await call_and_capture(spec, {"X-Flag": value})
+    assert requests[0].headers["x-flag"] == expected
+
+
+async def test_header_array_serialization() -> None:
+    spec = make_spec(
+        [
+            {
+                "name": "X-Tags",
+                "in": "header",
+                "required": True,
+                "schema": {"type": "array", "items": {"type": "string"}},
+            }
+        ]
+    )
+    requests = await call_and_capture(spec, {"X-Tags": ["a", "b"]})
+    assert requests[0].headers["x-tags"] == "a,b"
+
+
+@pytest.mark.parametrize(
+    "explode,expected",
+    [
+        (None, "R,100,G,200"),
+        (False, "R,100,G,200"),
+        (True, "R=100,G=200"),
+    ],
+)
+async def test_header_object_serialization(explode: bool | None, expected: str) -> None:
+    parameter: dict[str, Any] = {
+        "name": "X-Color",
+        "in": "header",
+        "required": True,
+        "schema": {"type": "object"},
+    }
+    if explode is not None:
+        parameter["explode"] = explode
+    spec = make_spec([parameter])
+    requests = await call_and_capture(spec, {"X-Color": {"R": 100, "G": 200}})
+    assert requests[0].headers["x-color"] == expected
+
+
+async def test_path_array_serialization() -> None:
+    spec = make_spec(
+        [
+            {
+                "name": "ids",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "array", "items": {"type": "string"}},
+            }
+        ],
+        path="/items/{ids}",
+    )
+    requests = await call_and_capture(spec, {"ids": ["a", "b"]})
+    assert requests[0].url.path == "/items/a,b"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "/items/true"),
+        (5, "/items/5"),
+        ("a b", "/items/a b"),
+    ],
+)
+async def test_path_scalar_serialization(value: Any, expected: str) -> None:
+    spec = make_spec(
+        [
+            {
+                "name": "id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string"},
+            }
+        ],
+        path="/items/{id}",
+    )
+    requests = await call_and_capture(spec, {"id": value})
+    assert requests[0].url.path == expected
+
+
+@pytest.mark.parametrize(
+    "explode,expected",
+    [
+        (None, "/items/R,100,G,200"),
+        (True, "/items/R=100,G=200"),
+    ],
+)
+async def test_path_object_serialization(explode: bool | None, expected: str) -> None:
+    parameter: dict[str, Any] = {
+        "name": "filter",
+        "in": "path",
+        "required": True,
+        "schema": {"type": "object"},
+    }
+    if explode is not None:
+        parameter["explode"] = explode
+    spec = make_spec([parameter], path="/items/{filter}")
+    requests = await call_and_capture(spec, {"filter": {"R": 100, "G": 200}})
+    assert requests[0].url.path == expected


### PR DESCRIPTION
## Description

Closes #4897

RequestDirector passed header parameter values to httpx2 as native Python types, so any non-string header parameter (boolean, integer, array, object) crashed request building with `TypeError: Header value must be str or bytes`. Path parameters were interpolated with `str()`, leaking Python reprs into the URL (`/items/['a', 'b']` for an array).

Both locations now serialize with the OpenAPI simple style, the same treatment query and cookie parameters already get: booleans render as `true`/`false`, arrays join with commas, and objects emit `k,v` or `k=v` pairs depending on `explode`. Path serialization runs before the existing URL-encoding guard, which is unchanged.

One adjacent adjustment: the custom-Content-Type branch now guards on `raw_content_type is not None`. Same semantics (`declared` derives from `raw`); it keeps type narrowing valid now that the headers dict is strictly typed.

Reproduced both halves on main (58d903c) before the fix and verified the corrected wire values after, twice each.

## Contribution type
- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)

## Checklist
- [x] This PR addresses an existing issue (#4897)
- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes (15: header scalars/arrays/objects, path scalars/arrays/objects)
- [x] prek passes on the changed files (ruff, ty, codespell); full openapi suites green (175 + 13)
- [ ] I have self-reviewed my changes
