### PR TITLE
fix: honor Claude Code POSIX project paths on Windows

### DIFF
--- a/fastmcp_slim/fastmcp/cli/discovery.py
+++ b/fastmcp_slim/fastmcp/cli/discovery.py
@@ -191,12 +191,18 @@ def _scan_claude_code(start_dir: Path) -> list[DiscoveredServer]:
                 )
             )
 
-    # Project-scoped servers matching start_dir
-    resolved_dir = str(start_dir.resolve())
+    # Project-scoped servers matching start_dir. Claude Code keys
+    # ``projects`` by a raw path string and on Windows often writes
+    # forward slashes (and a different drive-letter case) than
+    # ``Path.resolve()``, so compare resolved paths instead of strings.
+    resolved_dir = start_dir.resolve()
     projects = data.get("projects", {})
     if isinstance(projects, dict):
-        project_data = projects.get(resolved_dir, {})
-        if isinstance(project_data, dict):
+        for project_path, project_data in projects.items():
+            if not isinstance(project_path, str) or not isinstance(project_data, dict):
+                continue
+            if not _is_same_project_dir(project_path, resolved_dir):
+                continue
             if project_servers := project_data.get("mcpServers"):
                 if isinstance(project_servers, dict):
                     results.extend(
@@ -208,6 +214,14 @@ def _scan_claude_code(start_dir: Path) -> list[DiscoveredServer]:
                     )
 
     return results
+
+
+def _is_same_project_dir(stored: str, resolved_start: Path) -> bool:
+    """Return whether a Claude Code ``projects`` key names *resolved_start*."""
+    try:
+        return Path(stored).expanduser().resolve() == resolved_start
+    except OSError:
+        return False
 
 
 def _scan_cursor_workspace(start_dir: Path) -> list[DiscoveredServer]:

--- a/tests/cli/test_discovery.py
+++ b/tests/cli/test_discovery.py
@@ -322,6 +322,25 @@ class TestScanClaudeCode:
         assert len(servers) == 1
         assert servers[0].name == "api"
 
+    def test_project_servers_match_posix_path_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Claude Code on Windows stores project keys with forward slashes."""
+        monkeypatch.setattr("fastmcp.cli.discovery.Path.home", lambda: tmp_path)
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        config_path = tmp_path / ".claude.json"
+        _write_config(
+            config_path,
+            _claude_code_config(
+                project_path=project_dir.resolve().as_posix(),
+                project_servers={"api": {"url": "http://localhost:8000/mcp"}},
+            ),
+        )
+        servers = _scan_claude_code(project_dir)
+        assert len(servers) == 1
+        assert servers[0].name == "api"
+
     def test_global_and_project_combined(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):


### PR DESCRIPTION
Fixes #5094

## Problem

Claude Code on Windows stores `~/.claude.json` `projects` keys with forward slashes. Discovery compared that string to `str(Path.resolve())`, which uses backslashes, so project-scoped `mcpServers` were skipped.

## Solution

Resolve the stored key and compare `Path` objects. Trailing slashes and drive-letter case then match the current directory.

## User impact

Windows users who configured MCP servers in a Claude Code project now see those servers in FastMCP discovery.

## Evidence

- `uv run pytest tests/cli/test_discovery.py::TestScanClaudeCode -q` — 7 passed, including `test_project_servers_match_posix_path_key`
- Local check: `Path(stored).resolve() == start_dir.resolve()` is true when `stored` is `as_posix()`

Drafted with LLM assistance after reproducing the mismatch on Windows.

- [x] Bug fix (simple, well-scoped fix for a clearly broken behavior)
- [x] This PR addresses an existing issue (or fixes a self-evident bug)
- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes
- [x] I have self-reviewed my changes
- [x] If I used an LLM, it followed the repo's contributing conventions (not generic output)